### PR TITLE
Deprecate TensorBoard support

### DIFF
--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -1355,7 +1355,13 @@ class TrainingPipeline:
             logger.info("Random Forest classifier already trained. Exiting training loop.")
             return
 
-        # BUG: edge case where if save-tag was already used in the past, train_random_forest() will load previous model weights to train RF, since pipeline.save_models() happens after pipeline.train_random_forest(). add a check to validate_args() to make sure save-tag is distinct?
+        # # BUG:
+        # # edge case where if save-tag was already used in the past, train_random_forest() will
+        # # load previous model weights to train RF, since pipeline.save_models() happens after
+        # # pipeline.train_random_forest()
+        # # add a check to validate_args() to make sure save-tag is distinct?
+        # # note, should only be a problem during testing, since load_models() only runs if
+        # # check_encoder_trained() fails
         # Load encoder weights if untrained
         logger.info("Checking if encoder weights appear trained")
 


### PR DESCRIPTION
## Summary

Deprecates TensorBoard support from the training pipeline by commenting out all related functionality.

Resolves #10

## Changes

This PR includes the following commits:

1. **Commented out TensorBoard related functionality in train.py**
   - Commented out `_setup_tensorboard_logging()` method
   - Commented out `__del__()` destructor for TensorBoard writer cleanup
   - Commented out TensorBoard metric logging in `train_round()`

2. **Rename handle_directory() to archive_directory()**
   - Renamed function to better reflect its purpose
   - Added comments explaining TensorBoard-related functionality deprecation
   - Updated all function calls throughout the file

3. **Update TODOs**
   - Updated TODO comments to reflect TensorBoard removal status

## Code Changes

- **src/aetherscan/train.py**: 88 insertions(+), 77 deletions(-)

All TensorBoard code has been commented out (not deleted) to allow for potential future revival if needed. Each commented section is marked with `# COMMENTED OUT: Removing TensorBoard support` for easy identification.

## Testing

- [ ] Training pipeline runs without TensorBoard
- [ ] Training history still tracked in `self.history` dictionary
- [ ] Matplotlib plots still generated at checkpoints

## Notes

- Training metrics are still being tracked via the `self.history` dictionary
- Matplotlib-based progress plots are still generated via `plot_beta_vae_training_progress()`
- The `archive_directory()` function retains incomplete TensorBoard directory handling functionality (via `target_dirs` parameter) for potential future use