### PR TITLE
Add energy detection preprocessing for raw .h5 inference inputs

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - matplotlib=3.7.*
   - joblib=1.3.*
   - h5py=3.9.*
+  - hdf5plugin
   - psutil=5.9.*
   - pytest=7.4.*
   - ipykernel

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -456,7 +456,7 @@ def _add_inference_arguments(subparsers):
         type=str,
         nargs="+",
         default=None,
-        help="Space-separated list of CSV file names describing .h5 observations to group into cadences (resolved against <data-path>/inference/). If provided, triggers the energy detection preprocessing pipeline and takes precedence over --test-files",
+        help="Space-separated list of inference catalog file names (e.g. complete_cadences_catalog.csv). Expects .h5 filepaths to individual observations, and sufficient metadata for recovering cadence groupings. If provided, triggers the energy detection preprocessing pipeline and takes precedence over --test-files",
     )
 
     # Inference configuration
@@ -497,7 +497,7 @@ def _add_inference_arguments(subparsers):
         type=str,
         nargs="+",
         default=None,
-        help="Space-separated list of CSV column names whose joint value defines cadence membership (e.g., Target Session Band 'Cadence ID')",
+        help="Space-separated list of CSV column names whose joint value defines cadence membership (e.g., Target Session Band 'Cadence ID' Frequency)",
     )
     inf_parser.add_argument(
         "--cadence-h5-path-col",
@@ -569,7 +569,7 @@ def _add_inference_arguments(subparsers):
         "--preprocess-output-dir",
         type=str,
         default=None,
-        help="Directory for per-cadence .npy outputs from preprocessing (default: <output-path>/preprocessed)",
+        help="Directory for per-cadence .npy outputs from preprocessing",
     )
     inf_parser.add_argument(
         "--max-retries",
@@ -819,6 +819,7 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
         config.inference.stat_threshold = args.stat_threshold
     if hasattr(args, "stamp_width") and args.stamp_width is not None:
         config.inference.stamp_width = args.stamp_width
+    # NOTE: come back to this later (wtf does this comment mean?)
     # overlap_search is a store_true flag; only override when explicitly set
     if hasattr(args, "overlap_search") and args.overlap_search:
         config.inference.overlap_search = args.overlap_search
@@ -932,27 +933,28 @@ def validate_args(args: argparse.Namespace) -> None:
     #     if <validation_condition>:
     #         errors.append("Error message explaining the problem")
 
-    # Energy detection preprocessing checks
-    # If inference_files is provided, cadence_group_by_cols must be non-empty.
-    # Per-CSV column-existence checks are deferred to runtime (CSVs aren't loaded here).
-    # stamp_width == width_bin is validated at runtime in inference_command, where both
-    # are resolved together.
-    if hasattr(args, "inference_files") and args.inference_files is not None:
-        group_cols = getattr(args, "cadence_group_by_cols", None)
-        # If the user didn't pass --cadence-group-by-cols, the dataclass default kicks in
-        # (a non-empty list). Only fail if the user explicitly provided an empty list.
-        if group_cols is not None and len(group_cols) == 0:
-            errors.append(
-                "--cadence-group-by-cols must be non-empty when --inference-files is provided"
-            )
-
-    if hasattr(args, "detection_window_size") and args.detection_window_size is not None:
-        stamp_width = getattr(args, "stamp_width", None)
-        if stamp_width is not None and args.detection_window_size > stamp_width:
-            errors.append(
-                f"--detection-window-size ({args.detection_window_size}) must be "
-                f"<= --stamp-width ({stamp_width})"
-            )
+    # NOTE: come back to this later (are runtime checks properly implemented? does config defaults kick in before cli args are applied? if some but not all csvs are invalid, do we still process valid csvs & throw errors for the invalid ones with proper checkpointing, or do we fail loudly & immediately? are these checks comprehensive for energy detection + inference modules, e.g. overlap_fraction between 0 & 1?)
+    # # Energy detection preprocessing checks
+    # # If inference_files is provided, cadence_group_by_cols must be non-empty.
+    # # Per-CSV column-existence checks are deferred to runtime (CSVs aren't loaded here).
+    # # stamp_width == width_bin is validated at runtime in inference_command, where both
+    # # are resolved together.
+    # if hasattr(args, "inference_files") and args.inference_files is not None:
+    #     group_cols = getattr(args, "cadence_group_by_cols", None)
+    #     # If the user didn't pass --cadence-group-by-cols, the dataclass default kicks in
+    #     # (a non-empty list). Only fail if the user explicitly provided an empty list.
+    #     if group_cols is not None and len(group_cols) == 0:
+    #         errors.append(
+    #             "--cadence-group-by-cols must be non-empty when --inference-files is provided"
+    #         )
+    #
+    # if hasattr(args, "detection_window_size") and args.detection_window_size is not None:
+    #     stamp_width = getattr(args, "stamp_width", None)
+    #     if stamp_width is not None and args.detection_window_size > stamp_width:
+    #         errors.append(
+    #             f"--detection-window-size ({args.detection_window_size}) must be "
+    #             f"<= --stamp-width ({stamp_width})"
+    #         )
 
     # Throw an error if any validation fails
     if errors:

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -451,6 +451,13 @@ def _add_inference_arguments(subparsers):
         default=None,
         help="Space-separated list of testing data file names (e.g., real_filtered_LARGE_test_HIP15638.npy)",
     )
+    inf_parser.add_argument(
+        "--inference-files",
+        type=str,
+        nargs="+",
+        default=None,
+        help="Space-separated list of CSV file names describing .h5 observations to group into cadences (resolved against <data-path>/inference/). If provided, triggers the energy detection preprocessing pipeline and takes precedence over --test-files",
+    )
 
     # Inference configuration
     inf_parser.add_argument(
@@ -482,6 +489,99 @@ def _add_inference_arguments(subparsers):
         type=float,
         default=None,
         help="Classification threshold for candidate detection",
+    )
+
+    # Energy detection preprocessing
+    inf_parser.add_argument(
+        "--cadence-group-by-cols",
+        type=str,
+        nargs="+",
+        default=None,
+        help="Space-separated list of CSV column names whose joint value defines cadence membership (e.g., Target Session Band 'Cadence ID')",
+    )
+    inf_parser.add_argument(
+        "--cadence-h5-path-col",
+        type=str,
+        default=None,
+        help="CSV column containing the .h5 file path for each observation (default: '.h5 path')",
+    )
+    inf_parser.add_argument(
+        "--cadence-expected-obs",
+        type=int,
+        default=None,
+        help="Required number of observations per cadence (default: 6 for ABACAD)",
+    )
+    inf_parser.add_argument(
+        "--coarse-channel-width",
+        type=int,
+        default=None,
+        help="Number of fine channels per coarse channel (default: 1048576)",
+    )
+    inf_parser.add_argument(
+        "--parallel-coarse-chans",
+        type=int,
+        default=None,
+        help="Number of coarse channels to process in parallel per block (default: 28)",
+    )
+    inf_parser.add_argument(
+        "--spline-order",
+        type=int,
+        default=None,
+        help="Spline order for bandpass fitting (default: 16)",
+    )
+    inf_parser.add_argument(
+        "--detection-window-size",
+        type=int,
+        default=None,
+        help="Sliding window size in fine channels for normality test (default: 256)",
+    )
+    inf_parser.add_argument(
+        "--detection-step-size",
+        type=int,
+        default=None,
+        help="Step size in fine channels for sliding window (default: 128)",
+    )
+    inf_parser.add_argument(
+        "--stat-threshold",
+        type=float,
+        default=None,
+        help="D'Agostino-Pearson statistic threshold for hit detection (default: 2048.0)",
+    )
+    inf_parser.add_argument(
+        "--stamp-width",
+        type=int,
+        default=None,
+        help="Width in fine channels of the extracted stamp around each hit (default: 4096; must equal --width-bin)",
+    )
+    inf_parser.add_argument(
+        "--overlap-search",
+        action="store_true",
+        default=False,
+        help="If set, additionally extract stamps offset by ±overlap_fraction*stamp_width around each hit",
+    )
+    inf_parser.add_argument(
+        "--overlap-fraction",
+        type=float,
+        default=None,
+        help="Fractional offset (relative to stamp_width) for overlap-search stamps (default: 0.5)",
+    )
+    inf_parser.add_argument(
+        "--preprocess-output-dir",
+        type=str,
+        default=None,
+        help="Directory for per-cadence .npy outputs from preprocessing (default: <output-path>/preprocessed)",
+    )
+    inf_parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=None,
+        help="Maximum number of retry attempts for inference (including preprocessing) on failure",
+    )
+    inf_parser.add_argument(
+        "--retry-delay",
+        type=int,
+        default=None,
+        help="Delay in seconds between inference retry attempts",
     )
 
     # Checkpoint configuration
@@ -572,6 +672,8 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
         config.data.train_files = args.train_files
     if hasattr(args, "test_files") and args.test_files is not None:
         config.data.test_files = args.test_files
+    if hasattr(args, "inference_files") and args.inference_files is not None:
+        config.data.inference_files = args.inference_files
 
     # Training configuration
     if hasattr(args, "num_training_rounds") and args.num_training_rounds is not None:
@@ -656,9 +758,17 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
         config.training.patience_threshold = args.patience_threshold
     if hasattr(args, "lr_reduction_factor") and args.lr_reduction_factor is not None:
         config.training.reduction_factor = args.lr_reduction_factor
-    if hasattr(args, "max_retries") and args.max_retries is not None:
+    if (
+        hasattr(args, "max_retries")
+        and args.max_retries is not None
+        and getattr(args, "command", None) == "train"
+    ):
         config.training.max_retries = args.max_retries
-    if hasattr(args, "retry_delay") and args.retry_delay is not None:
+    if (
+        hasattr(args, "retry_delay")
+        and args.retry_delay is not None
+        and getattr(args, "command", None) == "train"
+    ):
         config.training.retry_delay = args.retry_delay
 
     # Checkpoint configuration
@@ -687,6 +797,47 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
         and getattr(args, "command", None) == "inference"
     ):
         config.inference.per_replica_batch_size = args.per_replica_batch_size
