### PR TITLE
Skip auto-assign for bot/agent senders

### DIFF
--- a/.github/workflows/auto-assign-author.yml
+++ b/.github/workflows/auto-assign-author.yml
@@ -21,22 +21,31 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const actor = context.payload.sender.login;
+            const sender = context.payload.sender;
 
-            if (context.eventName === "issues") {
-              await github.rest.issues.addAssignees({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.issue.number,
-                assignees: [actor],
-              });
+            // GitHub's REST API does not support assigning bot/agent accounts
+            // (e.g. GitHub Apps, Copilot/Claude agents) via App installation
+            // tokens, so skip the assignment when the sender is not a human user.
+            if (sender.type !== "User") {
+              core.info(`Skipping assignment: sender ${sender.login} has type "${sender.type}"`);
+              return;
             }
 
-            if (context.eventName === "pull_request") {
+            const issueNumber = context.eventName === "issues"
+              ? context.payload.issue.number
+              : context.payload.pull_request.number;
+
+            try {
               await github.rest.issues.addAssignees({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                assignees: [actor],
+                issue_number: issueNumber,
+                assignees: [sender.login],
               });
+            } catch (error) {
+              // Defense-in-depth: if GitHub still rejects the assignment (e.g.
+              // an agent identity slips past the type check above), log it
+              // rather than failing the workflow — the issue/PR was created
+              // successfully and assignment is a non-critical convenience.
+              core.warning(`Could not assign ${sender.login}: ${error.message}`);
             }


### PR DESCRIPTION
## Summary
- Skip the `addAssignees` call in `.github/workflows/auto-assign-author.yml` when `context.payload.sender.type !== "User"` so the workflow no longer fails when a GitHub App or Copilot/Claude agent opens an issue/PR.
- Wrap the assignment call in `try`/`catch` as a defense-in-depth fallback — if a future identity type slips past the type check, log a warning instead of failing the run.
- Collapse the duplicated `issues` / `pull_request` branches into a single `addAssignees` call now that the issue number is the only differing field.

Closes #67.

## Test plan
- [ ] Open a human-authored issue → workflow runs, issue is auto-assigned to the author (existing behavior preserved).
- [ ] Open a human-authored PR → workflow runs, PR is auto-assigned to the author (existing behavior preserved).
- [ ] Open an issue/PR via a GitHub App or agent identity → workflow finishes successfully, no assignee is set, log shows the "Skipping assignment" info line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)