### PR TITLE
Tighten follow-up loop (strict verbatim, handle-mention rule, PR label sync)

### DIFF
--- a/.claude/skills/aetherscan-repo-context/SKILL.md
+++ b/.claude/skills/aetherscan-repo-context/SKILL.md
@@ -165,6 +165,8 @@ Enforced by **ruff** (lint + format) via pre-commit; full config in `pyproject.t
 5. **PR** — rebase (not merge) onto `master`; **all commits need verified GPG signatures**; fill the PR template; link the issue via the Development sidebar or `Closes #N` / `Fixes #N` (enables label sync). PRs not tied to an issue may be closed.
 6. **Review** — needs passing checks, ≥1 maintainer approval, all conversations resolved, branch up to date. Approvals are voided when new commits are pushed. Claude provides an initial review automatically.
 
+**Invoking vs. mentioning the assistant.** The assistant workflow (`claude.yml`) triggers whenever the assistant handle — an `@` immediately followed by `claude` — appears in the title/body of a Discussion, issue, or PR (or a comment on one). Write it only when you actually want to summon the assistant (e.g. an auto-filed docs issue asking it to open a PR). To refer to the handle as plain text anywhere else — a PR description, issue body, commit message, review comment — write it as `"@ claude"` (a space after the `@`, double quotes on both sides) so the `contains(…, '@claude')` trigger can't match. Tagging it unintentionally spawns a spurious assistant run and follow-up PR (this is what happened around issue #83).
+
 **Pre-commit hooks** (`pre-commit install` to activate): `ruff` (lint, `--fix`), `ruff-format`, general `pre-commit-hooks` (large files >1 MB, case conflict, merge conflict, YAML/TOML syntax, EOF/trailing-whitespace, private-key detection, `no-commit-to-branch` on master), and `gitleaks` (secret detection). Ruff-format auto-reformats on commit — **re-run `git add` after** it modifies files, then commit again. Bypass only sparingly with `git commit --no-verify`.
 
 ```bash

--- a/.github/workflows/claude-update-docs.yml
+++ b/.github/workflows/claude-update-docs.yml
@@ -264,11 +264,15 @@ jobs:
                    cli_help_regenerated.txt — a later CI step automatically appends the
                    regenerated blocks (under a `### Regenerated CLI Reference` heading) to
                    the issue you file. Just state that README's `## CLI Reference` blocks