+
+    # Energy detection preprocessing
+    if hasattr(args, "cadence_group_by_cols") and args.cadence_group_by_cols is not None:
+        config.inference.cadence_group_by_cols = args.cadence_group_by_cols
+    if hasattr(args, "cadence_h5_path_col") and args.cadence_h5_path_col is not None:
+        config.inference.cadence_h5_path_col = args.cadence_h5_path_col
+    if hasattr(args, "cadence_expected_obs") and args.cadence_expected_obs is not None:
+        config.inference.cadence_expected_obs = args.cadence_expected_obs
+    if hasattr(args, "coarse_channel_width") and args.coarse_channel_width is not None:
+        config.inference.coarse_channel_width = args.coarse_channel_width
+    if hasattr(args, "parallel_coarse_chans") and args.parallel_coarse_chans is not None:
+        config.inference.parallel_coarse_chans = args.parallel_coarse_chans
+    if hasattr(args, "spline_order") and args.spline_order is not None:
+        config.inference.spline_order = args.spline_order
+    if hasattr(args, "detection_window_size") and args.detection_window_size is not None:
+        config.inference.detection_window_size = args.detection_window_size
+    if hasattr(args, "detection_step_size") and args.detection_step_size is not None:
+        config.inference.detection_step_size = args.detection_step_size
+    if hasattr(args, "stat_threshold") and args.stat_threshold is not None:
+        config.inference.stat_threshold = args.stat_threshold
+    if hasattr(args, "stamp_width") and args.stamp_width is not None:
+        config.inference.stamp_width = args.stamp_width
+    # overlap_search is a store_true flag; only override when explicitly set
+    if hasattr(args, "overlap_search") and args.overlap_search:
+        config.inference.overlap_search = args.overlap_search
+    if hasattr(args, "overlap_fraction") and args.overlap_fraction is not None:
+        config.inference.overlap_fraction = args.overlap_fraction
+    if hasattr(args, "preprocess_output_dir") and args.preprocess_output_dir is not None:
+        config.inference.preprocess_output_dir = args.preprocess_output_dir
+    if (
+        hasattr(args, "max_retries")
+        and args.max_retries is not None
+        and getattr(args, "command", None) == "inference"
+    ):
+        config.inference.max_retries = args.max_retries
+    if (
+        hasattr(args, "retry_delay")
+        and args.retry_delay is not None
+        and getattr(args, "command", None) == "inference"
+    ):
+        config.inference.retry_delay = args.retry_delay
 
 
 # NOTE: should we change validate_args() to validate_config() and run the tests on the final "applied" config singleton? or should we check both separately?
@@ -780,6 +931,28 @@ def validate_args(args: argparse.Namespace) -> None:
     # if hasattr(args, "some_param") and args.some_param is not None:
     #     if <validation_condition>:
     #         errors.append("Error message explaining the problem")
+
+    # Energy detection preprocessing checks
+    # If inference_files is provided, cadence_group_by_cols must be non-empty.
+    # Per-CSV column-existence checks are deferred to runtime (CSVs aren't loaded here).
+    # stamp_width == width_bin is validated at runtime in inference_command, where both
+    # are resolved together.
+    if hasattr(args, "inference_files") and args.inference_files is not None:
+        group_cols = getattr(args, "cadence_group_by_cols", None)
+        # If the user didn't pass --cadence-group-by-cols, the dataclass default kicks in
+        # (a non-empty list). Only fail if the user explicitly provided an empty list.
+        if group_cols is not None and len(group_cols) == 0:
+            errors.append(
+                "--cadence-group-by-cols must be non-empty when --inference-files is provided"
+            )
+
+    if hasattr(args, "detection_window_size") and args.detection_window_size is not None:
+        stamp_width = getattr(args, "stamp_width", None)
+        if stamp_width is not None and args.detection_window_size > stamp_width:
+            errors.append(
+                f"--detection-window-size ({args.detection_window_size}) must be "
+                f"<= --stamp-width ({stamp_width})"
+            )
 
     # Throw an error if any validation fails
     if errors:

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -555,9 +555,9 @@ def _add_inference_arguments(subparsers):
     )
     inf_parser.add_argument(
         "--overlap-search",
-        action="store_true",
-        default=False,
-        help="If set, additionally extract stamps offset by ±overlap_fraction*stamp_width around each hit",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Additionally extract stamps offset by ±overlap_fraction*stamp_width around each hit. Pass --no-overlap-search to disable when the config default is True.",
     )
     inf_parser.add_argument(
         "--overlap-fraction",
@@ -819,9 +819,11 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
         config.inference.stat_threshold = args.stat_threshold
     if hasattr(args, "stamp_width") and args.stamp_width is not None:
         config.inference.stamp_width = args.stamp_width
-    # NOTE: come back to this later (wtf does this comment mean?)
-    # overlap_search is a store_true flag; only override when explicitly set
-    if hasattr(args, "overlap_search") and args.overlap_search:
+    # overlap_search uses argparse.BooleanOptionalAction with default=None so that
+    # the CLI can express "leave the config default" (omit), "force on"
+    # (--overlap-search), and "force off" (--no-overlap-search). The `is not None`
+    # guard preserves the config default when the user passes neither.
+    if hasattr(args, "overlap_search") and args.overlap_search is not None:
         config.inference.overlap_search = args.overlap_search
     if hasattr(args, "overlap_fraction") and args.overlap_fraction is not None:
         config.inference.overlap_fraction = args.overlap_fraction

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -143,9 +143,7 @@ class DataConfig:
     # describe individual .h5 observations to be grouped into cadences.
     # If non-None, takes precedence over test_files during inference and triggers
     # the energy detection preprocessing pipeline.
-    inference_files: list[str] | None = field(
-        default_factory=lambda: ["complete_cadences_catalog.csv"]
-    )
+    inference_files: list[str] | None = field(default_factory=lambda: None)
 
 
 @dataclass

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -136,7 +136,11 @@ class DataConfig:
         ]
     )
     test_files: list[str] = field(default_factory=lambda: ["real_filtered_LARGE_test_HIP15638.npy"])
-    # TODO: have a new member called inference_files, whose values take precedence over test_files if not None (should still live inside self.data_path). test_files -> .npy, inference_files -> .h5 (add checks in validate_args & inference_command)
+    # Each entry is a CSV path (resolved via get_inference_file_path) whose rows
+    # describe individual .h5 observations to be grouped into cadences.
+    # If non-None, takes precedence over test_files during inference and triggers
+    # the energy detection preprocessing pipeline.
+    inference_files: list[str] | None = field(default_factory=lambda: None)
 
 
 @dataclass
@@ -255,6 +259,34 @@ class InferenceConfig:
     per_replica_batch_size: int = 2048  # NOTE: come back to this later
     classification_threshold: float = 0.9
 
+    # Energy detection preprocessing
+    cadence_group_by_cols: list[str] = field(
+        default_factory=lambda: ["Target", "Session", "Band", "Cadence ID"]
+    )
+    cadence_h5_path_col: str = ".h5 path"
+    cadence_expected_obs: int = 6  # observations per cadence (ABACAD)
+
+    coarse_channel_width: int = 1048576
+    parallel_coarse_chans: int = 28
+    spline_order: int = 16
+    detection_window_size: int = 256
+    detection_step_size: int = 128
+    stat_threshold: float = 2048.0
+    stamp_width: int = 4096
+
+    overlap_search: bool = False
+    overlap_fraction: float = 0.5
+
+    # Placeholder for future drop logic — wired but inert
+    discard_side_channels: bool = False
+    side_channel_count: int = 0
+
+    preprocess_output_dir: str | None = None  # defaults to <output_path>/preprocessed at runtime
+
+    # Fault tolerance (mirrors TrainingConfig)
+    max_retries: int = 3
+    retry_delay: int = 60  # seconds
+
 
 @dataclass
 class CheckpointConfig:
@@ -357,6 +389,10 @@ class Config:
         """Get full path for test data file"""
         return os.path.join(self.data_path, "testing", filename)
 
+    def get_inference_file_path(self, filename: str) -> str:
+        """Get full path for inference CSV file"""
+        return os.path.join(self.data_path, "inference", filename)
+
     def get_file_subset(self, filename: str) -> tuple[int | None, int | None]:
         """Get subset parameters for a file (start, end indices)"""
         # Option to define subsets for specific files to manage memory usage
@@ -435,6 +471,7 @@ class Config:
                 "inference_background_load_chunk_size": self.data.inference_background_load_chunk_size,
                 "train_files": self.data.train_files,
                 "test_files": self.data.test_files,
+                "inference_files": self.data.inference_files,
             },
             "training": {
                 "num_training_rounds": self.training.num_training_rounds,
@@ -481,6 +518,23 @@ class Config:
                 "config_path": self.inference.config_path,
                 "per_replica_batch_size": self.inference.per_replica_batch_size,
                 "classification_threshold": self.inference.classification_threshold,
+                "cadence_group_by_cols": self.inference.cadence_group_by_cols,
+                "cadence_h5_path_col": self.inference.cadence_h5_path_col,
+                "cadence_expected_obs": self.inference.cadence_expected_obs,
+                "coarse_channel_width": self.inference.coarse_channel_width,
+                "parallel_coarse_chans": self.inference.parallel_coarse_chans,
+                "spline_order": self.inference.spline_order,
+                "detection_window_size": self.inference.detection_window_size,
+                "detection_step_size": self.inference.detection_step_size,
+                "stat_threshold": self.inference.stat_threshold,
+                "stamp_width": self.inference.stamp_width,
+                "overlap_search": self.inference.overlap_search,
+                "overlap_fraction": self.inference.overlap_fraction,
+                "discard_side_channels": self.inference.discard_side_channels,
+                "side_channel_count": self.inference.side_channel_count,
+                "preprocess_output_dir": self.inference.preprocess_output_dir,
+                "max_retries": self.inference.max_retries,
+                "retry_delay": self.inference.retry_delay,
             },
             "checkpoint": {
                 "load_dir": self.checkpoint.load_dir,

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -113,6 +113,8 @@ class DataConfig:
     )
     max_chunks_per_file: int = 1  # Maximum chunks to load from a single file
 
+    # NOTE: should this be in DataConfig, InferenceConfig, or a new dataclass entirely (e.g. PreprocessingConfig)
+    # NOTE: should be renamed test_background_load_chunk_size? or no because inference_files still generate .npy which uses this same chunk size?
     # TODO: experiment with larger chunk sizes (how to track chunk processing efficiency)
     # We only specify chunk size during inference, since we assume all backgrounds from all files must be loaded
     inference_background_load_chunk_size: int = (
@@ -135,12 +137,15 @@ class DataConfig:
             "real_filtered_LARGE_HIP8497.npy",
         ]
     )
+    # TODO: add comment specifying test_files requirements & behavior (.npy instead of .csv containing individual .h5 files, in inference_files)
     test_files: list[str] = field(default_factory=lambda: ["real_filtered_LARGE_test_HIP15638.npy"])
     # Each entry is a CSV path (resolved via get_inference_file_path) whose rows
     # describe individual .h5 observations to be grouped into cadences.
     # If non-None, takes precedence over test_files during inference and triggers
     # the energy detection preprocessing pipeline.
-    inference_files: list[str] | None = field(default_factory=lambda: None)
+    inference_files: list[str] | None = field(
+        default_factory=lambda: ["complete_cadences_catalog.csv"]
+    )
 
 
 @dataclass
@@ -257,15 +262,17 @@ class InferenceConfig:
     rf_path: str = None
     config_path: str = None
     per_replica_batch_size: int = 2048  # NOTE: come back to this later
-    classification_threshold: float = 0.9
+    classification_threshold: float = 0.99
 
+    # NOTE: come back to this later (is this the optimal grouping?)
     # Energy detection preprocessing
     cadence_group_by_cols: list[str] = field(
-        default_factory=lambda: ["Target", "Session", "Band", "Cadence ID"]
+        default_factory=lambda: ["Target", "Session", "Band", "Cadence ID", "Frequency"]
     )
     cadence_h5_path_col: str = ".h5 path"
-    cadence_expected_obs: int = 6  # observations per cadence (ABACAD)
+    cadence_expected_obs: int = 6  # expected observations per cadence (ABACAD)
 
+    # NOTE: come back to this later (are these params correct?)
     coarse_channel_width: int = 1048576
     parallel_coarse_chans: int = 28
     spline_order: int = 16
@@ -274,16 +281,19 @@ class InferenceConfig:
     stat_threshold: float = 2048.0
     stamp_width: int = 4096
 
