### PR TITLE
Update claude-code-action to v1.0.85

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@6c61301d8e1ee91bef7b65172f93462bbb216394 # v1
+        uses: anthropics/claude-code-action@58dbe8ed6879f0d3b02ac295b20d5fdfe7733e0c # v1.0.85
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "claude[bot]"

--- a/.github/workflows/claude-contribution-check.yml
+++ b/.github/workflows/claude-contribution-check.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Contribution Check
-        uses: anthropics/claude-code-action@6c61301d8e1ee91bef7b65172f93462bbb216394 # v1
+        uses: anthropics/claude-code-action@58dbe8ed6879f0d3b02ac295b20d5fdfe7733e0c # v1.0.85
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "claude[bot]"

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Issue Triage
-        uses: anthropics/claude-code-action@6c61301d8e1ee91bef7b65172f93462bbb216394 # v1
+        uses: anthropics/claude-code-action@58dbe8ed6879f0d3b02ac295b20d5fdfe7733e0c # v1.0.85
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "claude[bot]"

--- a/.github/workflows/claude-update-docs.yml
+++ b/.github/workflows/claude-update-docs.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Claude Documentation Analysis
-        uses: anthropics/claude-code-action@6c61301d8e1ee91bef7b65172f93462bbb216394 # v1
+        uses: anthropics/claude-code-action@58dbe8ed6879f0d3b02ac295b20d5fdfe7733e0c # v1.0.85
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Run Claude Assistant
         id: claude
-        uses: anthropics/claude-code-action@6c61301d8e1ee91bef7b65172f93462bbb216394 # v1
+        uses: anthropics/claude-code-action@58dbe8ed6879f0d3b02ac295b20d5fdfe7733e0c # v1.0.85
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Updates `anthropics/claude-code-action` from pinned commit `6c61301d` to `58dbe8ed` (v1.0.85) across all 5 Claude workflow files
- Fixes Node.js 20 deprecation warnings caused by the older version's internal dependency on `oven-sh/setup-bun`

Closes #56

## Test plan
- [ ] Verify Claude workflows run without Node.js 20 deprecation warnings
- [ ] Trigger each workflow (issue triage, code review, contribution check, update docs, main claude action) and confirm they pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)