-                   drifted, and explicitly instruct the follow-up PR to replace each of the
-                   three code blocks under that section verbatim with the matching appended
-                   block (top → ### Top-Level Help, train → ### Train Command Help,
-                   inference → ### Inference Command Help), keeping each subsection's intro
-                   paragraph intact and running no command.
+                   drifted, and explicitly instruct the follow-up PR to do a STRICT,
+                   WHOLESALE replacement: delete the entire body of each of the three code
+                   blocks under that section and replace it with the matching appended block
+                   as-is (top → ### Top-Level Help, train → ### Train Command Help,
+                   inference → ### Inference Command Help). It must NOT hand-edit, cherry-pick
+                   individual flags/lines, or diff against the old block — the appended block
+                   is canonical and replaces the whole thing verbatim, so no drift (e.g. a
+                   second added flag) can be missed. Keep each subsection's intro paragraph
+                   intact and run no command.
                  - If the changes touched any canonical doc in contract (b) above
                    (README.md, CONTRIBUTING.md, SECURITY.md, KNOWN_ISSUES.md, or docs/*),
                    split the reconciliation by writability (see the write-access
@@ -362,9 +366,11 @@ jobs:
               '' \
               'Canonical `argparse` output for this PR, regenerated deterministically by CI.' \
               'The fenced block below holds the three sections in order — split on each' \
-              '`usage:` line: top-level, then `train`, then `inference`. Replace the matching' \
-              '`### Top-Level Help`, `### Train Command Help`, and `### Inference Command Help`' \
-              'code blocks in README.md with the corresponding section, verbatim.' \
+              '`usage:` line: top-level, then `train`, then `inference`. For each, do a' \
+              'strict WHOLESALE replacement: delete the ENTIRE body of the matching README' \
+              'block (`### Top-Level Help`, `### Train Command Help`, `### Inference Command' \
+              'Help`) and paste the corresponding section as-is — do NOT hand-edit or' \
+              'cherry-pick individual flags/lines; replace the whole block verbatim.' \
               '' \
               '````'
             cat cli_help_regenerated.txt

--- a/.github/workflows/sync-pr-labels.yml
+++ b/.github/workflows/sync-pr-labels.yml
@@ -24,7 +24,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const EXCLUDED_LABELS = new Set(['needs-issue', 'needs-discussion']);
+            // 'good first issue' describes an issue's difficulty, not a PR — don't sync it onto PRs.
+            const EXCLUDED_LABELS = new Set(['needs-issue', 'needs-discussion', 'good first issue']);
             const pr = context.payload.pull_request;
 
             // Use GraphQL to get formally linked issues (via "Development" sidebar)
@@ -105,7 +106,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const EXCLUDED_LABELS = new Set(['needs-issue', 'needs-discussion']);
+            // 'good first issue' describes an issue's difficulty, not a PR — don't sync it onto PRs.
+            const EXCLUDED_LABELS = new Set(['needs-issue', 'needs-discussion', 'good first issue']);
             const issueNumber = context.payload.issue.number;
             const newLabel = context.payload.label.name;
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ ruff lint+format, 100-char lines, Python 3.10 target ([`pyproject.toml`](pyproje
 ## Contributing
 
 - Every PR links an existing issue (`Closes #N`); branch prefixes `feature/`/`hotfix/`/`misc/`/`claude/`; rebase (not merge) onto `master`; commits need **verified GPG signatures**; all pre-commit hooks must pass (ruff-format may rewrite files → `git add` again before re-committing).
+- **Don't tag the assistant unintentionally.** The assistant handle (an `@` immediately followed by `claude`) in a Discussion/issue/PR title or body triggers the assistant workflow (`claude.yml`) — write it only when you actually want to invoke the assistant. To reference it as plain text, write `"@ claude"` (space after the `@`, double quotes on both sides) so the trigger can't match.
 - If you change `cli.py`, regenerate the README CLI Reference: `PYTHONPATH=src python utils/print_cli_help.py all`.
 - Bumping a dependency? Don't jump to the latest — target a proven version per [SECURITY.md](SECURITY.md) (the newer of ~2 minors back / latest stable ≥6 months old; a known advisory on that target overrides the lag). Never cross a documented ceiling (`numpy<2.0`, …) or the NGC TF 2.17 ABI, and keep `environment.yml` / `requirements-container.txt` / `aetherscan.def` in sync.
 - Security: non-critical → GitHub Discussion w/ "security" label; critical → [@zachtheyek](https://breakthroughlisten.slack.com/archives/D01SJG0L0TE) on Slack, no public issue. Rotate any leaked token immediately.


### PR DESCRIPTION
Closes #103

Three follow-ups from the end-to-end loop validation (#99 / #100):

- **claude-update-docs.yml** — force a strict *wholesale* CLI-block replacement (the follow-up #102 cherry-picked one flag and missed `--nccl-num-packs`).
- **CLAUDE.md + SKILL.md** — document the assistant-handle mention rule (literal mentions → escaped quoted form) so contributors do not trigger the assistant workflow by accident.
- **sync-pr-labels.yml** — exclude `good first issue` from label sync so it stays on issues, not PRs.

## Verification
- Both YAMLs parse; appended-note fences balance; no bare handle literal in the doc prose.
- pre-commit passes; all commits GPG-signed.

## Note
Redirected the label fix from `claude-issue-triage` (which only runs on issues) to `sync-pr-labels`, the actual mechanism that placed the label on PR #102.
