### PR TITLE
Add latent space visualization pipeline with UMAP parameter sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ usage:  train [-h] [--data-path DATA_PATH] [--model-path MODEL_PATH]
               [--plot-injection-outlier-percentile PLOT_INJECTION_OUTLIER_PERCENTILE]
               [--latent-viz-num-cadences-per-type LATENT_VIZ_NUM_CADENCES_PER_TYPE]
               [--latent-viz-step-interval LATENT_VIZ_STEP_INTERVAL]
+              [--latent-viz-gif-max-frames LATENT_VIZ_GIF_MAX_FRAMES]
               [--latent-viz-gif-duration-ms LATENT_VIZ_GIF_DURATION_MS]
               [--snr-base SNR_BASE] [--initial-snr-range INITIAL_SNR_RANGE]
               [--final-snr-range FINAL_SNR_RANGE]
@@ -342,6 +343,10 @@ options:
                         Capture a latent space snapshot every N training steps
                         (lower = more snapshots, more DB writes, and larger
                         storage costs)",
+  --latent-viz-gif-max-frames LATENT_VIZ_GIF_MAX_FRAMES
+                        Maximum number of frames in latent space GIF output
+                        (snapshots beyond this limit are log-subsampled,
+                        prioritizing earlier training steps)
   --latent-viz-gif-duration-ms LATENT_VIZ_GIF_DURATION_MS
                         Milliseconds per frame in latent space GIF output
   --snr-base SNR_BASE   Base signal-to-noise ratio for curriculum learning

--- a/README.md
+++ b/README.md
@@ -343,6 +343,11 @@ options:
                         Capture a latent space snapshot every N training steps
                         (lower = more snapshots, more DB writes, and larger
                         storage costs)",
+  --latent-viz-umap-fit-max-samples LATENT_VIZ_UMAP_FIT_MAX_SAMPLES
+                        Maximum number of pooled latent vectors used to fit
+                        the UMAP model (remaining vectors are projected via
+                        transform; lower = faster, higher = more faithful
+                        embedding)
   --latent-viz-gif-max-frames LATENT_VIZ_GIF_MAX_FRAMES
                         Maximum number of frames in latent space GIF output
                         (snapshots beyond this limit are log-subsampled,

--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ usage:  train [-h] [--data-path DATA_PATH] [--model-path MODEL_PATH]
               [--plot-injection-outlier-percentile PLOT_INJECTION_OUTLIER_PERCENTILE]
               [--latent-viz-num-cadences-per-type LATENT_VIZ_NUM_CADENCES_PER_TYPE]
               [--latent-viz-step-interval LATENT_VIZ_STEP_INTERVAL]
+              [--latent-viz-umap-n-neighbors LATENT_VIZ_UMAP_N_NEIGHBORS [LATENT_VIZ_UMAP_N_NEIGHBORS ...]]
+              [--latent-viz-umap-min-dist LATENT_VIZ_UMAP_MIN_DIST [LATENT_VIZ_UMAP_MIN_DIST ...]]
               [--latent-viz-gif-max-frames LATENT_VIZ_GIF_MAX_FRAMES]
               [--latent-viz-gif-duration-ms LATENT_VIZ_GIF_DURATION_MS]
               [--snr-base SNR_BASE] [--initial-snr-range INITIAL_SNR_RANGE]
@@ -348,6 +350,14 @@ options:
                         the UMAP model (remaining vectors are projected via
                         transform; lower = faster, higher = more faithful
                         embedding)
+  --latent-viz-umap-n-neighbors LATENT_VIZ_UMAP_N_NEIGHBORS [LATENT_VIZ_UMAP_N_NEIGHBORS ...]
+                        UMAP n_neighbors values to sweep for latent space
+                        visualization (e.g., --latent-viz-umap-n-neighbors
+                        5 15 30 50)
+  --latent-viz-umap-min-dist LATENT_VIZ_UMAP_MIN_DIST [LATENT_VIZ_UMAP_MIN_DIST ...]
+                        UMAP min_dist values to sweep for latent space
+                        visualization (e.g., --latent-viz-umap-min-dist
+                        0.0 0.1 0.5)
   --latent-viz-gif-max-frames LATENT_VIZ_GIF_MAX_FRAMES
                         Maximum number of frames in latent space GIF output
                         (snapshots beyond this limit are log-subsampled,

--- a/README.md
+++ b/README.md
@@ -337,10 +337,11 @@ options:
   --latent-viz-num-cadences-per-type LATENT_VIZ_NUM_CADENCES_PER_TYPE
                         Number of cadences per signal type for latent space
                         visualization batch (total points = 4× this value × 6
-                        observations)
+                        observations per cadence)
   --latent-viz-step-interval LATENT_VIZ_STEP_INTERVAL
                         Capture a latent space snapshot every N training steps
-                        (lower = more snapshots, larger DB)
+                        (lower = more snapshots, more DB writes, and larger
+                        storage costs)",
   --latent-viz-gif-duration-ms LATENT_VIZ_GIF_DURATION_MS
                         Milliseconds per frame in latent space GIF output
   --snr-base SNR_BASE   Base signal-to-noise ratio for curriculum learning

--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ usage:  train [-h] [--data-path DATA_PATH] [--model-path MODEL_PATH]
               [--signal-injection-chunk-size SIGNAL_INJECTION_CHUNK_SIZE]
               [--plot-injection-subsampling-count PLOT_INJECTION_SUBSAMPLING_COUNT]
               [--plot-injection-outlier-percentile PLOT_INJECTION_OUTLIER_PERCENTILE]
+              [--latent-viz-num-cadences-per-type LATENT_VIZ_NUM_CADENCES_PER_TYPE]
+              [--latent-viz-step-interval LATENT_VIZ_STEP_INTERVAL]
+              [--latent-viz-gif-duration-ms LATENT_VIZ_GIF_DURATION_MS]
               [--snr-base SNR_BASE] [--initial-snr-range INITIAL_SNR_RANGE]
               [--final-snr-range FINAL_SNR_RANGE]
               [--curriculum-schedule CURRICULUM_SCHEDULE]
@@ -331,6 +334,15 @@ options:
   --plot-injection-outlier-percentile PLOT_INJECTION_OUTLIER_PERCENTILE
                         Threshold for points to always be included in A→B
                         intensity bias scatter plots
+  --latent-viz-num-cadences-per-type LATENT_VIZ_NUM_CADENCES_PER_TYPE
+                        Number of cadences per signal type for latent space
+                        visualization batch (total points = 4× this value × 6
+                        observations)
+  --latent-viz-step-interval LATENT_VIZ_STEP_INTERVAL
+                        Capture a latent space snapshot every N training steps
+                        (lower = more snapshots, larger DB)
+  --latent-viz-gif-duration-ms LATENT_VIZ_GIF_DURATION_MS
+                        Milliseconds per frame in latent space GIF output
   --snr-base SNR_BASE   Base signal-to-noise ratio for curriculum learning
                         (minimum SNR difficulty level)
   --initial-snr-range INITIAL_SNR_RANGE

--- a/environment.yml
+++ b/environment.yml
@@ -24,3 +24,4 @@ dependencies:
       - tensorflow==2.16.*
       - setigen
       - slack-sdk>=3.23.0
+      - umap-learn>=0.5.0

--- a/environment.yml
+++ b/environment.yml
@@ -23,5 +23,6 @@ dependencies:
   - pip:
       - tensorflow==2.16.*
       - setigen
+      - imageio>=2.31.0
       - umap-learn>=0.5.0
       - slack-sdk>=3.23.0

--- a/environment.yml
+++ b/environment.yml
@@ -23,5 +23,5 @@ dependencies:
   - pip:
       - tensorflow==2.16.*
       - setigen
-      - slack-sdk>=3.23.0
       - umap-learn>=0.5.0
+      - slack-sdk>=3.23.0

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -273,6 +273,12 @@ def _add_train_arguments(subparsers):
         help="Capture a latent space snapshot every N training steps (lower = more snapshots, more DB writes, and larger storage costs)",
     )
     train_parser.add_argument(
+        "--latent-viz-gif-max-frames",
+        type=int,
+        default=None,
+        help="Maximum number of frames in latent space GIF output (snapshots beyond this limit are log-subsampled, prioritizing earlier training steps)",
+    )
+    train_parser.add_argument(
         "--latent-viz-gif-duration-ms",
         type=int,
         default=None,
@@ -590,6 +596,8 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
         config.training.latent_viz_num_cadences_per_type = args.latent_viz_num_cadences_per_type
     if hasattr(args, "latent_viz_step_interval") and args.latent_viz_step_interval is not None:
         config.training.latent_viz_step_interval = args.latent_viz_step_interval
+    if hasattr(args, "latent_viz_gif_max_frames") and args.latent_viz_gif_max_frames is not None:
+        config.training.latent_viz_gif_max_frames = args.latent_viz_gif_max_frames
     if hasattr(args, "latent_viz_gif_duration_ms") and args.latent_viz_gif_duration_ms is not None:
         config.training.latent_viz_gif_duration_ms = args.latent_viz_gif_duration_ms
     if hasattr(args, "snr_base") and args.snr_base is not None:
@@ -716,6 +724,8 @@ def validate_args(args: argparse.Namespace) -> None:
     # effective_batch_size is divisible by per_replica_batch_size * num_replicas
     # num_samples_beta_vae * train_val_split is divisible by effective_batch_size
     # num_samples_beta_vae * (1 - train_val_split) is divisible by per_replica_val_batch_size * num_replicas
+    # latent_viz_num_cadences_per_type * 4 <= num_samples_beta_vae * (1 - train_val_split)
+    # latent_viz_num_cadences_per_type * 4 is divisible by per_replica_val_batch_size * num_replicas
     # num_samples_rf is divisible by per_replica_val_batch_size * num_replicas
     # num_samples_rf is divisible by 2 (for generate_triplet_batch)
     # # how to ensure divisibility for actual n_samples during inference?

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -264,13 +264,13 @@ def _add_train_arguments(subparsers):
         "--latent-viz-num-cadences-per-type",
         type=int,
         default=None,
-        help="Number of cadences per signal type for latent space visualization batch (total points = 4× this value × 6 observations)",
+        help="Number of cadences per signal type for latent space visualization batch (total points = 4× this value × 6 observations per cadence)",
     )
     train_parser.add_argument(
         "--latent-viz-step-interval",
         type=int,
         default=None,
-        help="Capture a latent space snapshot every N training steps (lower = more snapshots, larger DB)",
+        help="Capture a latent space snapshot every N training steps (lower = more snapshots, more DB writes, and larger storage costs)",
     )
     train_parser.add_argument(
         "--latent-viz-gif-duration-ms",

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -260,6 +260,24 @@ def _add_train_arguments(subparsers):
         default=None,
         help="Threshold for points to always be included in A→B intensity bias scatter plots",
     )
+    train_parser.add_argument(
+        "--latent-viz-num-cadences-per-type",
+        type=int,
+        default=None,
+        help="Number of cadences per signal type for latent space visualization batch (total points = 4× this value × 6 observations)",
+    )
+    train_parser.add_argument(
+        "--latent-viz-step-interval",
+        type=int,
+        default=None,
+        help="Capture a latent space snapshot every N training steps (lower = more snapshots, larger DB)",
+    )
+    train_parser.add_argument(
+        "--latent-viz-gif-duration-ms",
+        type=int,
+        default=None,
+        help="Milliseconds per frame in latent space GIF output",
+    )
 
     train_parser.add_argument(
         "--snr-base",
@@ -565,6 +583,15 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
         and args.plot_injection_outlier_percentile is not None
     ):
         config.training.plot_injection_outlier_percentile = args.plot_injection_outlier_percentile
+    if (
+        hasattr(args, "latent_viz_num_cadences_per_type")
+        and args.latent_viz_num_cadences_per_type is not None
+    ):
+        config.training.latent_viz_num_cadences_per_type = args.latent_viz_num_cadences_per_type
+    if hasattr(args, "latent_viz_step_interval") and args.latent_viz_step_interval is not None:
+        config.training.latent_viz_step_interval = args.latent_viz_step_interval
+    if hasattr(args, "latent_viz_gif_duration_ms") and args.latent_viz_gif_duration_ms is not None:
+        config.training.latent_viz_gif_duration_ms = args.latent_viz_gif_duration_ms
     if hasattr(args, "snr_base") and args.snr_base is not None:
         config.training.snr_base = args.snr_base
     if hasattr(args, "initial_snr_range") and args.initial_snr_range is not None:

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -273,6 +273,12 @@ def _add_train_arguments(subparsers):
         help="Capture a latent space snapshot every N training steps (lower = more snapshots, more DB writes, and larger storage costs)",
     )
     train_parser.add_argument(
+        "--latent-viz-umap-fit-max-samples",
+        type=int,
+        default=None,
+        help="Maximum number of pooled latent vectors used to fit the UMAP model (remaining vectors are projected via transform; lower = faster, higher = more faithful embedding)",
+    )
+    train_parser.add_argument(
         "--latent-viz-gif-max-frames",
         type=int,
         default=None,
@@ -596,6 +602,11 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
         config.training.latent_viz_num_cadences_per_type = args.latent_viz_num_cadences_per_type
     if hasattr(args, "latent_viz_step_interval") and args.latent_viz_step_interval is not None:
         config.training.latent_viz_step_interval = args.latent_viz_step_interval
+    if (
+        hasattr(args, "latent_viz_umap_fit_max_samples")
+        and args.latent_viz_umap_fit_max_samples is not None
+    ):
+        config.training.latent_viz_umap_fit_max_samples = args.latent_viz_umap_fit_max_samples
     if hasattr(args, "latent_viz_gif_max_frames") and args.latent_viz_gif_max_frames is not None:
         config.training.latent_viz_gif_max_frames = args.latent_viz_gif_max_frames
     if hasattr(args, "latent_viz_gif_duration_ms") and args.latent_viz_gif_duration_ms is not None:

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -720,14 +720,14 @@ def validate_args(args: argparse.Namespace) -> None:
     # 0 <= train_val_split <= 1
     # per_replica_batch_size * num_replicas <= effective_batch_size <= num_samples_beta_vae * train_val_split
     # per_replica_val_batch_size * num_replicas <= num_samples_beta_vae * (1 - train_val_split)
-    # inference per_replica_val_batch_size * num_replicas <= num_samples_rf
+    # per_replica_val_batch_size * num_replicas <= num_samples_rf
+    # latent_viz_num_cadences_per_type * 4 <= num_samples_beta_vae * (1 - train_val_split)
     # effective_batch_size is divisible by per_replica_batch_size * num_replicas
     # num_samples_beta_vae * train_val_split is divisible by effective_batch_size
     # num_samples_beta_vae * (1 - train_val_split) is divisible by per_replica_val_batch_size * num_replicas
-    # latent_viz_num_cadences_per_type * 4 <= num_samples_beta_vae * (1 - train_val_split)
-    # latent_viz_num_cadences_per_type * 4 is divisible by per_replica_val_batch_size * num_replicas
     # num_samples_rf is divisible by per_replica_val_batch_size * num_replicas
     # num_samples_rf is divisible by 2 (for generate_triplet_batch)
+    # latent_viz_num_cadences_per_type * 4 is divisible by per_replica_val_batch_size * num_replicas
     # # how to ensure divisibility for actual n_samples during inference?
     # snr_base, initial_snr_range, final_snr_range > 0
     # initial_snr_range >= final_snr_range

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -279,6 +279,20 @@ def _add_train_arguments(subparsers):
         help="Maximum number of pooled latent vectors used to fit the UMAP model (remaining vectors are projected via transform; lower = faster, higher = more faithful embedding)",
     )
     train_parser.add_argument(
+        "--latent-viz-umap-n-neighbors",
+        type=int,
+        nargs="+",
+        default=None,
+        help="UMAP n_neighbors values to sweep for latent space visualization (e.g., --latent-viz-umap-n-neighbors 5 15 30 50)",
+    )
+    train_parser.add_argument(
+        "--latent-viz-umap-min-dist",
+        type=float,
+        nargs="+",
+        default=None,
+        help="UMAP min_dist values to sweep for latent space visualization (e.g., --latent-viz-umap-min-dist 0.0 0.1 0.5)",
+    )
+    train_parser.add_argument(
         "--latent-viz-gif-max-frames",
         type=int,
         default=None,
@@ -607,6 +621,13 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
         and args.latent_viz_umap_fit_max_samples is not None
     ):
         config.training.latent_viz_umap_fit_max_samples = args.latent_viz_umap_fit_max_samples
+    if (
+        hasattr(args, "latent_viz_umap_n_neighbors")
+        and args.latent_viz_umap_n_neighbors is not None
+    ):
+        config.training.latent_viz_umap_n_neighbors = args.latent_viz_umap_n_neighbors
+    if hasattr(args, "latent_viz_umap_min_dist") and args.latent_viz_umap_min_dist is not None:
+        config.training.latent_viz_umap_min_dist = args.latent_viz_umap_min_dist
     if hasattr(args, "latent_viz_gif_max_frames") and args.latent_viz_gif_max_frames is not None:
         config.training.latent_viz_gif_max_frames = args.latent_viz_gif_max_frames
     if hasattr(args, "latent_viz_gif_duration_ms") and args.latent_viz_gif_duration_ms is not None:

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -168,9 +168,10 @@ class TrainingConfig:
 
     # Latent space visualization params
     latent_viz_num_cadences_per_type: int = (
-        250  # Cadences per signal type for viz batch (total = 4×)
+        200  # Cadences per signal type for viz batch (total = 4×)
     )
     latent_viz_step_interval: int = 10  # Capture snapshot every N training steps
+    latent_viz_gif_max_frames: int = 200  # Max frames in output GIF (log-spaced subsampling)
     latent_viz_gif_duration_ms: int = 100  # Milliseconds per frame in output GIF
 
     # Curriculum learning params
@@ -402,6 +403,7 @@ class Config:
                 "plot_injection_outlier_percentile": self.training.plot_injection_outlier_percentile,
                 "latent_viz_num_cadences_per_type": self.training.latent_viz_num_cadences_per_type,
                 "latent_viz_step_interval": self.training.latent_viz_step_interval,
+                "latent_viz_gif_max_frames": self.training.latent_viz_gif_max_frames,
                 "latent_viz_gif_duration_ms": self.training.latent_viz_gif_duration_ms,
                 "snr_base": self.training.snr_base,
                 "initial_snr_range": self.training.initial_snr_range,

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -166,6 +166,13 @@ class TrainingConfig:
         99.0  # Always include injection_stats points beyond this percentile
     )
 
+    # Latent space visualization params
+    latent_viz_num_cadences_per_type: int = (
+        200  # Cadences per signal type for viz batch (total = 4×)
+    )
+    latent_viz_step_interval: int = 10  # Capture snapshot every N training steps
+    latent_viz_gif_duration_ms: int = 500  # Milliseconds per frame in output GIF
+
     # Curriculum learning params
     snr_base: int = 10
     initial_snr_range: int = 40
@@ -393,6 +400,9 @@ class Config:
                 "signal_injection_chunk_size": self.training.signal_injection_chunk_size,
                 "plot_injection_subsampling_count": self.training.plot_injection_subsampling_count,
                 "plot_injection_outlier_percentile": self.training.plot_injection_outlier_percentile,
+                "latent_viz_num_cadences_per_type": self.training.latent_viz_num_cadences_per_type,
+                "latent_viz_step_interval": self.training.latent_viz_step_interval,
+                "latent_viz_gif_duration_ms": self.training.latent_viz_gif_duration_ms,
                 "snr_base": self.training.snr_base,
                 "initial_snr_range": self.training.initial_snr_range,
                 "final_snr_range": self.training.final_snr_range,

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -174,6 +174,35 @@ class TrainingConfig:
     latent_viz_umap_fit_max_samples: int = (
         100_000  # Max pooled vectors for UMAP fit (rest are projected via .transform())
     )
+    # Note, Python dataclasses don't allow mutable objects (e.g. lists) to be used as defaults,
+    # since Python will create that object once when the class is defined, rather than each time
+    # a new object of that class is instantiated. This means that all instances of that class
+    # would share the same mutable object in memory (i.e. if we modified latent_viz_umap_n_neighbors
+    # in one instance, it would affect all other instances -- a dangerous bug).
+    # The default_factory parameter takes a callable (lambda function) that's called each time a
+    # new instance is created, ensuring each instance gets its own independent list, preventing
+    # the shared-state bug. Note that once created, the list behaves identical to any other list
+    latent_viz_umap_n_neighbors: list[int] = field(
+        # UMAP n_neighbors values to sweep
+        # n_neighbors constrains the size of the local neighborhood UMAP will look at when attempting
+        # to learn the manifold structure of the data. Lower values lead to better local structure,
+        # whereas larger values yield better global structure
+        # - 5: fine-grained local structure
+        # - 15: UMAP default, good baseline
+        # - 30: balanced local/global
+        # - 50: global topology emphasis
+        default_factory=lambda: [5, 15, 30, 50]
+    )
+    latent_viz_umap_min_dist: list[float] = field(
+        # UMAP min_dist values to sweep
+        # min_dist controls how tightly points in the lower-dimensional representation can be packed.
+        # Lower values result in clumpier embeddings (useful for observing clusters), whereas larger
+        # values preserve more of the broad topological structure
+        # - 0.0: maximum cluster tightness
+        # - 0.1: UMAP default, slight breathing room
+        # - 0.5: spread out, reveals continuous gradients
+        default_factory=lambda: [0.0, 0.1, 0.5]
+    )
     latent_viz_gif_max_frames: int = 500  # Max frames in output GIF (log-spaced subsampling)
     latent_viz_gif_duration_ms: int = 100  # Milliseconds per frame in output GIF
 
@@ -407,6 +436,8 @@ class Config:
                 "latent_viz_num_cadences_per_type": self.training.latent_viz_num_cadences_per_type,
                 "latent_viz_step_interval": self.training.latent_viz_step_interval,
                 "latent_viz_umap_fit_max_samples": self.training.latent_viz_umap_fit_max_samples,
+                "latent_viz_umap_n_neighbors": self.training.latent_viz_umap_n_neighbors,
+                "latent_viz_umap_min_dist": self.training.latent_viz_umap_min_dist,
                 "latent_viz_gif_max_frames": self.training.latent_viz_gif_max_frames,
                 "latent_viz_gif_duration_ms": self.training.latent_viz_gif_duration_ms,
                 "snr_base": self.training.snr_base,

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -144,13 +144,13 @@ class TrainingConfig:
     num_training_rounds: int = 20
     epochs_per_round: int = 100
 
-    num_samples_beta_vae: int = 399360
+    num_samples_beta_vae: int = 499200
     num_samples_rf: int = 99840
     train_val_split: float = 0.8
 
     per_replica_batch_size: int = 128
     effective_batch_size: int = 3072  # Effective batch size for gradient accumulation
-    per_replica_val_batch_size: int = 64  # Used for both model validation, viz batch latent generation, and random forest latent generation
+    per_replica_val_batch_size: int = 80  # Used for both model validation, viz batch latent generation, and random forest latent generation
 
     # Signal injection params
     # TODO: experiment with larger chunk sizes (how to track chunk processing efficiency)
@@ -168,10 +168,10 @@ class TrainingConfig:
 
     # Latent space visualization params
     latent_viz_num_cadences_per_type: int = (
-        192  # Cadences per signal type for viz batch (total = 4×)
+        240  # Cadences per signal type for viz batch (total = 4×)
     )
     latent_viz_step_interval: int = 10  # Capture snapshot every N training steps
-    latent_viz_gif_max_frames: int = 200  # Max frames in output GIF (log-spaced subsampling)
+    latent_viz_gif_max_frames: int = 500  # Max frames in output GIF (log-spaced subsampling)
     latent_viz_gif_duration_ms: int = 100  # Milliseconds per frame in output GIF
 
     # Curriculum learning params

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -144,13 +144,13 @@ class TrainingConfig:
     num_training_rounds: int = 20
     epochs_per_round: int = 100
 
-    num_samples_beta_vae: int = 499200
+    num_samples_beta_vae: int = 399360
     num_samples_rf: int = 99840
     train_val_split: float = 0.8
 
     per_replica_batch_size: int = 128
     effective_batch_size: int = 3072  # Effective batch size for gradient accumulation
-    per_replica_val_batch_size: int = 320
+    per_replica_val_batch_size: int = 64  # Used for both model validation, viz batch latent generation, and random forest latent generation
 
     # Signal injection params
     # TODO: experiment with larger chunk sizes (how to track chunk processing efficiency)
@@ -168,7 +168,7 @@ class TrainingConfig:
 
     # Latent space visualization params
     latent_viz_num_cadences_per_type: int = (
-        200  # Cadences per signal type for viz batch (total = 4×)
+        192  # Cadences per signal type for viz batch (total = 4×)
     )
     latent_viz_step_interval: int = 10  # Capture snapshot every N training steps
     latent_viz_gif_max_frames: int = 200  # Max frames in output GIF (log-spaced subsampling)

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -171,6 +171,9 @@ class TrainingConfig:
         240  # Cadences per signal type for viz batch (total = 4×)
     )
     latent_viz_step_interval: int = 10  # Capture snapshot every N training steps
+    latent_viz_umap_fit_max_samples: int = (
+        100_000  # Max pooled vectors for UMAP fit (rest are projected via .transform())
+    )
     latent_viz_gif_max_frames: int = 500  # Max frames in output GIF (log-spaced subsampling)
     latent_viz_gif_duration_ms: int = 100  # Milliseconds per frame in output GIF
 
@@ -403,6 +406,7 @@ class Config:
                 "plot_injection_outlier_percentile": self.training.plot_injection_outlier_percentile,
                 "latent_viz_num_cadences_per_type": self.training.latent_viz_num_cadences_per_type,
                 "latent_viz_step_interval": self.training.latent_viz_step_interval,
+                "latent_viz_umap_fit_max_samples": self.training.latent_viz_umap_fit_max_samples,
                 "latent_viz_gif_max_frames": self.training.latent_viz_gif_max_frames,
                 "latent_viz_gif_duration_ms": self.training.latent_viz_gif_duration_ms,
                 "snr_base": self.training.snr_base,

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -168,10 +168,10 @@ class TrainingConfig:
 
     # Latent space visualization params
     latent_viz_num_cadences_per_type: int = (
-        200  # Cadences per signal type for viz batch (total = 4×)
+        250  # Cadences per signal type for viz batch (total = 4×)
     )
     latent_viz_step_interval: int = 10  # Capture snapshot every N training steps
-    latent_viz_gif_duration_ms: int = 500  # Milliseconds per frame in output GIF
+    latent_viz_gif_duration_ms: int = 100  # Milliseconds per frame in output GIF
 
     # Curriculum learning params
     snr_base: int = 10

--- a/src/aetherscan/data_generation.py
+++ b/src/aetherscan/data_generation.py
@@ -1216,11 +1216,12 @@ class DataGenerator:
 
         logger.info(f"Generating {n_samples} samples in {n_chunks} chunks of max {max_chunk_size}")
 
+        # NOTE: freq & time dims hard-coded here
         # Pre-allocate output arrays
         all_main = np.empty((n_samples, 6, 16, self.width_bin), dtype=np.float32)
+        all_labels = np.empty(n_samples, dtype="U20")
         all_false = np.empty((n_samples, 6, 16, self.width_bin), dtype=np.float32)
         all_true = np.empty((n_samples, 6, 16, self.width_bin), dtype=np.float32)
-        all_labels = np.empty(n_samples, dtype="U20")
 
         for chunk_idx in range(n_chunks):
             chunk_size = min(max_chunk_size, n_samples - chunk_idx * max_chunk_size)
@@ -1236,8 +1237,10 @@ class DataGenerator:
             chunk_timestamp = time.time()
 
             # Split chunk into equal partitions (for balanced classes)
