### PR TITLE
Fix claude-update-docs dispatch validation (gh field name)

### DIFF
--- a/.github/workflows/claude-update-docs.yml
+++ b/.github/workflows/claude-update-docs.yml
@@ -46,9 +46,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-          STATE=$(gh pr view "$PR_NUMBER" --json state,merged --jq '.state + ":" + (.merged|tostring)')
-          if [[ "$STATE" != "MERGED:true" ]]; then
-            echo "::error::pr_number=$PR_NUMBER is not a merged PR (state:merged = $STATE)"
+          STATE=$(gh pr view "$PR_NUMBER" --json state --jq '.state')
+          if [[ "$STATE" != "MERGED" ]]; then
+            echo "::error::pr_number=$PR_NUMBER is not a merged PR (state = $STATE)"
             exit 1
           fi
           echo "PR #$PR_NUMBER is merged — proceeding."


### PR DESCRIPTION
Closes #92

Fixes the `workflow_dispatch` validation added in #91, which queried a non-existent `merged` JSON field (`gh pr view --json state,merged`) and errored `Unknown JSON field: "merged"` on every dispatch. Now checks `state == MERGED`.

## Verification
Dispatched from this branch (run 29159202860): the validation step plus **Guard, Checkout, Set up Python, and Regenerate CLI Reference all pass**, and the prompt assembles correctly (`PR NUMBER: 82`, `CLI REFERENCE REGENERATED: true`). The final `claude-code-action` step can't complete on a branch — the action requires the workflow file to be **identical to the default branch** ("Workflow validation failed") — so end-to-end confirmation needs this on master, after which a dispatch from master runs cleanly.
