### PR TITLE
Housekeeping: KNOWN_ISSUES #16, GPU legend grouping fix, run_container.sh extra binds

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -537,3 +537,41 @@ by `TF_CPP_MIN_LOG_LEVEL`, so it can't be suppressed without redirecting stderr.
 
 **Won't fix.** Expected LLVM/PTX version-skew behavior. See also
 [`docs/GPU_RUNTIME_GUIDE.md`](docs/GPU_RUNTIME_GUIDE.md).
+
+---
+
+## 16. Container-Build pip Resolver Warning (pydot/pyparsing)
+
+### Symptom
+
+During `singularity/apptainer build` of `aetherscan.def`, while `%post` runs
+`pip install -r requirements-container.txt`, the build log prints:
+
+```
+ERROR: pip's dependency resolver does not currently take into account all the packages
+that are installed. This behaviour is the source of the following dependency conflicts.
+pydot 3.0.4 requires pyparsing>=3.0.9, but you have pyparsing 2.4.7 which is incompatible.
+```
+
+### Cause
+
+The conflict is **pre-existing inside the NGC `tensorflow:25.02-tf2-py3` base image**,
+which ships `pydot 3.0.4` alongside `pyparsing 2.4.7`. Installing our extras makes pip's
+resolver re-inspect the environment and report the already-broken pair; nothing in
+`requirements-container.txt` installs or touches either package.
+
+### Impact
+
+**None.** Aetherscan never imports `pydot` (it is only used by
+`keras.utils.plot_model`-style graph plotting, which we don't call). The build completes
+and the image is fully functional.
+
+### Workaround
+
+None needed; safe to ignore. Do not "fix" by upgrading `pyparsing` in the base image —
+that risks disturbing NGC-pinned packages. NGC 25.02 is the final TF container release,
+so this won't change upstream.
+
+### Status
+
+**Won't fix.** Pre-existing conflict in the upstream NGC base image; documented here.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ SLACK_CHANNEL=your-slack-channel
 AETHERSCAN_DATA_PATH=/path/to/data
 AETHERSCAN_MODEL_PATH=/path/to/models
 AETHERSCAN_OUTPUT_PATH=/path/to/outputs
+
+# Optional: comma-separated extra host paths for run_container.sh to bind 1:1,
+# for data outside the standard dirs (e.g. raw .h5 files for CSV inference)
+AETHERSCAN_EXTRA_BINDS=/datag
 ```
 
 > [!TIP]
@@ -320,8 +324,9 @@ PYTHONPATH=src python -m aetherscan.main inference \
 **Inference from raw `.h5` files (invokes energy detection preprocessing)**
 
 ```bash
-# Container
-./utils/run_container.sh python -m aetherscan.main inference \
+# Container — the raw .h5 paths in the CSV live outside the standard bind
+# mounts (e.g. under /datag), so bind them via AETHERSCAN_EXTRA_BINDS
+AETHERSCAN_EXTRA_BINDS=/datag ./utils/run_container.sh python -m aetherscan.main inference \
     --inference-files complete_cadences_catalog.csv \
     --encoder-path /path/to/vae_encoder.keras \
     --rf-path /path/to/random_forest.joblib \

--- a/README.md
+++ b/README.md
@@ -109,19 +109,19 @@ Aetherscan reads secrets and path overrides from a `.env` file at the repo root.
 ```ini
 # .env example
 
-# If none specified, Slack integration is automatically disabled
-SLACK_BOT_TOKEN=your-slack-bot-token
-SLACK_CHANNEL=your-slack-channel
-
 # If none specified, defaults to /datax/scratch/zachy/{data|models|outputs}/aetherscan
 # Note, CLI flags (--data-path, --model-path, --output-path) override these
 AETHERSCAN_DATA_PATH=/path/to/data
 AETHERSCAN_MODEL_PATH=/path/to/models
 AETHERSCAN_OUTPUT_PATH=/path/to/outputs
 
-# Optional: comma-separated extra host paths for run_container.sh to bind 1:1,
-# for data outside the standard dirs (e.g. raw .h5 files for CSV inference)
-AETHERSCAN_EXTRA_BINDS=/datag
+# Optional: comma-separated extra host paths for run_container.sh to bind 1:1, for
+# data outside the standard dirs (e.g. parent dir with raw .h5 files for inference)
+AETHERSCAN_EXTRA_BINDS=/extra/host/paths
+
+# If none specified, Slack integration is automatically disabled
+SLACK_BOT_TOKEN=your-slack-bot-token
+SLACK_CHANNEL=your-slack-channel
 ```
 
 > [!TIP]
@@ -324,8 +324,8 @@ PYTHONPATH=src python -m aetherscan.main inference \
 **Inference from raw `.h5` files (invokes energy detection preprocessing)**
 
 ```bash
-# Container — the raw .h5 paths in the CSV live outside the standard bind
-# mounts (e.g. under /datag), so bind them via AETHERSCAN_EXTRA_BINDS
+# Container — if the raw .h5 paths in the CSV live outside the standard bind
+# mounts (e.g. under /datag), then we bind them via AETHERSCAN_EXTRA_BINDS
 AETHERSCAN_EXTRA_BINDS=/datag ./utils/run_container.sh python -m aetherscan.main inference \
     --inference-files complete_cadences_catalog.csv \
     --encoder-path /path/to/vae_encoder.keras \

--- a/src/aetherscan/monitor/monitor.py
+++ b/src/aetherscan/monitor/monitor.py
@@ -12,6 +12,7 @@ import contextlib
 import gc
 import json
 import logging
+import math
 import os
 import subprocess
 import threading
@@ -22,6 +23,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import psutil
 import tensorflow as tf
+from matplotlib.lines import Line2D
 
 matplotlib.use("Agg")  # Non-interactive backend for headless environments
 
@@ -582,13 +584,24 @@ class ResourceMonitor:
             ax_gpu.set_ylim(0, 100)
             ax_gpu_mem.set_ylim(0, 100)
 
-            # Combine legends
+            # Combine legends, grouped by metric. Matplotlib fills legends
+            # column-major, so pad each metric's entries with invisible
+            # handles up to a whole number of columns — usage entries then
+            # occupy their own column(s) and memory entries always start a
+            # fresh column (e.g. 5 GPUs -> columns of 3,2 | 3,2).
             lines1, labels1 = ax_gpu.get_legend_handles_labels()
             lines2, labels2 = ax_gpu_mem.get_legend_handles_labels()
+            cols_per_metric = math.ceil(len(gpu_data) / 3)  # cap the legend at 3 rows
+            nrows = math.ceil(len(gpu_data) / cols_per_metric)
+            slots = nrows * cols_per_metric
+            lines1 += [Line2D([], [], alpha=0)] * (slots - len(lines1))
+            labels1 += [""] * (slots - len(labels1))
+            lines2 += [Line2D([], [], alpha=0)] * (slots - len(lines2))
+            labels2 += [""] * (slots - len(labels2))
             ax_gpu.legend(
                 lines1 + lines2,
                 labels1 + labels2,
-                ncol=min(4, len(gpu_data) * 2),
+                ncol=2 * cols_per_metric,
                 fontsize=8,
                 loc="upper right",
             )

--- a/utils/run_container.sh
+++ b/utils/run_container.sh
@@ -26,13 +26,13 @@
 #                               (default: /datax/scratch/zachy/outputs/aetherscan)
 #     AETHERSCAN_EXTRA_BINDS    Comma-separated extra host paths, each bound 1:1
 #                               and appended to the standard bind list, e.g.
-#                               AETHERSCAN_EXTRA_BINDS=/datag for CSV inference
+#                               AETHERSCAN_EXTRA_BINDS=/datag for inference
 #                               (default: none)
 #     SLACK_BOT_TOKEN           Slack bot token, forwarded into the container
 #     SLACK_CHANNEL             Slack channel, forwarded into the container
 #
-# The runtime's native SINGULARITY_BIND / APPTAINER_BIND env vars still pass
-# through untouched and are additive with the binds set up here.
+# Note, the runtime's native SINGULARITY_BIND / APPTAINER_BIND env vars still pass
+# through untouched and are additive with the binds set up from AETHERSCAN_EXTRA_BINDS.
 #
 # <repo>/.env is auto-loaded if present, so secrets set by "source .env" in the
 # user's shell survive the trip into this child process. Anything already in our
@@ -105,7 +105,7 @@ BIND_ARGS=(
 )
 
 # Extra host paths (comma-separated), each bound 1:1, for data that lives
-# outside the standard dirs (e.g. raw .h5 files under /datag for CSV inference).
+# outside the standard dirs (e.g. raw .h5 files in /datag during inference).
 if [[ -n ${AETHERSCAN_EXTRA_BINDS:-} ]]; then
     IFS=',' read -ra EXTRA_BINDS <<<"$AETHERSCAN_EXTRA_BINDS"
     for extra_path in "${EXTRA_BINDS[@]}"; do

--- a/utils/run_container.sh
+++ b/utils/run_container.sh
@@ -24,8 +24,15 @@
 #                               (default: /datax/scratch/zachy/models/aetherscan)
 #     AETHERSCAN_OUTPUT_PATH    Host outputs dir, bound 1:1
 #                               (default: /datax/scratch/zachy/outputs/aetherscan)
+#     AETHERSCAN_EXTRA_BINDS    Comma-separated extra host paths, each bound 1:1
+#                               and appended to the standard bind list, e.g.
+#                               AETHERSCAN_EXTRA_BINDS=/datag for CSV inference
+#                               (default: none)
 #     SLACK_BOT_TOKEN           Slack bot token, forwarded into the container
 #     SLACK_CHANNEL             Slack channel, forwarded into the container
+#
+# The runtime's native SINGULARITY_BIND / APPTAINER_BIND env vars still pass
+# through untouched and are additive with the binds set up here.
 #
 # <repo>/.env is auto-loaded if present, so secrets set by "source .env" in the
 # user's shell survive the trip into this child process. Anything already in our
@@ -90,11 +97,25 @@ OUTPUT_PATH=${AETHERSCAN_OUTPUT_PATH:-/datax/scratch/zachy/outputs/aetherscan}
 # Each of the three data dirs gets a 1:1 bind (host path == container path) so
 # absolute paths persisted in the DB / config snapshots stay valid across both
 # host and container processes.
+BIND_ARGS=(
+    --bind "$REPO:/workspace/aetherscan"
+    --bind "$DATA_PATH:$DATA_PATH"
+    --bind "$MODEL_PATH:$MODEL_PATH"
+    --bind "$OUTPUT_PATH:$OUTPUT_PATH"
+)
+
+# Extra host paths (comma-separated), each bound 1:1, for data that lives
+# outside the standard dirs (e.g. raw .h5 files under /datag for CSV inference).
+if [[ -n ${AETHERSCAN_EXTRA_BINDS:-} ]]; then
+    IFS=',' read -ra EXTRA_BINDS <<<"$AETHERSCAN_EXTRA_BINDS"
+    for extra_path in "${EXTRA_BINDS[@]}"; do
+        [[ -z $extra_path ]] && continue
+        BIND_ARGS+=(--bind "$extra_path:$extra_path")
+    done
+fi
+
 exec "$RUNTIME" exec --nv \
-    --bind "$REPO:/workspace/aetherscan" \
-    --bind "$DATA_PATH:$DATA_PATH" \
-    --bind "$MODEL_PATH:$MODEL_PATH" \
-    --bind "$OUTPUT_PATH:$OUTPUT_PATH" \
+    "${BIND_ARGS[@]}" \
     --pwd /workspace/aetherscan \
     --env PYTHONPATH=/workspace/aetherscan/src \
     --env AETHERSCAN_DATA_PATH="$DATA_PATH" \


### PR DESCRIPTION
Closes #111

## Summary

Three small housekeeping items (PR-01 of the v1 push):

1. **KNOWN_ISSUES.md entry #16** — documents the pip dependency-resolver error (`pydot 3.0.4` vs `pyparsing 2.4.7`) printed during `singularity/apptainer build` of `aetherscan.def`. The conflict is pre-existing in the NGC `tensorflow:25.02-tf2-py3` base image, nothing in `requirements-container.txt` touches either package, Aetherscan never imports `pydot`, and the built image is fully functional. Status: won't fix (upstream base image); documented. Follows the exact Symptom/Cause/Impact/Workaround/Status format of entries 1-15.

2. **GPU legend grouping fix** (`src/aetherscan/monitor/monitor.py`) — the combined usage+memory legend used `ncol=min(4, n_gpus*2)`; matplotlib fills legends column-major, so with 5 GPUs the 10 entries landed in 4 columns as 3/3/2/2 with memory entries continuing mid-column under usage entries. Now each metric's handle/label lists are padded to a whole number of columns with invisible handles (`Line2D([], [], alpha=0)`, empty label), with `cols_per_metric = ceil(n_gpus/3)` (caps the legend at 3 rows) and `ncol = 2*cols_per_metric` — usage entries occupy their own column(s) and memory entries always start a fresh column (5 GPUs -> columns of 3,2 | 3,2).

3. **`utils/run_container.sh` extra binds** — new `AETHERSCAN_EXTRA_BINDS` env var: comma-separated host paths, each bound 1:1 and appended to the standard bind list, so CSV inference on blpc3 becomes `AETHERSCAN_EXTRA_BINDS=/datag ./utils/run_container.sh ...` instead of relying on the runtime's native `SINGULARITY_BIND` passthrough (which continues to work and remains additive). Documented in the script header, the README raw-`.h5` inference example, and the README `.env` example block.

No `cli.py` changes, so the README CLI Reference blocks are untouched.

## Verification

There is no test suite yet (tracked separately as the upcoming testing-suite PR), so no pytest claims — here is exactly what was verified and how:

**Legend fix (local matplotlib script, no cluster needed):** reproduced the exact pre-fix and post-fix legend construction (same twinx axes, per-GPU solid usage + dashed memory lines, same label format) for n_gpus in {1, 2, 4, 5, 6, 8} and eyeballed the saved PNGs:

- Old logic, 5 GPUs: columns of 3/3/2/2 with `... :0 (Memory)` appearing directly under `:3/:4 (Usage)` — the reported bug, reproduced.
- New logic: n=1 -> 1 row `usage | memory`; n=2 -> one usage column, one memory column; n=4 -> 2,2 | 2,2; n=5 -> 3,2 | 3,2; n=6 -> 3,3 | 3,3; n=8 -> 3,3,2 | 3,3,2. In every case memory entries start a fresh column and never share a column with usage entries.
- Edge cases checked in code: the branch only runs when `gpu_data` is non-empty (no zero division); only the GPU loop adds labeled artists to these axes, so entry counts never exceed the padded slot count; a GPU missing one metric just gets extra invisible padding.

**Extra binds (blpc3, this branch checked out in the cluster repo):**

```
$ AETHERSCAN_EXTRA_BINDS=/datag ./utils/run_container.sh ls /datag
blpd0 blpd1 ... blpd18 collate_mb incoming index.html lost_and_found mattl pipeline ptest public srt users

$ ./utils/run_container.sh ls /            # plain run, no regression
bin boot datax dev ... workspace

$ SINGULARITY_BIND=/datag ./utils/run_container.sh ls /datag   # passthrough still works
blpd0 blpd1 blpd10 ...
```

The cluster repo was restored to `master` afterward (clean tree). `pre-commit run --all-files` passes; `bash -n utils/run_container.sh` passes; all commits GPG-signed.

**Deferred validation:** none — nothing in this PR is bla0-only. The production resource plot renders on pipeline shutdown, so the next real cluster run will exercise the new legend path end-to-end.

## AI assistance disclosure

Implemented with Claude Code (implementation, documentation, and verification, per AI_POLICY.md). All changes were verified as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)