-    overlap_search: bool = False
+    # NOTE: come back to this later (is overlap search implemented correctly? redo analysis from peter forwards search paper)
+    overlap_search: bool = True
     overlap_fraction: float = 0.5
 
-    # Placeholder for future drop logic — wired but inert
+    # NOTE: come back to this later (placeholder for future drop logic — wired but inert)
     discard_side_channels: bool = False
     side_channel_count: int = 0
 
-    preprocess_output_dir: str | None = None  # defaults to <output_path>/preprocessed at runtime
+    # NOTE: come back to this later (is this consumed properly downstream? how does archiving functionality work with this? is there caching, e.g. if a h5 grouping already preprocessed & written to output dir, just read from it directly instead of wasting compute)
+    preprocess_output_dir: str | None = None  # Defaults to <output_path>/preprocessed at runtime
 
-    # Fault tolerance (mirrors TrainingConfig)
+    # NOTE: come back to this later (is this implemented correctly?)
+    # Fault tolerance
     max_retries: int = 3
     retry_delay: int = 60  # seconds
 

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -284,6 +284,8 @@ def inference_command():
         logger.error("No GPU strategy available. Inference requires GPU.")
         sys.exit(1)
 
+    # NOTE: come back to this later (does fault tolerance work properly with inference?)
+    # NOTE: come back to this later (should we add some async/back-and-forth design patterns -- e.g. preproc X files, inference X files, clear, repeat -- to reduce memory pressure? is this the most efficient architecture we can use? add comments about memory/performance trade-offs once inference pipeline complete (see preproc section in train_command())
     # Run preprocessing + inference with fault tolerance.
     # Recovery is state-based, not checkpoint-based: find_hits() writes per-cadence
     # .npy files as it goes and skips any whose .npy already exists, so simply
@@ -317,11 +319,11 @@ def inference_command():
                 cadence_data = preprocessor.load_inference_data().astype(np.float32)
                 npy_path_for_logging = config.data.test_files[0]
 
-            # Inference stage. NOTE: inference-stage resume (skipping cadences already
-            # in the DB) is mentioned in the plan but deferred to a follow-up.
+            # NOTE: come back to this later (inference-stage resume should skip cadences already in the DB. not yet implemented)
+            # Inference stage
             results = run_inference_pipeline(
                 cadence_data=cadence_data,
-                npy_path=npy_path_for_logging,
+                npy_path=npy_path_for_logging,  # TODO: handle multiple test_files properly
                 strategy=strategy,
                 # TODO: figure out how to pass preproc metadata into InferencePipeline (target, session, cadence_id, band, frequency_mhz, timestamp_observed, h5_path). should we roll these metadata + npy_path into a list/dict from preproc, then unroll them inside run_inference_pipeline()?
             )
@@ -342,7 +344,7 @@ def inference_command():
                 logger.error(f"Exceeded max retries ({max_retries}). Final error: {e}")
                 sys.exit(1)
 
-    # NOTE: should we create dedicated (tagged) directories inside output_path to store inference results (plots, configs, etc.)? note, data still written to db regardless
+    # NOTE: come back to this later (should we create dedicated (tagged) directories inside output_path to store inference results (plots, configs, etc.)? note, data still written to db regardless)
     # Save inference configuration
     config_path = os.path.join(config.output_path, f"config_{config.checkpoint.save_tag}.json")
     os.makedirs(os.path.dirname(config_path), exist_ok=True)  # Create dir if it doesn't exist

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -324,6 +324,12 @@ def inference_command():
                     ).astype(np.float32)
                     npy_path_for_logging = npy_paths[0]
                 else:
+                    if not config.data.test_files:
+                        logger.error(
+                            "Neither --inference-files nor --test-files is configured; "
+                            "nothing to load for inference"
+                        )
+                        sys.exit(1)
                     cadence_data = preprocessor.load_inference_data().astype(np.float32)
                     npy_path_for_logging = config.data.test_files[0]
             else:

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -245,6 +245,20 @@ def inference_command():
 
     # TODO: add a sanity check that verifies encoder, RF, and config path all have the same tag. throw a warning if false
 
+    # If inference_files is set, the energy detection preprocessing pipeline runs
+    # before inference; stamp_width must match the downstream width_bin so the
+    # extracted (n_hits, 6, 16, stamp_width) tensor is shaped correctly for the
+    # downsample + log-norm path.
+    if (
+        config.data.inference_files is not None
+        and config.inference.stamp_width != config.data.width_bin
+    ):
+        logger.error(
+            f"inference.stamp_width ({config.inference.stamp_width}) must equal "
+            f"data.width_bin ({config.data.width_bin}) when --inference-files is set"
+        )
+        sys.exit(1)
+
     logger.info("Configuration:")
     logger.info(f"  Data path: {config.data_path}")
     logger.info(f"  Model path: {config.model_path}")
@@ -252,7 +266,10 @@ def inference_command():
     logger.info(f"  Encoder path: {config.inference.encoder_path}")
     logger.info(f"  Random Forest path: {config.inference.rf_path}")
     logger.info(f"  Config path: {config.inference.config_path}")
-    logger.info(f"  Files to process: {config.data.test_files}")
+    if config.data.inference_files is not None:
+        logger.info(f"  Inference CSVs to process: {config.data.inference_files}")
+    else:
+        logger.info(f"  Files to process: {config.data.test_files}")
     logger.info(f"  Classification threshold: {config.inference.classification_threshold}")
 
     # Setup GPU strategy
@@ -267,32 +284,63 @@ def inference_command():
         logger.error("No GPU strategy available. Inference requires GPU.")
         sys.exit(1)
 
-    # NOTE: come back to this later (this is where we convert .h5 into .npy, and then downsample + log norm the .npy data)
-    # NOTE: will this lead to us holding too much data in memory for the sake of inference fault tolerance? should we add some async/back-and-forth design patterns (e.g. preproc X files, inference X files, clear, repeat) to reduce memory pressure? is this the most efficient architecture we can use? add comments about memory/performance trade-offs once inference pipeline complete (see preproc section in train_command())
-    # TODO: implement fault tolerance (should preproc have separate fault tolerance to inference?)
-    # Initialize preprocessor & load inference cadences
-    try:
-        preprocessor = DataPreprocessor()
-        cadence_data = preprocessor.load_inference_data().astype(np.float32)
-        # NOTE: do we need to close preprocessing pools and/or shared memory?
-    except Exception as e:
-        logger.error(f"Failed to load inference cadences: {e}")
-        sys.exit(1)
+    # Run preprocessing + inference with fault tolerance.
+    # Recovery is state-based, not checkpoint-based: find_hits() writes per-cadence
+    # .npy files as it goes and skips any whose .npy already exists, so simply
+    # retrying resumes from where the last attempt died. No checkpoint metadata
+    # is needed for the preprocessing stage.
+    preprocessor = DataPreprocessor()
+    max_retries = config.inference.max_retries
+    retry_delay = config.inference.retry_delay
+    results = None
 
-    # Run inference with fault tolerance
-    logger.info("Starting inference pipeline...")
+    for attempt in range(max_retries):
+        try:
+            logger.info(f"Inference attempt: {attempt + 1}/{max_retries}")
 
-    # TODO: implement fault tolerance
-    try:
-        results = run_inference_pipeline(
-            cadence_data=cadence_data,
-            npy_path=config.data.test_files[0],  # TODO: Handle multiple test files properly
-            strategy=strategy,
-            # TODO: figure out how to pass preproc metadata into InferencePipeline (target, session, cadence_id, band, frequency_mhz, timestamp_observed, h5_path). should we roll these metadata + npy_path into a list/dict from preproc, then unroll them inside run_inference_pipeline()?
-        )
-    except Exception as e:
-        logger.error(f"Inference failed: {e}")
-        sys.exit(1)
+            # Preprocessing stage (energy detection + stamp extraction)
+            if config.data.inference_files is not None:
+                cadence_results = preprocessor.find_hits()
+                if not cadence_results:
+                    logger.error("No cadence results produced by preprocessing")
+                    sys.exit(1)
+                npy_paths = [cr.npy_path for cr in cadence_results]
+                logger.info(
+                    f"Preprocessing produced {len(npy_paths)} cadence .npy file(s); "
+                    f"loading into inference"
+                )
+                cadence_data = preprocessor.load_inference_data(
+                    override_filepaths=npy_paths
+                ).astype(np.float32)
+                npy_path_for_logging = npy_paths[0]
+            else:
+                cadence_data = preprocessor.load_inference_data().astype(np.float32)
+                npy_path_for_logging = config.data.test_files[0]
+
+            # Inference stage. NOTE: inference-stage resume (skipping cadences already
+            # in the DB) is mentioned in the plan but deferred to a follow-up.
+            results = run_inference_pipeline(
+                cadence_data=cadence_data,
+                npy_path=npy_path_for_logging,
+                strategy=strategy,
+                # TODO: figure out how to pass preproc metadata into InferencePipeline (target, session, cadence_id, band, frequency_mhz, timestamp_observed, h5_path). should we roll these metadata + npy_path into a list/dict from preproc, then unroll them inside run_inference_pipeline()?
+            )
+            break  # success
+
+        except KeyboardInterrupt:
+            # Don't retry on user interruption; re-raise to propagate traceback
+            logger.info("Inference interrupted by user")
+            raise
+
+        except Exception as e:
+            logger.error(f"Inference attempt {attempt + 1} failed with error: {e}")
+            if attempt < max_retries - 1:
+                logger.info(f"Retrying in {retry_delay} seconds...")
+                gc.collect()
+                time.sleep(retry_delay)
+            else:
+                logger.error(f"Exceeded max retries ({max_retries}). Final error: {e}")
+                sys.exit(1)
 
     # NOTE: should we create dedicated (tagged) directories inside output_path to store inference results (plots, configs, etc.)? note, data still written to db regardless
     # Save inference configuration

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -295,29 +295,41 @@ def inference_command():
     max_retries = config.inference.max_retries
     retry_delay = config.inference.retry_delay
     results = None
+    # Cache cadence_data across retry attempts: once preprocessing + loading
+    # succeeds, an inference-only failure shouldn't trigger a re-load /
+    # re-downsample / re-log-norm pass. Mirrors how train_command loads
+    # background_data once outside its retry loop.
+    cadence_data: np.ndarray | None = None
+    npy_path_for_logging: str | None = None
 
     for attempt in range(max_retries):
         try:
             logger.info(f"Inference attempt: {attempt + 1}/{max_retries}")
 
-            # Preprocessing stage (energy detection + stamp extraction)
-            if config.data.inference_files is not None:
-                cadence_results = preprocessor.find_hits()
-                if not cadence_results:
-                    logger.error("No cadence results produced by preprocessing")
-                    sys.exit(1)
-                npy_paths = [cr.npy_path for cr in cadence_results]
-                logger.info(
-                    f"Preprocessing produced {len(npy_paths)} cadence .npy file(s); "
-                    f"loading into inference"
-                )
-                cadence_data = preprocessor.load_inference_data(
-                    override_filepaths=npy_paths
-                ).astype(np.float32)
-                npy_path_for_logging = npy_paths[0]
+            # Preprocessing + load stage. Skipped on retry if a previous attempt
+            # already produced cadence_data (i.e. only the inference stage failed).
+            if cadence_data is None:
+                if config.data.inference_files is not None:
+                    cadence_results = preprocessor.find_hits()
+                    if not cadence_results:
+                        logger.error("No cadence results produced by preprocessing")
+                        sys.exit(1)
+                    npy_paths = [cr.npy_path for cr in cadence_results]
+                    logger.info(
+                        f"Preprocessing produced {len(npy_paths)} cadence .npy file(s); "
+                        f"loading into inference"
+                    )
+                    cadence_data = preprocessor.load_inference_data(
+                        override_filepaths=npy_paths
+                    ).astype(np.float32)
+                    npy_path_for_logging = npy_paths[0]
+                else:
+                    cadence_data = preprocessor.load_inference_data().astype(np.float32)
+                    npy_path_for_logging = config.data.test_files[0]
             else:
