### PR TITLE
Fix bot actor restriction and add CI workflow guardrails

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -54,6 +54,7 @@ jobs:
             - See AGENTS.md for context about the repository
             - Only post GitHub comments — don't submit review text as messages
             - Be constructive and helpful in your feedback
+            - Your only responsibilities are to review the current PR. Do not do anything that is not within this job scope.
 
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh issue view:*),Bash(git fetch:*),Bash(git diff:*),Bash(git log:*),Read,Glob,Grep"

--- a/.github/workflows/claude-contribution-check.yml
+++ b/.github/workflows/claude-contribution-check.yml
@@ -97,6 +97,7 @@ jobs:
             ## Important:
             - Be concise in your comments (2-3 sentences max)
             - Do NOT close or reject any PRs or issues — only warn and label
+            - Your only responsibilities are to enforce contribution compliance. Do not do anything that is not within this job scope.
 
           claude_args: |
             --allowedTools "Bash(gh issue:*),Bash(gh pr:*),Bash(gh search:*),Bash(gh label:*),Bash(gh api:*),Read,Glob,Grep"

--- a/.github/workflows/claude-update-docs.yml
+++ b/.github/workflows/claude-update-docs.yml
@@ -70,7 +70,7 @@ jobs:
                  - Summary of changes that require documentation
                  - Specific files that need updates
                  - Suggested changes or additions
-                 - Tag @claude with instructions to open a PR with the specified updates
+                 - Tag @claude with instructions to open a PR linking to this issue with the specified updates
 
             5. If no documentation updates are needed, do not create an issue.
                Only create an issue if there are meaningful documentation gaps.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -62,6 +62,9 @@ jobs:
         uses: anthropics/claude-code-action@58dbe8ed6879f0d3b02ac295b20d5fdfe7733e0c # v1.0.85
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Allow claude[bot] so the claude-update-docs workflow can automatically trigger Claude
+          # to open a PR after it creates the documentation issue
+          allowed_bots: "claude[bot]"
 
           # Trigger configuration
           trigger_phrase: "@claude"


### PR DESCRIPTION
## Summary
- Adds `claude[bot]` to `allowed_bots` in `claude.yml` so the docs update pipeline works end-to-end
- Refines `claude-update-docs` prompt to instruct PRs to link back to their source issue
- Adds scope-limiting guardrails to code-review and contribution-check CI agents

Fixes #60

## Test plan
- [ ] Merge a PR that introduces documentation gaps and verify `claude-update-docs` creates an issue tagging `@claude`
- [ ] Verify `claude-assistant` accepts the trigger from `claude[bot]` and opens a PR linking to the issue
- [ ] Verify code-review and contribution-check workflows still function correctly with the new guardrails

🤖 Generated with [Claude Code](https://claude.com/claude-code)