-            quarter = max(1, chunk_size // 4)
-            half = max(1, chunk_size // 2)
+            # Ceiling division ensures 4*quarter >= chunk_size and 2*half >= chunk_size,
+            # so we always generate enough samples. Excess is randomly discarded after concat.
+            quarter = max(1, -(-chunk_size // 4))
+            half = max(1, -(-chunk_size // 2))
 
             # Pure background (main)
             batch_start = time.time()
@@ -1255,18 +1258,7 @@ class DataGenerator:
                 n_processes=self.n_processes,
                 chunks_per_worker=self.chunks_per_worker,
             )
-            self._write_batch_stats(
-                stats_list=stats_main_false_no_signal,
-                round_number=round_num,
-                chunk_number=chunk_idx + 1,
-                signal_class="main",
-                signal_type="false_no_signal",
-                snr_range_floor=snr_base,
-                snr_range_ceil=snr_base + snr_range,
-                num_samples=quarter,
-                inject_duration=time.time() - batch_start,
-                timestamp=chunk_timestamp,
-            )
+            duration_main_false_no_signal = time.time() - batch_start
 
             # RFI only (main)
             batch_start = time.time()
@@ -1284,18 +1276,7 @@ class DataGenerator:
                 n_processes=self.n_processes,
                 chunks_per_worker=self.chunks_per_worker,
             )
-            self._write_batch_stats(
-                stats_list=stats_main_false_with_rfi,
-                round_number=round_num,
-                chunk_number=chunk_idx + 1,
-                signal_class="main",
-                signal_type="false_with_rfi",
-                snr_range_floor=snr_base,
-                snr_range_ceil=snr_base + snr_range,
-                num_samples=quarter,
-                inject_duration=time.time() - batch_start,
-                timestamp=chunk_timestamp,
-            )
+            duration_main_false_with_rfi = time.time() - batch_start
 
             # ETI only (main)
             batch_start = time.time()
@@ -1312,18 +1293,7 @@ class DataGenerator:
                 n_processes=self.n_processes,
                 chunks_per_worker=self.chunks_per_worker,
             )
-            self._write_batch_stats(
-                stats_list=stats_main_true_only_eti,
-                round_number=round_num,
-                chunk_number=chunk_idx + 1,
-                signal_class="main",
-                signal_type="true_only_eti",
-                snr_range_floor=snr_base,
-                snr_range_ceil=snr_base + snr_range,
-                num_samples=quarter,
-                inject_duration=time.time() - batch_start,
-                timestamp=chunk_timestamp,
-            )
+            duration_main_true_only_eti = time.time() - batch_start
 
             # ETI + RFI (main)
             batch_start = time.time()
@@ -1341,18 +1311,7 @@ class DataGenerator:
                 n_processes=self.n_processes,
                 chunks_per_worker=self.chunks_per_worker,
             )
-            self._write_batch_stats(
-                stats_list=stats_main_true_eti_rfi,
-                round_number=round_num,
-                chunk_number=chunk_idx + 1,
-                signal_class="main",
-                signal_type="true_eti_rfi",
-                snr_range_floor=snr_base,
-                snr_range_ceil=snr_base + snr_range,
-                num_samples=quarter,
-                inject_duration=time.time() - batch_start,
-                timestamp=chunk_timestamp,
-            )
+            duration_main_true_eti_rfi = time.time() - batch_start
 
             # Concatenate for main training data (collapsed cadences)
             chunk_main = np.concatenate(
@@ -1364,6 +1323,56 @@ class DataGenerator:
                 ],
                 axis=0,
             )
+
+            # Build per-cadence labels for this chunk
+            chunk_labels = np.array(
+                ["false_no_signal"] * quarter
+                + ["false_with_rfi"] * quarter
+                + ["true_only_eti"] * quarter
+                + ["true_eti_rfi"] * quarter,
+                dtype="U20",
+            )
+
+            # Subsample to chunk_size if we generated more than needed (ceiling division remainder)
+            n_generated_main = 4 * quarter
+            if n_generated_main > chunk_size:
+                keep_main = np.sort(
+                    np.random.choice(n_generated_main, size=chunk_size, replace=False)
+                )
+                chunk_main = chunk_main[keep_main]
+                chunk_labels = chunk_labels[keep_main]
+
+                # Filter stats to only include kept samples
+                main_stats_groups = [
+                    (stats_main_false_no_signal, 0),
+                    (stats_main_false_with_rfi, quarter),
+                    (stats_main_true_only_eti, 2 * quarter),
+                    (stats_main_true_eti_rfi, 3 * quarter),
+                ]
+                for stats_ref, offset in main_stats_groups:
+                    type_mask = (keep_main >= offset) & (keep_main < offset + quarter)
+                    kept_indices = keep_main[type_mask] - offset
+                    stats_ref[:] = [stats_ref[i] for i in kept_indices]
+
+            # Write main batch stats (deferred to after subsampling so only kept samples are written)
+            for stats_list, signal_type, duration in [
+                (stats_main_false_no_signal, "false_no_signal", duration_main_false_no_signal),
+                (stats_main_false_with_rfi, "false_with_rfi", duration_main_false_with_rfi),
+                (stats_main_true_only_eti, "true_only_eti", duration_main_true_only_eti),
+                (stats_main_true_eti_rfi, "true_eti_rfi", duration_main_true_eti_rfi),
+            ]:
+                self._write_batch_stats(
+                    stats_list=stats_list,
+                    round_number=round_num,
+                    chunk_number=chunk_idx + 1,
+                    signal_class="main",
+                    signal_type=signal_type,
+                    snr_range_floor=snr_base,
+                    snr_range_ceil=snr_base + snr_range,
+                    num_samples=len(stats_list),
+                    inject_duration=duration,
+                    timestamp=chunk_timestamp,
+                )
 
             # Generate separate true/false non-collapsed cadences for training set diversity
             # Used to calculate clustering loss & train RF
@@ -1384,18 +1393,7 @@ class DataGenerator:
                 n_processes=self.n_processes,
                 chunks_per_worker=self.chunks_per_worker,
             )
-            self._write_batch_stats(
-                stats_list=stats_false_no_signal,
-                round_number=round_num,
-                chunk_number=chunk_idx + 1,
-                signal_class="false",
-                signal_type="false_no_signal",
-                snr_range_floor=snr_base,
-                snr_range_ceil=snr_base + snr_range,
-                num_samples=half,
-                inject_duration=time.time() - batch_start,
-                timestamp=chunk_timestamp,
-            )
+            duration_false_no_signal = time.time() - batch_start
 
             # RFI only (false)
             batch_start = time.time()
@@ -1413,18 +1411,7 @@ class DataGenerator:
                 n_processes=self.n_processes,
                 chunks_per_worker=self.chunks_per_worker,
             )
-            self._write_batch_stats(
-                stats_list=stats_false_with_rfi,
-                round_number=round_num,
-                chunk_number=chunk_idx + 1,
-                signal_class="false",
-                signal_type="false_with_rfi",
-                snr_range_floor=snr_base,
-                snr_range_ceil=snr_base + snr_range,
-                num_samples=half,
-                inject_duration=time.time() - batch_start,
-                timestamp=chunk_timestamp,
-            )
+            duration_false_with_rfi = time.time() - batch_start
 
             # ETI only (true)
             batch_start = time.time()
@@ -1441,18 +1428,7 @@ class DataGenerator:
                 n_processes=self.n_processes,
                 chunks_per_worker=self.chunks_per_worker,
             )
-            self._write_batch_stats(
-                stats_list=stats_true_only_eti,
-                round_number=round_num,
-                chunk_number=chunk_idx + 1,
-                signal_class="true",
-                signal_type="true_only_eti",
-                snr_range_floor=snr_base,
-                snr_range_ceil=snr_base + snr_range,
-                num_samples=half,
-                inject_duration=time.time() - batch_start,
-                timestamp=chunk_timestamp,
-            )
+            duration_true_only_eti = time.time() - batch_start
 
             # ETI + RFI (true)
             batch_start = time.time()
@@ -1470,37 +1446,65 @@ class DataGenerator:
                 n_processes=self.n_processes,
                 chunks_per_worker=self.chunks_per_worker,
             )
-            self._write_batch_stats(
-                stats_list=stats_true_eti_rfi,
-                round_number=round_num,
-                chunk_number=chunk_idx + 1,
-                signal_class="true",
-                signal_type="true_eti_rfi",
-                snr_range_floor=snr_base,
-                snr_range_ceil=snr_base + snr_range,
-                num_samples=half,
-                inject_duration=time.time() - batch_start,
-                timestamp=chunk_timestamp,
-            )
+            duration_true_eti_rfi = time.time() - batch_start
 
             chunk_false = np.concatenate([half_false_no_signal, half_false_with_rfi], axis=0)
 
             chunk_true = np.concatenate([half_true_single, half_true_double], axis=0)
 
-            # Build per-cadence labels for this chunk
-            chunk_labels = np.array(
-                ["false_no_signal"] * quarter
-                + ["false_with_rfi"] * quarter
-                + ["true_only_eti"] * quarter
-                + ["true_eti_rfi"] * (chunk_size - 3 * quarter),
-                dtype="U20",
-            )
+            # Subsample to chunk_size if we generated more than needed (ceiling division remainder)
+            n_generated_half = 2 * half
+            if n_generated_half > chunk_size:
+                keep_false = np.sort(
+                    np.random.choice(n_generated_half, size=chunk_size, replace=False)
+                )
+                keep_true = np.sort(
+                    np.random.choice(n_generated_half, size=chunk_size, replace=False)
+                )
+                chunk_false = chunk_false[keep_false]
+                chunk_true = chunk_true[keep_true]
+
+                # Filter stats to only include kept samples
+                # chunk_false layout: [0, half) = no_signal, [half, 2*half) = with_rfi
+                stats_false_no_signal[:] = [
+                    stats_false_no_signal[i] for i in keep_false[keep_false < half]
+                ]
+                stats_false_with_rfi[:] = [
+                    stats_false_with_rfi[i - half] for i in keep_false[keep_false >= half]
+                ]
+                # chunk_true layout: [0, half) = only_eti, [half, 2*half) = eti_rfi
+                stats_true_only_eti[:] = [
+                    stats_true_only_eti[i] for i in keep_true[keep_true < half]
+                ]
+                stats_true_eti_rfi[:] = [
+                    stats_true_eti_rfi[i - half] for i in keep_true[keep_true >= half]
+                ]
+
+            # Write false/true batch stats (deferred to after subsampling)
+            for stats_list, signal_class, signal_type, duration in [
+                (stats_false_no_signal, "false", "false_no_signal", duration_false_no_signal),
+                (stats_false_with_rfi, "false", "false_with_rfi", duration_false_with_rfi),
+                (stats_true_only_eti, "true", "true_only_eti", duration_true_only_eti),
+                (stats_true_eti_rfi, "true", "true_eti_rfi", duration_true_eti_rfi),
+            ]:
+                self._write_batch_stats(
+                    stats_list=stats_list,
+                    round_number=round_num,
+                    chunk_number=chunk_idx + 1,
+                    signal_class=signal_class,
+                    signal_type=signal_type,
+                    snr_range_floor=snr_base,
+                    snr_range_ceil=snr_base + snr_range,
+                    num_samples=len(stats_list),
+                    inject_duration=duration,
+                    timestamp=chunk_timestamp,
+                )
 
             # Store chunks directly into output array
             all_main[start_idx:end_idx] = chunk_main
+            all_labels[start_idx:end_idx] = chunk_labels
             all_false[start_idx:end_idx] = chunk_false
             all_true[start_idx:end_idx] = chunk_true
-            all_labels[start_idx:end_idx] = chunk_labels
 
             # Clean up chunk data immediately
             del (
@@ -1510,7 +1514,7 @@ class DataGenerator:
                 quarter_true_double,
             )
             del half_false_no_signal, half_false_with_rfi, half_true_single, half_true_double
-            del chunk_main, chunk_false, chunk_true, chunk_labels
+            del chunk_main, chunk_labels, chunk_false, chunk_true
             del stats_main_false_no_signal, stats_main_false_with_rfi
             del stats_main_true_only_eti, stats_main_true_eti_rfi
             del stats_false_no_signal, stats_false_with_rfi
@@ -1522,9 +1526,9 @@ class DataGenerator:
         # Create result dictionary with references to pre-allocated arrays
         result = {
             "concatenated": all_main,
+            "labels": all_labels,
             "false": all_false,
             "true": all_true,
-            "labels": all_labels,
         }
 
         # NOTE: is there a more efficient way to do this? these checks currently take a few minutes to complete. should we comment this portion out?

--- a/src/aetherscan/data_generation.py
+++ b/src/aetherscan/data_generation.py
@@ -1220,6 +1220,7 @@ class DataGenerator:
         all_main = np.empty((n_samples, 6, 16, self.width_bin), dtype=np.float32)
         all_false = np.empty((n_samples, 6, 16, self.width_bin), dtype=np.float32)
         all_true = np.empty((n_samples, 6, 16, self.width_bin), dtype=np.float32)
+        all_labels = np.empty(n_samples, dtype="U20")
 
         for chunk_idx in range(n_chunks):
             chunk_size = min(max_chunk_size, n_samples - chunk_idx * max_chunk_size)
@@ -1486,10 +1487,20 @@ class DataGenerator:
 
             chunk_true = np.concatenate([half_true_single, half_true_double], axis=0)
 
+            # Build per-cadence labels for this chunk
+            chunk_labels = np.array(
+                ["false_no_signal"] * quarter
+                + ["false_with_rfi"] * quarter
+                + ["true_only_eti"] * quarter
+                + ["true_eti_rfi"] * (chunk_size - 3 * quarter),
+                dtype="U20",
+            )
+
             # Store chunks directly into output array
             all_main[start_idx:end_idx] = chunk_main
             all_false[start_idx:end_idx] = chunk_false
             all_true[start_idx:end_idx] = chunk_true
+            all_labels[start_idx:end_idx] = chunk_labels
 
             # Clean up chunk data immediately
             del (
@@ -1499,7 +1510,7 @@ class DataGenerator:
                 quarter_true_double,
             )
             del half_false_no_signal, half_false_with_rfi, half_true_single, half_true_double
-            del chunk_main, chunk_false, chunk_true
+            del chunk_main, chunk_false, chunk_true, chunk_labels
             del stats_main_false_no_signal, stats_main_false_with_rfi
             del stats_main_true_only_eti, stats_main_true_eti_rfi
             del stats_false_no_signal, stats_false_with_rfi
@@ -1509,7 +1520,12 @@ class DataGenerator:
             logger.info(f"Chunk {chunk_idx + 1} complete, memory cleared")
 
         # Create result dictionary with references to pre-allocated arrays
-        result = {"concatenated": all_main, "false": all_false, "true": all_true}
+        result = {
+            "concatenated": all_main,
+            "false": all_false,
+            "true": all_true,
+            "labels": all_labels,
+        }
 
         # NOTE: is there a more efficient way to do this? these checks currently take a few minutes to complete. should we comment this portion out?
         # Sanity check: verify post-injection data normalization

--- a/src/aetherscan/data_generation.py
+++ b/src/aetherscan/data_generation.py
@@ -1532,28 +1532,28 @@ class DataGenerator:
         }
 
         # NOTE: is there a more efficient way to do this? these checks currently take a few minutes to complete. should we comment this portion out?
-        # Sanity check: verify post-injection data normalization
-        for key in ["concatenated", "false", "true"]:
-            min_val = np.min(result[key])
-            max_val = np.max(result[key])
-            mean_val = np.mean(result[key])
-            logger.info(
-                f"Post-injection {key} stats: min={min_val:.6f}, max={max_val:.6f}, mean={mean_val:.6f}"
-            )
-            if max_val > 1.0:
-                logger.error(f"Post-injection {key} values too large! Max: {max_val}")
-                raise ValueError(f"Post-injection {key} normalization check failed")
-            elif min_val < 0.0:
-                logger.error(f"Post-injection {key} values too small! Min: {min_val}")
-                raise ValueError(f"Post-injection {key} normalization check failed")
-            elif np.isnan(result[key]).any():
-                logger.error(f"Post-injection {key} contains NaN values!")
-                raise ValueError(f"Post-injection {key} normalization check failed")
-            elif np.isinf(result[key]).any():
-                logger.error(f"Post-injection {key} contains Inf values!")
-                raise ValueError(f"Post-injection {key} normalization check failed")
-            else:
-                logger.info(f"Post-injection {key} data properly normalized")
+        # # Sanity check: verify post-injection data normalization
+        # for key in ["concatenated", "false", "true"]:
+        #     min_val = np.min(result[key])
+        #     max_val = np.max(result[key])
+        #     mean_val = np.mean(result[key])
+        #     logger.info(
+        #         f"Post-injection {key} stats: min={min_val:.6f}, max={max_val:.6f}, mean={mean_val:.6f}"
+        #     )
+        #     if max_val > 1.0:
+        #         logger.error(f"Post-injection {key} values too large! Max: {max_val}")
+        #         raise ValueError(f"Post-injection {key} normalization check failed")
+        #     elif min_val < 0.0:
+        #         logger.error(f"Post-injection {key} values too small! Min: {min_val}")
+        #         raise ValueError(f"Post-injection {key} normalization check failed")
+        #     elif np.isnan(result[key]).any():
+        #         logger.error(f"Post-injection {key} contains NaN values!")
+        #         raise ValueError(f"Post-injection {key} normalization check failed")
+        #     elif np.isinf(result[key]).any():
+        #         logger.error(f"Post-injection {key} contains Inf values!")
+        #         raise ValueError(f"Post-injection {key} normalization check failed")
+        #     else:
+        #         logger.info(f"Post-injection {key} data properly normalized")
 
         return result
 

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -271,6 +271,31 @@ class Database:
                 ON training_stats(tag, timestamp, model_name, stat_name)
             """)
 
+            # Latent snapshots table
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS latent_snapshots (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp REAL NOT NULL,
+                    model_name TEXT NOT NULL,
+                    round_number INTEGER NOT NULL,
+                    epoch_number INTEGER NOT NULL,
+                    step_number INTEGER NOT NULL,
+                    cadence_index INTEGER NOT NULL,
+                    signal_type TEXT NOT NULL,
+                    latent_vector TEXT NOT NULL,
+                    snr_base INTEGER,
+                    snr_range INTEGER,
+                    tag TEXT,
+                    metadata TEXT
+                )
+            """)
+
+            # Composite index for common filter pattern (tag + timestamp + model_name + round_number + epoch_number + step_number)
+            cursor.execute("""
+                CREATE INDEX IF NOT EXISTS idx_latent_snapshots_filter
+                ON latent_snapshots(tag, timestamp, model_name, round_number, epoch_number, step_number)
+            """)
+
             # Inference results table
             cursor.execute("""
                 CREATE TABLE IF NOT EXISTS inference_results (
@@ -297,30 +322,6 @@ class Database:
             cursor.execute("""
                 CREATE INDEX IF NOT EXISTS idx_inference_results_filter
                 ON inference_results(tag, timestamp, confidence, prediction)
-            """)
-
-            # Latent snapshots table (for latent space visualization)
-            cursor.execute("""
-                CREATE TABLE IF NOT EXISTS latent_snapshots (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    timestamp REAL NOT NULL,
-                    round_number INTEGER NOT NULL,
-                    epoch_number INTEGER NOT NULL,
-                    step_number INTEGER NOT NULL,
-                    cadence_index INTEGER NOT NULL,
-                    signal_type TEXT NOT NULL,
-                    latent_vector TEXT NOT NULL,
-                    snr_base INTEGER,
-                    snr_range INTEGER,
-                    tag TEXT,
-                    metadata TEXT
-                )
-            """)
-
-            # Composite index for common filter pattern (tag + round + epoch + step)
-            cursor.execute("""
-                CREATE INDEX IF NOT EXISTS idx_latent_snapshots_filter
-                ON latent_snapshots(tag, round_number, epoch_number, step_number)
             """)
 
             conn.commit()
@@ -522,8 +523,8 @@ class Database:
                 system_resources_records: list[tuple] = []
                 injection_stats_records: list[tuple] = []
                 training_stats_records: list[tuple] = []
-                inference_results_records: list[tuple] = []
                 latent_snapshots_records: list[tuple] = []
+                inference_results_records: list[tuple] = []
 
                 for table, values in self.buffer:
                     if table == "system_resources":
@@ -532,10 +533,10 @@ class Database:
                         injection_stats_records.append(values)
                     elif table == "training_stats":
                         training_stats_records.append(values)
-                    elif table == "inference_results":
-                        inference_results_records.append(values)
                     elif table == "latent_snapshots":
                         latent_snapshots_records.append(values)
+                    elif table == "inference_results":
+                        inference_results_records.append(values)
 
                 # Bulk insert each table type
                 if system_resources_records:
@@ -571,6 +572,18 @@ class Database:
                         training_stats_records,
                     )
 
+                if latent_snapshots_records:
+                    cursor.executemany(
+                        """
+                        INSERT INTO latent_snapshots
+                        (timestamp, model_name, round_number, epoch_number, step_number,
+                         cadence_index, signal_type, latent_vector, snr_base, snr_range, tag,
+                         metadata)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        latent_snapshots_records,
+                    )
+
                 if inference_results_records:
                     cursor.executemany(
                         """
@@ -581,17 +594,6 @@ class Database:
                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         inference_results_records,
-                    )
-
-                if latent_snapshots_records:
-                    cursor.executemany(
-                        """
-                        INSERT INTO latent_snapshots
-                        (timestamp, round_number, epoch_number, step_number, cadence_index,
-                         signal_type, latent_vector, snr_base, snr_range, tag, metadata)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                        """,
-                        latent_snapshots_records,
                     )
 
                 conn.commit()
@@ -752,6 +754,60 @@ class Database:
         )
 
     # TODO: write checks to sanitize values before writing to db. raise error if problematic value passed
+    def write_latent_snapshot(
+        self,
+        model_name: str,
+        round_number: int,
+        epoch_number: int,
+        step_number: int,
+        cadence_index: int,
+        signal_type: str,
+        latent_vector: list[list[float]],
+        snr_base: int | None = None,
+        snr_range: int | None = None,
+        tag: str | None = None,
+        timestamp: float | None = None,
+    ):
+        """
+        Queue write to latent_snapshots table (non-blocking)
+
+        Args:
+            model_name: Model name (e.g. 'beta_vae')
+            round_number: Current training round number
+            epoch_number: Current training epoch number
+            step_number: Current training step number
+            cadence_index: Position within the viz batch (0 to num_cadences-1)
+            signal_type: Signal type (e.g. false_no_signal, false_with_rfi, true_only_eti, true_eti_rfi)
+            latent_vector: Latent vectors for this cadence, shape (6, latent_dim) as nested list
+            snr_base: Optional SNR base value
+            snr_range: Optional SNR range value
+            tag: Optional tag for current pipeline run
+            timestamp: Optional timestamp (uses current time if not provided)
+        """
+        metadata_json = get_system_metadata()
+        latent_vector_json = json.dumps(latent_vector)
+
+        self.write_queue.put(
+            (
+                "latent_snapshots",
+                (
+                    timestamp or time.time(),
+                    model_name,
+                    round_number,
+                    epoch_number,
+                    step_number,
+                    cadence_index,
+                    signal_type,
+                    latent_vector_json,
+                    snr_base,
+                    snr_range,
+                    tag,
+                    metadata_json,
+                ),
+            )
+        )
+
+    # TODO: write checks to sanitize values before writing to db. raise error if problematic value passed
     def write_inference_result(
         self,
         npy_path: str,
@@ -777,7 +833,7 @@ class Database:
             snippet_index: Index of the snippet within the .npy file
             prediction: Classification prediction (0=RFI, 1=candidate)
             confidence: Classification confidence score (0.0 to 1.0)
-            latent_vector: Optional latent vector (6 x 8 features) for later analysis
+            latent_vector: Optional latent vector (6 observations * latent_dim features) for later analysis
             target: Optional observation target name (e.g. "DDO210")
             session: Optional observing session identifier (e.g. "AGBT18A_999_103")
             cadence_id: Optional cadence ID from the observation (e.g. "24777")
@@ -812,56 +868,6 @@ class Database:
                     frequency_mhz,
                     timestamp_observed,
                     h5_path,
-                    tag,
-                    metadata_json,
-                ),
-            )
-        )
-
-    def write_latent_snapshot(
-        self,
-        round_number: int,
-        epoch_number: int,
-        step_number: int,
-        cadence_index: int,
-        signal_type: str,
-        latent_vector: list[list[float]],
-        snr_base: int | None = None,
-        snr_range: int | None = None,
-        tag: str | None = None,
-        timestamp: float | None = None,
-    ):
-        """
-        Queue write to latent_snapshots table (non-blocking)
-
-        Args:
-            round_number: Current training round number
-            epoch_number: Current training epoch number
-            step_number: Current training step number
-            cadence_index: Position within the viz batch (0 to num_cadences-1)
-            signal_type: Signal type (e.g. false_no_signal, false_with_rfi, true_only_eti, true_eti_rfi)
-            latent_vector: Latent vectors for this cadence, shape (6, latent_dim) as nested list
-            snr_base: Optional SNR base value
-            snr_range: Optional SNR range value
-            tag: Optional tag for current pipeline run
-            timestamp: Optional timestamp (uses current time if not provided)
-        """
-        metadata_json = get_system_metadata()
-        latent_vector_json = json.dumps(latent_vector)
-
-        self.write_queue.put(
-            (
-                "latent_snapshots",
-                (
-                    timestamp or time.time(),
-                    round_number,
-                    epoch_number,
-                    step_number,
-                    cadence_index,
-                    signal_type,
-                    latent_vector_json,
-                    snr_base,
-                    snr_range,
                     tag,
                     metadata_json,
                 ),
@@ -907,6 +913,21 @@ class Database:
         "tag",
         "metadata",
     }
+    _LATENT_SNAPSHOTS_COLUMNS = {
+        "id",
+        "timestamp",
+        "model_name",
+        "round_number",
+        "epoch_number",
+        "step_number",
+        "cadence_index",
+        "signal_type",
+        "latent_vector",
+        "snr_base",
+        "snr_range",
+        "tag",
+        "metadata",
+    }
     _INFERENCE_RESULTS_COLUMNS = {
         "id",
         "timestamp",
@@ -922,20 +943,6 @@ class Database:
         "frequency_mhz",
         "timestamp_observed",
         "h5_path",
-        "tag",
-        "metadata",
-    }
-    _LATENT_SNAPSHOTS_COLUMNS = {
-        "id",
-        "timestamp",
-        "round_number",
-        "epoch_number",
-        "step_number",
-        "cadence_index",
-        "signal_type",
-        "latent_vector",
-        "snr_base",
-        "snr_range",
         "tag",
         "metadata",
     }
@@ -1345,7 +1352,139 @@ class Database:
             return [dict(zip(result_columns, row, strict=False)) for row in cursor.fetchall()]
 
     # NOTE: how to additionally filter by metadata (e.g. machine_name)?
-    # NOTE: should we also let user filter by value (e.g. >= or <= some value)?
+    def query_latent_snapshots(
+        self,
+        model_name: str | list[str] | None = None,
+        round_number: int | None = None,
+        epoch_number: int | None = None,
+        step_number: int | None = None,
+        signal_type: str | list[str] | None = None,
+        tag: str | list[str] | None = None,
+        start_time: float | None = None,
+        end_time: float | None = None,
+        columns: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Query from latent_snapshots table
+
+        Args:
+            model_name: Model name (e.g. 'beta_vae'). Accepts str or list[str].
+            round_number: Filter by exact round number
+            epoch_number: Filter by exact epoch number
+            step_number: Filter by exact step number
+            signal_type: Signal type filter. Accepts str or list[str].
+            tag: Tag for current pipeline run. Accepts str or list[str].
+            start_time: Start timestamp (unix time)
+            end_time: End timestamp (unix time)
+            columns: Optional list of columns to select (default: all). Validated against schema.
+
+        Returns:
+            List of snapshot dictionaries (latent_vector is JSON string — caller parses with json.loads)
+        """
+        with self._get_connection() as conn:
+            cursor = conn.cursor()
+
+            select = self._build_select("latent_snapshots", columns, self._LATENT_SNAPSHOTS_COLUMNS)
+            # WHERE 1=1 is a way of building parametrized queries
+            # Since 1=1 is always true, it does nothing functionally
+            # But it allows us to safely add more conditions by appending AND clauses
+            # While not breaking the query if none are added
+            query = f"{select} WHERE 1=1"
+            params = []
+
+            # Build the query dynamically based on user-specified conditions
+            if model_name:
+                query = self._add_str_filter(query, params, "model_name", model_name)
+
+            if round_number is not None:
+                query += " AND round_number = ?"
+                params.append(round_number)
+
+            if epoch_number is not None:
+                query += " AND epoch_number = ?"
+                params.append(epoch_number)
+
+            if step_number is not None:
+                query += " AND step_number = ?"
+                params.append(step_number)
+
+            if signal_type:
+                query = self._add_str_filter(query, params, "signal_type", signal_type)
+
+            if tag:
+                query = self._add_str_filter(query, params, "tag", tag)
+
+            if start_time is not None:
+                query += " AND timestamp >= ?"
+                params.append(start_time)
+
+            if end_time is not None:
+                query += " AND timestamp <= ?"
+                params.append(end_time)
+
+            # NOTE: hard-coded ORDER BY? add template index to init_db
+
+            cursor.execute(query, params)
+
+            # Create a list of column names using query result's metadata
+            result_columns = [desc[0] for desc in cursor.description]
+            # Pair column names with values and return to user as a dict
+            return [dict(zip(result_columns, row, strict=False)) for row in cursor.fetchall()]
+
+    def query_latent_snapshot_keys(
+        self,
+        tag: str | list[str] | None = None,
+        start_time: float | None = None,
+        end_time: float | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Get distinct snapshot keys (model, round, epoch, step, snr_base, snr_range) sorted by progression.
+        Avoids having to load every row from latent_snapshots using query_latent_snapshots()
+
+        Returns:
+            List of dicts with {model_name, round_number, epoch_number, step_number, snr_base, snr_range}
+        """
+        with self._get_connection() as conn:
+            cursor = conn.cursor()
+
+            query = """
+                SELECT DISTINCT model_name, round_number, epoch_number, step_number, snr_base, snr_range
+                FROM latent_snapshots
+                WHERE 1=1
+            """
+            params: list = []
+
+            # Build the query dynamically based on user-specified conditions
+            if tag:
+                query = self._add_str_filter(query, params, "tag", tag)
+
+            if start_time is not None:
+                query += " AND timestamp >= ?"
+                params.append(start_time)
+
+            if end_time is not None:
+                query += " AND timestamp <= ?"
+                params.append(end_time)
+
+            # This ORDER BY doesn't make full use of idx_latent_snapshots_filter, since the ORDER BY
+            # columns don't follow contiguously in the index
+            # However, as long as both tag & timestamp are present in the query's WHERE clause,
+            # idx_latent_snapshots_filter can still be used to optimize the query
+            # The remaining rows form a small set of DISTINCT keys that aren't expensive for SQLite
+            # to perform a filesort
+            # If you measure a bottleneck in the future, consider adding a second schema index like
+            # (tag, model_name, round_number, epoch_number, step_number, timestamp) and then sorting
+            # the rows in that order
+            query += " ORDER BY model_name, round_number, epoch_number, step_number"
+
+            cursor.execute(query, params)
+
+            # Create a list of column names using query result's metadata
+            result_columns = [desc[0] for desc in cursor.description]
+            # Pair column names with values and return to user as a dict
+            return [dict(zip(result_columns, row, strict=False)) for row in cursor.fetchall()]
+
+    # NOTE: how to additionally filter by metadata (e.g. machine_name)?
     def query_inference_result(
         self,
         npy_path: str | list[str] | None = None,
@@ -1484,111 +1623,7 @@ class Database:
             # Pair column names with values and return to user as a dict
             return [dict(zip(result_columns, row, strict=False)) for row in cursor.fetchall()]
 
-    def query_latent_snapshots(
-        self,
-        tag: str | list[str] | None = None,
-        round_number: int | None = None,
-        epoch_number: int | None = None,
-        step_number: int | None = None,
-        signal_type: str | list[str] | None = None,
-        start_time: float | None = None,
-        end_time: float | None = None,
-        columns: list[str] | None = None,
-    ) -> list[dict[str, Any]]:
-        """
-        Query from latent_snapshots table
-
-        Args:
-            tag: Tag for current pipeline run. Accepts str or list[str].
-            round_number: Filter by exact round number
-            epoch_number: Filter by exact epoch number
-            step_number: Filter by exact step number
-            signal_type: Signal type filter. Accepts str or list[str].
-            start_time: Start timestamp (unix time)
-            end_time: End timestamp (unix time)
-            columns: Optional list of columns to select (default: all). Validated against schema.
-
-        Returns:
-            List of snapshot dictionaries (latent_vector is JSON string — caller parses with json.loads)
-        """
-        with self._get_connection() as conn:
-            cursor = conn.cursor()
-
-            select = self._build_select("latent_snapshots", columns, self._LATENT_SNAPSHOTS_COLUMNS)
-            query = f"{select} WHERE 1=1"
-            params = []
-
-            if tag:
-                query = self._add_str_filter(query, params, "tag", tag)
-
-            if round_number is not None:
-                query += " AND round_number = ?"
-                params.append(round_number)
-
-            if epoch_number is not None:
-                query += " AND epoch_number = ?"
-                params.append(epoch_number)
-
-            if step_number is not None:
-                query += " AND step_number = ?"
-                params.append(step_number)
-
-            if signal_type:
-                query = self._add_str_filter(query, params, "signal_type", signal_type)
-
-            if start_time is not None:
-                query += " AND timestamp >= ?"
-                params.append(start_time)
-
-            if end_time is not None:
-                query += " AND timestamp <= ?"
-                params.append(end_time)
-
-            cursor.execute(query, params)
-
-            result_columns = [desc[0] for desc in cursor.description]
-            return [dict(zip(result_columns, row, strict=False)) for row in cursor.fetchall()]
-
-    def query_latent_snapshot_keys(
-        self,
-        tag: str | list[str] | None = None,
-        start_time: float | None = None,
-        end_time: float | None = None,
-    ) -> list[dict[str, Any]]:
-        """
-        Get distinct snapshot keys (round, epoch, step, snr_base, snr_range) sorted by progression.
-
-        Returns:
-            List of dicts with {round_number, epoch_number, step_number, snr_base, snr_range}
-        """
-        with self._get_connection() as conn:
-            cursor = conn.cursor()
-
-            query = """
-                SELECT DISTINCT round_number, epoch_number, step_number, snr_base, snr_range
-                FROM latent_snapshots
-                WHERE 1=1
-            """
-            params: list = []
-
-            if tag:
-                query = self._add_str_filter(query, params, "tag", tag)
-
-            if start_time is not None:
-                query += " AND timestamp >= ?"
-                params.append(start_time)
-
-            if end_time is not None:
-                query += " AND timestamp <= ?"
-                params.append(end_time)
-
-            query += " ORDER BY round_number, epoch_number, step_number"
-
-            cursor.execute(query, params)
-
-            result_columns = [desc[0] for desc in cursor.description]
-            return [dict(zip(result_columns, row, strict=False)) for row in cursor.fetchall()]
-
+    # NOTE: this call gets expensive as db grows. create a separate schema to track num_rows_added per pipeline run. then count & update as part of db cleanup routine? or use SQLite's dbstat virtual table or periodic ANALYZE?
     def get_db_stats(self) -> dict[str, Any]:
         """Get summary statistics for the database"""
         with self._get_connection() as conn:
@@ -1606,11 +1641,11 @@ class Database:
             cursor.execute("SELECT COUNT(*) FROM training_stats")
             stats["training_stats_row_count"] = cursor.fetchone()[0]
 
-            cursor.execute("SELECT COUNT(*) FROM inference_results")
-            stats["inference_results_row_count"] = cursor.fetchone()[0]
-
             cursor.execute("SELECT COUNT(*) FROM latent_snapshots")
             stats["latent_snapshots_row_count"] = cursor.fetchone()[0]
+
+            cursor.execute("SELECT COUNT(*) FROM inference_results")
+            stats["inference_results_row_count"] = cursor.fetchone()[0]
 
             # Time range
             # Use system_resources as proxy

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -299,6 +299,30 @@ class Database:
                 ON inference_results(tag, timestamp, confidence, prediction)
             """)
 
+            # Latent snapshots table (for latent space visualization)
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS latent_snapshots (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp REAL NOT NULL,
+                    round_number INTEGER NOT NULL,
+                    epoch_number INTEGER NOT NULL,
+                    step_number INTEGER NOT NULL,
+                    cadence_index INTEGER NOT NULL,
+                    signal_type TEXT NOT NULL,
+                    latent_vector TEXT NOT NULL,
+                    snr_base INTEGER,
+                    snr_range INTEGER,
+                    tag TEXT,
+                    metadata TEXT
+                )
+            """)
+
+            # Composite index for common filter pattern (tag + round + epoch + step)
+            cursor.execute("""
+                CREATE INDEX IF NOT EXISTS idx_latent_snapshots_filter
+                ON latent_snapshots(tag, round_number, epoch_number, step_number)
+            """)
+
             conn.commit()
 
             # Enable Write-Ahead Logging (WAL) mode for better concurrent read performance
@@ -499,6 +523,7 @@ class Database:
                 injection_stats_records: list[tuple] = []
                 training_stats_records: list[tuple] = []
                 inference_results_records: list[tuple] = []
+                latent_snapshots_records: list[tuple] = []
 
                 for table, values in self.buffer:
                     if table == "system_resources":
@@ -509,6 +534,8 @@ class Database:
                         training_stats_records.append(values)
                     elif table == "inference_results":
                         inference_results_records.append(values)
+                    elif table == "latent_snapshots":
+                        latent_snapshots_records.append(values)
 
                 # Bulk insert each table type
                 if system_resources_records:
@@ -554,6 +581,17 @@ class Database:
                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         inference_results_records,
+                    )
+
+                if latent_snapshots_records:
+                    cursor.executemany(
+                        """
+                        INSERT INTO latent_snapshots
+                        (timestamp, round_number, epoch_number, step_number, cadence_index,
+                         signal_type, latent_vector, snr_base, snr_range, tag, metadata)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        latent_snapshots_records,
                     )
 
                 conn.commit()
