### PR TITLE
Raise claude-update-docs timeout to 30 min for large PRs

### DIFF
--- a/.github/workflows/claude-update-docs.yml
+++ b/.github/workflows/claude-update-docs.yml
@@ -23,9 +23,8 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    # Most merged diffs analyse well within 15 min, but an outsized PR (e.g. the ~60-file
-    # Blackwell migration in #82) runs past it — the Opus analysis of that diff was cancelled
-    # at the 15-min cap before it could file the issue. Bumped to 30 to cover large merges.
+    # Analysing one merged diff against the doc set + source↔doc contracts shouldn't take
+    # more than 30 mins (refine if data shows otherwise)
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/claude-update-docs.yml
+++ b/.github/workflows/claude-update-docs.yml
@@ -23,9 +23,10 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    # Analysing one merged diff against the doc set + source↔doc contracts shouldn't take
-    # more than 15 mins (refine if data shows otherwise)
-    timeout-minutes: 15
+    # Most merged diffs analyse well within 15 min, but an outsized PR (e.g. the ~60-file
+    # Blackwell migration in #82) runs past it — the Opus analysis of that diff was cancelled
+    # at the 15-min cap before it could file the issue. Bumped to 30 to cover large merges.
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Closes #95

Raises the `claude-update-docs` job `timeout-minutes` from 15 to 30. The Opus analysis of the ~60-file Blackwell diff (#82) was cancelled at the 15-min cap before filing the issue (run 29159976207). Normal PRs finish well under 15 min; this only adds headroom for large merges.

Once merged, I'll re-dispatch `gh workflow run claude-update-docs.yml -f pr_number=82` from master.
