### PR TITLE
Prevent triage from re-triggering Claude via claude label

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -46,6 +46,14 @@ jobs:
 
             If it appears to be a duplicate, post a comment mentioning the original issue.
 
+            ## Label restrictions
+            Do NOT apply the "claude" label during triage. That label is a control
+            signal reserved for human users who want to manually summon @claude on
+            an existing issue — adding it here re-triggers the `claude.yml`
+            assistant workflow on top of any `@claude` mention already present in
+            the issue body, producing duplicate PRs. Stick to categorization labels
+            (bug, enhancement, documentation, question, priority levels, etc.).
+
             Your only responsibilities are to triage the current issue. Do not do anything that is not within this job scope.
 
           claude_args: |


### PR DESCRIPTION
## Summary
- Tighten the `claude-issue-triage.yml` prompt so the triage step only applies categorization labels (bug, enhancement, documentation, question, priority levels) and explicitly skips the `claude` label.
- The `claude` label is a manual control signal for humans summoning the assistant on existing issues; auto-applying it during triage re-triggers `claude.yml` on top of the `@claude` mention already present in auto-docs issues, producing duplicate PRs (e.g. PRs #65 and #66 both closing #64).

Closes #69.

## Test plan
- [ ] Merge a PR that causes `claude-update-docs.yml` to open a documentation issue with `@claude` in the body; confirm only **one** `claude.yml` run succeeds and only **one** PR is opened.
- [ ] Open an unrelated bug-style issue (no `@claude` mention); confirm the triage workflow still applies sensible categorization labels (`bug`, priority, etc.) and does **not** apply `claude`.
- [ ] Manually add the `claude` label to an existing issue and confirm `claude.yml` still fires (the human-summon path is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)