@@ -780,6 +818,56 @@ class Database:
             )
         )
 
+    def write_latent_snapshot(
+        self,
+        round_number: int,
+        epoch_number: int,
+        step_number: int,
+        cadence_index: int,
+        signal_type: str,
+        latent_vector: list[list[float]],
+        snr_base: int | None = None,
+        snr_range: int | None = None,
+        tag: str | None = None,
+        timestamp: float | None = None,
+    ):
+        """
+        Queue write to latent_snapshots table (non-blocking)
+
+        Args:
+            round_number: Current training round number
+            epoch_number: Current training epoch number
+            step_number: Current training step number
+            cadence_index: Position within the viz batch (0 to num_cadences-1)
+            signal_type: Signal type (e.g. false_no_signal, false_with_rfi, true_only_eti, true_eti_rfi)
+            latent_vector: Latent vectors for this cadence, shape (6, latent_dim) as nested list
+            snr_base: Optional SNR base value
+            snr_range: Optional SNR range value
+            tag: Optional tag for current pipeline run
+            timestamp: Optional timestamp (uses current time if not provided)
+        """
+        metadata_json = get_system_metadata()
+        latent_vector_json = json.dumps(latent_vector)
+
+        self.write_queue.put(
+            (
+                "latent_snapshots",
+                (
+                    timestamp or time.time(),
+                    round_number,
+                    epoch_number,
+                    step_number,
+                    cadence_index,
+                    signal_type,
+                    latent_vector_json,
+                    snr_base,
+                    snr_range,
+                    tag,
+                    metadata_json,
+                ),
+            )
+        )
+
     # Column whitelists per table (for SQL injection prevention when using column projection)
     _SYSTEM_RESOURCES_COLUMNS = {
         "id",
@@ -834,6 +922,20 @@ class Database:
         "frequency_mhz",
         "timestamp_observed",
         "h5_path",
+        "tag",
+        "metadata",
+    }
+    _LATENT_SNAPSHOTS_COLUMNS = {
+        "id",
+        "timestamp",
+        "round_number",
+        "epoch_number",
+        "step_number",
+        "cadence_index",
+        "signal_type",
+        "latent_vector",
+        "snr_base",
+        "snr_range",
         "tag",
         "metadata",
     }
@@ -1382,6 +1484,111 @@ class Database:
             # Pair column names with values and return to user as a dict
             return [dict(zip(result_columns, row, strict=False)) for row in cursor.fetchall()]
 
+    def query_latent_snapshots(
+        self,
+        tag: str | list[str] | None = None,
+        round_number: int | None = None,
+        epoch_number: int | None = None,
+        step_number: int | None = None,
+        signal_type: str | list[str] | None = None,
+        start_time: float | None = None,
+        end_time: float | None = None,
+        columns: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Query from latent_snapshots table
+
+        Args:
+            tag: Tag for current pipeline run. Accepts str or list[str].
+            round_number: Filter by exact round number
+            epoch_number: Filter by exact epoch number
+            step_number: Filter by exact step number
+            signal_type: Signal type filter. Accepts str or list[str].
+            start_time: Start timestamp (unix time)
+            end_time: End timestamp (unix time)
+            columns: Optional list of columns to select (default: all). Validated against schema.
+
+        Returns:
+            List of snapshot dictionaries (latent_vector is JSON string — caller parses with json.loads)
+        """
+        with self._get_connection() as conn:
+            cursor = conn.cursor()
+
+            select = self._build_select("latent_snapshots", columns, self._LATENT_SNAPSHOTS_COLUMNS)
+            query = f"{select} WHERE 1=1"
+            params = []
+
+            if tag:
+                query = self._add_str_filter(query, params, "tag", tag)
+
+            if round_number is not None:
+                query += " AND round_number = ?"
+                params.append(round_number)
+
+            if epoch_number is not None:
+                query += " AND epoch_number = ?"
+                params.append(epoch_number)
+
+            if step_number is not None:
+                query += " AND step_number = ?"
+                params.append(step_number)
+
+            if signal_type:
+                query = self._add_str_filter(query, params, "signal_type", signal_type)
+
+            if start_time is not None:
+                query += " AND timestamp >= ?"
+                params.append(start_time)
+
+            if end_time is not None:
+                query += " AND timestamp <= ?"
+                params.append(end_time)
+
+            cursor.execute(query, params)
+
+            result_columns = [desc[0] for desc in cursor.description]
+            return [dict(zip(result_columns, row, strict=False)) for row in cursor.fetchall()]
+
+    def query_latent_snapshot_keys(
+        self,
+        tag: str | list[str] | None = None,
+        start_time: float | None = None,
+        end_time: float | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Get distinct snapshot keys (round, epoch, step, snr_base, snr_range) sorted by progression.
+
+        Returns:
+            List of dicts with {round_number, epoch_number, step_number, snr_base, snr_range}
+        """
+        with self._get_connection() as conn:
+            cursor = conn.cursor()
+
+            query = """
+                SELECT DISTINCT round_number, epoch_number, step_number, snr_base, snr_range
+                FROM latent_snapshots
+                WHERE 1=1
+            """
+            params: list = []
+
+            if tag:
+                query = self._add_str_filter(query, params, "tag", tag)
+
+            if start_time is not None:
+                query += " AND timestamp >= ?"
+                params.append(start_time)
+
+            if end_time is not None:
+                query += " AND timestamp <= ?"
+                params.append(end_time)
+
+            query += " ORDER BY round_number, epoch_number, step_number"
+
+            cursor.execute(query, params)
+
+            result_columns = [desc[0] for desc in cursor.description]
+            return [dict(zip(result_columns, row, strict=False)) for row in cursor.fetchall()]
+
     def get_db_stats(self) -> dict[str, Any]:
         """Get summary statistics for the database"""
         with self._get_connection() as conn:
@@ -1401,6 +1608,9 @@ class Database:
 
             cursor.execute("SELECT COUNT(*) FROM inference_results")
             stats["inference_results_row_count"] = cursor.fetchone()[0]
+
+            cursor.execute("SELECT COUNT(*) FROM latent_snapshots")
+            stats["latent_snapshots_row_count"] = cursor.fetchone()[0]
 
             # Time range
             # Use system_resources as proxy

--- a/src/aetherscan/inference.py
+++ b/src/aetherscan/inference.py
@@ -83,15 +83,13 @@ def prepare_distributed_inf_dataset(
     """
     global_inf_batch_size = per_replica_inf_batch_size * num_replicas
 
-    # NOTE: does trimming/divisibility matter for inference?
-    # Trim datasets to fit batch sizes (prevents uneven batches on final step)
-    # Note, n_samples should already be divisible by effective_batch_size
-    # Trimming here is just a defensive measure to doubly ensure divisibility before creating &
-    # distributing our datasets
-    # Alternatively, we could also pad the data instead of trimming
+    # # NOTE: does trimming/divisibility matter for inference?
+    # # Trim datasets to fit batch sizes (prevents uneven batches on final step)
+    # # Note, n_samples should already be divisible by effective_batch_size
+    # # Trimming here is just a defensive measure to doubly ensure divisibility before creating &
+    # # distributing our datasets
+    # # Alternatively, we could also pad the data instead of trimming
     # n_inf_trimmed = (n_samples // global_inf_batch_size) * global_inf_batch_size
-    #
-    # logger.info(f"Data alignment: Inf {n_samples}→{n_inf_trimmed}")
     n_inf_trimmed = n_samples
 
     # Sanity check: verify there's enough samples to run inference
@@ -100,8 +98,14 @@ def prepare_distributed_inf_dataset(
             f"Not enough samples ({n_samples}) for global batch size ({per_replica_inf_batch_size} * {num_replicas})"
             f"Reduce per_replica_batch_size or provide more samples"
         )
+    # logger.info(f"Data alignment: Inf {n_samples}→{n_inf_trimmed}")
 
-    # Prepare data
+    # # Randomly subsample to trimmed size (avoids positional bias from slicing the tail)
+    # if n_inf_trimmed < n_samples:
+    #     indices = np.random.choice(n_samples, size=n_inf_trimmed, replace=False)
+    #     inf_data = data[indices]
+    # else:
+    #     inf_data = data[:n_inf_trimmed]
     inf_data = data[:n_inf_trimmed]
     inf_holder = InfDataHolder(inf_data)
 
@@ -139,7 +143,7 @@ def prepare_distributed_inf_dataset(
     inf_dataset = (
         tf.data.Dataset.from_generator(inf_generator, output_signature=output_signature)
         .batch(global_inf_batch_size, drop_remainder=True)
-        # NOTE: do we need repeat for inf dataset?
+        # NOTE: do we need repeat for inf dataset? run test without repeat & see if anything breaks?
         .repeat()
         .prefetch(tf.data.AUTOTUNE)
     )

--- a/src/aetherscan/logger/slack_handler.py
+++ b/src/aetherscan/logger/slack_handler.py
@@ -356,6 +356,7 @@ class SlackHandler(logging.Handler):
             cli_args = sys.argv
         cli_args_str = " ".join(cli_args)
 
+        # NOTE: the command shown does not match the actual command ran (/home/zachy/Aetherscan/src/aetherscan/main.py train --num-training-rounds 1 --max-retries 1 --save-tag test_v0 VS SLACK_BOT_TOKEN=$SLACK_BOT_TOKEN SLACK_CHANNEL=$SLACK_CHANNEL PYTHONPATH=src python -m aetherscan.main train --num-training-rounds 1 --max-retries 1 --save-tag test_v0)
         # Build the run summary message
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         summary_lines = [

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -1272,7 +1272,7 @@ class TrainingPipeline:
             )
 
             # Generate latent space GIF
-            self.plot_latent_space_gif(tag=f"round_{round_idx + 1:02d}", dir="checkpoints")
+            # self.plot_latent_space_gif(tag=f"round_{round_idx + 1:02d}", dir="checkpoints")
 
             # Save checkpoint
             self.save_models(tag=f"round_{round_idx + 1:02d}", dir="checkpoints")
@@ -3640,25 +3640,6 @@ class TrainingPipeline:
 
         del pooled
 
-        # # NOTE: come back to this later (what hyperparams are we using for UMAP? how do we store the final UMAP model params for use later -- e.g. in inference.py's results viz? use a global config seed instead of hard-coding?)
-        # # Fit global UMAP
-        # # Note that by setting random_state, we get a deterministic UMAP fit, at the expense of
-        # # single-thread performance (n_jobs=1). This is a hard constraint of the UMAP library.
-        # # We compensate by fitting the UMAP model to a stratified subsample of the pooled latents
-        # umap_model = umap.UMAP(n_components=2, random_state=11).fit(fit_pool)
-        #
-        # del fit_pool
-        # gc.collect()
-        #
-        # # Transform each snapshot and compute global axis limits
-        # umap_transformed = []
-        #
-        # for coords in all_coords:
-        #     umap_transformed.append(umap_model.transform(coords))
-        #
-        # del all_coords, umap_model
-        # gc.collect()
-
         # Compute consistent axis limits with 5% padding (streaming min/max to avoid concat)
         def _compute_limits(transformed_list):
             x_min = min(t[:, 0].min() for t in transformed_list)
@@ -3668,8 +3649,6 @@ class TrainingPipeline:
             x_pad = (x_max - x_min) * 0.05
             y_pad = (y_max - y_min) * 0.05
             return (x_min - x_pad, x_max + x_pad), (y_min - y_pad, y_max + y_pad)
-
-        # umap_xlim, umap_ylim = _compute_limits(umap_transformed)
 
         # Generate frames and assemble GIF
         colors = {
@@ -3697,20 +3676,24 @@ class TrainingPipeline:
         # NOTE: instead of temp_dir, save frames in persistent dir. update dir archiving to handle
         temp_dir = tempfile.mkdtemp(prefix="latent_gif_")
 
-        # methods = [
-        #     ("umap", umap_transformed, umap_xlim, umap_ylim),
-        # ]
-
         gif_paths = {}
         duration_ms = self.config.training.latent_viz_gif_duration_ms
 
-        # --- Experiment: sweep n_neighbors × min_dist ---
+        # NOTE: let user specify which combinations to use via config.py or cli flags
+        # NOTE: how do we store final UMAP model params for later use (e.g. during inference results viz)
         n_neighbors_values = [2, 5, 10, 15, 20, 30, 50, 100]
         min_dist_values = [0.0, 0.1, 0.25, 0.5, 0.8, 0.99]
 
         for nn in n_neighbors_values:
             for md in min_dist_values:
                 logger.info(f"Fitting UMAP with n_neighbors={nn}, min_dist={md}")
+
+                # NOTE: use a global config seed instead of hard-coding
+                # Fit UMAP model
+                # Note that by setting random_state, we get a deterministic UMAP fit, at the expense
+                # of single-thread performance (n_jobs=1). This is a hard constraint of the UMAP
+                # library. We compensate by fitting the UMAP model to a stratified subsample of the
+                # pooled latents
                 umap_model = umap.UMAP(
                     n_components=2,
                     random_state=11,
@@ -3718,12 +3701,14 @@ class TrainingPipeline:
                     min_dist=md,
                 ).fit(fit_pool)
 
+                # Transform each snapshot
                 transformed = []
                 for coords in all_coords:
                     transformed.append(umap_model.transform(coords))
                 del umap_model
                 gc.collect()
 
+                # Compute global axis limits
                 xlim, ylim = _compute_limits(transformed)
 
                 method_name = f"umap_nn{nn}_md{md}"
@@ -3776,16 +3761,6 @@ class TrainingPipeline:
                             if snr_base is not None and snr_range is not None
                             else "?"
                         )
-                        # ax.set_title(
-                        #     f"Beta-VAE Latent Space ({method_name.upper()}) — "
-                        #     f"Round {meta['round_number']}, "
-                        #     f"Epoch {meta['epoch_number']}, "
-                        #     f"Step {meta['step_number']} "
-                        #     f"(SNR: {snr_base}–{snr_ceil})",
-                        #     fontsize=11,
-                        # )
-                        # ax.set_xlabel(f"{method_name.upper()} 1")
-                        # ax.set_ylabel(f"{method_name.upper()} 2")
                         ax.set_title(
                             f"Beta-VAE Latent Space ({display_method}) — "
                             f"Round {meta['round_number']}, "

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -3679,10 +3679,9 @@ class TrainingPipeline:
         gif_paths = {}
         duration_ms = self.config.training.latent_viz_gif_duration_ms
 
-        # NOTE: let user specify which combinations to use via config.py or cli flags
         # NOTE: how do we store final UMAP model params for later use (e.g. during inference results viz)
-        n_neighbors_values = [2, 5, 10, 15, 20, 30, 50, 100]
-        min_dist_values = [0.0, 0.1, 0.25, 0.5, 0.8, 0.99]
+        n_neighbors_values = self.config.training.latent_viz_umap_n_neighbors
+        min_dist_values = self.config.training.latent_viz_umap_min_dist
 
         for nn in n_neighbors_values:
             for md in min_dist_values:

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -3599,9 +3599,9 @@ class TrainingPipeline:
             f"for UMAP fitting"
         )
 
-        # NOTE: come back to this later (what hyperparams are we using for UMAP? how do we store the final UMAP model params for use later -- e.g. in inference.py's results viz?)
+        # NOTE: come back to this later (what hyperparams are we using for UMAP? how do we store the final UMAP model params for use later -- e.g. in inference.py's results viz? use a global config seed instead of hard-coding?)
         # Fit global UMAP
-        umap_model = umap.UMAP(n_components=2, random_state=42).fit(pooled)
+        umap_model = umap.UMAP(n_components=2, random_state=11).fit(pooled)
 
         del pooled
         gc.collect()

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -364,7 +364,6 @@ def prepare_distributed_train_dataset(
     num_replicas: int,
     strategy: tf.distribute.Strategy,
     shuffle: bool = True,
-    labels: np.ndarray | None = None,
 ) -> dict:
     """
     Prepare distributed datasets for training & validation
@@ -379,12 +378,11 @@ def prepare_distributed_train_dataset(
         num_replicas: Number of replicas in strategy
         strategy: TensorFlow distribution strategy
         shuffle: Whether to shuffle training data
-        labels: Optional per-cadence signal type labels (e.g. from generate_triplet_batch)
 
     Returns: {train_dataset, val_dataset, n_train_trimmed, n_val_trimmed, train_steps,
-              accumulation_steps, val_steps, _train_holder, _val_holder, val_labels}
+              accumulation_steps, val_steps, _train_holder, _val_holder}
              Train/val distributed datasets, number of samples in each, number of steps for each
-              (including accumulation sub-steps), DataHolder references for each, and val labels
+              (including accumulation sub-steps), and DataHoldedr references for each
     """
     global_train_batch_size = per_replica_batch_size * num_replicas
     global_val_batch_size = per_replica_val_batch_size * num_replicas
@@ -418,8 +416,6 @@ def prepare_distributed_train_dataset(
     val_true = data["true"][val_start:val_end]
     val_false = data["false"][val_start:val_end]
     val_holder = DataHolder(val_concat, val_true, val_false)
-
-    val_labels = labels[val_start:val_end] if labels is not None else None
 
     # Create generator functions for memory-efficient data loading
     def train_generator():
@@ -535,7 +531,6 @@ def prepare_distributed_train_dataset(
         "val_steps": val_steps,
         "_train_holder": train_holder,
         "_val_holder": val_holder,
-        "val_labels": val_labels,
     }
 
 
@@ -902,12 +897,17 @@ class TrainingPipeline:
 
         return current_lr
 
-    def _prepare_latent_viz_batch(self, val_holder, val_labels):
+    def _prepare_latent_viz_batch(self, concat_data, labels):
         """
-        Subsample validation set by signal type for latent space visualization.
+        Subsample the full dataset by signal type for latent space visualization.
 
-        Selects `latent_viz_num_cadences_per_type` cadences per signal type from the
-        validation holder, storing the subsampled batch and labels as instance attributes.
+        Must be called on the full pre-split dataset (not the val set) because
+        the sequential label layout within chunks means the 80/20 train/val split
+        can leave the val set with only the last signal type.
+
+        Args:
+            concat_data: Full concatenated cadences array, shape (n_samples, 6, 16, width_bin)
+            labels: Per-cadence signal type labels, shape (n_samples,)
         """
         n_per_type = self.config.training.latent_viz_num_cadences_per_type
         signal_types = ["false_no_signal", "false_with_rfi", "true_only_eti", "true_eti_rfi"]
@@ -916,10 +916,13 @@ class TrainingPipeline:
         selected_labels = []
 
         for stype in signal_types:
-            type_indices = np.where(val_labels == stype)[0]
+            type_indices = np.where(labels == stype)[0]
+            if len(type_indices) == 0:
+                logger.warning(f"No cadences for {stype} — skipping this type for viz batch")
+                continue
             if len(type_indices) < n_per_type:
                 logger.warning(
-                    f"Only {len(type_indices)} cadences for {stype} in val set "
+                    f"Only {len(type_indices)} cadences for {stype} "
                     f"(requested {n_per_type}), using all available"
                 )
                 sampled = type_indices
@@ -928,22 +931,19 @@ class TrainingPipeline:
             selected_indices.append(sampled)
             selected_labels.extend([stype] * len(sampled))
 
+        if not selected_indices:
+            logger.warning("No cadences found for any signal type — skipping viz batch")
+            self._latent_viz_batch = None
+            self._latent_viz_labels = None
+            return
+
         all_indices = np.concatenate(selected_indices)
-
-        # Access val_holder data with lock
-        with val_holder._lock:
-            if val_holder._cleared:
-                logger.warning("Val holder cleared before viz batch preparation")
-                self._latent_viz_batch = None
-                self._latent_viz_labels = None
-                return
-            self._latent_viz_batch = val_holder.concat[all_indices].copy()
-
+        self._latent_viz_batch = concat_data[all_indices].copy()
         self._latent_viz_labels = np.array(selected_labels, dtype="U20")
 
         logger.info(
             f"Prepared latent viz batch: {len(all_indices)} cadences "
-            f"({len(selected_indices[0])} per type × {len(signal_types)} types)"
+            f"({n_per_type} per type × {len(signal_types)} types)"
         )
 
     def _capture_latent_snapshot(self, round_idx, epoch, step, snr_base, snr_range):
@@ -1059,6 +1059,14 @@ class TrainingPipeline:
             self.config.training.num_samples_beta_vae, snr_base, snr_range, round_idx + 1
         )
 
+        # Prepare latent viz batch from full dataset before train/val split
+        # (must happen before del train_data, since labels are sequential within
+        # chunks and the 80/20 split would leave the val tail with only the last type)
+        train_labels = train_data.get("labels")
+        if train_labels is not None:
+            self._prepare_latent_viz_batch(train_data["concatenated"], train_labels)
+        del train_labels
+
         # Distribute training data
         data = prepare_distributed_train_dataset(
             data=train_data,
@@ -1070,7 +1078,6 @@ class TrainingPipeline:
             num_replicas=self.strategy.num_replicas_in_sync,
             strategy=self.strategy,
             shuffle=True,
-            labels=train_data.get("labels"),
         )
 
         del train_data
@@ -1085,15 +1092,9 @@ class TrainingPipeline:
         val_steps = data["val_steps"]
         train_holder = data["_train_holder"]
         val_holder = data["_val_holder"]
-        val_labels = data.get("val_labels")
 
         del data
         gc.collect()
-
-        # Prepare latent space visualization batch from validation data
-        if val_labels is not None:
-            self._prepare_latent_viz_batch(val_holder, val_labels)
-        del val_labels
 
         logger.info(
             f"Initializing training loop with {steps_per_epoch} train steps, {val_steps} val steps"

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -3753,11 +3753,12 @@ class TrainingPipeline:
                         ax.set_xlim(xlim)
                         ax.set_ylim(ylim)
 
-                        snr_base = meta["snr_base"]
-                        snr_range = meta["snr_range"]
-                        snr_ceil = (
-                            snr_base + snr_range
-                            if snr_base is not None and snr_range is not None
+                        meta_snr_base = meta["snr_base"]
+                        meta_snr_range = meta["snr_range"]
+                        meta_snr_floor = meta_snr_base if meta_snr_base is not None else "?"
+                        meta_snr_ceil = (
+                            meta_snr_base + meta_snr_range
+                            if meta_snr_base is not None and meta_snr_range is not None
                             else "?"
                         )
                         ax.set_title(
@@ -3765,7 +3766,7 @@ class TrainingPipeline:
                             f"Round {meta['round_number']}, "
                             f"Epoch {meta['epoch_number']}, "
                             f"Step {meta['step_number']} "
-                            f"(SNR: {snr_base}–{snr_ceil})",
+                            f"(SNR: {meta_snr_floor}–{meta_snr_ceil})",
                             fontsize=11,
                         )
                         ax.set_xlabel("UMAP 1")

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -3599,11 +3599,28 @@ class TrainingPipeline:
             f"for UMAP fitting"
         )
 
-        # NOTE: come back to this later (what hyperparams are we using for UMAP? how do we store the final UMAP model params for use later -- e.g. in inference.py's results viz? use a global config seed instead of hard-coding?)
-        # Fit global UMAP
-        umap_model = umap.UMAP(n_components=2, random_state=11).fit(pooled)
+        # Subsample pooled vectors for UMAP fit (fitting on the full set of pooled vectors is slow;
+        # the subsampled fit generalizes well and remaining vectors are projected via .transform())
+        umap_fit_max = self.config.training.latent_viz_umap_fit_max_samples
+        if pooled.shape[0] > umap_fit_max:
+            # NOTE: use a global config seed instead of hard-coding
+            rng = np.random.default_rng(11)
+            fit_indices = rng.choice(pooled.shape[0], size=umap_fit_max, replace=False)
+            fit_pool = pooled[fit_indices]
+            logger.info(
+                f"Subsampled {fit_pool.shape[0]} / {pooled.shape[0]} latent vectors for UMAP fit"
+            )
+            del fit_indices
+        else:
+            fit_pool = pooled
 
         del pooled
+
+        # NOTE: come back to this later (what hyperparams are we using for UMAP? how do we store the final UMAP model params for use later -- e.g. in inference.py's results viz? use a global config seed instead of hard-coding?)
+        # Fit global UMAP
+        umap_model = umap.UMAP(n_components=2, random_state=11).fit(fit_pool)
+
+        del fit_pool
         gc.collect()
 
         # Transform each snapshot and compute global axis limits

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -3714,6 +3714,10 @@ class TrainingPipeline:
                 method_name = f"umap_nn{nn}_md{md}"
                 display_method = f"UMAP (n_neighbors={nn}, min_dist={md})"
 
+                # Using a list here is a remnant from when we were testing multiple DR methods
+                # Currently this will always be a single-element list
+                # However, we're choosing not to remove the list wrapper & loop in case we wish to
+                # further explore different DR methods in the future
                 methods = [
                     (method_name, display_method, transformed, xlim, ylim),
                 ]

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -3601,14 +3601,38 @@ class TrainingPipeline:
 
         # Subsample pooled vectors for UMAP fit (fitting on the full set of pooled vectors is slow;
         # the subsampled fit generalizes well and remaining vectors are projected via .transform())
+        # Stratified by signal_type × ON/OFF (8 classes) for balanced representation
         umap_fit_max = self.config.training.latent_viz_umap_fit_max_samples
         if pooled.shape[0] > umap_fit_max:
+            pooled_labels = np.concatenate(
+                [np.array(lab, dtype="U") for lab in all_snapshot_labels]
+            )
+            pooled_onoff = np.concatenate([np.array(o, dtype="U") for o in all_snapshot_onoff])
+            strata = np.char.add(np.char.add(pooled_labels, "|"), pooled_onoff)
+            del pooled_labels, pooled_onoff
+
             # NOTE: use a global config seed instead of hard-coding
             rng = np.random.default_rng(11)
-            fit_indices = rng.choice(pooled.shape[0], size=umap_fit_max, replace=False)
+            unique_classes = np.unique(strata)
+            per_class = umap_fit_max // len(unique_classes)
+            fit_indices = []
+            for cls in unique_classes:
+                cls_idx = np.nonzero(strata == cls)[0]
+                n_take = min(per_class, len(cls_idx))
+                if n_take < per_class:
+                    logger.warning(
+                        f"Only {n_take} latents for {cls} "
+                        f"(requested {per_class}), using all available"
+                    )
+                fit_indices.append(rng.choice(cls_idx, size=n_take, replace=False))
+            fit_indices = np.concatenate(fit_indices)
+            del strata
+
             fit_pool = pooled[fit_indices]
             logger.info(
-                f"Subsampled {fit_pool.shape[0]} / {pooled.shape[0]} latent vectors for UMAP fit"
+                f"Stratified subsampled {fit_pool.shape[0]} / {pooled.shape[0]} "
+                f"latent vectors for UMAP fit ({len(unique_classes)} classes, "
+                f"~{per_class} per class)"
             )
             del fit_indices
         else:
@@ -3618,6 +3642,9 @@ class TrainingPipeline:
 
         # NOTE: come back to this later (what hyperparams are we using for UMAP? how do we store the final UMAP model params for use later -- e.g. in inference.py's results viz? use a global config seed instead of hard-coding?)
         # Fit global UMAP
+        # Note that by setting random_state, we get a deterministic UMAP fit, at the expense of
+        # single-thread performance (n_jobs=1). This is a hard constraint of the UMAP library.
+        # We compensate by fitting the UMAP model to a stratified subsample of the pooled latents
         umap_model = umap.UMAP(n_components=2, random_state=11).fit(fit_pool)
 
         del fit_pool
@@ -3704,7 +3731,6 @@ class TrainingPipeline:
                             c=color,
                             marker=markers[status],
                             s=5,
-                            alpha=0.3,
                             label=display_names[(stype, status)],
                             rasterized=True,
                         )
@@ -3720,7 +3746,7 @@ class TrainingPipeline:
                     snr_base + snr_range if snr_base is not None and snr_range is not None else "?"
                 )
                 ax.set_title(
-                    f"Latent Space ({method_name.upper()}) — "
+                    f"Beta-VAE Latent Space ({method_name.upper()}) — "
                     f"Round {meta['round_number']}, "
                     f"Epoch {meta['epoch_number']}, "
                     f"Step {meta['step_number']} "

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -1744,7 +1744,9 @@ class TrainingPipeline:
 
         return current_lr
 
-    def _distributed_encode(self, dataset, n_steps, encode_fn, n_samples, latent_dim):
+    def _distributed_encode(
+        self, dataset, n_steps, encode_fn, n_samples, latent_dim, logging=False
+    ):
         """
         Run distributed encoding over a dataset using a provided @tf.function.
 
@@ -1757,6 +1759,7 @@ class TrainingPipeline:
             encode_fn: @tf.function that takes a batch and returns one or more per-replica tensors
             n_samples: Total number of output rows per array
             latent_dim: Latent dimension
+            logging: Whether to log progress (default: False)
 
         Returns:
             List of np.ndarray. Each shape (n_samples, latent_dim).
@@ -1767,7 +1770,7 @@ class TrainingPipeline:
         outputs = None
 
         try:
-            for step in range(n_steps):
+            for _ in range(n_steps):
                 batch = next(iterator)
 
                 # Get per-replica latents for this batch
@@ -1796,9 +1799,9 @@ class TrainingPipeline:
 
                 current_idx += batch_size
 
-                # Log progress every 10 steps or on the final step
-                if (step + 1) % 10 == 0 or (step + 1) == n_steps:
-                    logger.info(f"Encoded step {step + 1}/{n_steps}")
+                # Log progress
+                if logging:
+                    logger.info(f"Finished encoding {n_steps} steps")
 
                 del results
                 gc.collect()
@@ -1927,6 +1930,7 @@ class TrainingPipeline:
                 encode_fn=rf_encode_fn,
                 n_samples=n_inf_trimmed * num_observations,
                 latent_dim=latent_dim,
+                logging=True,
             )
 
             # Train Random Forest classifier
@@ -3903,6 +3907,7 @@ class TrainingPipeline:
             encode_fn=self._viz_encode_fn,
             n_samples=n_padded * num_obs,
             latent_dim=latent_dim,
+            logging=False,
         )
 
         # Truncate padding and reshape to per-cadence: (n_samples, 6, latent_dim)

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -1799,12 +1799,12 @@ class TrainingPipeline:
 
                 current_idx += batch_size
 