-                cadence_data = preprocessor.load_inference_data().astype(np.float32)
-                npy_path_for_logging = config.data.test_files[0]
+                logger.info(
+                    "Reusing cadence_data from previous attempt (skipping preprocessing + load)"
+                )
 
             # NOTE: come back to this later (inference-stage resume should skip cadences already in the DB. not yet implemented)
             # Inference stage

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -11,9 +11,9 @@ from __future__ import annotations
 import contextlib
 import csv
 import gc
+import json
 import logging
 import os
-import pickle
 import re
 import signal
 from collections import OrderedDict
@@ -331,7 +331,7 @@ class CadenceResult:
     h5_paths: list[str]  # Same as in CadenceGroup
     key: tuple  # Same as in CadenceGroup
     n_hits: int
-    metadata_path: str  # Sibling .pkl with hit details
+    metadata_path: str  # Sibling .json with hit details
 
 
 # NOTE: come back to this later
@@ -987,8 +987,29 @@ class DataPreprocessor:
 
     @staticmethod
     def _cadence_metadata_path(npy_path: str) -> str:
-        """Return the sibling .pkl path for a cadence's metadata."""
-        return os.path.splitext(npy_path)[0] + ".pkl"
+        """Return the sibling .json path for a cadence's metadata."""
+        return os.path.splitext(npy_path)[0] + ".json"
+
+    @staticmethod
+    def _to_json_safe(obj):
+        """
+        Coerce h5py / numpy values into JSON-native types.
+
+        h5py attributes can be bytes, numpy scalars, or numpy arrays — none of
+        which json.dump handles by default. Walk the structure once and
+        convert leaf nodes; everything else passes through.
+        """
+        if isinstance(obj, dict):
+            return {str(k): DataPreprocessor._to_json_safe(v) for k, v in obj.items()}
+        if isinstance(obj, (list, tuple)):
+            return [DataPreprocessor._to_json_safe(v) for v in obj]
+        if isinstance(obj, bytes):
+            return obj.decode("utf-8", errors="replace")
+        if isinstance(obj, np.ndarray):
+            return DataPreprocessor._to_json_safe(obj.tolist())
+        if isinstance(obj, (np.integer, np.floating, np.bool_)):
+            return obj.item()
+        return obj
 
     # NOTE: come back to this later (does a cadence snippet get created if only 1 of the ON observations crosses the threshold, or all 3? should probably be all 3 as of now since models are trained on signals that don't yet drift out of frame?)
     def _process_cadence(self, group: CadenceGroup, npy_path: str) -> CadenceResult | None:
@@ -1188,8 +1209,8 @@ class DataPreprocessor:
             "overlap_fraction": overlap_fraction if overlap_search else None,
         }
         tmp_metadata_path = metadata_path + ".tmp"
-        with open(tmp_metadata_path, "wb") as f:
-            pickle.dump(metadata, f)
+        with open(tmp_metadata_path, "w") as f:
+            json.dump(self._to_json_safe(metadata), f, indent=2)
         os.replace(tmp_metadata_path, metadata_path)
 
         gc.collect()

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass, field
 from multiprocessing.shared_memory import SharedMemory
 
 import h5py
+
+# NOTE: come back to this later (why noqa: F401? what's the difference between h5py & hdf5plugin?)
 import hdf5plugin  # noqa: F401  # registers bitshuffle codec with h5py at import time
 import numpy as np
 from scipy import interpolate, stats
@@ -147,16 +149,12 @@ def _downsample_worker(args):
         return None
 
 
-# --- Energy detection helpers & workers ---
-
-
+# NOTE: come back to this later (mirrors preprocess_fine.py:72-75 from the reference implementation)
 def _remove_dc_spike(
     block_data: np.ndarray, coarse_channel_width: int, n_coarse_channels: int
 ) -> None:
     """
     Interpolate over the 2-bin DC spike at the center of each coarse channel, in place.
-
-    Mirrors preprocess_fine.py:72-75 from the reference implementation.
 
     Args:
         block_data: shape (time_bins, n_coarse_channels * coarse_channel_width)
@@ -170,13 +168,12 @@ def _remove_dc_spike(
         block_data[:, dc_ind - 1] = (block_data[:, dc_ind + 2] + block_data[:, dc_ind - 2]) / 2
 
 
+# NOTE: come back to this later (mirrors utils.py:17-22 from the reference implementation.)
 def _fit_channel_bandpass(
     integrated_channel: np.ndarray, channel_width: int, spl_order: int
 ) -> np.ndarray:
     """
     Fit a spline bandpass to a time-integrated coarse channel.
-
-    Mirrors utils.py:17-22 from the reference implementation.
 
     Args:
         integrated_channel: 1-D array of shape (channel_width,), time-integrated