-                # Log progress
-                if logging:
-                    logger.info(f"Finished encoding {n_steps} steps")
-
                 del results
                 gc.collect()
+
+            # Log progress
+            if logging:
+                logger.info(f"Finished encoding {n_steps} steps")
         finally:
             # NOTE: should check to make sure iterator exists first
             del iterator

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -3640,24 +3640,24 @@ class TrainingPipeline:
 
         del pooled
 
-        # NOTE: come back to this later (what hyperparams are we using for UMAP? how do we store the final UMAP model params for use later -- e.g. in inference.py's results viz? use a global config seed instead of hard-coding?)
-        # Fit global UMAP
-        # Note that by setting random_state, we get a deterministic UMAP fit, at the expense of
-        # single-thread performance (n_jobs=1). This is a hard constraint of the UMAP library.
-        # We compensate by fitting the UMAP model to a stratified subsample of the pooled latents
-        umap_model = umap.UMAP(n_components=2, random_state=11).fit(fit_pool)
-
-        del fit_pool
-        gc.collect()
-
-        # Transform each snapshot and compute global axis limits
-        umap_transformed = []
-
-        for coords in all_coords:
-            umap_transformed.append(umap_model.transform(coords))
-
-        del all_coords, umap_model
-        gc.collect()
+        # # NOTE: come back to this later (what hyperparams are we using for UMAP? how do we store the final UMAP model params for use later -- e.g. in inference.py's results viz? use a global config seed instead of hard-coding?)
+        # # Fit global UMAP
+        # # Note that by setting random_state, we get a deterministic UMAP fit, at the expense of
+        # # single-thread performance (n_jobs=1). This is a hard constraint of the UMAP library.
+        # # We compensate by fitting the UMAP model to a stratified subsample of the pooled latents
+        # umap_model = umap.UMAP(n_components=2, random_state=11).fit(fit_pool)
+        #
+        # del fit_pool
+        # gc.collect()
+        #
+        # # Transform each snapshot and compute global axis limits
+        # umap_transformed = []
+        #
+        # for coords in all_coords:
+        #     umap_transformed.append(umap_model.transform(coords))
+        #
+        # del all_coords, umap_model
+        # gc.collect()
 
         # Compute consistent axis limits with 5% padding (streaming min/max to avoid concat)
         def _compute_limits(transformed_list):
@@ -3669,7 +3669,7 @@ class TrainingPipeline:
             y_pad = (y_max - y_min) * 0.05
             return (x_min - x_pad, x_max + x_pad), (y_min - y_pad, y_max + y_pad)
 