@@ -192,6 +189,7 @@ def _fit_channel_bandpass(
     return interpolate.splev(x, spl)
 
 
+# NOTE: come back to this later
 def _read_coarse_channel_worker(args: tuple) -> np.ndarray:
     """
     Worker: read one coarse channel from an .h5 file.
@@ -211,6 +209,7 @@ def _read_coarse_channel_worker(args: tuple) -> np.ndarray:
         return hf["data"][:, 0, start:end]
 
 
+# NOTE: come back to this later
 def _remove_bandpass_worker(args: tuple) -> np.ndarray:
     """
     Worker: subtract the per-coarse-channel spline bandpass from one coarse channel.
@@ -238,6 +237,7 @@ def _remove_bandpass_worker(args: tuple) -> np.ndarray:
     return channel - fit
 
 
+# NOTE: come back to this later
 def _threshold_hits_worker(args: tuple) -> list[tuple]:
     """
     Worker: slide a window across one coarse channel and emit hits above threshold.
@@ -282,6 +282,7 @@ def _threshold_hits_worker(args: tuple) -> list[tuple]:
     return hits
 
 
+# NOTE: come back to this later
 # def _drop_side_channels(
 #     block_data: np.ndarray, side_channel_count: int, coarse_channel_width: int
 # ) -> None:
@@ -294,24 +295,26 @@ def _threshold_hits_worker(args: tuple) -> list[tuple]:
 class CadenceGroup:
     """One cadence's worth of observations grouped from a CSV."""
 
-    key: tuple  # the group-by column values
-    h5_paths: list[str]  # observation .h5 paths, in row order
-    csv_path: str  # source CSV
+    key: tuple  # The group-by column values
+    h5_paths: list[str]  # Observation .h5 paths, in row order
+    csv_path: str  # Source CSV
     expected_obs: int
     is_valid: bool  # True iff len(h5_paths) == expected_obs
 
 
+# NOTE: come back to this later (what does metadata_path store exactly?)
 @dataclass
 class CadenceResult:
     """Output of processing one cadence."""
 
     npy_path: str
-    h5_paths: list[str]
-    key: tuple
+    h5_paths: list[str]  # Same as in CadenceGroup
+    key: tuple  # Same as in CadenceGroup
     n_hits: int
-    metadata_path: str  # sibling .pkl with hit details
+    metadata_path: str  # Sibling .pkl with hit details
 
 
+# NOTE: come back to this later
 @dataclass
 class CadenceHit:
     """A single energy detection hit on an ON-source observation."""
@@ -322,6 +325,7 @@ class CadenceHit:
     frequency_mhz: float = field(default=float("nan"))
 
 
+# NOTE: come back to this later (add sorting functionality to sort rows in csv after grouping, e.g. via timestamp metadata from filenames? edge case where multiple 6-cadence observations of the same target & with the same grouping params, but differed by time, e.g. t=X to t=X+ε, then t=Y to t=Y+σ, for some small numbers ε and σ, and where X and Y are far apart from each other. add a way to distinguish these cases from problematic cases where we actually want to invalidate a cadence with a weird number of grouped observations, e.g. if multiple of 6 and enough of a gap between X and Y, then count as separate cadences?)
 def group_observations_from_csv(
     csv_path: str,
     group_by_cols: list[str],
@@ -360,6 +364,7 @@ def group_observations_from_csv(
         reader = csv.DictReader(f)
         available = reader.fieldnames or []
 
+        # NOTE: come back to this later (does this fail for all if one csv has missing columns, or does it skip the invalid csvs and continue processing the valid ones? is proper downstream checkpointing implemented in the latter case?)
         missing = [c for c in required_cols if c not in available]
         if missing:
             raise KeyError(
@@ -841,6 +846,7 @@ class DataPreprocessor:
 
         return cadence_array
 
+    # NOTE: come back to this later (based on docstring, we're processing cadences sequentially. if so, any way to parallelize?)
     def find_hits(self) -> list[CadenceResult]:
         """
         Convert raw .h5 cadence observations into (n_hits, 6, 16, stamp_width) .npy snippets.
@@ -944,6 +950,7 @@ class DataPreprocessor:
         logger.info(f"find_hits completed: {len(results)} cadence .npy files available")
         return results
 
+    # NOTE: come back to this later (ensure filenames are structured similarly as in train_files & test_files)
     @staticmethod
     def _cadence_npy_filename(csv_stem: str, key: tuple) -> str:
         """Build a deterministic filename for a cadence group's .npy output."""
@@ -958,6 +965,7 @@ class DataPreprocessor:
         """Return the sibling .pkl path for a cadence's metadata."""
         return os.path.splitext(npy_path)[0] + ".pkl"
 
+    # NOTE: come back to this later (does a cadence snippet get created if only 1 of the ON observations crosses the threshold, or all 3? should probably be all 3 as of now since models are trained on signals that don't yet drift out of frame?)
     def _process_cadence(self, group: CadenceGroup, npy_path: str) -> CadenceResult | None:
         """
         Run energy detection on one cadence and write its stamp .npy.
@@ -998,6 +1006,7 @@ class DataPreprocessor:
         fch1 = float(header["fch1"])
         n_time_avail = int(data_shape[0])
 
+        # NOTE: come back to this later (why do we only check if n_time_avail < time_bins? what happens if n_time_avail > time_bins?)
         if n_time_avail < time_bins:
             logger.warning(
                 f"Cadence {group.key}: primary file has only {n_time_avail} time bins, "
@@ -1072,6 +1081,7 @@ class DataPreprocessor:
 
         logger.info(f"Cadence {group.key}: {len(all_hits)} raw hits across ON-source files")
 
+        # NOTE: come back to this later (what's the trade-off for doing dedup vs not? e.g. lower storage & compute, but higher FNR or lower DR sensitivity?)
         # Deduplicate: greedy merge of any pair within stamp_width // 2
         merged_hits = self._deduplicate_hits(all_hits, stamp_width)
         logger.info(
@@ -1170,13 +1180,15 @@ class DataPreprocessor:
             for ch in range(block_num * parallel_chans, (block_num + 1) * parallel_chans)
         ]
 
+        # NOTE: come back to this later (is this correct?)
         # The read worker doesn't need shared memory; create a plain pool
         if n_processes > 1:
             pool = self.manager.create_pool(
                 n_processes=min(parallel_chans, n_processes),
-                name=f"DataPreproc_read_block_{block_num}",
+                name=f"DataPreproc_read_block_{block_num}",  # NOTE: come back to this later
             )
             try:
+                # NOTE: come back to this later (is pool.map correct here?)
                 results = pool.map(_read_coarse_channel_worker, args_list)
             finally:
                 self.manager.close_pool(pool)
@@ -1185,6 +1197,7 @@ class DataPreprocessor:
 
         return np.concatenate(results, axis=1)
 
+    # NOTE: come back to this later
     def _remove_block_bandpass(
         self,
         block_data: np.ndarray,
@@ -1199,14 +1212,14 @@ class DataPreprocessor:
         if n_processes > 1:
             shm = self.manager.create_shared_memory(
                 size=block_data.nbytes,
-                name="DataPreproc_bandpass_block",
+                name="DataPreproc_bandpass_block",  # NOTE: come back to this later
             )
             shared = np.ndarray(block_data.shape, dtype=block_data.dtype, buffer=shm.buf)
             shared[:] = block_data[:]
 
             pool = self.manager.create_pool(
                 n_processes=min(parallel_chans, n_processes),
-                name="DataPreproc_bandpass_block",
+                name="DataPreproc_bandpass_block",  # NOTE: come back to this later
                 initializer=_init_worker,
                 initargs=(shm.name, block_data.shape, block_data.dtype),
             )
@@ -1224,6 +1237,7 @@ class DataPreprocessor:
 
         return np.concatenate(results, axis=1)
 
+    # NOTE: come back to this later
     def _threshold_block_hits(
         self,
         cleaned_block: np.ndarray,
@@ -1244,14 +1258,14 @@ class DataPreprocessor:
         if n_processes > 1:
             shm = self.manager.create_shared_memory(
                 size=cleaned_block.nbytes,
-                name="DataPreproc_threshold_block",
+                name="DataPreproc_threshold_block",  # NOTE: come back to this later
             )
             shared = np.ndarray(cleaned_block.shape, dtype=cleaned_block.dtype, buffer=shm.buf)
             shared[:] = cleaned_block[:]
 
             pool = self.manager.create_pool(
                 n_processes=min(parallel_chans, n_processes),
-                name="DataPreproc_threshold_block",
+                name="DataPreproc_threshold_block",  # NOTE: come back to this later
                 initializer=_init_worker,
                 initargs=(shm.name, cleaned_block.shape, cleaned_block.dtype),
             )
@@ -1272,6 +1286,7 @@ class DataPreprocessor:
             flat.extend(r)
         return flat
 
+    # NOTE: come back to this later (what's the trade-off for doing dedup vs not? e.g. lower storage & compute, but higher FNR or lower DR sensitivity?)
     @staticmethod
     def _deduplicate_hits(hits: list[tuple], stamp_width: int) -> list[tuple]:
         """

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -14,6 +14,7 @@ import gc
 import logging
 import os
 import pickle
+import re
 import signal
 from collections import OrderedDict
 from dataclasses import dataclass, field
@@ -976,10 +977,12 @@ class DataPreprocessor:
     @staticmethod
     def _cadence_npy_filename(csv_stem: str, key: tuple) -> str:
         """Build a deterministic filename for a cadence group's .npy output."""
-        # Sanitize: replace path separators and whitespace in key components
-        safe_parts = [
-            str(part).replace(os.sep, "_").replace(" ", "_").replace("/", "_") for part in key
-        ]
+        # Sanitize each key component via an allowlist: only word chars, dash, and
+        # dot survive — everything else collapses to underscore. This is broader
+        # than just stripping path separators / whitespace: CSV column values can
+        # carry quotes, control chars, shell metacharacters, or path-traversal
+        # sequences (e.g. "..") that would otherwise leak through.
+        safe_parts = [re.sub(r"[^\w\-.]+", "_", str(part)) for part in key]
         return f"{csv_stem}_{'_'.join(safe_parts)}.npy"
 
     @staticmethod

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -933,6 +933,9 @@ class DataPreprocessor:
                             f"Existing .npy at {npy_path} could not be inspected ({e}); "
                             f"reprocessing cadence"
                         )
+                        # Fall through (no continue) to the _process_cadence call
+                        # below so a corrupted .npy gets regenerated rather than
+                        # silently skipped.
                     else:
                         logger.info(
                             f"Skipping cadence {group.key}: {npy_path} already exists "

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -1115,6 +1115,14 @@ class DataPreprocessor:
             logger.info(f"Cadence {group.key}: no valid in-bounds stamps; skipping")
             return None
 
+        # Sort stamps by start index before extraction. With overlap_search the raw
+        # order is hit-interleaved (hit1-off, hit1, hit1+off, hit2-off, ...), so
+        # neighboring hits can produce out-of-order starts. Reads against
+        # bitshuffle-compressed .h5 files are dominated by chunk decompression cost;
+        # sequential start order gives the OS / hdf5 chunk cache a chance to reuse a
+        # decompressed chunk across adjacent stamps instead of redecompressing it.
+        stamp_centers.sort(key=lambda s: s[0])
+
         # Extract stamps for all 6 observations (sequential per file, no pool)
         cadence_stamps = np.zeros(
             (len(stamp_centers), len(group.h5_paths), time_bins, stamp_width), dtype=np.float32

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -13,6 +13,7 @@ import csv
 import gc
 import logging
 import os
+import pickle
 import signal
 from collections import OrderedDict
 from dataclasses import dataclass, field
@@ -827,6 +828,453 @@ class DataPreprocessor:
 
         return cadence_array
 
-    # TODO: complete find_hits function to perform DC spike removal, bandpass filtering, and energy detection. should take .h5 filepaths as input, then write hits into (n, 6, 16, 4096) shaped .npy files (to data_path? output_path?). have boolean flag overlap_search as arg. if true, write additional cadence snippets +/- 50% in frequency from the actual hit to the .npy file. parametrize overlap amount to InferenceConfig().
-    def find_hits(self):
-        pass
+    def find_hits(self) -> list[CadenceResult]:
+        """
+        Convert raw .h5 cadence observations into (n_hits, 6, 16, stamp_width) .npy snippets.
+
+        Driven by CSVs in config.data.inference_files. Each CSV is grouped into
+        cadences via group_observations_from_csv() and processed sequentially.
+        Within each cadence, energy detection runs on ON-source files (positions
+        0, 2, 4 in ABACAD); stamps are extracted from all 6 observations at hit
+        frequencies.
+
+        Each cadence produces one .npy file on disk as soon as it's ready
+        (periodic checkpointing). On retry, cadences whose output already exists
+        are skipped.
+
+        Returns:
+            List of CadenceResult, one per successfully processed (or already
+            cached) cadence.
+        """
+        inference_files = self.config.data.inference_files
+        if not inference_files:
+            logger.warning("find_hits() called with no inference_files configured")
+            return []
+
+        # Resolve output directory
+        output_dir = self.config.inference.preprocess_output_dir or os.path.join(
+            self.config.output_path, "preprocessed"
+        )
+        os.makedirs(output_dir, exist_ok=True)
+        logger.info(f"Preprocessing output directory: {output_dir}")
+
+        group_by_cols = self.config.inference.cadence_group_by_cols
+        h5_path_col = self.config.inference.cadence_h5_path_col
+        expected_obs = self.config.inference.cadence_expected_obs
+
+        results: list[CadenceResult] = []
+
+        for csv_filename in inference_files:
+            csv_path = self.config.get_inference_file_path(csv_filename)
+            logger.info(f"Processing inference CSV: {csv_path}")
+
+            try:
+                valid_groups, flagged_groups = group_observations_from_csv(
+                    csv_path=csv_path,
+                    group_by_cols=group_by_cols,
+                    h5_path_col=h5_path_col,
+                    expected_obs=expected_obs,
+                )
+            except (FileNotFoundError, KeyError) as e:
+                logger.error(f"Failed to group CSV {csv_path}: {e}")
+                continue
+
+            logger.info(
+                f"CSV {csv_filename}: {len(valid_groups)} valid, {len(flagged_groups)} flagged"
+            )
+
+            csv_stem = os.path.splitext(os.path.basename(csv_path))[0]
+
+            for group in valid_groups:
+                npy_filename = self._cadence_npy_filename(csv_stem, group.key)
+                npy_path = os.path.join(output_dir, npy_filename)
+
+                if os.path.exists(npy_path):
+                    # Resume path: rebuild a minimal CadenceResult from the existing file
+                    metadata_path = self._cadence_metadata_path(npy_path)
+                    try:
+                        existing = np.load(npy_path, mmap_mode="r")
+                        n_hits = existing.shape[0]
+                        del existing
+                    except Exception as e:
+                        logger.warning(
+                            f"Existing .npy at {npy_path} could not be inspected ({e}); "
+                            f"reprocessing cadence"
+                        )
+                    else:
+                        logger.info(
+                            f"Skipping cadence {group.key}: {npy_path} already exists "
+                            f"({n_hits} hits)"
+                        )
+                        results.append(
+                            CadenceResult(
+                                npy_path=npy_path,
+                                h5_paths=group.h5_paths,
+                                key=group.key,
+                                n_hits=n_hits,
+                                metadata_path=metadata_path,
+                            )
+                        )
+                        continue
+
+                try:
+                    cadence_result = self._process_cadence(group, npy_path)
+                except Exception as e:
+                    # Single-cadence failures should not abort the whole CSV;
+                    # the retry loop at the inference_command level handles broader recovery
+                    logger.error(f"Failed to process cadence {group.key}: {e}")
+                    continue
+
+                if cadence_result is not None:
+                    results.append(cadence_result)
+
+        logger.info(f"find_hits completed: {len(results)} cadence .npy files available")
+        return results
+
+    @staticmethod
+    def _cadence_npy_filename(csv_stem: str, key: tuple) -> str:
+        """Build a deterministic filename for a cadence group's .npy output."""
+        # Sanitize: replace path separators and whitespace in key components
+        safe_parts = [
+            str(part).replace(os.sep, "_").replace(" ", "_").replace("/", "_") for part in key
+        ]
+        return f"{csv_stem}_{'_'.join(safe_parts)}.npy"
+
+    @staticmethod
+    def _cadence_metadata_path(npy_path: str) -> str:
+        """Return the sibling .pkl path for a cadence's metadata."""
+        return os.path.splitext(npy_path)[0] + ".pkl"
+
+    def _process_cadence(self, group: CadenceGroup, npy_path: str) -> CadenceResult | None:
+        """
+        Run energy detection on one cadence and write its stamp .npy.
+
+        Energy detection runs only on ON-source observations (positions 0, 2, 4
+        in ABACAD order). Hits define the frequency slices extracted from all 6
+        observations.
+
+        Args:
+            group: validated CadenceGroup (len(h5_paths) == expected_obs)
+            npy_path: target output path (already absolute)
+
+        Returns:
+            CadenceResult on success, or None if no hits survived.
+        """
+        coarse_channel_width = self.config.inference.coarse_channel_width
+        parallel_chans = self.config.inference.parallel_coarse_chans
+        spl_order = self.config.inference.spline_order
+        window_size = self.config.inference.detection_window_size
+        step_size = self.config.inference.detection_step_size
+        stat_threshold = self.config.inference.stat_threshold
+        stamp_width = self.config.inference.stamp_width
+        overlap_search = self.config.inference.overlap_search
+        overlap_fraction = self.config.inference.overlap_fraction
+        time_bins = self.config.data.time_bins
+        n_processes = self.config.manager.n_processes
+
+        # Read header / metadata from the first ON-source file
+        on_source_paths = [group.h5_paths[i] for i in (0, 2, 4)]
+        primary_h5 = on_source_paths[0]
+
+        with h5py.File(primary_h5, "r") as hf:
+            header = {k: hf["data"].attrs[k] for k in hf["data"].attrs}
+            data_shape = hf["data"].shape
+
+        n_chans = int(header.get("nchans", data_shape[-1]))
+        foff = float(header["foff"])
+        fch1 = float(header["fch1"])
+        n_time_avail = int(data_shape[0])
+
+        if n_time_avail < time_bins:
+            logger.warning(
+                f"Cadence {group.key}: primary file has only {n_time_avail} time bins, "
+                f"expected >= {time_bins}; skipping"
+            )
+            return None
+
+        num_blocks = n_chans // (coarse_channel_width * parallel_chans)
+        if num_blocks == 0:
+            logger.warning(
+                f"Cadence {group.key}: n_chans={n_chans} is smaller than one block "
+                f"({coarse_channel_width * parallel_chans}); skipping"
+            )
+            return None
+
+        block_width = coarse_channel_width * parallel_chans
+        logger.info(
+            f"Cadence {group.key}: n_chans={n_chans}, num_blocks={num_blocks}, "
+            f"block_width={block_width}, ON-source files={len(on_source_paths)}"
+        )
+
+        # Aggregate hits across all ON-source files
+        all_hits: list[tuple] = []  # (abs_idx, stat, p)
+
+        for on_source_idx, on_h5 in enumerate(on_source_paths):
+            logger.info(
+                f"Cadence {group.key}: running energy detection on ON-source "
+                f"{on_source_idx + 1}/{len(on_source_paths)}: {on_h5}"
+            )
+
+            for block_num in range(num_blocks):
+                block_offset = block_num * block_width
+                logger.info(
+                    f"  Block {block_num + 1}/{num_blocks} "
+                    f"(coarse {block_num * parallel_chans}..{(block_num + 1) * parallel_chans - 1})"
+                )
+
+                block_data = self._read_block(
+                    on_h5, block_num, parallel_chans, coarse_channel_width, n_processes
+                )
+
+                # Slice to first time_bins
+                block_data = block_data[:time_bins]
+
+                # In-place DC spike removal
+                _remove_dc_spike(block_data, coarse_channel_width, parallel_chans)
+
+                # _drop_side_channels(block_data, side_channel_count, coarse_channel_width)
+
+                cleaned_block = self._remove_block_bandpass(
+                    block_data, parallel_chans, coarse_channel_width, spl_order, n_processes
+                )
+
+                # Free original block memory; we only need the cleaned residuals downstream
+                del block_data
+
+                block_hits = self._threshold_block_hits(
+                    cleaned_block,
+                    parallel_chans,
+                    coarse_channel_width,
+                    window_size,
+                    step_size,
+                    stat_threshold,
+                    block_offset,
+                    n_processes,
+                )
+
+                all_hits.extend(block_hits)
+
+                del cleaned_block
+                gc.collect()
+
+        logger.info(f"Cadence {group.key}: {len(all_hits)} raw hits across ON-source files")
+
+        # Deduplicate: greedy merge of any pair within stamp_width // 2
+        merged_hits = self._deduplicate_hits(all_hits, stamp_width)
+        logger.info(
+            f"Cadence {group.key}: {len(merged_hits)} hits after deduplication "
+            f"(stamp_width={stamp_width})"
+        )
+
+        if not merged_hits:
+            logger.info(f"Cadence {group.key}: no hits survived; skipping")
+            return None
+
+        # Build the stamp centers (optionally including overlap offsets)
+        stamp_centers: list[tuple[int, float, float]] = []
+        offsets = [0]
+        if overlap_search:
+            offset_mag = int(overlap_fraction * stamp_width)
+            offsets = [-offset_mag, 0, offset_mag]
+
+        half = stamp_width // 2
+        for hit in merged_hits:
+            abs_idx, stat, pval = hit
+            for offset in offsets:
+                center = abs_idx + offset
+                start = center - half
+                end = center + half
+                if start < 0 or end > n_chans:
+                    continue
+                stamp_centers.append((start, stat, pval))
+
+        if not stamp_centers:
+            logger.info(f"Cadence {group.key}: no valid in-bounds stamps; skipping")
+            return None
+
+        # Extract stamps for all 6 observations (sequential per file, no pool)
+        cadence_stamps = np.zeros(
+            (len(stamp_centers), len(group.h5_paths), time_bins, stamp_width), dtype=np.float32
+        )
+
+        for obs_idx, obs_h5 in enumerate(group.h5_paths):
+            with h5py.File(obs_h5, "r") as hf:
+                for stamp_idx, (start, _, _) in enumerate(stamp_centers):
+                    end = start + stamp_width
+                    cadence_stamps[stamp_idx, obs_idx] = hf["data"][:time_bins, 0, start:end]
+
+        # Write the .npy and the sibling metadata
+        np.save(npy_path, cadence_stamps)
+
+        metadata_path = self._cadence_metadata_path(npy_path)
+        # Per-stamp frequency = center bin's frequency, computed from header's fch1/foff
+        stamp_freqs_mhz = [float(fch1 + foff * (start + half)) for start, _, _ in stamp_centers]
+        stamp_stats = [float(s) for _, s, _ in stamp_centers]
+        stamp_pvals = [float(p) for _, _, p in stamp_centers]
+
+        metadata = {
+            "key": group.key,
+            "csv_path": group.csv_path,
+            "h5_paths": group.h5_paths,
+            "header": header,
+            "stamp_starts": [int(start) for start, _, _ in stamp_centers],
+            "stamp_width": stamp_width,
+            "stamp_frequencies_mhz": stamp_freqs_mhz,
+            "stamp_statistics": stamp_stats,
+            "stamp_pvalues": stamp_pvals,
+            "overlap_search": overlap_search,
+            "overlap_fraction": overlap_fraction if overlap_search else None,
+        }
+        with open(metadata_path, "wb") as f:
+            pickle.dump(metadata, f)
+
+        gc.collect()
+
+        logger.info(
+            f"Cadence {group.key}: wrote {cadence_stamps.shape[0]} stamps -> "
+            f"{npy_path} (metadata: {metadata_path})"
+        )
+
+        return CadenceResult(
+            npy_path=npy_path,
+            h5_paths=group.h5_paths,
+            key=group.key,
+            n_hits=cadence_stamps.shape[0],
+            metadata_path=metadata_path,
+        )
+
+    def _read_block(
+        self,
+        h5_path: str,
+        block_num: int,
+        parallel_chans: int,
+        coarse_channel_width: int,
+        n_processes: int,
+    ) -> np.ndarray:
+        """Read parallel_chans coarse channels in parallel and concatenate."""
+        args_list = [
+            (h5_path, ch, coarse_channel_width)
+            for ch in range(block_num * parallel_chans, (block_num + 1) * parallel_chans)
+        ]
+
+        # The read worker doesn't need shared memory; create a plain pool
+        if n_processes > 1:
+            pool = self.manager.create_pool(
+                n_processes=min(parallel_chans, n_processes),
+                name=f"DataPreproc_read_block_{block_num}",
+            )
+            try:
+                results = pool.map(_read_coarse_channel_worker, args_list)
+            finally:
+                self.manager.close_pool(pool)
+        else:
+            results = [_read_coarse_channel_worker(a) for a in args_list]
+
+        return np.concatenate(results, axis=1)
+
+    def _remove_block_bandpass(
+        self,
+        block_data: np.ndarray,
+        parallel_chans: int,
+        coarse_channel_width: int,
+        spl_order: int,
+        n_processes: int,
+    ) -> np.ndarray:
+        """Spline-fit + subtract bandpass per coarse channel, return cleaned block."""
+        args_list = [(ch, coarse_channel_width, spl_order) for ch in range(parallel_chans)]
+
+        if n_processes > 1:
+            shm = self.manager.create_shared_memory(
+                size=block_data.nbytes,
+                name="DataPreproc_bandpass_block",
+            )
+            shared = np.ndarray(block_data.shape, dtype=block_data.dtype, buffer=shm.buf)
+            shared[:] = block_data[:]
+
+            pool = self.manager.create_pool(
+                n_processes=min(parallel_chans, n_processes),
+                name="DataPreproc_bandpass_block",
+                initializer=_init_worker,
+                initargs=(shm.name, block_data.shape, block_data.dtype),
+            )
+            try:
+                results = pool.map(_remove_bandpass_worker, args_list)
+            finally:
+                del shared
+                self.manager.close_shared_memory(shm)
+                self.manager.close_pool(pool)
+        else:
+            global _GLOBAL_CHUNK_DATA
+            _GLOBAL_CHUNK_DATA = block_data
+            results = [_remove_bandpass_worker(a) for a in args_list]
+            _GLOBAL_CHUNK_DATA = None
+
+        return np.concatenate(results, axis=1)
+
+    def _threshold_block_hits(
+        self,
+        cleaned_block: np.ndarray,
+        parallel_chans: int,
+        coarse_channel_width: int,
+        window_size: int,
+        step_size: int,
+        stat_threshold: float,
+        block_offset: int,
+        n_processes: int,
+    ) -> list[tuple]:
+        """Sliding-window normality test across one cleaned block, return all hits."""
+        args_list = [
+            (ch, coarse_channel_width, window_size, step_size, stat_threshold, block_offset)
+            for ch in range(parallel_chans)
+        ]
+
+        if n_processes > 1:
+            shm = self.manager.create_shared_memory(
+                size=cleaned_block.nbytes,
+                name="DataPreproc_threshold_block",
+            )
+            shared = np.ndarray(cleaned_block.shape, dtype=cleaned_block.dtype, buffer=shm.buf)
+            shared[:] = cleaned_block[:]
+
+            pool = self.manager.create_pool(
+                n_processes=min(parallel_chans, n_processes),
+                name="DataPreproc_threshold_block",
+                initializer=_init_worker,
+                initargs=(shm.name, cleaned_block.shape, cleaned_block.dtype),
+            )
+            try:
+                results = pool.map(_threshold_hits_worker, args_list)
+            finally:
+                del shared
+                self.manager.close_shared_memory(shm)
+                self.manager.close_pool(pool)
+        else:
+            global _GLOBAL_CHUNK_DATA
+            _GLOBAL_CHUNK_DATA = cleaned_block
+            results = [_threshold_hits_worker(a) for a in args_list]
+            _GLOBAL_CHUNK_DATA = None
+
+        flat: list[tuple] = []
+        for r in results:
+            flat.extend(r)
+        return flat
+
+    @staticmethod
+    def _deduplicate_hits(hits: list[tuple], stamp_width: int) -> list[tuple]:
+        """
+        Greedy merge of hits whose centers are within stamp_width // 2,
+        keeping the one with the higher statistic.
+        """
+        if not hits:
+            return []
+        sorted_hits = sorted(hits, key=lambda h: h[0])
+        half = stamp_width // 2
+        merged: list[tuple] = [sorted_hits[0]]
+        for h in sorted_hits[1:]:
+            prev = merged[-1]
+            if h[0] - prev[0] < half:
+                if h[1] > prev[1]:
+                    merged[-1] = h
+            else:
+                merged.append(h)
+        return merged

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -1156,8 +1156,14 @@ class DataPreprocessor:
                     end = start + stamp_width
                     cadence_stamps[stamp_idx, obs_idx] = hf["data"][:time_bins, 0, start:end]
 
-        # Write the .npy and the sibling metadata
-        np.save(npy_path, cadence_stamps)
+        # Write the .npy and the sibling metadata atomically. A process kill
+        # mid-write must not leave a corrupt file at the canonical path —
+        # find_hits' resume path treats the existence of npy_path as proof of
+        # a complete write. We achieve that by writing to a .tmp sibling first
+        # then os.replace()-ing it onto the canonical name.
+        tmp_npy_path = os.path.splitext(npy_path)[0] + ".tmp.npy"
+        np.save(tmp_npy_path, cadence_stamps)
+        os.replace(tmp_npy_path, npy_path)
 
         metadata_path = self._cadence_metadata_path(npy_path)
         # Per-stamp frequency = center bin's frequency, computed from header's fch1/foff
@@ -1178,8 +1184,10 @@ class DataPreprocessor:
             "overlap_search": overlap_search,
             "overlap_fraction": overlap_fraction if overlap_search else None,
         }
-        with open(metadata_path, "wb") as f:
+        tmp_metadata_path = metadata_path + ".tmp"
+        with open(tmp_metadata_path, "wb") as f:
             pickle.dump(metadata, f)
+        os.replace(tmp_metadata_path, metadata_path)
 
         gc.collect()
 

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -620,10 +620,16 @@ class DataPreprocessor:
 
     # NOTE: shared resources currently created & destroyed within function itself. think about abstractions once preprocessing.py is complete
     # NOTE: calculate intensity statistics to overlay with training distributions (C' vs C)?
-    def load_inference_data(self) -> np.ndarray:
+    def load_inference_data(self, override_filepaths: list[str] | None = None) -> np.ndarray:
         """
         Load & preprocess data for inference
         Uses parallel processing to load, downsample, and log-normalize the data
+
+        Args:
+            override_filepaths: If provided, iterate these absolute paths directly
+                instead of resolving config.data.test_files via get_test_file_path.
+                Used by find_hits() to chain per-cadence .npy outputs into inference
+                without monkey-patching paths.
 
         Returns:
             Array of preprocessed cadences with shape (n, 6, 16, width_bin_downsampled)
@@ -642,9 +648,16 @@ class DataPreprocessor:
 
         all_cadences = []
 
-        for filename in self.config.data.test_files:
-            filepath = self.config.get_test_file_path(filename)
+        if override_filepaths is not None:
+            # Iterate absolute paths directly (e.g. per-cadence .npy outputs from find_hits)
+            file_iter = [(os.path.basename(p), p) for p in override_filepaths]
+        else:
+            file_iter = [
+                (filename, self.config.get_test_file_path(filename))
+                for filename in self.config.data.test_files
+            ]
 
+        for filename, filepath in file_iter:
             if not os.path.exists(filepath):
                 logger.warning(f"File not found: {filepath}")
                 continue

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -190,6 +190,12 @@ def _fit_channel_bandpass(
         1-D bandpass fit of shape (channel_width,)
     """
     x = np.arange(channel_width)
+    # Interior knots must lie strictly inside (x[0], x[-1]); knots[1:] drops the
+    # leading 0, which satisfies that constraint for the default config
+    # (channel_width=1048576, spl_order=16). A pathological config with very
+    # small channel_width relative to spl_order could produce a knots array
+    # that violates the constraint — splrep would raise then. The defaults
+    # used in InferenceConfig are safe.
     knots = np.arange(0, channel_width, channel_width // spl_order + 1)
     spl = interpolate.splrep(x, integrated_channel, t=knots[1:])
     return interpolate.splev(x, spl)

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -9,12 +9,16 @@ Uses multiprocessing and shared memory to process data in parallel
 from __future__ import annotations
 
 import contextlib
+import csv
 import gc
 import logging
 import os
 import signal
+from collections import OrderedDict
+from dataclasses import dataclass, field
 from multiprocessing.shared_memory import SharedMemory
 
+import hdf5plugin  # noqa: F401  # registers bitshuffle codec with h5py at import time
 import numpy as np
 from skimage.transform import downscale_local_mean
 
@@ -138,6 +142,115 @@ def _downsample_worker(args):
     else:
         logger.warning("No global chunk data available")
         return None
+
+
+@dataclass
+class CadenceGroup:
+    """One cadence's worth of observations grouped from a CSV."""
+
+    key: tuple  # the group-by column values
+    h5_paths: list[str]  # observation .h5 paths, in row order
+    csv_path: str  # source CSV
+    expected_obs: int
+    is_valid: bool  # True iff len(h5_paths) == expected_obs
+
+
+@dataclass
+class CadenceResult:
+    """Output of processing one cadence."""
+
+    npy_path: str
+    h5_paths: list[str]
+    key: tuple
+    n_hits: int
+    metadata_path: str  # sibling .pkl with hit details
+
+
+@dataclass
+class CadenceHit:
+    """A single energy detection hit on an ON-source observation."""
+
+    fine_channel: int  # absolute fine-channel index into the full spectrum
+    statistic: float  # D'Agostino-Pearson statistic
+    pvalue: float
+    frequency_mhz: float = field(default=float("nan"))
+
+
+def group_observations_from_csv(
+    csv_path: str,
+    group_by_cols: list[str],
+    h5_path_col: str,
+    expected_obs: int = 6,
+) -> tuple[list[CadenceGroup], list[CadenceGroup]]:
+    """
+    Group rows of a CSV into cadences.
+
+    Rows are grouped by the joint value of `group_by_cols` (rows are assumed
+    already ordered correctly within each group in the source CSV). The function
+    is column-agnostic: it never assumes specific column names beyond what the
+    caller provides.
+
+    Args:
+        csv_path: path to CSV
+        group_by_cols: columns whose joint value defines cadence membership
+        h5_path_col: column containing the .h5 file path for that observation
+        expected_obs: required number of observations per cadence (typically 6)
+
+    Returns:
+        (valid_groups, flagged_groups) — flagged groups have wrong obs count.
+
+    Raises:
+        FileNotFoundError: if csv_path doesn't exist.
+        KeyError: if any column in group_by_cols + [h5_path_col] is missing.
+    """
+    if not os.path.exists(csv_path):
+        raise FileNotFoundError(f"CSV not found: {csv_path}")
+
+    required_cols = list(group_by_cols) + [h5_path_col]
+
+    groups: OrderedDict[tuple, list[str]] = OrderedDict()
+
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        available = reader.fieldnames or []
+
+        missing = [c for c in required_cols if c not in available]
+        if missing:
+            raise KeyError(
+                f"CSV {csv_path} is missing required column(s): {missing}. "
+                f"Available columns: {available}"
+            )
+
+        for row in reader:
+            key = tuple(row[c] for c in group_by_cols)
+            groups.setdefault(key, []).append(row[h5_path_col])
+
+    valid: list[CadenceGroup] = []
+    flagged: list[CadenceGroup] = []
+    for key, h5_paths in groups.items():
+        is_valid = len(h5_paths) == expected_obs
+        cg = CadenceGroup(
+            key=key,
+            h5_paths=h5_paths,
+            csv_path=csv_path,
+            expected_obs=expected_obs,
+            is_valid=is_valid,
+        )
+        (valid if is_valid else flagged).append(cg)
+
+    if flagged:
+        sample = [(g.key, len(g.h5_paths)) for g in flagged[:5]]
+        logger.warning(
+            f"Found {len(flagged)} cadence group(s) in {csv_path} with obs count != "
+            f"{expected_obs}; flagged and skipped. First {len(sample)}: {sample}"
+        )
+
+    logger.info(
+        f"Grouped {csv_path}: {len(valid)} valid cadence(s), {len(flagged)} flagged "
+        f"(expected_obs={expected_obs})"
+    )
+
+    return valid, flagged
 
 
 class DataPreprocessor:

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -18,8 +18,10 @@ from collections import OrderedDict
 from dataclasses import dataclass, field
 from multiprocessing.shared_memory import SharedMemory
 
+import h5py
 import hdf5plugin  # noqa: F401  # registers bitshuffle codec with h5py at import time
 import numpy as np
+from scipy import interpolate, stats
 from skimage.transform import downscale_local_mean
 
 from aetherscan.config import get_config
@@ -142,6 +144,149 @@ def _downsample_worker(args):
     else:
         logger.warning("No global chunk data available")
         return None
+
+
+# --- Energy detection helpers & workers ---
+
+
+def _remove_dc_spike(
+    block_data: np.ndarray, coarse_channel_width: int, n_coarse_channels: int
+) -> None:
+    """
+    Interpolate over the 2-bin DC spike at the center of each coarse channel, in place.
+
+    Mirrors preprocess_fine.py:72-75 from the reference implementation.
+
+    Args:
+        block_data: shape (time_bins, n_coarse_channels * coarse_channel_width)
+        coarse_channel_width: fine channels per coarse channel
+        n_coarse_channels: number of coarse channels in block_data
+    """
+    half_chan = coarse_channel_width // 2
+    for i in range(n_coarse_channels):
+        dc_ind = i * coarse_channel_width + half_chan
+        block_data[:, dc_ind] = (block_data[:, dc_ind + 1] + block_data[:, dc_ind - 3]) / 2
+        block_data[:, dc_ind - 1] = (block_data[:, dc_ind + 2] + block_data[:, dc_ind - 2]) / 2
+
+
+def _fit_channel_bandpass(
+    integrated_channel: np.ndarray, channel_width: int, spl_order: int
+) -> np.ndarray:
+    """
+    Fit a spline bandpass to a time-integrated coarse channel.
+
+    Mirrors utils.py:17-22 from the reference implementation.
+
+    Args:
+        integrated_channel: 1-D array of shape (channel_width,), time-integrated
+        channel_width: fine channels per coarse channel
+        spl_order: spline order (higher = more knots = finer fit)
+
+    Returns:
+        1-D bandpass fit of shape (channel_width,)
+    """
+    x = np.arange(channel_width)
+    knots = np.arange(0, channel_width, channel_width // spl_order + 1)
+    spl = interpolate.splrep(x, integrated_channel, t=knots[1:])
+    return interpolate.splev(x, spl)
+
+
+def _read_coarse_channel_worker(args: tuple) -> np.ndarray:
+    """
+    Worker: read one coarse channel from an .h5 file.
+
+    Workers open their own h5py.File (h5py file handles are fork-unsafe to share).
+
+    Args:
+        args: (h5_path, channel_index, coarse_channel_width)
+
+    Returns:
+        ndarray of shape (time_bins, coarse_channel_width)
+    """
+    h5_path, channel_index, coarse_channel_width = args
+    start = channel_index * coarse_channel_width
+    end = (channel_index + 1) * coarse_channel_width
+    with h5py.File(h5_path, "r") as hf:
+        return hf["data"][:, 0, start:end]
+
+
+def _remove_bandpass_worker(args: tuple) -> np.ndarray:
+    """
+    Worker: subtract the per-coarse-channel spline bandpass from one coarse channel.
+
+    Reads its slice from _GLOBAL_CHUNK_DATA (a (time_bins, n_coarse*width) view of
+    the current block's shared memory).
+
+    Args:
+        args: (channel_index, coarse_channel_width, spl_order)
+
+    Returns:
+        Bandpass-cleaned slice of shape (time_bins, coarse_channel_width)
+    """
+    channel_index, coarse_channel_width, spl_order = args
+
+    if _GLOBAL_CHUNK_DATA is None:
+        logger.warning("No global chunk data available for bandpass removal")
+        return np.zeros((0, coarse_channel_width))
+
+    start = channel_index * coarse_channel_width
+    end = (channel_index + 1) * coarse_channel_width
+    channel = _GLOBAL_CHUNK_DATA[:, start:end]
+    integrated_channel = np.mean(channel, axis=0)
+    fit = _fit_channel_bandpass(integrated_channel, coarse_channel_width, spl_order)
+    return channel - fit
+
+
+def _threshold_hits_worker(args: tuple) -> list[tuple]:
+    """
+    Worker: slide a window across one coarse channel and emit hits above threshold.
+
+    The window is run through scipy.stats.normaltest (D'Agostino-Pearson).
+    Reads its slice from _GLOBAL_CHUNK_DATA (cleaned residuals for this block).
+
+    Args:
+        args: (channel_index, coarse_channel_width, window_size, step_size,
+               stat_threshold, block_offset)
+            block_offset is added to the returned absolute index so callers see
+            indices in the full spectrum rather than block-relative.
+
+    Returns:
+        List of (absolute_fine_channel_index, statistic, pvalue) tuples.
+    """
+    (
+        channel_index,
+        coarse_channel_width,
+        window_size,
+        step_size,
+        stat_threshold,
+        block_offset,
+    ) = args
+
+    if _GLOBAL_CHUNK_DATA is None:
+        logger.warning("No global chunk data available for hit thresholding")
+        return []
+
+    start = channel_index * coarse_channel_width
+    end = (channel_index + 1) * coarse_channel_width
+    channel = _GLOBAL_CHUNK_DATA[:, start:end]
+
+    hits: list[tuple] = []
+    for i in range(0, coarse_channel_width - window_size, step_size):
+        window = channel[:, i : i + window_size]
+        s, p = stats.normaltest(window.flatten())
+        if s > stat_threshold:
+            abs_idx = block_offset + channel_index * coarse_channel_width + i
+            hits.append((abs_idx, float(s), float(p)))
+
+    return hits
+
+
+# def _drop_side_channels(
+#     block_data: np.ndarray, side_channel_count: int, coarse_channel_width: int
+# ) -> None:
+#     """Zero out the leading/trailing side_channel_count coarse channels of a block.
+#     Reserved for future use — leave as-is until the energy-profile criterion is defined."""
+#     pass
 
 
 @dataclass

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -164,6 +164,12 @@ def _remove_dc_spike(
     half_chan = coarse_channel_width // 2
     for i in range(n_coarse_channels):
         dc_ind = i * coarse_channel_width + half_chan
+        # The two replacements are asymmetric on purpose: dc_ind pulls from
+        # (+1, -3) and dc_ind-1 from (+2, -2). This matches the reference
+        # implementation byte-for-byte (FX196/SETI-Energy-Detection
+        # preprocess_fine.py:72-75) — the bins immediately around the spike
+        # are themselves contaminated, so the offsets reach across the spike
+        # to clean neighbors on both sides.
         block_data[:, dc_ind] = (block_data[:, dc_ind + 1] + block_data[:, dc_ind - 3]) / 2
         block_data[:, dc_ind - 1] = (block_data[:, dc_ind + 2] + block_data[:, dc_ind - 2]) / 2
 

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -1240,8 +1240,12 @@ class DataPreprocessor:
         else:
             global _GLOBAL_CHUNK_DATA
             _GLOBAL_CHUNK_DATA = block_data
-            results = [_remove_bandpass_worker(a) for a in args_list]
-            _GLOBAL_CHUNK_DATA = None
+            try:
+                results = [_remove_bandpass_worker(a) for a in args_list]
+            finally:
+                # Always clear the global, even if a worker raised, so subsequent
+                # calls in the same process don't see stale state
+                _GLOBAL_CHUNK_DATA = None
 
         return np.concatenate(results, axis=1)
 
@@ -1286,8 +1290,12 @@ class DataPreprocessor:
         else:
             global _GLOBAL_CHUNK_DATA
             _GLOBAL_CHUNK_DATA = cleaned_block
-            results = [_threshold_hits_worker(a) for a in args_list]
-            _GLOBAL_CHUNK_DATA = None
+            try:
+                results = [_threshold_hits_worker(a) for a in args_list]
+            finally:
+                # Always clear the global, even if a worker raised, so subsequent
+                # calls in the same process don't see stale state
+                _GLOBAL_CHUNK_DATA = None
 
         flat: list[tuple] = []
         for r in results:

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -271,6 +271,13 @@ def _threshold_hits_worker(args: tuple) -> list[tuple]:
     end = (channel_index + 1) * coarse_channel_width
     channel = _GLOBAL_CHUNK_DATA[:, start:end]
 
+    # TODO: profile on HPC and consider vectorizing. With default config this loop
+    # runs ~8190 windows per coarse channel × parallel_chans × num_blocks × 3
+    # ON-source files per cadence. scipy.stats.normaltest copies + flattens each
+    # window and re-derives skew/kurtosis via separate scipy calls. A stride_tricks
+    # view over the cleaned block followed by vectorized scipy.stats.skew /
+    # kurtosis (with axis arg) would replace the Python loop with a few large
+    # ndarray ops and could be substantially faster end-to-end.
     hits: list[tuple] = []
     for i in range(0, coarse_channel_width - window_size, step_size):
         window = channel[:, i : i + window_size]

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -712,9 +712,7 @@ def _select_positive_class_shap(values, log_loss: bool = False) -> np.ndarray:
         values = np.asarray(values)
         # newer shap preserves the class axis even for model_output="log_loss":
         # (n, F, 2) → (n, F); (n, F, F, 2) → (n, F, F)
-        if values.ndim == 3 and values.shape[-1] == 2:
-            return values[..., 1]
-        if values.ndim == 4 and values.shape[-1] == 2:
+        if values.ndim >= 3 and values.shape[-1] == 2:
             return values[..., 1]
         return values
 
@@ -723,9 +721,7 @@ def _select_positive_class_shap(values, log_loss: bool = False) -> np.ndarray:
 
     values = np.asarray(values)
     # (n, F, 2) → (n, F); (n, F, F, 2) → (n, F, F)
-    if values.ndim == 3 and values.shape[-1] == 2:
-        return values[..., 1]
-    if values.ndim == 4 and values.shape[-1] == 2:
+    if values.ndim >= 3 and values.shape[-1] == 2:
         return values[..., 1]
     return values
 

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -709,7 +709,14 @@ def _select_positive_class_shap(values, log_loss: bool = False) -> np.ndarray:
     if log_loss:
         if isinstance(values, list):
             return np.asarray(values[0])
-        return np.asarray(values)
+        values = np.asarray(values)
+        # newer shap preserves the class axis even for model_output="log_loss":
+        # (n, F, 2) → (n, F); (n, F, F, 2) → (n, F, F)
+        if values.ndim == 3 and values.shape[-1] == 2:
+            return values[..., 1]
+        if values.ndim == 4 and values.shape[-1] == 2:
+            return values[..., 1]
+        return values
 
     if isinstance(values, list):
         return np.asarray(values[1])


### PR DESCRIPTION
Closes #71.

## Summary

- Adds an energy detection preprocessing stage that turns BL `.h5` filterbank files into the `(n_hits, 6, 16, 4096)` `.npy` stamps the existing inference pipeline expects. Driven by metadata CSVs via a new `--inference-files` flag.
- Pipeline mirrors [FX196/SETI-Energy-Detection](https://github.com/FX196/SETI-Energy-Detection): block-wise read of coarse channels → DC spike interpolation → per-coarse-channel spline bandpass subtraction → D'Agostino-Pearson sliding-window thresholding → hit dedupe → per-cadence stamp extraction from all 6 observations. ON-source files (positions 0, 2, 4) drive detection.
- Per-cadence `.npy` files are written as soon as they're ready; a shared inference-level retry loop (`inference.max_retries` / `retry_delay`) wraps both preprocessing and inference, with state-based resume — `find_hits()` skips cadences whose `.npy` already exists, so retries pick up where the last attempt died.
- Adds `hdf5plugin` to `environment.yml` (BL filterbank files are bitshuffle-compressed).

## Files touched

- `environment.yml` — add `hdf5plugin`.
- `src/aetherscan/config.py` — extend `InferenceConfig` with energy-detection / retry fields; add `inference_files` to `DataConfig`; add `get_inference_file_path`; wire new fields into `to_dict`.
- `src/aetherscan/cli.py` — new `--inference-files`, `--cadence-*`, coarse-channel / detection / stamp / overlap flags, `--preprocess-output-dir`, and inference-side `--max-retries` / `--retry-delay` gated on `args.command == \"inference\"`. Extends `validate_args`.
- `src/aetherscan/preprocessing.py` — adds `CadenceGroup` / `CadenceResult` / `CadenceHit` dataclasses; standalone, column-agnostic `group_observations_from_csv`; helpers `_remove_dc_spike` / `_fit_channel_bandpass`; workers `_read_coarse_channel_worker` / `_remove_bandpass_worker` / `_threshold_hits_worker`; replaces the `find_hits` stub with the real CSV-driven pipeline + `_process_cadence`; adds `override_filepaths` to `load_inference_data`. Commented-out `_drop_side_channels` stub and call site left in place for future work.
- `src/aetherscan/main.py` — `stamp_width == width_bin` runtime sanity check when `inference_files` is set; wraps preprocessing + inference in a retry loop with state-based resume.

## Test plan

> ⚠️ **Testing is blocked.** End-to-end verification needs the HPC cluster, but this branch can't be exercised there until another PR currently in flight is merged to `master`. The plan is to merge this PR first (the local checks below cover what's possible on the dev machine), then once the blocking PR also lands on `master`, rebase this work, run the HPC test plan below in full, and open a separate issue + PR to close out testing.

Local checks already run on the implementing machine:

- [x] `ruff check src/aetherscan/` and `ruff format --check src/aetherscan/` pass.
- [x] All touched files `py_compile` cleanly.
- [x] `group_observations_from_csv` sanity-checked on the real CSV at `outputs/targets/complete_cadences_catalog.csv` (36,558 rows; 162 valid 6-obs groups + 297 flagged groups with other counts; bogus column name raises `KeyError` as expected).
- [ ] Full `import aetherscan.preprocessing` smoke test — skipped, blocked by a local `tensorflow` AVX-instruction issue unrelated to this change.

HPC tests deferred until after merge + rebase:

- [ ] Run inference with one CSV pointing to a small set of cadences.
- [ ] Confirm `.npy` files appear under `<output_path>/preprocessed/` per cadence as preprocessing progresses (not all at once).
- [ ] Confirm the existing inference flow picks them up, downsamples, log-normalizes, and writes candidates to the DB.
- [ ] Kill the process mid-run and restart; confirm already-written cadences are skipped on the rerun.
- [ ] Exercise `--overlap-search`.
- [ ] Spot-check hit frequencies against a known terrestrial RFI line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)