-        umap_xlim, umap_ylim = _compute_limits(umap_transformed)
+        # umap_xlim, umap_ylim = _compute_limits(umap_transformed)
 
         # Generate frames and assemble GIF
         colors = {
@@ -3697,117 +3697,165 @@ class TrainingPipeline:
         # NOTE: instead of temp_dir, save frames in persistent dir. update dir archiving to handle
         temp_dir = tempfile.mkdtemp(prefix="latent_gif_")
 
-        methods = [
-            ("umap", umap_transformed, umap_xlim, umap_ylim),
-        ]
+        # methods = [
+        #     ("umap", umap_transformed, umap_xlim, umap_ylim),
+        # ]
 
         gif_paths = {}
         duration_ms = self.config.training.latent_viz_gif_duration_ms
 
-        for method_name, transformed_list, xlim, ylim in methods:
-            frame_paths = []
+        # --- Experiment: sweep n_neighbors × min_dist ---
+        n_neighbors_values = [2, 5, 10, 15, 20, 30, 50, 100]
+        min_dist_values = [0.0, 0.1, 0.25, 0.5, 0.8, 0.99]
 
-            for frame_idx, (coords_2d, labels, onoff, meta) in enumerate(
-                zip(
-                    transformed_list,
-                    all_snapshot_labels,
-                    all_snapshot_onoff,
-                    snapshot_metadata,
-                    strict=True,
-                )
-            ):
-                fig, ax = plt.subplots(1, 1, figsize=(10, 8))
+        for nn in n_neighbors_values:
+            for md in min_dist_values:
+                logger.info(f"Fitting UMAP with n_neighbors={nn}, min_dist={md}")
+                umap_model = umap.UMAP(
+                    n_components=2,
+                    random_state=11,
+                    n_neighbors=nn,
+                    min_dist=md,
+                ).fit(fit_pool)
 
-                # Plot each category
-                labels_arr = np.array(labels)
-                onoff_arr = np.array(onoff)
+                transformed = []
+                for coords in all_coords:
+                    transformed.append(umap_model.transform(coords))
+                del umap_model
+                gc.collect()
 
-                for (stype, status), color in colors.items():
-                    mask = (labels_arr == stype) & (onoff_arr == status)
-                    if mask.any():
-                        ax.scatter(
-                            coords_2d[mask, 0],
-                            coords_2d[mask, 1],
-                            c=color,
-                            marker=markers[status],
-                            s=5,
-                            label=display_names[(stype, status)],
-                            rasterized=True,
+                xlim, ylim = _compute_limits(transformed)
+
+                method_name = f"umap_nn{nn}_md{md}"
+                display_method = f"UMAP (n_neighbors={nn}, min_dist={md})"
+
+                methods = [
+                    (method_name, display_method, transformed, xlim, ylim),
+                ]
+
+                for method_name, display_method, transformed_list, xlim, ylim in methods:
+                    frame_paths = []
+
+                    for frame_idx, (coords_2d, labels, onoff, meta) in enumerate(
+                        zip(
+                            transformed_list,
+                            all_snapshot_labels,
+                            all_snapshot_onoff,
+                            snapshot_metadata,
+                            strict=True,
+                        )
+                    ):
+                        fig, ax = plt.subplots(1, 1, figsize=(10, 8))
+
+                        # Plot each category
+                        labels_arr = np.array(labels)
+                        onoff_arr = np.array(onoff)
+
+                        for (stype, status), color in colors.items():
+                            mask = (labels_arr == stype) & (onoff_arr == status)
+                            if mask.any():
+                                ax.scatter(
+                                    coords_2d[mask, 0],
+                                    coords_2d[mask, 1],
+                                    c=color,
+                                    marker=markers[status],
+                                    s=5,
+                                    label=display_names[(stype, status)],
+                                    rasterized=True,
+                                )
+
+                        del labels_arr, onoff_arr
+
+                        ax.set_xlim(xlim)
+                        ax.set_ylim(ylim)
+
+                        snr_base = meta["snr_base"]
+                        snr_range = meta["snr_range"]
+                        snr_ceil = (
+                            snr_base + snr_range
+                            if snr_base is not None and snr_range is not None
+                            else "?"
+                        )
+                        # ax.set_title(
+                        #     f"Beta-VAE Latent Space ({method_name.upper()}) — "
+                        #     f"Round {meta['round_number']}, "
+                        #     f"Epoch {meta['epoch_number']}, "
+                        #     f"Step {meta['step_number']} "
+                        #     f"(SNR: {snr_base}–{snr_ceil})",
+                        #     fontsize=11,
+                        # )
+                        # ax.set_xlabel(f"{method_name.upper()} 1")
+                        # ax.set_ylabel(f"{method_name.upper()} 2")
+                        ax.set_title(
+                            f"Beta-VAE Latent Space ({display_method}) — "
+                            f"Round {meta['round_number']}, "
+                            f"Epoch {meta['epoch_number']}, "
+                            f"Step {meta['step_number']} "
+                            f"(SNR: {snr_base}–{snr_ceil})",
+                            fontsize=11,
+                        )
+                        ax.set_xlabel("UMAP 1")
+                        ax.set_ylabel("UMAP 2")
+                        ax.legend(
+                            loc="upper right",
+                            fontsize=7,
+                            markerscale=3,
+                            ncol=2,
+                            framealpha=0.8,
                         )
 
-                del labels_arr, onoff_arr
+                        plt.tight_layout()
 
-                ax.set_xlim(xlim)
-                ax.set_ylim(ylim)
-
-                snr_base = meta["snr_base"]
-                snr_range = meta["snr_range"]
-                snr_ceil = (
-                    snr_base + snr_range if snr_base is not None and snr_range is not None else "?"
-                )
-                ax.set_title(
-                    f"Beta-VAE Latent Space ({method_name.upper()}) — "
-                    f"Round {meta['round_number']}, "
-                    f"Epoch {meta['epoch_number']}, "
-                    f"Step {meta['step_number']} "
-                    f"(SNR: {snr_base}–{snr_ceil})",
-                    fontsize=11,
-                )
-                ax.set_xlabel(f"{method_name.upper()} 1")
-                ax.set_ylabel(f"{method_name.upper()} 2")
-                ax.legend(
-                    loc="upper right",
-                    fontsize=7,
-                    markerscale=3,
-                    ncol=2,
-                    framealpha=0.8,
-                )
-
-                plt.tight_layout()
-
-                frame_path = os.path.join(temp_dir, f"{method_name}_frame_{frame_idx:05d}.png")
-                fig.savefig(frame_path, dpi=100)
-                plt.close(fig)
-                frame_paths.append(frame_path)
-
-            del transformed_list
-
-            # Assemble GIF by streaming one frame at a time via imageio (reduces memory pressure)
-            gif_filename = f"latent_space_{method_name}_{tag}.gif"
-            gif_path = os.path.join(save_dir, gif_filename)
-
-            n_frames = len(frame_paths)
-            if n_frames > 0:
-                with iio.imopen(gif_path, "w", plugin="pillow") as gif_writer:
-                    for frame_path in frame_paths:
-                        frame = iio.imread(frame_path)
-                        gif_writer.write(
-                            frame,
-                            duration=duration_ms,
-                            loop=0,
-                            is_batch=False,
+                        frame_path = os.path.join(
+                            temp_dir, f"{method_name}_frame_{frame_idx:05d}.png"
                         )
-                        del frame
+                        fig.savefig(frame_path, dpi=100)
+                        plt.close(fig)
+                        frame_paths.append(frame_path)
 
-                logger.info(
-                    f"Latent space {method_name.upper()} GIF saved: {gif_path} ({n_frames} frames)"
-                )
+                    del transformed_list
 
-                # Upload to Slack
-                logger_instance = get_logger()
-                if logger_instance:
-                    logger_instance.upload_image_to_slack(
-                        gif_path,
-                        title=f"Latent Space {method_name.upper()} - ({tag})",
-                    )
+                    # Assemble GIF by streaming one frame at a time via imageio (reduces memory pressure)
+                    gif_filename = f"latent_space_{method_name}_{tag}.gif"
+                    gif_path = os.path.join(save_dir, gif_filename)
 
-            del frame_paths
-            gc.collect()
+                    n_frames = len(frame_paths)
+                    if n_frames > 0:
+                        with iio.imopen(gif_path, "w", plugin="pillow") as gif_writer:
+                            for frame_path in frame_paths:
+                                frame = iio.imread(frame_path)
+                                gif_writer.write(
+                                    frame,
+                                    duration=duration_ms,
+                                    loop=0,
+                                    is_batch=False,
+                                )
+                                del frame
 
-            gif_paths[method_name] = gif_path
+                        logger.info(
+                            f"Latent space {method_name.upper()} GIF saved: "
+                            f"{gif_path} ({n_frames} frames)"
+                        )
+
+                        # Upload to Slack
+                        logger_instance = get_logger()
+                        if logger_instance:
+                            logger_instance.upload_image_to_slack(
+                                gif_path,
+                                title=f"Latent Space {display_method} - ({tag})",
+                            )
+
+                    del frame_paths
+                    gc.collect()
+
+                    gif_paths[method_name] = gif_path
+
+                del transformed
+                gc.collect()
 
         # Cleanup
-        del umap_transformed
+        del fit_pool, all_coords
+        # del umap_transformed
         del all_snapshot_labels, all_snapshot_onoff, snapshot_metadata
         # NOTE: temp_dir isn't cleaned on exception (should use try/finally or tempfile.TemporaryDirectory() with context manager)
         shutil.rmtree(temp_dir, ignore_errors=True)

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 import shutil
+import tempfile
 import threading
 import time
 from collections.abc import Callable
@@ -25,6 +26,9 @@ import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
+import umap
+from PIL import Image
+from sklearn.decomposition import PCA
 from tensorflow.keras.initializers import GlorotNormal, HeNormal
 from tensorflow.keras.layers import Conv2D, Dense
 
@@ -360,6 +364,7 @@ def prepare_distributed_train_dataset(
     num_replicas: int,
     strategy: tf.distribute.Strategy,
     shuffle: bool = True,
+    labels: np.ndarray | None = None,
 ) -> dict:
     """
     Prepare distributed datasets for training & validation
@@ -374,11 +379,12 @@ def prepare_distributed_train_dataset(
         num_replicas: Number of replicas in strategy
         strategy: TensorFlow distribution strategy
         shuffle: Whether to shuffle training data
+        labels: Optional per-cadence signal type labels (e.g. from generate_triplet_batch)
 
     Returns: {train_dataset, val_dataset, n_train_trimmed, n_val_trimmed, train_steps,
-              accumulation_steps, val_steps, _train_holder, _val_holder}
+              accumulation_steps, val_steps, _train_holder, _val_holder, val_labels}
              Train/val distributed datasets, number of samples in each, number of steps for each
-              (including accumulation sub-steps), and DataHoldedr references for each
+              (including accumulation sub-steps), DataHolder references for each, and val labels
     """
     global_train_batch_size = per_replica_batch_size * num_replicas
     global_val_batch_size = per_replica_val_batch_size * num_replicas
@@ -412,6 +418,8 @@ def prepare_distributed_train_dataset(
     val_true = data["true"][val_start:val_end]
     val_false = data["false"][val_start:val_end]
     val_holder = DataHolder(val_concat, val_true, val_false)
+
+    val_labels = labels[val_start:val_end] if labels is not None else None
 
     # Create generator functions for memory-efficient data loading
     def train_generator():
@@ -527,6 +535,7 @@ def prepare_distributed_train_dataset(
         "val_steps": val_steps,
         "_train_holder": train_holder,
         "_val_holder": val_holder,
+        "val_labels": val_labels,
     }
 
 
@@ -893,6 +902,108 @@ class TrainingPipeline:
 
         return current_lr
 
+    def _prepare_latent_viz_batch(self, val_holder, val_labels):
+        """
+        Subsample validation set by signal type for latent space visualization.
+
+        Selects `latent_viz_num_cadences_per_type` cadences per signal type from the
+        validation holder, storing the subsampled batch and labels as instance attributes.
+        """
+        n_per_type = self.config.training.latent_viz_num_cadences_per_type
+        signal_types = ["false_no_signal", "false_with_rfi", "true_only_eti", "true_eti_rfi"]
+
+        selected_indices = []
+        selected_labels = []
+
+        for stype in signal_types:
+            type_indices = np.where(val_labels == stype)[0]
+            if len(type_indices) < n_per_type:
+                logger.warning(
+                    f"Only {len(type_indices)} cadences for {stype} in val set "
+                    f"(requested {n_per_type}), using all available"
+                )
+                sampled = type_indices
+            else:
+                sampled = np.random.choice(type_indices, size=n_per_type, replace=False)
+            selected_indices.append(sampled)
+            selected_labels.extend([stype] * len(sampled))
+
+        all_indices = np.concatenate(selected_indices)
+
+        # Access val_holder data with lock
+        with val_holder._lock:
+            if val_holder._cleared:
+                logger.warning("Val holder cleared before viz batch preparation")
+                self._latent_viz_batch = None
+                self._latent_viz_labels = None
+                return
+            self._latent_viz_batch = val_holder.concat[all_indices].copy()
+
+        self._latent_viz_labels = np.array(selected_labels, dtype="U20")
+
+        logger.info(
+            f"Prepared latent viz batch: {len(all_indices)} cadences "
+            f"({len(selected_indices[0])} per type × {len(signal_types)} types)"
+        )
+
+    def _capture_latent_snapshot(self, round_idx, epoch, step, snr_base, snr_range):
+        """
+        Run encoder on viz batch and write latent vectors to DB.
+
+        Processes the viz batch through the encoder, extracts z_mean,
+        and writes one row per cadence to the latent_snapshots table.
+        """
+        if self._latent_viz_batch is None:
+            return
+
+        n_cadences = self._latent_viz_batch.shape[0]
+        num_obs = self._latent_viz_batch.shape[1]  # 6
+
+        # Reshape for encoder: (N*6, 16, 512, 1) — add channel dim
+        encoder_input = self._latent_viz_batch.reshape(
+            n_cadences * num_obs,
+            self._latent_viz_batch.shape[2],
+            self._latent_viz_batch.shape[3],
+        )
+        # Add channel dimension for Conv2D
+        encoder_input = np.expand_dims(encoder_input, axis=-1)
+
+        # Process in chunks to avoid GPU OOM
+        chunk_size = 1024
+        z_mean_parts = []
+        for i in range(0, len(encoder_input), chunk_size):
+            chunk = tf.constant(encoder_input[i : i + chunk_size], dtype=tf.float32)
+            z_mean_chunk, _, _ = self.vae.encoder(chunk, training=False)
+            z_mean_parts.append(tf.stop_gradient(z_mean_chunk).numpy())
+
+        z_mean_np = np.concatenate(z_mean_parts, axis=0)
+        del encoder_input, z_mean_parts
+
+        # Reshape back to per-cadence: (N, 6, latent_dim)
+        latent_dim = z_mean_np.shape[-1]
+        z_mean_per_cadence = z_mean_np.reshape(n_cadences, num_obs, latent_dim)
+        del z_mean_np
+
+        # Write to DB
+        timestamp = time.time()
+        tag = self.config.checkpoint.save_tag
+        for cadence_idx in range(n_cadences):
+            latent_vector_list = np.round(z_mean_per_cadence[cadence_idx], 8).tolist()
+            self.db.write_latent_snapshot(
+                round_number=round_idx + 1,
+                epoch_number=epoch + 1,
+                step_number=step + 1,
+                cadence_index=cadence_idx,
+                signal_type=str(self._latent_viz_labels[cadence_idx]),
+                latent_vector=latent_vector_list,
+                snr_base=snr_base,
+                snr_range=snr_range,
+                tag=tag,
+                timestamp=timestamp,
+            )
+
+        del z_mean_per_cadence
+
     def train_beta_vae(self):
         """
         Train beta-VAE with curriculum learning & adaptive LR setup
@@ -959,6 +1070,7 @@ class TrainingPipeline:
             num_replicas=self.strategy.num_replicas_in_sync,
             strategy=self.strategy,
             shuffle=True,
+            labels=train_data.get("labels"),
         )
 
         del train_data
@@ -973,17 +1085,31 @@ class TrainingPipeline:
         val_steps = data["val_steps"]
         train_holder = data["_train_holder"]
         val_holder = data["_val_holder"]
+        val_labels = data.get("val_labels")
 
         del data
         gc.collect()
+
+        # Prepare latent space visualization batch from validation data
+        if val_labels is not None:
+            self._prepare_latent_viz_batch(val_holder, val_labels)
+        del val_labels
 
         logger.info(
             f"Initializing training loop with {steps_per_epoch} train steps, {val_steps} val steps"
         )
         logger.info(f"Gradients accumulated every {accumulation_steps} sub-steps")
 
+        # Set context for latent snapshot capture (read by _train_epoch -> _capture_latent_snapshot)
+        self._current_round_idx = round_idx
+        self._current_snr_base = snr_base
+        self._current_snr_range = snr_range
+        self._latent_viz_step_interval = self.config.training.latent_viz_step_interval
+
         try:
             for epoch in range(epochs):
+                self._current_epoch = epoch
+
                 logger.info(f"{'-' * 30}")
                 logger.info(f"Epoch {epoch + 1}/{epochs} Start")
 
@@ -1177,6 +1303,9 @@ class TrainingPipeline:
                 dir="checkpoints",
             )
 
+            # Generate latent space GIF (accumulates all rounds so far)
+            self.plot_latent_space_gif(tag=f"round_{round_idx + 1:02d}", dir="checkpoints")
+
             # Save checkpoint
             self.save_models(tag=f"round_{round_idx + 1:02d}", dir="checkpoints")
 
@@ -1186,6 +1315,10 @@ class TrainingPipeline:
 
         # Run cleanup regardless if round finishes successfully or not
         finally:
+            # Clear latent viz batch
+            self._latent_viz_batch = None
+            self._latent_viz_labels = None
+
             # NOTE: should check to make sure holders & datasets exist first
             # Clear intermediate data
             train_holder.clear()
@@ -1300,6 +1433,21 @@ class TrainingPipeline:
                 # Apply accumulated gradients
                 global_norm = self._apply_gradients(accumulated_gradients)
                 epoch_gradient_norms.append(float(global_norm))
+
+                # Capture latent snapshot every N steps
+                if (
+                    hasattr(self, "_latent_viz_step_interval")
+                    and (step + 1) % self._latent_viz_step_interval == 0
+                    and hasattr(self, "_latent_viz_batch")
+                    and self._latent_viz_batch is not None
+                ):
+                    self._capture_latent_snapshot(
+                        self._current_round_idx,
+                        self._current_epoch,
+                        step,
+                        self._current_snr_base,
+                        self._current_snr_range,
+                    )
 
                 for key, loss in step_losses.items():
                     # Average step losses over sub-steps
@@ -3204,6 +3352,278 @@ class TrainingPipeline:
                 title=f"Final global intensity biases - ({tag}, {machine_name})",
             )
 
+    def plot_latent_space_gif(self, tag: str | None = None, dir: str | None = None):
+        """
+        Generate GIFs showing how the latent space evolves during training.
+
+        Produces two GIFs (PCA and UMAP) with 8 color categories (4 signal types × ON/OFF).
+        Queries latent snapshots from DB, fits global DR models, and renders frames with
+        consistent axes.
+
+        Args:
+            tag: Plot tag for filename (defaults to save_tag)
+            dir: Subdirectory (e.g., "checkpoints" for per-round)
+        """
+        if tag is None:
+            tag = self.config.checkpoint.save_tag
+
+        if dir is not None:
+            save_dir = os.path.join(self.config.output_path, "plots", dir)
+        else:
+            save_dir = os.path.join(self.config.output_path, "plots")
+        os.makedirs(save_dir, exist_ok=True)
+
+        if self.db is None:
+            raise RuntimeError("No database instance detected - cannot generate latent space GIF")
+
+        # Flush database to ensure all latent snapshots are written before plotting
+        logger.info("Flushing database before latent space GIF generation...")
+        if not self.db.flush():
+            logger.warning(
+                "Database flush failed. GIF generation may encounter issues. Proceeding anyways..."
+            )
+        else:
+            logger.info("Database flushed")
+
+        # Step 1: Query distinct snapshot keys
+        snapshot_keys = self.db.query_latent_snapshot_keys(
+            tag=self.config.checkpoint.save_tag,
+            start_time=self.start_time,
+        )
+
+        if not snapshot_keys:
+            logger.warning("No latent snapshots found in database — skipping GIF generation")
+            return
+
+        logger.info(f"Found {len(snapshot_keys)} unique snapshots for GIF generation")
+
+        # Step 1b: Subsample to ~200 frames if too many snapshots
+        max_frames = 200
+        if len(snapshot_keys) > max_frames:
+            # Use log-spaced indices for more detail early in training
+            indices = np.unique(
+                np.logspace(0, np.log10(len(snapshot_keys) - 1), num=max_frames).astype(int)
+            )
+            snapshot_keys = [snapshot_keys[i] for i in indices]
+            logger.info(f"Subsampled to {len(snapshot_keys)} frames (log-spaced)")
+
+        # Step 2: Load selected snapshots and pool latent data
+        all_coords = []  # List of (N_obs, latent_dim) arrays per snapshot
+        all_snapshot_labels = []  # List of (N_obs,) label arrays per snapshot
+        all_snapshot_onoff = []  # List of (N_obs,) ON/OFF arrays per snapshot
+        snapshot_metadata = []  # (round, epoch, step, snr_base, snr_range) per snapshot
+
+        for key in snapshot_keys:
+            rows = self.db.query_latent_snapshots(
+                tag=self.config.checkpoint.save_tag,
+                round_number=key["round_number"],
+                epoch_number=key["epoch_number"],
+                step_number=key["step_number"],
+                columns=["cadence_index", "signal_type", "latent_vector"],
+            )
+
+            if not rows:
+                continue
+
+            # Parse latent vectors and build arrays
+            snapshot_latents = []
+            snapshot_labels = []
+            snapshot_onoff = []
+
+            for row in rows:
+                latent_6x = json.loads(row["latent_vector"])  # (6, latent_dim)
+                for obs_idx, vec in enumerate(latent_6x):
+                    snapshot_latents.append(vec)
+                    snapshot_labels.append(row["signal_type"])
+                    snapshot_onoff.append("ON" if obs_idx % 2 == 0 else "OFF")
+
+            all_coords.append(np.array(snapshot_latents, dtype=np.float32))
+            all_snapshot_labels.append(snapshot_labels)
+            all_snapshot_onoff.append(snapshot_onoff)
+            snapshot_metadata.append(key)
+
+        if not all_coords:
+            logger.warning("No valid latent data loaded — skipping GIF generation")
+            return
+
+        # Pool all latents for global DR fit
+        pooled = np.concatenate(all_coords, axis=0)
+        logger.info(
+            f"Pooled {pooled.shape[0]} latent vectors from {len(all_coords)} snapshots "
+            f"for DR fitting"
+        )
+
+        # Step 3: Fit global DR models
+        pca = PCA(n_components=2, random_state=42).fit(pooled)
+        umap_model = umap.UMAP(n_components=2, random_state=42).fit(pooled)
+        del pooled
+
+        # Step 4: Transform each snapshot and compute global axis limits
+        pca_transformed = []
+        umap_transformed = []
+
+        for coords in all_coords:
+            pca_transformed.append(pca.transform(coords))
+            umap_transformed.append(umap_model.transform(coords))
+
+        del all_coords
+
+        # Compute consistent axis limits with 5% padding
+        def _compute_limits(transformed_list):
+            all_2d = np.concatenate(transformed_list, axis=0)
+            x_min, x_max = all_2d[:, 0].min(), all_2d[:, 0].max()
+            y_min, y_max = all_2d[:, 1].min(), all_2d[:, 1].max()
+            x_pad = (x_max - x_min) * 0.05
+            y_pad = (y_max - y_min) * 0.05
+            return (x_min - x_pad, x_max + x_pad), (y_min - y_pad, y_max + y_pad)
+
+        pca_xlim, pca_ylim = _compute_limits(pca_transformed)
+        umap_xlim, umap_ylim = _compute_limits(umap_transformed)
+
+        # Step 5: Generate frames
+        colors = {
+            ("false_no_signal", "ON"): "#90CAF9",
+            ("false_no_signal", "OFF"): "#1565C0",
+            ("false_with_rfi", "ON"): "#FFCC80",
+            ("false_with_rfi", "OFF"): "#E65100",
+            ("true_only_eti", "ON"): "#A5D6A7",
+            ("true_only_eti", "OFF"): "#2E7D32",
+            ("true_eti_rfi", "ON"): "#EF9A9A",
+            ("true_eti_rfi", "OFF"): "#C62828",
+        }
+        display_names = {
+            ("false_no_signal", "ON"): "No Signal ON",
+            ("false_no_signal", "OFF"): "No Signal OFF",
+            ("false_with_rfi", "ON"): "RFI Only ON",
+            ("false_with_rfi", "OFF"): "RFI Only OFF",
+            ("true_only_eti", "ON"): "ETI Only ON",
+            ("true_only_eti", "OFF"): "ETI Only OFF",
+            ("true_eti_rfi", "ON"): "ETI+RFI ON",
+            ("true_eti_rfi", "OFF"): "ETI+RFI OFF",
+        }
+
+        temp_dir = tempfile.mkdtemp(prefix="latent_gif_")
+
+        methods = [
+            ("pca", pca_transformed, pca_xlim, pca_ylim),
+            ("umap", umap_transformed, umap_xlim, umap_ylim),
+        ]
+
+        gif_paths = {}
+
+        for method_name, transformed_list, xlim, ylim in methods:
+            frame_paths = []
+
+            for frame_idx, (coords_2d, labels, onoff, meta) in enumerate(
+                zip(
+                    transformed_list,
+                    all_snapshot_labels,
+                    all_snapshot_onoff,
+                    snapshot_metadata,
+                    strict=True,
+                )
+            ):
+                fig, ax = plt.subplots(1, 1, figsize=(10, 8))
+
+                # Plot each category
+                labels_arr = np.array(labels)
+                onoff_arr = np.array(onoff)
+
+                for (stype, status), color in colors.items():
+                    mask = (labels_arr == stype) & (onoff_arr == status)
+                    if mask.any():
+                        ax.scatter(
+                            coords_2d[mask, 0],
+                            coords_2d[mask, 1],
+                            c=color,
+                            s=5,
+                            alpha=0.3,
+                            label=display_names[(stype, status)],
+                            rasterized=True,
+                        )
+
+                ax.set_xlim(xlim)
+                ax.set_ylim(ylim)
+
+                snr_base = meta["snr_base"]
+                snr_range = meta["snr_range"]
+                snr_ceil = snr_base + snr_range if snr_base and snr_range else "?"
+                ax.set_title(
+                    f"Latent Space ({method_name.upper()}) — "
+                    f"Round {meta['round_number']}, "
+                    f"Epoch {meta['epoch_number']}, "
+                    f"Step {meta['step_number']} "
+                    f"(SNR: {snr_base}–{snr_ceil})",
+                    fontsize=11,
+                )
+                ax.set_xlabel(f"{method_name.upper()} 1")
+                ax.set_ylabel(f"{method_name.upper()} 2")
+
+                # Legend (only on first frame, carried across)
+                if frame_idx == 0:
+                    ax.legend(
+                        loc="upper right",
+                        fontsize=7,
+                        markerscale=3,
+                        ncol=2,
+                        framealpha=0.8,
+                    )
+                else:
+                    # Recreate legend on every frame for GIF consistency
+                    ax.legend(
+                        loc="upper right",
+                        fontsize=7,
+                        markerscale=3,
+                        ncol=2,
+                        framealpha=0.8,
+                    )
+
+                plt.tight_layout()
+
+                frame_path = os.path.join(temp_dir, f"{method_name}_frame_{frame_idx:05d}.png")
+                fig.savefig(frame_path, dpi=100)
+                plt.close(fig)
+                frame_paths.append(frame_path)
+
+            # Step 6: Assemble GIF
+            gif_filename = f"latent_space_{method_name}_{tag}.gif"
+            gif_path = os.path.join(save_dir, gif_filename)
+
+            frames = [Image.open(p) for p in frame_paths]
+            if frames:
+                frames[0].save(
+                    gif_path,
+                    save_all=True,
+                    append_images=frames[1:],
+                    duration=self.config.training.latent_viz_gif_duration_ms,
+                    loop=0,
+                )
+                logger.info(
+                    f"Latent space {method_name.upper()} GIF saved: {gif_path} "
+                    f"({len(frames)} frames)"
+                )
+
+                # Upload to Slack
+                logger_instance = get_logger()
+                if logger_instance:
+                    logger_instance.upload_image_to_slack(
+                        gif_path,
+                        title=f"Latent Space {method_name.upper()} - ({tag})",
+                    )
+
+            # Close PIL images
+            for f in frames:
+                f.close()
+            del frames
+
+            gif_paths[method_name] = gif_path
+
+        # Step 8: Cleanup
+        del pca_transformed, umap_transformed
+        del all_snapshot_labels, all_snapshot_onoff, snapshot_metadata
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        gc.collect()
+
     def save_models(self, tag: str | None = None, dir: str | None = None):
         """Save model weights"""
         if tag is None:
@@ -3347,6 +3767,9 @@ def run_training_pipeline(
 
             # Plot injection stats
             pipeline.plot_injection_stats()
+
+            # Plot latent space GIF
+            pipeline.plot_latent_space_gif()
         except Exception as e:
             logger.error(f"Error in plotting: {e}")
             raise  # Re-raise to propagate error

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -21,14 +21,13 @@ import time
 from collections.abc import Callable
 from datetime import datetime
 
+import imageio.v3 as iio
 import matplotlib.lines as mlines
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import numpy as np
 import tensorflow as tf
 import umap
-from PIL import Image
-from sklearn.decomposition import PCA
 from tensorflow.keras.initializers import GlorotNormal, HeNormal
 from tensorflow.keras.layers import Conv2D, Dense
 
@@ -318,25 +317,25 @@ def check_encoder_trained(encoder, threshold=0.2):
 
 
 # Create data holder objects, to be paired with data generators, for TF's distributed datasets
-# Allows for explicit dereferencing of large arrays using DataHolder.clear(), which lets
+# Allows for explicit dereferencing of large arrays using holder.clear(), which lets
 # Python's garbage collector free up memory on-demand
-# Note, DataHolder.clear() is only useful at the end of an epoch, once indices have been exhausted,
+# Note, holder.clear() is only useful at the end of an epoch, once indices have been exhausted,
 # since the data generators' local caches maintain references to the data until then
 # This is not an issue in our current implementation, where we only clear & reset resources at the
 # end of a round. However, if you require early exit behavior, you may want to remove the _lock and
 # use explicit _cleared() checks instead, which negates the need for local caches (see commit hash
 # 2a404a4). The trade-off being that you're at risk of race conditions if multiple threads attempt
-# to access/clear the DataHolder simultaneously. While this is not the case in our current
+# to access/clear the holder simultaneously. While this is not the case in our current
 # implementation, we opted for a more defensive approach rather than accomodating future design
-# patterns. As well, the data should not be modified once the DataHolder has been initialized to
-# prevent corrupted state in the DataHolder
-# Note, there's a potential deadlock issue with DataHolder's lock contention
+# patterns. As well, the data should not be modified once the holder has been initialized to
+# prevent corrupted state in the holder
+# Note, there's a potential deadlock issue with holder lock contention
 # Since the generators acquire locks at the start of every loop iteration, if TF's prefetch threads
 # (.prefetch(tf.data.AUTOTUNE)) are blocked waiting on this lock while the main thread is trying to
-# call self.data_generator.clear() (which also needs the lock), there could be contention.
+# call holder.clear() (which also needs the lock), there could be contention.
 # This has not been an issue so far, but if you encounter this in the future, pls update this
 # comment with your findings
-class DataHolder:
+class TrainDataHolder:
     def __init__(self, concat, true, false):
         self._cleared = False
         self._lock = threading.Lock()
@@ -354,9 +353,38 @@ class DataHolder:
             self.false = None
 
 
+class InfDataHolder:
+    def __init__(self, true, false):
+        self._cleared = False
+        self._lock = threading.Lock()
+        self.true = true
+        self.false = false
+
+    def clear(self):
+        with self._lock:
+            if self._cleared:
+                return
+            self._cleared = True
+            self.true = None
+            self.false = None
+
+
+class VizDataHolder:
+    def __init__(self, concat):
+        self._cleared = False
+        self._lock = threading.Lock()
+        self.concat = concat
+
+    def clear(self):
+        with self._lock:
+            if self._cleared:
+                return
+            self._cleared = True
+            self.concat = None
+
+
 def prepare_distributed_train_dataset(
     data: dict,
-    n_samples: int,
     train_val_split: float,
     per_replica_batch_size: int,
     effective_batch_size: int,
@@ -367,10 +395,10 @@ def prepare_distributed_train_dataset(
 ) -> dict:
     """
     Prepare distributed datasets for training & validation
+    Yields datasets with signature ((concat, true, false), concat)
 
     Args:
         data: Dictionary with keys 'concatenated', 'true', 'false' (numpy arrays)
-        n_samples: Number of samples in data
         train_val_split: Split data into train/val sets
         per_replica_batch_size: Batch size per replica for training
         effective_batch_size: Effective batch size across all replicas for training
@@ -380,16 +408,36 @@ def prepare_distributed_train_dataset(
         shuffle: Whether to shuffle training data
 
     Returns: {train_dataset, val_dataset, n_train_trimmed, n_val_trimmed, train_steps,
-              accumulation_steps, val_steps, _train_holder, _val_holder}
+              accumulation_steps, val_steps, _train_holder, _val_holder, val_indices}
              Train/val distributed datasets, number of samples in each, number of steps for each
-              (including accumulation sub-steps), and DataHoldedr references for each
+              (including accumulation sub-steps), TrainDataHolder references for each, and the
+              stratified validation indices into the original data arrays
     """
     global_train_batch_size = per_replica_batch_size * num_replicas
     global_val_batch_size = per_replica_val_batch_size * num_replicas
 
-    # Split into train & val
-    n_train = int(n_samples * train_val_split)
-    n_val = n_samples - n_train
+    # Stratified train/val split to ensure both sets contain proportional representation
+    # of all 4 signal types (false_no_signal, false_with_rfi, true_only_eti, true_eti_rfi).
+    # This is necessary because generate_triplet_batch() arranges labels sequentially within
+    # chunks, so a naive positional split would over-represent later signal types in val.
+    labels = data["labels"]
+    unique_labels = np.unique(labels)
+
+    train_indices = []
+    val_indices = []
+
+    for label in unique_labels:
+        label_indices = np.where(labels == label)[0]
+        np.random.shuffle(label_indices)
+        n_label_train = int(len(label_indices) * train_val_split)
+        train_indices.append(label_indices[:n_label_train])
+        val_indices.append(label_indices[n_label_train:])
+
+    train_indices = np.concatenate(train_indices)
+    val_indices = np.concatenate(val_indices)
+
+    n_train = len(train_indices)
+    n_val = len(val_indices)
 
     # Trim datasets to fit train/val batch sizes (prevents uneven batches on final step)
     # Note, n_train should already be divisible by effective_batch_size and
@@ -401,21 +449,24 @@ def prepare_distributed_train_dataset(
     n_train_trimmed = (n_train // effective_batch_size) * effective_batch_size
     n_val_trimmed = (n_val // global_val_batch_size) * global_val_batch_size
 
+    # Randomly subsample to trimmed size (avoids positional bias from slicing the tail)
+    if n_train_trimmed < n_train:
+        train_indices = np.random.choice(train_indices, size=n_train_trimmed, replace=False)
+    if n_val_trimmed < n_val:
+        val_indices = np.random.choice(val_indices, size=n_val_trimmed, replace=False)
+
     logger.info(f"Data alignment: Train {n_train}→{n_train_trimmed}, Val {n_val}→{n_val_trimmed}")
 
-    # Prepare data
-    train_concat = data["concatenated"][:n_train_trimmed]
-    train_true = data["true"][:n_train_trimmed]
-    train_false = data["false"][:n_train_trimmed]
-    train_holder = DataHolder(train_concat, train_true, train_false)
+    # Prepare data using stratified indices
+    train_concat = data["concatenated"][train_indices]
+    train_true = data["true"][train_indices]
+    train_false = data["false"][train_indices]
+    train_holder = TrainDataHolder(train_concat, train_true, train_false)
 
-    val_start = n_train
-    val_end = val_start + n_val_trimmed
-
-    val_concat = data["concatenated"][val_start:val_end]
-    val_true = data["true"][val_start:val_end]
-    val_false = data["false"][val_start:val_end]
-    val_holder = DataHolder(val_concat, val_true, val_false)
+    val_concat = data["concatenated"][val_indices]
+    val_true = data["true"][val_indices]
+    val_false = data["false"][val_indices]
+    val_holder = TrainDataHolder(val_concat, val_true, val_false)
 
     # Create generator functions for memory-efficient data loading
     def train_generator():
@@ -491,7 +542,7 @@ def prepare_distributed_train_dataset(
     val_dataset = (
         tf.data.Dataset.from_generator(val_generator, output_signature=output_signature)
         .batch(global_val_batch_size, drop_remainder=True)
-        # NOTE: do we need repeat for val dataset?
+        # NOTE: do we need repeat for val dataset? run test without repeat & see if anything breaks?
         .repeat()
         .prefetch(tf.data.AUTOTUNE)
     )
@@ -531,34 +582,36 @@ def prepare_distributed_train_dataset(
         "val_steps": val_steps,
         "_train_holder": train_holder,
         "_val_holder": val_holder,
+        "val_indices": val_indices,  # For train_round() -> _prepare_latent_viz_batch()
     }
 
 
 def prepare_distributed_inf_dataset(
     data: dict,
-    n_samples: int,
     per_replica_inf_batch_size: int,
     num_replicas: int,
     strategy: tf.distribute.Strategy,
 ) -> dict:
     """
     Prepare distributed datasets for inference
+    Yields datasets with signature (true, false)
+
     Note, this function is meant for RF training
     It is different from aetherscan.inference.prepare_distributed_inf_dataset(),
     since we assume signal classes are known ahead of time
 
     Args:
         data: Dictionary with keys 'concatenated', 'true', 'false' (numpy arrays)
-        n_samples: Number of samples in data
         per_replica_inf_batch_size: Batch size per replica for inference
         num_replicas: Number of replicas in strategy
         strategy: TensorFlow distribution strategy
 
     Returns: {inf_dataset, n_inf_trimmed, inf_steps, _inf_holder}
              Inference distributed dataset, number of samples, number of steps,
-              and DataHolder reference
+              and InfDataHolder reference
     """
     global_inf_batch_size = per_replica_inf_batch_size * num_replicas
+    n_samples = data["true"].shape[0]
 
     # NOTE: does trimming/divisibility matter for inference?
     # Trim datasets to fit batch sizes (prevents uneven batches on final step)
@@ -570,11 +623,16 @@ def prepare_distributed_inf_dataset(
 
     logger.info(f"Data alignment: Inf {n_samples}→{n_inf_trimmed}")
 
-    # Prepare data
-    inf_concat = data["concatenated"][:n_inf_trimmed]
-    inf_true = data["true"][:n_inf_trimmed]
-    inf_false = data["false"][:n_inf_trimmed]
-    inf_holder = DataHolder(inf_concat, inf_true, inf_false)
+    # Randomly subsample to trimmed size (avoids positional bias from slicing the tail)
+    if n_inf_trimmed < n_samples:
+        indices = np.random.choice(n_samples, size=n_inf_trimmed, replace=False)
+        inf_true = data["true"][indices]
+        inf_false = data["false"][indices]
+    else:
+        inf_true = data["true"][:n_inf_trimmed]
+        inf_false = data["false"][:n_inf_trimmed]
+
+    inf_holder = InfDataHolder(inf_true, inf_false)
 
     # Create generator function for memory-efficient data loading
     def inf_generator():
@@ -585,26 +643,21 @@ def prepare_distributed_inf_dataset(
                 if inf_holder._cleared:
                     return  # Exit if data already cleared
                 # Cache references while holding lock
-                concat = inf_holder.concat
                 true = inf_holder.true
                 false = inf_holder.false
 
             # Maintain order on each epoch since shuffling provides no benefits (no gradients
             # are calculated during inference)
-            for idx in range(len(concat)):
-                yield (concat[idx], true[idx], false[idx]), concat[idx]
+            for idx in range(len(true)):
+                yield true[idx], false[idx]
 
             # Remove cache references for future garbage collection
-            del concat, true, false
+            del true, false
 
     # Determine dataset output signature
-    sample_shape = inf_concat.shape[1:]
+    sample_shape = inf_true.shape[1:]
     output_signature = (
-        (
-            tf.TensorSpec(shape=sample_shape, dtype=tf.float32),
-            tf.TensorSpec(shape=sample_shape, dtype=tf.float32),
-            tf.TensorSpec(shape=sample_shape, dtype=tf.float32),
-        ),
+        tf.TensorSpec(shape=sample_shape, dtype=tf.float32),
         tf.TensorSpec(shape=sample_shape, dtype=tf.float32),
     )
 
@@ -619,7 +672,7 @@ def prepare_distributed_inf_dataset(
     inf_dataset = (
         tf.data.Dataset.from_generator(inf_generator, output_signature=output_signature)
         .batch(global_inf_batch_size, drop_remainder=True)
-        # NOTE: do we need repeat for inf dataset?
+        # NOTE: do we need repeat for inf dataset? run test without repeat & see if anything breaks?
         .repeat()
         .prefetch(tf.data.AUTOTUNE)
     )
@@ -643,6 +696,112 @@ def prepare_distributed_inf_dataset(
         "n_inf_trimmed": n_inf_trimmed,
         "inf_steps": inf_steps,
         "_inf_holder": inf_holder,
+    }
+
+
+def prepare_distributed_viz_dataset(
+    concat_data: np.ndarray,
+    per_replica_inf_batch_size: int,
+    num_replicas: int,
+    strategy: tf.distribute.Strategy,
+) -> dict:
+    """
+    Prepare distributed datasets for latent space visualization
+    Yields datasets with signature (concat)
+
+    Args:
+        concat_data: Concatenated cadences array, shape (n_cadences, 6, 16, width_bin)
+        per_replica_inf_batch_size: Batch size per replica for inference
+        num_replicas: Number of replicas in strategy
+        strategy: TensorFlow distribution strategy
+
+    Returns: {viz_dataset, n_padded, n_samples, viz_steps, _viz_holder}
+             Viz distributed dataset, number of padded samples, number of real/unpadded samples,
+              number of steps, and VizDataHolder reference
+    """
+    global_viz_batch_size = per_replica_inf_batch_size * num_replicas
+    n_samples = concat_data.shape[0]
+
+    # NOTE: does padding/divisibility matter for inference?
+    # Pad datasets to fit batch sizes (prevents uneven batches on final step)
+    # Note, n_samples should already be divisible by effective_batch_size
+    # Padding here is just a defensive measure to doubly ensure divisibility before creating &
+    # distributing our datasets
+    # Alternatively, we could also trim the data instead of padding
+    n_padded = int(np.ceil(n_samples / global_viz_batch_size)) * global_viz_batch_size
+
+    if n_padded > n_samples:
+        pad_count = n_padded - n_samples
+        pad_indices = np.random.choice(n_samples, size=pad_count, replace=True)
+        padded_data = np.concatenate([concat_data, concat_data[pad_indices]], axis=0)
+        logger.info(f"Data alignment: Viz {n_samples}→{n_padded} (padded {pad_count})")
+    else:
+        padded_data = concat_data
+        logger.info(f"Data alignment: Viz {n_samples} (no padding needed)")
+
+    viz_holder = VizDataHolder(padded_data)
+
+    # Create generator function for memory-efficient data loading
+    def viz_generator():
+        while True:  # Make generator infinite to reset state between passes
+            # Acquire lock to check cleared status and capture data references
+            # Local references keep data alive even if clear() is called mid-epoch
+            with viz_holder._lock:
+                if viz_holder._cleared:
+                    return  # Exit if data already cleared
+                # Cache references while holding lock
+                concat = viz_holder.concat
+
+            # WARN: DO NOT SHUFFLE viz_generator(), OR ELSE YOU'LL BREAK plot_latent_space_gif()
+            # Maintain order on each epoch since shuffling provides no benefits (no gradients
+            # are calculated during inference)
+            for idx in range(len(concat)):
+                yield concat[idx]
+
+            # Remove cache references for future garbage collection
+            del concat
+
+    # Determine dataset output signature
+    sample_shape = padded_data.shape[1:]
+    output_signature = tf.TensorSpec(shape=sample_shape, dtype=tf.float32)
+
+    # Create dataset using generator to reduce GPU memory pressure
+    # Data is kept on CPU & transferred to GPU in batches on-demand
+    # Note that the dataset yields data in batches before being sharded (distributed) across replicas
+    # Hence, we use global batch sizes here to ensure per replica batch sizes match expectations
+    logger.info(
+        f"Creating infinite dataset from generator with global batch size: {global_viz_batch_size}"
+    )
+
+    viz_dataset = (
+        tf.data.Dataset.from_generator(viz_generator, output_signature=output_signature)
+        .batch(global_viz_batch_size, drop_remainder=True)
+        # NOTE: do we need repeat for viz dataset? run test without repeat & see if anything breaks?
+        .repeat()
+        .prefetch(tf.data.AUTOTUNE)
+    )
+
+    # Distribute dataset across GPUs
+    logger.info(f"Distributing dataset across {num_replicas} GPUs")
+
+    viz_dataset_distributed = strategy.experimental_distribute_dataset(viz_dataset)
+
+    # Calculate steps
+    viz_steps = n_padded // global_viz_batch_size
+
+    # Sanity check: verify step sizes are valid before returning
+    if viz_steps < 1:
+        raise ValueError(
+            f"viz_steps < 1: n_padded ({n_padded}) must be >= "
+            f"per_replica_inf_batch_size * num_replicas ({per_replica_inf_batch_size} * {num_replicas})"
+        )
+
+    return {
+        "viz_dataset": viz_dataset_distributed,
+        "n_padded": n_padded,
+        "n_samples": n_samples,
+        "viz_steps": viz_steps,
+        "_viz_holder": viz_holder,
     }
 
 
@@ -676,6 +835,17 @@ class TrainingPipeline:
             self.vae = create_beta_vae_model()
             self._build_optimizer()
 
+        # NOTE: this approach doesn't play well with fault tolerance. rethink later
+        # Latent viz data (prepared once on first round, persisted across rounds)
+        self._latent_viz_batch = None
+        self._latent_viz_labels = None
+        self._latent_viz_dataset = None
+        self._latent_viz_n_padded = None
+        self._latent_viz_n_samples = None
+        self._latent_viz_steps = None
+        self._latent_viz_holder = None
+        self._viz_encode_fn = None
+
         # Initialize RF model as None
         self.rf_model = None
 
@@ -689,12 +859,10 @@ class TrainingPipeline:
 
         except Exception as e:
             logger.error(f"Error loading models from checkpoint: {e}")
-
             logger.info("Resetting config.checkpoint to start training from scratch")
             self.config.checkpoint.load_dir = None
             self.config.checkpoint.load_tag = None
             self.config.checkpoint.start_round = 1
-
             raise  # Re-raise to propagate error
 
         # NOTE: similar to _setup_directories() & archive_directory(), perhaps we need a flag that gets toggled when fault tolerance is triggered, s.t. future reads from the db know to ignore the flagged rows as "archived" from a previous failed training run?
@@ -789,221 +957,6 @@ class TrainingPipeline:
     #     logger.info(f"TensorBoard logs directory: {logs_dir}")
     #     logger.info(f"Initial global_step: {self.global_step}")
 
-    def _calculate_curriculum_snr(self, round_idx: int) -> tuple[int, int]:
-        """
-        Calculate SNR parameters for curriculum learning
-
-        Args:
-            round_idx: Current training round (0-indexed)
-            total_rounds: Total number of training rounds
-
-        Returns:
-            (snr_base, snr_range) tuple
-        """
-        total_rounds = self.config.training.num_training_rounds
-        snr_base = self.config.training.snr_base
-        initial_snr_range = self.config.training.initial_snr_range
-        final_snr_range = self.config.training.final_snr_range
-        schedule = self.config.training.curriculum_schedule
-
-        # Edge case: use initial snr range if only training for 1 round
-        if total_rounds == 1:
-            return snr_base, initial_snr_range
-
-        # Progress through curriculum: 0.0 (easy) -> 1.0 (hard)
-        progress = round_idx / (total_rounds - 1)
-
-        # Linear progression from wide to narrow SNR range
-        if schedule == "linear":
-            current_range = initial_snr_range - progress * (initial_snr_range - final_snr_range)
-        # Exponential decay - start easy, then get hard quickly
-        elif schedule == "exponential":
-            decay_rate = self.config.training.exponential_decay_rate
-            # Sanity check: validate decay_rate < 0 to avoid division by zero
-            if decay_rate >= 0:
-                raise ValueError(
-                    f"exponential_decay_rate must be < 0 for exponential schedule, got {decay_rate}"
-                )
-            # Normalize exponential to ensure exact endpoints at progress=0 and progress=1
-            decay_factor = (np.exp(decay_rate * progress) - np.exp(decay_rate)) / (
-                1 - np.exp(decay_rate)
-            )
-            current_range = final_snr_range + (initial_snr_range - final_snr_range) * decay_factor
-        # TODO: generalize this to receive a step schedule (as a list/dict?) validate that len(list/dict) is divisible by num_training_rounds
-        # Step function - easy for first part, hard for second part
-        elif schedule == "step":
-            easy_rounds = self.config.training.step_easy_rounds
-            hard_rounds = self.config.training.step_hard_rounds
-            # Sanity check: validate easy_rounds + hard_rounds add up to total_rounds
-            if easy_rounds + hard_rounds != total_rounds:
-                raise ValueError(
-                    f"easy_rounds ({easy_rounds}) + hard_rounds ({hard_rounds}) must equal total_rounds ({total_rounds}), got {easy_rounds + hard_rounds} instead"
-                )
-            if round_idx < easy_rounds:
-                current_range = initial_snr_range
-            elif round_idx - easy_rounds < hard_rounds:
-                current_range = final_snr_range
-            else:
-                raise RuntimeError(
-                    f"round_idx ({round_idx}) exceeded easy_rounds + hard_rounds ({easy_rounds} + {hard_rounds})"
-                )
-        else:
-            raise ValueError(
-                f"'{schedule} is invalid. Accepted values: 'linear', 'exponential', 'step'"
-            )
-
-        return snr_base, int(current_range)
-
-    def _update_learning_rate(self, val_losses):
-        """
-        Robust adaptive learning rate with multiple safeguards
-
-        Note the following heuristic:
-        min_learning_rate - base_learning_rate * (1 - reduction_factor) ^ (epochs_per_round / patience_threshold)
-          => LR can only reach min_learning_rate during round if above expression is > 0
-          => else LR will reset at start of new round before reaching min_learning_rate
-        """
-
-        current_lr = self.vae.optimizer.learning_rate.numpy()
-        if current_lr <= self.config.training.min_learning_rate:
-            return current_lr
-
-        # Use validation loss for better generalization
-        if not hasattr(self, "best_val_loss"):
-            self.best_val_loss = float("inf")
-            self.patience_counter = 0
-
-        current_val_loss = float(val_losses["total"])
-
-        # Check if validation loss improved
-        if current_val_loss < self.best_val_loss * (1 - self.config.training.min_pct_improvement):
-            self.best_val_loss = current_val_loss
-            self.patience_counter = 0
-        else:
-            self.patience_counter += 1
-
-        # Reduce LR if no meaningful improvement for consecutive epochs
-        if self.patience_counter >= self.config.training.patience_threshold:
-            new_lr = max(
-                current_lr * (1 - self.config.training.reduction_factor),
-                self.config.training.min_learning_rate,
-            )
-
-            self.vae.optimizer.learning_rate.assign(new_lr)
-            self.patience_counter = 0  # Reset counter
-
-            logger.info(f"Reduced learning rate: {current_lr:.2e} -> {new_lr:.2e}")
-            return new_lr
-
-        return current_lr
-
-    def _prepare_latent_viz_batch(self, concat_data, labels):
-        """
-        Subsample the full dataset by signal type for latent space visualization.
-
-        Must be called on the full pre-split dataset (not the val set) because
-        the sequential label layout within chunks means the 80/20 train/val split
-        can leave the val set with only the last signal type.
-
-        Args:
-            concat_data: Full concatenated cadences array, shape (n_samples, 6, 16, width_bin)
-            labels: Per-cadence signal type labels, shape (n_samples,)
-        """
-        n_per_type = self.config.training.latent_viz_num_cadences_per_type
-        signal_types = ["false_no_signal", "false_with_rfi", "true_only_eti", "true_eti_rfi"]
-
-        selected_indices = []
-        selected_labels = []
-
-        for stype in signal_types:
-            type_indices = np.where(labels == stype)[0]
-            if len(type_indices) == 0:
-                logger.warning(f"No cadences for {stype} — skipping this type for viz batch")
-                continue
-            if len(type_indices) < n_per_type:
-                logger.warning(
-                    f"Only {len(type_indices)} cadences for {stype} "
-                    f"(requested {n_per_type}), using all available"
-                )
-                sampled = type_indices
-            else:
-                sampled = np.random.choice(type_indices, size=n_per_type, replace=False)
-            selected_indices.append(sampled)
-            selected_labels.extend([stype] * len(sampled))
-
-        if not selected_indices:
-            logger.warning("No cadences found for any signal type — skipping viz batch")
-            self._latent_viz_batch = None
-            self._latent_viz_labels = None
-            return
-
-        all_indices = np.concatenate(selected_indices)
-        self._latent_viz_batch = concat_data[all_indices].copy()
-        self._latent_viz_labels = np.array(selected_labels, dtype="U20")
-
-        logger.info(
-            f"Prepared latent viz batch: {len(all_indices)} cadences "
-            f"({n_per_type} per type × {len(signal_types)} types)"
-        )
-
-    def _capture_latent_snapshot(self, round_idx, epoch, step, snr_base, snr_range):
-        """
-        Run encoder on viz batch and write latent vectors to DB.
-
-        Processes the viz batch through the encoder, extracts z_mean,
-        and writes one row per cadence to the latent_snapshots table.
-        """
-        if self._latent_viz_batch is None:
-            return
-
-        n_cadences = self._latent_viz_batch.shape[0]
-        num_obs = self._latent_viz_batch.shape[1]  # 6
-
-        # Reshape for encoder: (N*6, 16, 512, 1) — add channel dim
-        encoder_input = self._latent_viz_batch.reshape(
-            n_cadences * num_obs,
-            self._latent_viz_batch.shape[2],
-            self._latent_viz_batch.shape[3],
-        )
-        # Add channel dimension for Conv2D
-        encoder_input = np.expand_dims(encoder_input, axis=-1)
-
-        # Process in chunks to avoid GPU OOM
-        chunk_size = 1024
-        z_mean_parts = []
-        for i in range(0, len(encoder_input), chunk_size):
-            chunk = tf.constant(encoder_input[i : i + chunk_size], dtype=tf.float32)
-            z_mean_chunk, _, _ = self.vae.encoder(chunk, training=False)
-            z_mean_parts.append(tf.stop_gradient(z_mean_chunk).numpy())
-
-        z_mean_np = np.concatenate(z_mean_parts, axis=0)
-        del encoder_input, z_mean_parts
-
-        # Reshape back to per-cadence: (N, 6, latent_dim)
-        latent_dim = z_mean_np.shape[-1]
-        z_mean_per_cadence = z_mean_np.reshape(n_cadences, num_obs, latent_dim)
-        del z_mean_np
-
-        # Write to DB
-        timestamp = time.time()
-        tag = self.config.checkpoint.save_tag
-        for cadence_idx in range(n_cadences):
-            latent_vector_list = np.round(z_mean_per_cadence[cadence_idx], 8).tolist()
-            self.db.write_latent_snapshot(
-                round_number=round_idx + 1,
-                epoch_number=epoch + 1,
-                step_number=step + 1,
-                cadence_index=cadence_idx,
-                signal_type=str(self._latent_viz_labels[cadence_idx]),
-                latent_vector=latent_vector_list,
-                snr_base=snr_base,
-                snr_range=snr_range,
-                tag=tag,
-                timestamp=timestamp,
-            )
-
-        del z_mean_per_cadence
-
     def train_beta_vae(self):
         """
         Train beta-VAE with curriculum learning & adaptive LR setup
@@ -1022,29 +975,37 @@ class TrainingPipeline:
         # NOTE: this approach doesn't play well with fault tolerance. rethink later
         self.start_time = time.time()
 
-        for round_idx in range(start_round - 1, n_rounds):
-            snr_base, snr_range = self._calculate_curriculum_snr(round_idx)
+        try:
+            for round_idx in range(start_round - 1, n_rounds):
+                snr_base, snr_range = self._calculate_curriculum_snr(round_idx)
 
-            logger.info(f"{'=' * 50}")
-            logger.info(f"ROUND {round_idx + 1}/{n_rounds}")
-            logger.info(f"SNR range: {snr_base}-{snr_base + snr_range}")
-            logger.info(f"{'=' * 50}")
+                logger.info(f"{'=' * 50}")
+                logger.info(f"ROUND {round_idx + 1}/{n_rounds}")
+                logger.info(f"SNR range: {snr_base}-{snr_base + snr_range}")
+                logger.info(f"{'=' * 50}")
 
-            # Reset learning rate & adaptive state before new curriculum stage
-            original_lr = self.config.training.base_learning_rate
-            current_lr = self.vae.optimizer.learning_rate.numpy()
-            self.vae.optimizer.learning_rate.assign(original_lr)
+                # Reset learning rate & adaptive state before new curriculum stage
+                original_lr = self.config.training.base_learning_rate
+                current_lr = self.vae.optimizer.learning_rate.numpy()
+                self.vae.optimizer.learning_rate.assign(original_lr)
 
-            if hasattr(self, "best_val_loss"):
-                delattr(self, "best_val_loss")
-            if hasattr(self, "patience_counter"):
-                delattr(self, "patience_counter")
+                if hasattr(self, "best_val_loss"):
+                    delattr(self, "best_val_loss")
+                if hasattr(self, "patience_counter"):
+                    delattr(self, "patience_counter")
 
-            logger.info(f"Curriculum LR reset: {current_lr:.2e} → {original_lr:.2e}")
+                logger.info(f"Curriculum LR reset: {current_lr:.2e} → {original_lr:.2e}")
 
-            self.train_round(
-                round_idx=round_idx, epochs=epochs, snr_base=snr_base, snr_range=snr_range
-            )
+                self.train_round(
+                    round_idx=round_idx, epochs=epochs, snr_base=snr_base, snr_range=snr_range
+                )
+        finally:
+            # NOTE: this approach doesn't play well with fault tolerance. rethink later
+            # Free the latent viz batch once all rounds are complete (or on failure)
+            del self._latent_viz_batch, self._latent_viz_labels
+            self._latent_viz_batch = None
+            self._latent_viz_labels = None
+            gc.collect()
 
     def train_round(self, round_idx: int, epochs: int, snr_base: int, snr_range: int):
         """
@@ -1059,18 +1020,9 @@ class TrainingPipeline:
             self.config.training.num_samples_beta_vae, snr_base, snr_range, round_idx + 1
         )
 
-        # Prepare latent viz batch from full dataset before train/val split
-        # (must happen before del train_data, since labels are sequential within
-        # chunks and the 80/20 split would leave the val tail with only the last type)
-        train_labels = train_data.get("labels")
-        if train_labels is not None:
-            self._prepare_latent_viz_batch(train_data["concatenated"], train_labels)
-        del train_labels
-
         # Distribute training data
         data = prepare_distributed_train_dataset(
             data=train_data,
-            n_samples=self.config.training.num_samples_beta_vae,
             train_val_split=self.config.training.train_val_split,
             per_replica_batch_size=self.config.training.per_replica_batch_size,
             effective_batch_size=self.config.training.effective_batch_size,
@@ -1079,6 +1031,24 @@ class TrainingPipeline:
             strategy=self.strategy,
             shuffle=True,
         )
+
+        # Prepare latent viz batch (if it's the first round) using the validation partition.
+        # Using held-out data ensures the latent space visualization captures generalization, while
+        # persisting the same data across rounds eliminates the effects of distribution shift (from
+        # the curriculum schedule)
+        if self._latent_viz_batch is None:
+            train_labels = train_data.get("labels")
+            if train_labels is not None:
+                val_indices = data["val_indices"]
+                self._prepare_latent_viz_batch(
+                    train_data["concatenated"][val_indices],
+                    train_labels[val_indices],
+                )
+                del train_labels, val_indices
+        # On subsequent rounds, the latent viz batch is persisted,
+        # but the distributed dataset needs to be rebuilt
+        elif self._latent_viz_batch is not None and self._latent_viz_dataset is None:
+            self._build_latent_viz_dataset()
 
         del train_data
         gc.collect()
@@ -1101,19 +1071,18 @@ class TrainingPipeline:
         )
         logger.info(f"Gradients accumulated every {accumulation_steps} sub-steps")
 
-        # Set context for latent snapshot capture (read by _train_epoch -> _capture_latent_snapshot)
-        self._current_round_idx = round_idx
-        self._current_snr_base = snr_base
-        self._current_snr_range = snr_range
-        self._latent_viz_step_interval = self.config.training.latent_viz_step_interval
-
         try:
             for epoch in range(epochs):
-                self._current_epoch = epoch
-
                 # Training
                 epoch_losses, epoch_gradient_norms, train_duration = self._train_epoch(
-                    train_dataset, steps_per_epoch, accumulation_steps, time.time()
+                    round_idx,
+                    epoch,
+                    snr_base,
+                    snr_range,
+                    train_dataset,
+                    steps_per_epoch,
+                    accumulation_steps,
+                    time.time(),
                 )
 
                 # Validation
@@ -1283,7 +1252,7 @@ class TrainingPipeline:
                 # Adaptive learning rate
                 self._update_learning_rate(val_losses)
 
-            # NOTE: combine plot_beta_vae_loss_curves() and plot_beta_vae_training_stability() into plot_training_progress()?
+            # NOTE: combine plot_beta_vae_loss_curves(), plot_beta_vae_training_stability(), and plot_latent_space_gif() into plot_training_progress()?
             # Plot loss curves
             self.plot_beta_vae_loss_curves(tag=f"round_{round_idx + 1:02d}", dir="checkpoints")
 
@@ -1298,7 +1267,7 @@ class TrainingPipeline:
                 dir="checkpoints",
             )
 
-            # Generate latent space GIF (accumulates all rounds so far)
+            # Generate latent space GIF
             self.plot_latent_space_gif(tag=f"round_{round_idx + 1:02d}", dir="checkpoints")
 
             # Save checkpoint
@@ -1310,15 +1279,21 @@ class TrainingPipeline:
 
         # Run cleanup regardless if round finishes successfully or not
         finally:
-            # Clear latent viz batch
-            self._latent_viz_batch = None
-            self._latent_viz_labels = None
-
             # NOTE: should check to make sure holders & datasets exist first
             # Clear intermediate data
             train_holder.clear()
             val_holder.clear()
             del train_dataset, val_dataset
+
+            # Clear latent viz distributed dataset (rebuilt each round)
+            if self._latent_viz_holder is not None:
+                self._latent_viz_holder.clear()
+            self._latent_viz_dataset = None
+            self._latent_viz_n_padded = None
+            self._latent_viz_n_samples = None
+            self._latent_viz_steps = None
+            self._latent_viz_holder = None
+            self._viz_encode_fn = None
 
             # Force TensorFlow to release internal references to datasets/iterators
             # This prevents generator closures from accumulating in memory between rounds
@@ -1328,10 +1303,21 @@ class TrainingPipeline:
             # Reset multiprocessing pools in DataGenerator after each round
             # to further avoid memory accumulation
             self.data_generator.reset_managed_pool()
+            logger.info("Reset managed pools")
 
             gc.collect()
 
-    def _train_epoch(self, dataset, steps_per_epoch, accumulation_steps=1, start_time=None):
+    def _train_epoch(
+        self,
+        round_idx,
+        epoch_idx,
+        snr_base,
+        snr_range,
+        dataset,
+        steps_per_epoch,
+        accumulation_steps=1,
+        start_time=None,
+    ):
         """
         Perform a single training epoch with gradient accumulation
         """
@@ -1429,19 +1415,16 @@ class TrainingPipeline:
                 global_norm = self._apply_gradients(accumulated_gradients)
                 epoch_gradient_norms.append(float(global_norm))
 
-                # Capture latent snapshot every N steps
-                if (
-                    hasattr(self, "_latent_viz_step_interval")
-                    and (step + 1) % self._latent_viz_step_interval == 0
-                    and hasattr(self, "_latent_viz_batch")
-                    and self._latent_viz_batch is not None
-                ):
+                # Capture latent snapshot every N steps, and on the final step
+                is_interval_step = (step + 1) % self.config.training.latent_viz_step_interval == 0
+                is_final_step = (step + 1) == steps_per_epoch
+                if (is_interval_step or is_final_step) and self._latent_viz_dataset is not None:
                     self._capture_latent_snapshot(
-                        self._current_round_idx,
-                        self._current_epoch,
+                        round_idx,
+                        epoch_idx,
                         step,
-                        self._current_snr_base,
-                        self._current_snr_range,
+                        snr_base,
+                        snr_range,
                     )
 
                 for key, loss in step_losses.items():
@@ -1466,7 +1449,7 @@ class TrainingPipeline:
 
         # Run cleanup regardless if epoch finishes successfully or not
         finally:
-            # NOTE: should check to make sure iterator exist first
+            # NOTE: should check to make sure iterator exists first
             del iterator
             gc.collect()
 
@@ -1506,7 +1489,7 @@ class TrainingPipeline:
 
         # Run cleanup regardless if epoch finishes successfully or not
         finally:
-            # NOTE: should check to make sure iterator exist first
+            # NOTE: should check to make sure iterator exists first
             del iterator
             gc.collect()
 
@@ -1650,8 +1633,180 @@ class TrainingPipeline:
 
         return reduced_losses
 
-    # NOTE: write what to db?
-    # NOTE: move some of the latent generation functionality to inference.py & import into train.py instead?
+    def _calculate_curriculum_snr(self, round_idx: int) -> tuple[int, int]:
+        """
+        Calculate SNR parameters for curriculum learning
+
+        Args:
+            round_idx: Current training round (0-indexed)
+            total_rounds: Total number of training rounds
+
+        Returns:
+            (snr_base, snr_range) tuple
+        """
+        total_rounds = self.config.training.num_training_rounds
+        snr_base = self.config.training.snr_base
+        initial_snr_range = self.config.training.initial_snr_range
+        final_snr_range = self.config.training.final_snr_range
+        schedule = self.config.training.curriculum_schedule
+
+        # Edge case: use initial snr range if only training for 1 round
+        if total_rounds == 1:
+            return snr_base, initial_snr_range
+
+        # Progress through curriculum: 0.0 (easy) -> 1.0 (hard)
+        progress = round_idx / (total_rounds - 1)
+
+        # Linear progression from wide to narrow SNR range
+        if schedule == "linear":
+            current_range = initial_snr_range - progress * (initial_snr_range - final_snr_range)
+        # Exponential decay - start easy, then get hard quickly
+        elif schedule == "exponential":
+            decay_rate = self.config.training.exponential_decay_rate
+            # Sanity check: validate decay_rate < 0 to avoid division by zero
+            if decay_rate >= 0:
+                raise ValueError(
+                    f"exponential_decay_rate must be < 0 for exponential schedule, got {decay_rate}"
+                )
+            # Normalize exponential to ensure exact endpoints at progress=0 and progress=1
+            decay_factor = (np.exp(decay_rate * progress) - np.exp(decay_rate)) / (
+                1 - np.exp(decay_rate)
+            )
+            current_range = final_snr_range + (initial_snr_range - final_snr_range) * decay_factor
+        # TODO: generalize this to receive a step schedule (as a list/dict?) validate that len(list/dict) is divisible by num_training_rounds
+        # Step function - easy for first part, hard for second part
+        elif schedule == "step":
+            easy_rounds = self.config.training.step_easy_rounds
+            hard_rounds = self.config.training.step_hard_rounds
+            # Sanity check: validate easy_rounds + hard_rounds add up to total_rounds
+            if easy_rounds + hard_rounds != total_rounds:
+                raise ValueError(
+                    f"easy_rounds ({easy_rounds}) + hard_rounds ({hard_rounds}) must equal total_rounds ({total_rounds}), got {easy_rounds + hard_rounds} instead"
+                )
+            if round_idx < easy_rounds:
+                current_range = initial_snr_range
+            elif round_idx - easy_rounds < hard_rounds:
+                current_range = final_snr_range
+            else:
+                raise RuntimeError(
+                    f"round_idx ({round_idx}) exceeded easy_rounds + hard_rounds ({easy_rounds} + {hard_rounds})"
+                )
+        else:
+            raise ValueError(
+                f"'{schedule} is invalid. Accepted values: 'linear', 'exponential', 'step'"
+            )
+
+        return snr_base, int(current_range)
+
+    def _update_learning_rate(self, val_losses):
+        """
+        Robust adaptive learning rate with multiple safeguards
+
+        Note the following heuristic:
+        min_learning_rate - base_learning_rate * (1 - reduction_factor) ^ (epochs_per_round / patience_threshold)
+          => LR can only reach min_learning_rate during round if above expression is > 0
+          => else LR will reset at start of new round before reaching min_learning_rate
+        """
+
+        current_lr = self.vae.optimizer.learning_rate.numpy()
+        if current_lr <= self.config.training.min_learning_rate:
+            return current_lr
+
+        # Use validation loss for better generalization
+        if not hasattr(self, "best_val_loss"):
+            self.best_val_loss = float("inf")
+            self.patience_counter = 0
+
+        current_val_loss = float(val_losses["total"])
+
+        # Check if validation loss improved
+        if current_val_loss < self.best_val_loss * (1 - self.config.training.min_pct_improvement):
+            self.best_val_loss = current_val_loss
+            self.patience_counter = 0
+        else:
+            self.patience_counter += 1
+
+        # Reduce LR if no meaningful improvement for consecutive epochs
+        if self.patience_counter >= self.config.training.patience_threshold:
+            new_lr = max(
+                current_lr * (1 - self.config.training.reduction_factor),
+                self.config.training.min_learning_rate,
+            )
+
+            self.vae.optimizer.learning_rate.assign(new_lr)
+            self.patience_counter = 0  # Reset counter
+
+            logger.info(f"Reduced learning rate: {current_lr:.2e} -> {new_lr:.2e}")
+            return new_lr
+
+        return current_lr
+
+    def _distributed_encode(self, dataset, n_steps, encode_fn, n_samples, latent_dim):
+        """
+        Run distributed encoding over a dataset using a provided @tf.function.
+
+        The number of output arrays is inferred from encode_fn's return type on the first step:
+        a single PerReplica tensor produces 1 output, a tuple of PerReplica tensors produces N.
+
+        Args:
+            dataset: Distributed dataset to iterate
+            n_steps: Number of steps to iterate
+            encode_fn: @tf.function that takes a batch and returns one or more per-replica tensors
+            n_samples: Total number of output rows per array
+            latent_dim: Latent dimension
+
+        Returns:
+            List of np.ndarray. Each shape (n_samples, latent_dim).
+        """
+        # Process all batches
+        iterator = iter(dataset)
+        current_idx = 0
+        outputs = None
+
+        try:
+            for step in range(n_steps):
+                batch = next(iterator)
+
+                # Get per-replica latents for this batch
+                results = encode_fn(batch)
+
+                # Normalize to tuple: a single PerReplica tensor is not a tuple,
+                # while multiple outputs are returned as a tuple of PerReplica tensors
+                if not isinstance(results, tuple):
+                    results = (results,)
+
+                # Lazily allocate output arrays on first step (avoids needing n_outputs param)
+                if outputs is None:
+                    outputs = [
+                        np.empty((n_samples, latent_dim), dtype=np.float32)
+                        for _ in range(len(results))
+                    ]
+
+                # Extract results from each replica and concatenate across all replicas
+                # This avoids the inefficient gather operation with NCCL
+                for i, per_replica in enumerate(results):
+                    local_results = self.strategy.experimental_local_results(per_replica)
+                    batch_np = np.concatenate([r.numpy() for r in local_results], axis=0)
+                    batch_size = batch_np.shape[0]
+                    outputs[i][current_idx : current_idx + batch_size] = batch_np
+                    del local_results, batch_np
+
+                current_idx += batch_size
+
+                # Log progress every 10 steps or on the final step
+                if (step + 1) % 10 == 0 or (step + 1) == n_steps:
+                    logger.info(f"Encoded step {step + 1}/{n_steps}")
+
+                del results
+                gc.collect()
+        finally:
+            # NOTE: should check to make sure iterator exists first
+            del iterator
+            gc.collect()
+
+        return outputs
+
+    # NOTE: write what to db? (e.g. accuracy, F1)
     # TODO: visualize classification accuracy (ROC-AUC, precision-recall) at different thresholds when training is complete
     def train_random_forest(self):
         """Train Random Forest"""
@@ -1697,8 +1852,9 @@ class TrainingPipeline:
             logger.warning(f"Could not verify encoder weights status: {e}")
             logger.warning("Proceeding with current encoder weights")
 
-        # NOTE: divide by 2 to compensate for generate_triplet_batch creating n_samples * 2 samples
-        n_samples = self.config.training.num_samples_rf // 2
+        n_samples = (
+            self.config.training.num_samples_rf // 2
+        )  # Divide by 2 to compensate for generate_triplet_batch internally creating n * 2 samples (n true, n false)
         snr_base = self.config.training.snr_base
         snr_range = (
             self.config.training.initial_snr_range
@@ -1717,7 +1873,6 @@ class TrainingPipeline:
         # Prepare distributed dataset for inference
         results = prepare_distributed_inf_dataset(
             data=rf_data,
-            n_samples=n_samples,
             per_replica_inf_batch_size=self.config.training.per_replica_val_batch_size,
             num_replicas=self.strategy.num_replicas_in_sync,
             strategy=self.strategy,
@@ -1736,28 +1891,21 @@ class TrainingPipeline:
 
         logger.info(f"Generating latents for {n_inf_trimmed} samples using distributed inference")
 
-        # Pre-allocate latent arrays
-        # Use np.empty() instead of np.zeros() so problematic latent values don't fail silently
-        true_latents = np.empty((n_inf_trimmed * num_observations, latent_dim), dtype=np.float32)
-        false_latents = np.empty((n_inf_trimmed * num_observations, latent_dim), dtype=np.float32)
-
         # Create distributed inference function
         @tf.function
-        def distributed_encode(batch_data):
+        def rf_encode_fn(batch_data):
             """Encode batch data using distributed strategy"""
 
             def encode_fn(data):
                 """Per-replica encoding step"""
-                x, _ = data
-                true_data = x[1]  # Extract true component
-                false_data = x[2]  # Extract false component
+                # Extract true & false components
+                true_data, false_data = data
 
                 # Reshape for encoder: (batch, 6, 16, 512) -> (batch * 6, 16, 512, 1)
-                batch_size = tf.shape(true_data)[0]
                 true_reshaped = tf.reshape(true_data, [-1, time_bins, width_bin, 1])
                 false_reshaped = tf.reshape(false_data, [-1, time_bins, width_bin, 1])
 
-                # Encode (returns mean, log_var, z)
+                # Encode (returns z_mean, z_log_var, z)
                 _, _, true_z = self.vae.encoder(true_reshaped, training=False)
                 _, _, false_z = self.vae.encoder(false_reshaped, training=False)
 
@@ -1768,39 +1916,15 @@ class TrainingPipeline:
 
             return per_replica_true, per_replica_false
 
-        # Process all batches
-        iterator = iter(inf_dataset)
-        current_idx = 0
-
         try:
-            for step in range(inf_steps):
-                batch = next(iterator)
-
-                # Get per-replica latents for this batch
-                per_replica_true, per_replica_false = distributed_encode(batch)
-
-                # Extract results from each replica and concatenate
-                # This avoids the inefficient gather operation with NCCL
-                true_results = self.strategy.experimental_local_results(per_replica_true)
-                false_results = self.strategy.experimental_local_results(per_replica_false)
-
-                # Concatenate results from all replicas
-                true_batch_np = np.concatenate([t.numpy() for t in true_results], axis=0)
-                false_batch_np = np.concatenate([f.numpy() for f in false_results], axis=0)
-
-                batch_latent_size = true_batch_np.shape[0]
-                true_latents[current_idx : current_idx + batch_latent_size] = true_batch_np
-                false_latents[current_idx : current_idx + batch_latent_size] = false_batch_np
-
-                current_idx += batch_latent_size
-
-                # Log progress
-                if (step + 1) % 10 == 0 or (step + 1) == inf_steps:
-                    logger.info(f"Generated latents for step {step + 1}/{inf_steps}")
-
-                del per_replica_true, true_results, true_batch_np
-                del per_replica_false, false_results, false_batch_np
-                gc.collect()
+            # TEST: make sure this works after refactor
+            true_latents, false_latents = self._distributed_encode(
+                dataset=inf_dataset,
+                n_steps=inf_steps,
+                encode_fn=rf_encode_fn,
+                n_samples=n_inf_trimmed * num_observations,
+                latent_dim=latent_dim,
+            )
 
             # Train Random Forest classifier
             self.rf_model.train(true_latents, false_latents)
@@ -1812,9 +1936,6 @@ class TrainingPipeline:
             raise  # Re-raise to propagate error
 
         finally:
-            # NOTE: should check to make sure iterator exist first
-            del iterator
-
             # NOTE: should check to make sure holder & dataset exist first
             # Clear intermediate data
             inf_holder.clear()
@@ -1827,134 +1948,14 @@ class TrainingPipeline:
 
             # Reset multiprocessing pools in DataGenerator to further avoid memory accumulation
             self.data_generator.reset_managed_pool()
+            logger.info("Reset managed pools")
 
             # NOTE: should check to make sure arrays exist first
             del true_latents, false_latents
             gc.collect()
 
-    def _get_snr_by_round(self, current_time: float) -> dict[int, dict[str, float]]:
-        """
-        Query SNR range data from training_stats and return per-round SNR info.
-
-        Returns:
-            Dict mapping round_number to {"floor": x, "ceil": y}
-        """
-        if self.db is None:
-            return {}
-
-        snr_by_round: dict[int, dict[str, float]] = {}
-
-        # Query snr_range_floor
-        floor_results = self.db.query_training_stat(
-            model_name="beta_vae",
-            stat_name="snr_range_floor",
-            tag=self.config.checkpoint.save_tag,
-            start_time=self.start_time,
-            end_time=current_time,
-        )
-
-        for r in floor_results:
-            round_num = r["round_number"]
-            if round_num not in snr_by_round:
-                snr_by_round[round_num] = {}
-            snr_by_round[round_num]["floor"] = r["value"]
-
-        del floor_results
-
-        # Query snr_range_ceil
-        ceil_results = self.db.query_training_stat(
-            model_name="beta_vae",
-            stat_name="snr_range_ceil",
-            tag=self.config.checkpoint.save_tag,
-            start_time=self.start_time,
-            end_time=current_time,
-        )
-
-        for r in ceil_results:
-            round_num = r["round_number"]
-            if round_num not in snr_by_round:
-                snr_by_round[round_num] = {}
-            snr_by_round[round_num]["ceil"] = r["value"]
-
-        del ceil_results
-
-        return snr_by_round
-
-    def _add_snr_range_shading(
-        self,
-        ax,
-        snr_by_round: dict[int, dict[str, float]],
-        epochs_per_round: int | None = None,
-        use_rounds: bool = False,
-        show_text_annotations: bool = True,
-    ) -> None:
-        """
-        Add transparent background regions showing SNR range per round.
-
-        Args:
-            ax: Matplotlib axis to add shading to
-            snr_by_round: Dict mapping round_number to {"floor": x, "ceil": y}
-            epochs_per_round: Number of epochs per training round (required if use_rounds=False)
-            use_rounds: If True, use round numbers for x-axis; if False, use epochs
-            show_text_annotations: If True, show SNR range text annotations in subplot
-        """
-        if not snr_by_round:
-            return
-
-        if not use_rounds and epochs_per_round is None:
-            raise ValueError("epochs_per_round is required when use_rounds=False")
-
-        # Alternating colors for visual distinction
-        colors = ["#e6f2ff", "#fff2e6"]  # Light blue, light orange
-        hatches = ["//", None]  # Striped for odd idx, solid for even idx
-
-        fontsize, rotation = 10, 0
-
-        for idx, (round_num, snr_info) in enumerate(sorted(snr_by_round.items())):
-            if "floor" not in snr_info or "ceil" not in snr_info:
-                continue
-
-            # Calculate x positions based on use_rounds flag
-            if use_rounds:
-                start_x = round_num - 0.5
-                end_x = round_num + 0.5
-                mid_x = round_num
-            else:
-                start_epoch = (round_num - 1) * epochs_per_round + 1
-                end_epoch = round_num * epochs_per_round
-                start_x = start_epoch - 0.5
-                end_x = end_epoch + 0.5
-                mid_x = (start_epoch + end_epoch) / 2
-
-            # Add shaded region with alternating hatch patterns
-            hatch = hatches[idx % 2]
-            ax.axvspan(
-                start_x,
-                end_x,
-                color=colors[idx % 2],
-                alpha=0.5,
-                zorder=0,
-                hatch=hatch,
-                edgecolor="gray" if hatch else None,
-            )
-
-            # Add SNR text annotation at top of region
-            if show_text_annotations:
-                snr_floor = int(snr_info["floor"])
-                snr_ceil = int(snr_info["ceil"])
-                ax.text(
-                    mid_x,
-                    0.98,
-                    f"SNR: {snr_floor}-{snr_ceil}",
-                    transform=ax.get_xaxis_transform(),
-                    ha="center",
-                    va="top",
-                    fontsize=fontsize,
-                    rotation=rotation,
-                    alpha=0.7,
-                )
-
-    # NOTE: combine with plot_beta_vae_training_stability() into plot_training_stats(), similar to plot_injection_stats()?
+    # TODO: reorder plot methods (def & call sites): train -> latent -> injection
+    # NOTE: combine plot_beta_vae_loss_curves(), plot_beta_vae_training_stability(), and plot_latent_space_gif() into plot_training_progress()?
     def plot_beta_vae_loss_curves(self, tag: str | None = None, dir: str | None = None):
         """Plot beta-VAE training history"""
         if tag is None:
@@ -2153,7 +2154,8 @@ class TrainingPipeline:
         del snr_by_round
         gc.collect()
 
-    # NOTE: combine with plot_beta_vae_loss_curves() into plot_training_stats(), similar to plot_injection_stats()?
+    # TODO: reorder plot methods (def & call sites): train -> latent -> injection
+    # NOTE: combine plot_beta_vae_loss_curves(), plot_beta_vae_training_stability(), and plot_latent_space_gif() into plot_training_progress()?
     def plot_beta_vae_training_stability(self, tag: str | None = None, dir: str | None = None):
         """
         Plot gradient clipping rate and gradient norm statistics.
@@ -2385,6 +2387,129 @@ class TrainingPipeline:
         del history, snr_by_round, epochs
         gc.collect()
 
+    def _get_snr_by_round(self, current_time: float) -> dict[int, dict[str, float]]:
+        """
+        Query SNR range data from training_stats and return per-round SNR info.
+
+        Returns:
+            Dict mapping round_number to {"floor": x, "ceil": y}
+        """
+        if self.db is None:
+            return {}
+
+        snr_by_round: dict[int, dict[str, float]] = {}
+
+        # Query snr_range_floor
+        floor_results = self.db.query_training_stat(
+            model_name="beta_vae",
+            stat_name="snr_range_floor",
+            tag=self.config.checkpoint.save_tag,
+            start_time=self.start_time,
+            end_time=current_time,
+        )
+
+        for r in floor_results:
+            round_num = r["round_number"]
+            if round_num not in snr_by_round:
+                snr_by_round[round_num] = {}
+            snr_by_round[round_num]["floor"] = r["value"]
+
+        del floor_results
+
+        # Query snr_range_ceil
+        ceil_results = self.db.query_training_stat(
+            model_name="beta_vae",
+            stat_name="snr_range_ceil",
+            tag=self.config.checkpoint.save_tag,
+            start_time=self.start_time,
+            end_time=current_time,
+        )
+
+        for r in ceil_results:
+            round_num = r["round_number"]
+            if round_num not in snr_by_round:
+                snr_by_round[round_num] = {}
+            snr_by_round[round_num]["ceil"] = r["value"]
+
+        del ceil_results
+
+        return snr_by_round
+
+    def _add_snr_range_shading(
+        self,
+        ax,
+        snr_by_round: dict[int, dict[str, float]],
+        epochs_per_round: int | None = None,
+        use_rounds: bool = False,
+        show_text_annotations: bool = True,
+    ) -> None:
+        """
+        Add transparent background regions showing SNR range per round.
+
+        Args:
+            ax: Matplotlib axis to add shading to
+            snr_by_round: Dict mapping round_number to {"floor": x, "ceil": y}
+            epochs_per_round: Number of epochs per training round (required if use_rounds=False)
+            use_rounds: If True, use round numbers for x-axis; if False, use epochs
+            show_text_annotations: If True, show SNR range text annotations in subplot
+        """
+        if not snr_by_round:
+            return
+
+        if not use_rounds and epochs_per_round is None:
+            raise ValueError("epochs_per_round is required when use_rounds=False")
+
+        # Alternating colors for visual distinction
+        colors = ["#e6f2ff", "#fff2e6"]  # Light blue, light orange
+        hatches = ["//", None]  # Striped for odd idx, solid for even idx
+
+        fontsize, rotation = 10, 0
+
+        for idx, (round_num, snr_info) in enumerate(sorted(snr_by_round.items())):
+            if "floor" not in snr_info or "ceil" not in snr_info:
+                continue
+
+            # Calculate x positions based on use_rounds flag
+            if use_rounds:
+                start_x = round_num - 0.5
+                end_x = round_num + 0.5
+                mid_x = round_num
+            else:
+                start_epoch = (round_num - 1) * epochs_per_round + 1
+                end_epoch = round_num * epochs_per_round
+                start_x = start_epoch - 0.5
+                end_x = end_epoch + 0.5
+                mid_x = (start_epoch + end_epoch) / 2
+
+            # Add shaded region with alternating hatch patterns
+            hatch = hatches[idx % 2]
+            ax.axvspan(
+                start_x,
+                end_x,
+                color=colors[idx % 2],
+                alpha=0.5,
+                zorder=0,
+                hatch=hatch,
+                edgecolor="gray" if hatch else None,
+            )
+
+            # Add SNR text annotation at top of region
+            if show_text_annotations:
+                snr_floor = int(snr_info["floor"])
+                snr_ceil = int(snr_info["ceil"])
+                ax.text(
+                    mid_x,
+                    0.98,
+                    f"SNR: {snr_floor}-{snr_ceil}",
+                    transform=ax.get_xaxis_transform(),
+                    ha="center",
+                    va="top",
+                    fontsize=fontsize,
+                    rotation=rotation,
+                    alpha=0.7,
+                )
+
+    # TODO: reorder plot methods (def & call sites): train -> latent -> injection
     # TODO: move injection plots to data_generation.py & call at end of generate_triplet_batch() (instead of at the end of train_round() & run_training_pipeline())
     # NOTE: there's a ton of improvements we could make to this function (and subsequent _plot functions), but i just care that it works well enough for now
     def plot_injection_stats(self, tag: str | None = None, dir: str | None = None):
@@ -3335,13 +3460,13 @@ class TrainingPipeline:
                 title=f"Final global intensity biases - ({tag}, {machine_name})",
             )
 
+    # NOTE: come back to this later (verify what happens when self._latent_viz_batch and/or self._latent_viz_labels is None)
+    # TODO: reorder plot methods (def & call sites): train -> latent -> injection
+    # NOTE: combine plot_beta_vae_loss_curves(), plot_beta_vae_training_stability(), and plot_latent_space_gif() into plot_training_progress()?
     def plot_latent_space_gif(self, tag: str | None = None, dir: str | None = None):
         """
-        Generate GIFs showing how the latent space evolves during training.
-
-        Produces two GIFs (PCA and UMAP) with 8 color categories (4 signal types × ON/OFF).
-        Queries latent snapshots from DB, fits global DR models, and renders frames with
-        consistent axes.
+        Generate GIF showing how the latent space evolves during training using using UMAP with 8
+        color categories (4 signal types * ON/OFF).
 
         Args:
             tag: Plot tag for filename (defaults to save_tag)
@@ -3354,7 +3479,8 @@ class TrainingPipeline:
             save_dir = os.path.join(self.config.output_path, "plots", dir)
         else:
             save_dir = os.path.join(self.config.output_path, "plots")
-        os.makedirs(save_dir, exist_ok=True)
+
+        os.makedirs(save_dir, exist_ok=True)  # Create dir if it doesn't exist
 
         if self.db is None:
             raise RuntimeError("No database instance detected - cannot generate latent space GIF")
@@ -3368,7 +3494,8 @@ class TrainingPipeline:
         else:
             logger.info("Database flushed")
 
-        # Step 1: Query distinct snapshot keys
+        # Query distinct snapshot keys (model, round, epoch, step, snr_base, snr_range)
+        # Sorting already handled on the query side (i.e. in query_latent_snapshot_keys)
         snapshot_keys = self.db.query_latent_snapshot_keys(
             tag=self.config.checkpoint.save_tag,
             start_time=self.start_time,
@@ -3380,29 +3507,52 @@ class TrainingPipeline:
 
         logger.info(f"Found {len(snapshot_keys)} unique snapshots for GIF generation")
 
-        # Step 1b: Subsample to ~200 frames if too many snapshots
-        max_frames = 200
+        # Subsample to max_frames if too many snapshots
+        # Uses log-spaced indices so earlier training steps (where the most dramatic
+        # latent space changes occur) get higher frame density than later steps
+        # Only works if snapshot_keys is sorted by progression
+        max_frames = self.config.training.latent_viz_gif_max_frames
         if len(snapshot_keys) > max_frames:
-            # Use log-spaced indices for more detail early in training
-            indices = np.unique(
-                np.logspace(0, np.log10(len(snapshot_keys) - 1), num=max_frames).astype(int)
-            )
+            n = len(snapshot_keys)
+            # Generate more candidates than needed, then deduplicate to hit max_frames
+            # Log-spacing naturally clusters near index 0, so oversampling + dedup
+            # preserves the early-training bias while filling the frame budget
+            oversample = max_frames
+            indices = set()
+            indices.add(0)  # Always include first snapshot
+            while len(indices) < max_frames:
+                oversample *= 2  # NOTE: is 2 a good choice here?
+                raw = np.logspace(0, np.log10(n - 1), num=oversample).astype(int)
+                indices = {0} | set(raw)
+                del raw
+                if oversample > n * 10:
+                    break  # Safety valve: can't exceed unique indices available
+            # Sort and trim to exactly max_frames
+            indices = sorted(indices)[:max_frames]
             snapshot_keys = [snapshot_keys[i] for i in indices]
-            logger.info(f"Subsampled to {len(snapshot_keys)} frames (log-spaced)")
 
-        # Step 2: Load selected snapshots and pool latent data
+            logger.info(
+                f"Subsampled to {len(snapshot_keys)} frames (log-spaced, max {max_frames}, oversample {oversample})"
+            )
+
+            del indices
+            gc.collect()
+
+        # Load selected snapshots and pool latent data
         all_coords = []  # List of (N_obs, latent_dim) arrays per snapshot
         all_snapshot_labels = []  # List of (N_obs,) label arrays per snapshot
         all_snapshot_onoff = []  # List of (N_obs,) ON/OFF arrays per snapshot
-        snapshot_metadata = []  # (round, epoch, step, snr_base, snr_range) per snapshot
+        snapshot_metadata = []  # (model, round, epoch, step, snr_base, snr_range) per snapshot
 
         for key in snapshot_keys:
             rows = self.db.query_latent_snapshots(
-                tag=self.config.checkpoint.save_tag,
+                model_name=key["model_name"],
                 round_number=key["round_number"],
                 epoch_number=key["epoch_number"],
                 step_number=key["step_number"],
-                columns=["cadence_index", "signal_type", "latent_vector"],
+                tag=self.config.checkpoint.save_tag,
+                start_time=self.start_time,
+                columns=["signal_type", "latent_vector"],
             )
 
             if not rows:
@@ -3425,74 +3575,83 @@ class TrainingPipeline:
             all_snapshot_onoff.append(snapshot_onoff)
             snapshot_metadata.append(key)
 
+            del rows, snapshot_latents, snapshot_labels, snapshot_onoff
+            gc.collect()
+
+        del snapshot_keys
+        gc.collect()
+
         if not all_coords:
             logger.warning("No valid latent data loaded — skipping GIF generation")
             return
 
-        # Pool all latents for global DR fit
+        # Pool all latents for global UMAP fit
         pooled = np.concatenate(all_coords, axis=0)
         logger.info(
             f"Pooled {pooled.shape[0]} latent vectors from {len(all_coords)} snapshots "
-            f"for DR fitting"
+            f"for UMAP fitting"
         )
 
-        # Step 3: Fit global DR models
-        pca = PCA(n_components=2, random_state=42).fit(pooled)
+        # NOTE: come back to this later (what hyperparams are we using for UMAP? how do we store the final UMAP model params for use later -- e.g. in inference.py's results viz?)
+        # Fit global UMAP
         umap_model = umap.UMAP(n_components=2, random_state=42).fit(pooled)
-        del pooled
 
-        # Step 4: Transform each snapshot and compute global axis limits
-        pca_transformed = []
+        del pooled
+        gc.collect()
+
+        # Transform each snapshot and compute global axis limits
         umap_transformed = []
 
         for coords in all_coords:
-            pca_transformed.append(pca.transform(coords))
             umap_transformed.append(umap_model.transform(coords))
 
-        del all_coords
+        del all_coords, umap_model
+        gc.collect()
 
-        # Compute consistent axis limits with 5% padding
+        # Compute consistent axis limits with 5% padding (streaming min/max to avoid concat)
         def _compute_limits(transformed_list):
-            all_2d = np.concatenate(transformed_list, axis=0)
-            x_min, x_max = all_2d[:, 0].min(), all_2d[:, 0].max()
-            y_min, y_max = all_2d[:, 1].min(), all_2d[:, 1].max()
+            x_min = min(t[:, 0].min() for t in transformed_list)
+            x_max = max(t[:, 0].max() for t in transformed_list)
+            y_min = min(t[:, 1].min() for t in transformed_list)
+            y_max = max(t[:, 1].max() for t in transformed_list)
             x_pad = (x_max - x_min) * 0.05
             y_pad = (y_max - y_min) * 0.05
             return (x_min - x_pad, x_max + x_pad), (y_min - y_pad, y_max + y_pad)
 
-        pca_xlim, pca_ylim = _compute_limits(pca_transformed)
         umap_xlim, umap_ylim = _compute_limits(umap_transformed)
 
-        # Step 5: Generate frames
+        # Generate frames and assemble GIF
         colors = {
-            ("false_no_signal", "ON"): "#90CAF9",
-            ("false_no_signal", "OFF"): "#1565C0",
-            ("false_with_rfi", "ON"): "#FFCC80",
-            ("false_with_rfi", "OFF"): "#E65100",
-            ("true_only_eti", "ON"): "#A5D6A7",
-            ("true_only_eti", "OFF"): "#2E7D32",
-            ("true_eti_rfi", "ON"): "#EF9A9A",
-            ("true_eti_rfi", "OFF"): "#C62828",
+            ("false_no_signal", "ON"): "#1565C0",
+            ("false_no_signal", "OFF"): "#64B5F6",
+            ("false_with_rfi", "ON"): "#F9A825",
+            ("false_with_rfi", "OFF"): "#FFF176",
+            ("true_only_eti", "ON"): "#2E7D32",
+            ("true_only_eti", "OFF"): "#81C784",
+            ("true_eti_rfi", "ON"): "#C62828",
+            ("true_eti_rfi", "OFF"): "#EF5350",
         }
+        markers = {"ON": "o", "OFF": "x"}
         display_names = {
-            ("false_no_signal", "ON"): "No Signal ON",
-            ("false_no_signal", "OFF"): "No Signal OFF",
-            ("false_with_rfi", "ON"): "RFI Only ON",
-            ("false_with_rfi", "OFF"): "RFI Only OFF",
-            ("true_only_eti", "ON"): "ETI Only ON",
-            ("true_only_eti", "OFF"): "ETI Only OFF",
-            ("true_eti_rfi", "ON"): "ETI+RFI ON",
-            ("true_eti_rfi", "OFF"): "ETI+RFI OFF",
+            ("false_no_signal", "ON"): "No Signal (ON)",
+            ("false_no_signal", "OFF"): "No Signal (OFF)",
+            ("false_with_rfi", "ON"): "RFI Only (ON)",
+            ("false_with_rfi", "OFF"): "RFI Only (OFF)",
+            ("true_only_eti", "ON"): "ETI Only (ON)",
+            ("true_only_eti", "OFF"): "ETI Only (OFF)",
+            ("true_eti_rfi", "ON"): "ETI+RFI (ON)",
+            ("true_eti_rfi", "OFF"): "ETI+RFI (OFF)",
         }
 
+        # NOTE: instead of temp_dir, save frames in persistent dir. update dir archiving to handle
         temp_dir = tempfile.mkdtemp(prefix="latent_gif_")
 
         methods = [
-            ("pca", pca_transformed, pca_xlim, pca_ylim),
             ("umap", umap_transformed, umap_xlim, umap_ylim),
         ]
 
         gif_paths = {}
+        duration_ms = self.config.training.latent_viz_gif_duration_ms
 
         for method_name, transformed_list, xlim, ylim in methods:
             frame_paths = []
@@ -3519,18 +3678,23 @@ class TrainingPipeline:
                             coords_2d[mask, 0],
                             coords_2d[mask, 1],
                             c=color,
+                            marker=markers[status],
                             s=5,
                             alpha=0.3,
                             label=display_names[(stype, status)],
                             rasterized=True,
                         )
 
+                del labels_arr, onoff_arr
+
                 ax.set_xlim(xlim)
                 ax.set_ylim(ylim)
 
                 snr_base = meta["snr_base"]
                 snr_range = meta["snr_range"]
-                snr_ceil = snr_base + snr_range if snr_base and snr_range else "?"
+                snr_ceil = (
+                    snr_base + snr_range if snr_base is not None and snr_range is not None else "?"
+                )
                 ax.set_title(
                     f"Latent Space ({method_name.upper()}) — "
                     f"Round {meta['round_number']}, "
@@ -3541,25 +3705,13 @@ class TrainingPipeline:
                 )
                 ax.set_xlabel(f"{method_name.upper()} 1")
                 ax.set_ylabel(f"{method_name.upper()} 2")
-
-                # Legend (only on first frame, carried across)
-                if frame_idx == 0:
-                    ax.legend(
-                        loc="upper right",
-                        fontsize=7,
-                        markerscale=3,
-                        ncol=2,
-                        framealpha=0.8,
-                    )
-                else:
-                    # Recreate legend on every frame for GIF consistency
-                    ax.legend(
-                        loc="upper right",
-                        fontsize=7,
-                        markerscale=3,
-                        ncol=2,
-                        framealpha=0.8,
-                    )
+                ax.legend(
+                    loc="upper right",
+                    fontsize=7,
+                    markerscale=3,
+                    ncol=2,
+                    framealpha=0.8,
+                )
 
                 plt.tight_layout()
 
@@ -3568,22 +3720,27 @@ class TrainingPipeline:
                 plt.close(fig)
                 frame_paths.append(frame_path)
 
-            # Step 6: Assemble GIF
+            del transformed_list
+
+            # Assemble GIF by streaming one frame at a time via imageio (reduces memory pressure)
             gif_filename = f"latent_space_{method_name}_{tag}.gif"
             gif_path = os.path.join(save_dir, gif_filename)
 
-            frames = [Image.open(p) for p in frame_paths]
-            if frames:
-                frames[0].save(
-                    gif_path,
-                    save_all=True,
-                    append_images=frames[1:],
-                    duration=self.config.training.latent_viz_gif_duration_ms,
-                    loop=0,
-                )
+            n_frames = len(frame_paths)
+            if n_frames > 0:
+                with iio.imopen(gif_path, "w", plugin="pillow") as gif_writer:
+                    for frame_path in frame_paths:
+                        frame = iio.imread(frame_path)
+                        gif_writer.write(
+                            frame,
+                            duration=duration_ms,
+                            loop=0,
+                            is_batch=False,
+                        )
+                        del frame
+
                 logger.info(
-                    f"Latent space {method_name.upper()} GIF saved: {gif_path} "
-                    f"({len(frames)} frames)"
+                    f"Latent space {method_name.upper()} GIF saved: {gif_path} ({n_frames} frames)"
                 )
 
                 # Upload to Slack
@@ -3594,18 +3751,171 @@ class TrainingPipeline:
                         title=f"Latent Space {method_name.upper()} - ({tag})",
                     )
 
-            # Close PIL images
-            for f in frames:
-                f.close()
-            del frames
+            del frame_paths
+            gc.collect()
 
             gif_paths[method_name] = gif_path
 
-        # Step 8: Cleanup
-        del pca_transformed, umap_transformed
+        # Cleanup
+        del umap_transformed
         del all_snapshot_labels, all_snapshot_onoff, snapshot_metadata
+        # NOTE: temp_dir isn't cleaned on exception (should use try/finally or tempfile.TemporaryDirectory() with context manager)
         shutil.rmtree(temp_dir, ignore_errors=True)
         gc.collect()
+
+    def _prepare_latent_viz_batch(self, concat_data, labels):
+        """
+        Subsample cadences from concat_data for latent space visualization
+        Will attempt to preserve an equal distribution of distinct values from labels if possible
+
+        Called once on the first round's stratified validation partition and persisted across
+        subsequent rounds. Using held-out data ensures the latent space visualization captures
+        generalization, while persisting the same data across rounds eliminates the effects of
+        distribution shift (from the curriculum schedule)
+
+        Args:
+            concat_data: Validation-partition cadences array, shape (n_val, 6, 16, width_bin)
+            labels: Per-cadence signal type labels for the validation partition, shape (n_val,)
+        """
+        n_per_type = self.config.training.latent_viz_num_cadences_per_type
+        signal_types = ["false_no_signal", "false_with_rfi", "true_only_eti", "true_eti_rfi"]
+
+        selected_indices = []
+        selected_labels = []
+
+        for stype in signal_types:
+            type_indices = np.where(labels == stype)[0]
+            if len(type_indices) == 0:
+                logger.warning(f"No cadences for {stype} — skipping this type for viz batch")
+                continue
+            if len(type_indices) < n_per_type:
+                logger.warning(
+                    f"Only {len(type_indices)} cadences for {stype} "
+                    f"(requested {n_per_type}), using all available"
+                )
+                sampled = type_indices
+            else:
+                sampled = np.random.choice(type_indices, size=n_per_type, replace=False)
+            selected_indices.append(sampled)
+            selected_labels.extend([stype] * len(sampled))
+
+        if not selected_indices:
+            logger.warning("No cadences found for any signal type — skipping viz batch")
+            self._latent_viz_batch = None
+            self._latent_viz_labels = None
+            return
+
+        all_indices = np.concatenate(selected_indices)
+        self._latent_viz_batch = concat_data[all_indices].copy()
+        self._latent_viz_labels = np.array(selected_labels, dtype="U20")
+
+        if len(all_indices) < n_per_type * len(signal_types):
+            logger.warning(
+                f"Requested {n_per_type} per type * {len(signal_types)} types. "
+                f"Only {len(all_indices)} cadences available in latent viz batch"
+            )
+        else:
+            logger.info(
+                f"Prepared latent viz batch: {len(all_indices)} cadences "
+                f"({n_per_type} per type * {len(signal_types)} types)"
+            )
+
+        # Build distributed dataset
+        self._build_latent_viz_dataset()
+
+    def _build_latent_viz_dataset(self):
+        """Build the distributed viz dataset from the persisted viz batch."""
+        # Prepare distributed dataset for latent viz encoding
+        viz_results = prepare_distributed_viz_dataset(
+            concat_data=self._latent_viz_batch,
+            per_replica_inf_batch_size=self.config.training.per_replica_val_batch_size,
+            num_replicas=self.strategy.num_replicas_in_sync,
+            strategy=self.strategy,
+        )
+
+        self._latent_viz_dataset = viz_results["viz_dataset"]
+        self._latent_viz_n_padded = viz_results["n_padded"]
+        self._latent_viz_n_samples = viz_results["n_samples"]
+        self._latent_viz_steps = viz_results["viz_steps"]
+        self._latent_viz_holder = viz_results["_viz_holder"]
+        del viz_results
+
+        time_bins = self.config.data.time_bins
+        width_bin = self.config.data.width_bin // self.config.data.downsample_factor
+
+        # Create distributed inference function
+        @tf.function
+        def viz_encode_fn(batch_data):
+            """Encode batch data using distributed strategy"""
+
+            def encode_fn(data):
+                """Per-replica encoding step"""
+                # Reshape for encoder: (batch, 6, 16, 512) -> (batch * 6, 16, 512, 1)
+                reshaped = tf.reshape(data, [-1, time_bins, width_bin, 1])
+
+                # Encode (returns z_mean, z_log_var, z)
+                z_mean, _, _ = self.vae.encoder(reshaped, training=False)
+
+                return z_mean
+
+            # Run encoding on all replicas
+            per_replica_z_mean = self.strategy.run(encode_fn, args=(batch_data,))
+
+            return per_replica_z_mean
+
+        self._viz_encode_fn = viz_encode_fn
+
+    def _capture_latent_snapshot(self, round_idx, epoch, step, snr_base, snr_range):
+        """
+        Run distributed inference on viz batch and write latent vectors to DB.
+
+        Uses the distributed viz dataset and shared _distributed_encode() method to encode
+        cadences across all GPUs, then writes one row per cadence to the latent_snapshots table.
+        """
+        if self._latent_viz_dataset is None:
+            return
+
+        n_padded = self._latent_viz_n_padded
+        n_samples = self._latent_viz_n_samples
+        num_obs = self.config.data.num_observations
+        latent_dim = self.config.beta_vae.latent_dim
+
+        # TEST: make sure this works as expected
+        # Encode all cadences using distributed inference
+        [all_z_mean] = self._distributed_encode(
+            dataset=self._latent_viz_dataset,
+            n_steps=self._latent_viz_steps,
+            encode_fn=self._viz_encode_fn,
+            n_samples=n_padded * num_obs,
+            latent_dim=latent_dim,
+        )
+
+        # Truncate padding and reshape to per-cadence: (n_samples, 6, latent_dim)
+        all_z_mean = all_z_mean[: n_samples * num_obs]
+        z_mean_per_cadence = all_z_mean.reshape(n_samples, num_obs, latent_dim)
+        del all_z_mean
+
+        # Write to DB
+        timestamp = time.time()
+        tag = self.config.checkpoint.save_tag
+        for cadence_idx in range(n_samples):
+            # NOTE: 8 decimal precison for stored latents
+            latent_vector_list = np.round(z_mean_per_cadence[cadence_idx], 8).tolist()
+            self.db.write_latent_snapshot(
+                model_name="beta_vae",
+                round_number=round_idx + 1,
+                epoch_number=epoch + 1,
+                step_number=step + 1,
+                cadence_index=cadence_idx,
+                signal_type=str(self._latent_viz_labels[cadence_idx]),
+                latent_vector=latent_vector_list,
+                snr_base=snr_base,
+                snr_range=snr_range,
+                tag=tag,
+                timestamp=timestamp,
+            )
+
+        del z_mean_per_cadence
 
     def save_models(self, tag: str | None = None, dir: str | None = None):
         """Save model weights"""
@@ -3741,7 +4051,7 @@ def run_training_pipeline(
             raise  # Re-raise to propagate error
 
         try:
-            # NOTE: combine plot_beta_vae_loss_curves() and plot_beta_vae_training_stability() into plot_training_progress()?
+            # NOTE: combine plot_beta_vae_loss_curves(), plot_beta_vae_training_stability(), and plot_latent_space_gif() into plot_training_progress()?
             # Plot loss curves
             pipeline.plot_beta_vae_loss_curves()
 

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -1271,6 +1271,7 @@ class TrainingPipeline:
                 dir="checkpoints",
             )
 
+            # NOTE: commented out to save compute. a final latent space gif at the end of training should suffice
             # Generate latent space GIF
             # self.plot_latent_space_gif(tag=f"round_{round_idx + 1:02d}", dir="checkpoints")
 

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -1236,13 +1236,13 @@ class TrainingPipeline:
                     f"KL: {epoch_losses['kl']:.4f}, "
                     f"True: {epoch_losses['true']:.4f}, "
                     f"False: {epoch_losses['false']:.4f}, "
-                    f"Duration: {train_duration} "
+                    f"Duration: {train_duration:.2f} "
                 )
                 logger.info(
-                    f"Gradient norm -- Mean: {gradient_norm_mean}, "
-                    f"Std: {gradient_norm_std}, "
-                    f"Max: {gradient_norm_max}, "
-                    f"Clipping rate: {clipping_rate} "
+                    f"Gradient norm -- Mean: {gradient_norm_mean:.4f}, "
+                    f"Std: {gradient_norm_std:.4f}, "
+                    f"Max: {gradient_norm_max:.4f}, "
+                    f"Clipping rate: {clipping_rate:.4f} "
                 )
                 logger.info(
                     f"Val -- Total: {val_losses['total']:.4f}, "
@@ -1250,7 +1250,7 @@ class TrainingPipeline:
                     f"KL: {val_losses['kl']:.4f}, "
                     f"True: {val_losses['true']:.4f}, "
                     f"False: {val_losses['false']:.4f}, "
-                    f"Duration: {val_duration} "
+                    f"Duration: {val_duration:.2f} "
                 )
 
                 # Adaptive learning rate

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -1110,9 +1110,6 @@ class TrainingPipeline:
             for epoch in range(epochs):
                 self._current_epoch = epoch
 
-                logger.info(f"{'-' * 30}")
-                logger.info(f"Epoch {epoch + 1}/{epochs} Start")
-
                 # Training
                 epoch_losses, epoch_gradient_norms, train_duration = self._train_epoch(
                     train_dataset, steps_per_epoch, accumulation_steps, time.time()
@@ -1122,8 +1119,6 @@ class TrainingPipeline:
                 val_losses, val_duration = self._validate_epoch(val_dataset, val_steps, time.time())
 
                 # Queue db writes (non-blocking) & log results
-                logger.info(f"Epoch {epoch + 1} Complete")
-
                 current_time = time.time()
 
                 if self.db is None:
@@ -1260,6 +1255,7 @@ class TrainingPipeline:
                 # # Increment global step
                 # self.global_step += 1
 
+                logger.info(f"Epoch {epoch + 1}")
                 logger.info(
                     f"Train -- Total: {epoch_losses['total']:.4f}, "
                     f"Recon: {epoch_losses['reconstruction']:.4f}, "
@@ -1285,8 +1281,6 @@ class TrainingPipeline:
 
                 # Adaptive learning rate
                 self._update_learning_rate(val_losses)
-
-                logger.info(f"Epoch {epoch + 1}/{epochs} End")
 
             # NOTE: combine plot_beta_vae_loss_curves() and plot_beta_vae_training_stability() into plot_training_progress()?
             # Plot loss curves
@@ -1455,18 +1449,6 @@ class TrainingPipeline:
                     step_losses[key] = avg_loss
                     # Accumulate epoch losses over training steps
                     epoch_losses[key] += avg_loss
-
-                # Log progress every 10 steps
-                if (step + 1) % 10 == 0 or (step + 1) == steps_per_epoch:
-                    logger.info(
-                        f"Step {step + 1}/{steps_per_epoch}, "
-                        f"Total: {step_losses['total']:.4f}, "
-                        f"Recon: {step_losses['reconstruction']:.4f}, "
-                        f"KL: {step_losses['kl']:.4f}, "
-                        f"True: {step_losses['true']:.4f}, "
-                        f"False: {step_losses['false']:.4f}, "
-                        f"Gradient norm: {global_norm:.4f} "
-                    )
 
             # Average epoch losses over training steps
             for key in epoch_losses:

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -408,10 +408,11 @@ def prepare_distributed_train_dataset(
         shuffle: Whether to shuffle training data
 
     Returns: {train_dataset, val_dataset, n_train_trimmed, n_val_trimmed, train_steps,
-              accumulation_steps, val_steps, _train_holder, _val_holder, val_indices}
+              accumulation_steps, val_steps, _train_holder, val_indices}
              Train/val distributed datasets, number of samples in each, number of steps for each
-              (including accumulation sub-steps), TrainDataHolder references for each, and the
-              stratified validation indices into the original data arrays
+              (including accumulation sub-steps), shared TrainDataHolder reference (both generators
+              read from the original arrays via index subsets — no copies), and the stratified
+              validation indices into the original data arrays
     """
     global_train_batch_size = per_replica_batch_size * num_replicas
     global_val_batch_size = per_replica_val_batch_size * num_replicas
@@ -457,16 +458,11 @@ def prepare_distributed_train_dataset(
 
     logger.info(f"Data alignment: Train {n_train}→{n_train_trimmed}, Val {n_val}→{n_val_trimmed}")
 
-    # Prepare data using stratified indices
-    train_concat = data["concatenated"][train_indices]
-    train_true = data["true"][train_indices]
-    train_false = data["false"][train_indices]
-    train_holder = TrainDataHolder(train_concat, train_true, train_false)
-
-    val_concat = data["concatenated"][val_indices]
-    val_true = data["true"][val_indices]
-    val_false = data["false"][val_indices]
-    val_holder = TrainDataHolder(val_concat, val_true, val_false)
+    # Share the original arrays between train and val generators via a single data holder.
+    # The stratified split requires non-contiguous indices, which would force numpy to create
+    # full copies via fancy indexing (~2x peak memory). Instead, both generators read from the
+    # same original arrays using their respective index subsets — zero extra copies.
+    train_holder = TrainDataHolder(data["concatenated"], data["true"], data["false"])
 
     # Create generator functions for memory-efficient data loading
     def train_generator():
@@ -482,7 +478,8 @@ def prepare_distributed_train_dataset(
                 false = train_holder.false
 
             # Work with local references (safe from clearing, no per-sample lock needed)
-            indices = np.arange(len(concat))
+            # Copy train_indices because np.random.shuffle mutates in-place
+            indices = train_indices.copy()
             if shuffle:
                 # Perform global shuffle on each epoch so each pass through the data is unique
                 np.random.shuffle(indices)
@@ -496,24 +493,24 @@ def prepare_distributed_train_dataset(
         while True:  # Make generators infinite to reset state between epochs
             # Acquire lock to check cleared status and capture data references
             # Local references keep data alive even if clear() is called mid-epoch
-            with val_holder._lock:
-                if val_holder._cleared:
+            with train_holder._lock:
+                if train_holder._cleared:
                     return  # Exit if data already cleared
                 # Cache references while holding lock
-                concat = val_holder.concat
-                true = val_holder.true
-                false = val_holder.false
+                concat = train_holder.concat
+                true = train_holder.true
+                false = train_holder.false
 
             # Maintain order on each epoch since shuffling provides no benefits (no gradients
             # are calculated during validation)
-            for idx in range(len(concat)):
+            for idx in val_indices:
                 yield (concat[idx], true[idx], false[idx]), concat[idx]
 
             # Remove cache references to ensure garbage collection in future
             del concat, true, false
 
     # Determine dataset output signature
-    sample_shape = train_concat.shape[1:]
+    sample_shape = data["concatenated"].shape[1:]
     output_signature = (
         (
             tf.TensorSpec(shape=sample_shape, dtype=tf.float32),
@@ -581,7 +578,6 @@ def prepare_distributed_train_dataset(
         "accumulation_steps": accumulation_steps,
         "val_steps": val_steps,
         "_train_holder": train_holder,
-        "_val_holder": val_holder,
         "val_indices": val_indices,  # For train_round() -> _prepare_latent_viz_batch()
     }
 
@@ -1020,6 +1016,11 @@ class TrainingPipeline:
             self.config.training.num_samples_beta_vae, snr_base, snr_range, round_idx + 1
         )
 
+        # Extract labels before distributing (prepare_distributed_train_dataset keeps the
+        # original arrays alive via a shared train_holder — no copies — so we can free the
+        # dict reference immediately after)
+        train_labels = train_data.get("labels")
+
         # Distribute training data
         data = prepare_distributed_train_dataset(
             data=train_data,
@@ -1032,25 +1033,29 @@ class TrainingPipeline:
             shuffle=True,
         )
 
+        # Free the dict shell (original arrays stay alive via the shared train_holder)
+        del train_data
+        gc.collect()
+
         # Prepare latent viz batch (if it's the first round) using the validation partition.
         # Using held-out data ensures the latent space visualization captures generalization, while
         # persisting the same data across rounds eliminates the effects of distribution shift (from
         # the curriculum schedule)
         if self._latent_viz_batch is None:
-            train_labels = train_data.get("labels")
             if train_labels is not None:
-                val_indices = data["val_indices"]
+                # Use the data holder's original arrays directly with val_indices to avoid creating
+                # an intermediate copy of the entire validation partition
                 self._prepare_latent_viz_batch(
-                    train_data["concatenated"][val_indices],
-                    train_labels[val_indices],
+                    concat_data=data["_train_holder"].concat,
+                    labels=train_labels,
+                    candidate_indices=data["val_indices"],
                 )
-                del train_labels, val_indices
         # On subsequent rounds, the latent viz batch is persisted,
         # but the distributed dataset needs to be rebuilt
         elif self._latent_viz_batch is not None and self._latent_viz_dataset is None:
             self._build_latent_viz_dataset()
 
-        del train_data
+        del train_labels
         gc.collect()
 
         train_dataset = data["train_dataset"]
@@ -1061,7 +1066,6 @@ class TrainingPipeline:
         accumulation_steps = data["accumulation_steps"]
         val_steps = data["val_steps"]
         train_holder = data["_train_holder"]
-        val_holder = data["_val_holder"]
 
         del data
         gc.collect()
@@ -1279,10 +1283,9 @@ class TrainingPipeline:
 
         # Run cleanup regardless if round finishes successfully or not
         finally:
-            # NOTE: should check to make sure holders & datasets exist first
+            # NOTE: should check to make sure train_holder & datasets exist first
             # Clear intermediate data
             train_holder.clear()
-            val_holder.clear()
             del train_dataset, val_dataset
 
             # Clear latent viz distributed dataset (rebuilt each round)
@@ -3763,7 +3766,7 @@ class TrainingPipeline:
         shutil.rmtree(temp_dir, ignore_errors=True)
         gc.collect()
 
-    def _prepare_latent_viz_batch(self, concat_data, labels):
+    def _prepare_latent_viz_batch(self, concat_data, labels, candidate_indices=None):
         """
         Subsample cadences from concat_data for latent space visualization
         Will attempt to preserve an equal distribution of distinct values from labels if possible
@@ -3774,28 +3777,39 @@ class TrainingPipeline:
         distribution shift (from the curriculum schedule)
 
         Args:
-            concat_data: Validation-partition cadences array, shape (n_val, 6, 16, width_bin)
-            labels: Per-cadence signal type labels for the validation partition, shape (n_val,)
+            concat_data: Full cadences array, shape (n_total, 6, 16, width_bin)
+            labels: Per-cadence signal type labels, shape (n_total,)
+            candidate_indices: Optional indices into concat_data/labels restricting which
+                samples are eligible (e.g. validation partition indices). If None, all
+                samples are eligible.
         """
         n_per_type = self.config.training.latent_viz_num_cadences_per_type
         signal_types = ["false_no_signal", "false_with_rfi", "true_only_eti", "true_eti_rfi"]
+
+        # Restrict to candidate subset if provided (avoids copying the entire partition)
+        if candidate_indices is not None:
+            candidate_labels = labels[candidate_indices]
+        else:
+            candidate_indices = np.arange(len(labels))
+            candidate_labels = labels
 
         selected_indices = []
         selected_labels = []
 
         for stype in signal_types:
-            type_indices = np.where(labels == stype)[0]
-            if len(type_indices) == 0:
+            type_mask = candidate_labels == stype
+            type_global_indices = candidate_indices[type_mask]
+            if len(type_global_indices) == 0:
                 logger.warning(f"No cadences for {stype} — skipping this type for viz batch")
                 continue
-            if len(type_indices) < n_per_type:
+            if len(type_global_indices) < n_per_type:
                 logger.warning(
-                    f"Only {len(type_indices)} cadences for {stype} "
+                    f"Only {len(type_global_indices)} cadences for {stype} "
                     f"(requested {n_per_type}), using all available"
                 )
-                sampled = type_indices
+                sampled = type_global_indices
             else:
-                sampled = np.random.choice(type_indices, size=n_per_type, replace=False)
+                sampled = np.random.choice(type_global_indices, size=n_per_type, replace=False)
             selected_indices.append(sampled)
             selected_labels.extend([stype] * len(sampled))
 
@@ -3805,8 +3819,9 @@ class TrainingPipeline:
             self._latent_viz_labels = None
             return
 
+        # Fancy indexing already creates a new independent array (no .copy() needed)
         all_indices = np.concatenate(selected_indices)
-        self._latent_viz_batch = concat_data[all_indices].copy()
+        self._latent_viz_batch = concat_data[all_indices]
         self._latent_viz_labels = np.array(selected_labels, dtype="U20")
 
         if len(all_indices) < n_per_type * len(signal_types):


### PR DESCRIPTION
Closes #53

## Summary
- Add end-to-end latent space visualization pipeline: periodic snapshot capture during training, `latent_snapshots` DB table, and animated GIF generation showing latent space evolution across rounds/epochs/steps
- Sweep configurable UMAP `n_neighbors` × `min_dist` combinations (one GIF per combo), with parameters in filenames and plot titles
- Add `--latent-viz-umap-n-neighbors` and `--latent-viz-umap-min-dist` CLI flags (defaults: `[5, 15, 30, 50]` and `[0.0, 0.1, 0.5]`)
- Refactor data pipeline: stratified train/val split, `TrainDataHolder`/`InfDataHolder`/`VizDataHolder` specialization, shared-array design to avoid OOM from fancy-indexing copies
- Distributed multi-GPU latent encoding via `_distributed_encode()`, shared between RF training and snapshot capture
- Memory-efficient GIF assembly (streaming one frame at a time) and sequential UMAP combo processing (one transformed dataset in memory at a time)

## Changes
- **`src/aetherscan/train.py`** — Core visualization pipeline (`plot_latent_space_gif`, `_capture_latent_snapshot`, `_prepare_latent_viz_batch`, `_distributed_encode`), stratified split, data holder refactor
- **`src/aetherscan/db/db.py`** — `latent_snapshots` table schema, write/query methods, column whitelist
- **`src/aetherscan/config.py`** — Latent viz config fields (`latent_viz_umap_n_neighbors`, `latent_viz_umap_min_dist`, `latent_viz_umap_fit_max_samples`, `latent_viz_gif_max_frames`, `latent_viz_gif_duration_ms`, etc.)
- **`src/aetherscan/cli.py`** — CLI flags for all latent viz params
- **`src/aetherscan/data_generation.py`** — Return per-cadence signal type labels from `generate_triplet_batch()`
- **`src/aetherscan/inference.py`** — Adapt to simplified inference dataset yield signature `(true, false)`
- **`README.md`** — Document new CLI flags
- **`environment.yml`** — Add `umap-learn` dependency

## Test plan
- [ ] Run training with latent snapshots enabled — verify `latent_snapshots` DB table is populated with correct round/epoch/step metadata
- [ ] Trigger `plot_latent_space_gif()` — verify N×M GIF files generated with filenames like `latent_space_umap_nn15_md0.1_<tag>.gif`
- [ ] Spot-check GIF frames — titles should show `UMAP (n_neighbors=15, min_dist=0.1)` with correct round/epoch/step/SNR
- [ ] Override defaults via CLI (`--latent-viz-umap-n-neighbors 10 20 --latent-viz-umap-min-dist 0.0 0.5`) — verify only specified combos are generated
- [ ] Monitor memory during GIF generation — no spike vs. single-model baseline
- [ ] Verify stratified train/val split has proportional signal type representation (check logs)
- [ ] Verify inference pipeline still works with simplified `(true, false)` dataset signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)