### PR TITLE
Training data pipeline: disk-backed memmap rounds, background producer, batched tf.data input

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,10 @@ usage: train [-h] [--data-path DATA_PATH] [--model-path MODEL_PATH]
              [--effective-batch-size EFFECTIVE_BATCH_SIZE]
              [--per-replica-val-batch-size PER_REPLICA_VAL_BATCH_SIZE]
              [--signal-injection-chunk-size SIGNAL_INJECTION_CHUNK_SIZE]
+             [--data-gen-task-size DATA_GEN_TASK_SIZE]
+             [--round-data-dir ROUND_DATA_DIR]
+             [--overlap-data-generation | --no-overlap-data-generation]
+             [--keep-round-data | --no-keep-round-data]
              [--plot-injection-subsampling-count PLOT_INJECTION_SUBSAMPLING_COUNT]
              [--plot-injection-outlier-percentile PLOT_INJECTION_OUTLIER_PERCENTILE]
              [--latent-viz-num-cadences-per-type LATENT_VIZ_NUM_CADENCES_PER_TYPE]
@@ -556,6 +560,25 @@ options:
   --signal-injection-chunk-size SIGNAL_INJECTION_CHUNK_SIZE
                         Maximum cadences to process at once during synthetic
                         signal injection (must be divisible by 4)
+  --data-gen-task-size DATA_GEN_TASK_SIZE
+                        Cadences per batched signal-injection worker task
+                        (workers write results straight into the round's on-
+                        disk memmap; must be >= 1)
+  --round-data-dir ROUND_DATA_DIR
+                        Directory for disk-backed per-round training datasets
+                        (defaults to <output-path>/round_data; needs ~2.2x one
+                        round's size free when data-generation overlap is
+                        enabled, ~1.1x otherwise)
+  --overlap-data-generation, --no-overlap-data-generation
+                        Generate round k+1's training data in a background
+                        producer process while round k trains (default:
+                        enabled). Pass --no-overlap-data-generation to fall
+                        back to sequential in-process generation for debugging
+  --keep-round-data, --no-keep-round-data
+                        Retain each round's on-disk training data after that
+                        round finishes (default: disabled — round k's data
+                        directory is deleted as soon as round k's training
+                        completes). Enable for debugging
   --plot-injection-subsampling-count PLOT_INJECTION_SUBSAMPLING_COUNT
                         Max points per stat name, per signal type, for A→B
                         intensity bias scatter plots. Outliers are

--- a/README.md
+++ b/README.md
@@ -566,9 +566,9 @@ options:
                         disk memmap; must be >= 1)
   --round-data-dir ROUND_DATA_DIR
                         Directory for disk-backed per-round training datasets
-                        (defaults to <output-path>/round_data; needs ~2.2x one
-                        round's size free when data-generation overlap is
-                        enabled, ~1.1x otherwise)
+                        (defaults to <data-path>/training/round_data; needs
+                        ~2.2x one round's size free when data-generation
+                        overlap is enabled, ~1.1x otherwise)
   --overlap-data-generation, --no-overlap-data-generation
                         Generate round k+1's training data in a background
                         producer process while round k trains (default:

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -431,7 +431,7 @@ def _add_train_flags_to(parser):
         "--round-data-dir",
         type=str,
         default=None,
-        help="Directory for disk-backed per-round training datasets (defaults to <output-path>/round_data; needs ~2.2x one round's size free when data-generation overlap is enabled, ~1.1x otherwise)",
+        help="Directory for disk-backed per-round training datasets (defaults to <data-path>/training/round_data; needs ~2.2x one round's size free when data-generation overlap is enabled, ~1.1x otherwise)",
     )
     parser.add_argument(
         "--overlap-data-generation",
@@ -1331,10 +1331,11 @@ def collect_validation_errors(
         nob = _resolve(args, "num_observations", config.data.num_observations)
         tb = _resolve(args, "time_bins", config.data.time_bins)
         overlap = _resolve(args, "overlap_data_generation", config.training.overlap_data_generation)
-        output_path = _resolve(args, "output_path", config.output_path)
         round_data_dir = _resolve(args, "round_data_dir", config.training.round_data_dir)
         if round_data_dir is None:
-            round_data_dir = os.path.join(output_path, "round_data")
+            # data_path was resolved in the Data block above; round data are generated
+            # training data, so they live under the training-data root
+            round_data_dir = config.get_training_file_path("round_data", data_path)
         if all(v is not None for v in (nsb, nob, tb, wb)) and df:
             round_nbytes = _estimate_round_data_nbytes(nsb, nob, tb, wb // df)
             required_factor = 2.2 if overlap else 1.1

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -1279,7 +1279,7 @@ def collect_validation_errors(
                 ValidationError(
                     field="training.num_samples_rf",
                     current=nsr,
-                    message=f"--num-samples-rf must be divisible by 2 for generate_triplet_batch, got {nsr}",
+                    message=f"--num-samples-rf must be divisible by 2 for the balanced true/false halves in data generation, got {nsr}",
                     fix_kind="divisibility",
                     divisor=2,
                 )

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import re
+import shutil
 from dataclasses import dataclass, field, is_dataclass
 from itertools import product
 from typing import Any
@@ -53,6 +54,32 @@ def _resolve(args: argparse.Namespace, arg_name: str, default: Any) -> Any:
     """Return `args.<arg_name>` if present and not None, otherwise `default` (typically the config value at startup time)."""
     val = getattr(args, arg_name, None)
     return val if val is not None else default
+
+
+def _estimate_round_data_nbytes(
+    n_samples: int, num_observations: int, time_bins: int, width_bin_downsampled: int
+) -> int:
+    """
+    Estimate the on-disk size of one round's disk-backed dataset (see round_data.py): three
+    float32 arrays of shape (n_samples, num_observations, time_bins, width_bin_downsampled)
+    plus a tiny U20 labels array. Kept stdlib-only (no numpy) so utils/print_cli_help.py can
+    keep importing cli.py without the scientific stack.
+    """
+    per_sample_bytes = num_observations * time_bins * width_bin_downsampled * 4  # float32
+    labels_bytes = n_samples * 20 * 4  # numpy "U20" = 20 UCS-4 code points per label
+    return 3 * n_samples * per_sample_bytes + labels_bytes
+
+
+def _nearest_existing_ancestor(path: str) -> str:
+    """Walk up from `path` to the closest directory that exists (for shutil.disk_usage on a
+    round-data dir that hasn't been created yet)."""
+    probe = os.path.abspath(path)
+    while probe and not os.path.exists(probe):
+        parent = os.path.dirname(probe)
+        if parent == probe:
+            break
+        probe = parent
+    return probe
 
 
 def _resolve_num_replicas(args: argparse.Namespace) -> int | None:
@@ -393,6 +420,30 @@ def _add_train_flags_to(parser):
         default=None,
         # NOTE: divisible by 4 or num_replicas?
         help="Maximum cadences to process at once during synthetic signal injection (must be divisible by 4)",
+    )
+    parser.add_argument(
+        "--data-gen-task-size",
+        type=int,
+        default=None,
+        help="Cadences per batched signal-injection worker task (workers write results straight into the round's on-disk memmap; must be >= 1)",
+    )
+    parser.add_argument(
+        "--round-data-dir",
+        type=str,
+        default=None,
+        help="Directory for disk-backed per-round training datasets (defaults to <output-path>/round_data; needs ~2.2x one round's size free when data-generation overlap is enabled, ~1.1x otherwise)",
+    )
+    parser.add_argument(
+        "--overlap-data-generation",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Generate round k+1's training data in a background producer process while round k trains (default: enabled). Pass --no-overlap-data-generation to fall back to sequential in-process generation for debugging",
+    )
+    parser.add_argument(
+        "--keep-round-data",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Retain each round's on-disk training data after that round finishes (default: disabled — round k's data directory is deleted as soon as round k's training completes). Enable for debugging",
     )
     parser.add_argument(
         "--plot-injection-subsampling-count",
@@ -920,6 +971,18 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
         and args.signal_injection_chunk_size is not None
     ):
         config.training.signal_injection_chunk_size = args.signal_injection_chunk_size
+    if hasattr(args, "data_gen_task_size") and args.data_gen_task_size is not None:
+        config.training.data_gen_task_size = args.data_gen_task_size
+    if hasattr(args, "round_data_dir") and args.round_data_dir is not None:
+        config.training.round_data_dir = args.round_data_dir
+    # overlap_data_generation / keep_round_data use argparse.BooleanOptionalAction with
+    # default=None so that the CLI can express "leave the config default" (omit), "force on"
+    # (--overlap-data-generation), and "force off" (--no-overlap-data-generation). The
+    # `is not None` guard preserves the config default when the user passes neither
+    if hasattr(args, "overlap_data_generation") and args.overlap_data_generation is not None:
+        config.training.overlap_data_generation = args.overlap_data_generation
+    if hasattr(args, "keep_round_data") and args.keep_round_data is not None:
+        config.training.keep_round_data = args.keep_round_data
     if (
         hasattr(args, "plot_injection_subsampling_count")
         and args.plot_injection_subsampling_count is not None
@@ -1246,6 +1309,62 @@ def collect_validation_errors(
                     divisor=4,
                 )
             )
+
+        # data_gen_task_size >= 1 (batched memmap worker tasks)
+        dgts = _resolve(args, "data_gen_task_size", config.training.data_gen_task_size)
+        if dgts is not None and dgts < 1:
+            errors.append(
+                ValidationError(
+                    field="training.data_gen_task_size",
+                    current=dgts,
+                    message=f"--data-gen-task-size must be >= 1, got {dgts}",
+                    fix_kind="clamp_low",
+                    min_val=1,
+                )
+            )
+
+        # Disk budget for the disk-backed round datasets (round_data.py): with overlap enabled
+        # two rounds coexist on disk (round k trains while round k+1 generates), so require
+        # 2.2x one round's estimated size free; 1.1x when overlap is disabled. Estimated from
+        # sample counts only — actual usage tracks the estimate closely since the arrays are
+        # fixed-shape float32.
+        nob = _resolve(args, "num_observations", config.data.num_observations)
+        tb = _resolve(args, "time_bins", config.data.time_bins)
+        overlap = _resolve(args, "overlap_data_generation", config.training.overlap_data_generation)
+        output_path = _resolve(args, "output_path", config.output_path)
+        round_data_dir = _resolve(args, "round_data_dir", config.training.round_data_dir)
+        if round_data_dir is None:
+            round_data_dir = os.path.join(output_path, "round_data")
+        if all(v is not None for v in (nsb, nob, tb, wb)) and df:
+            round_nbytes = _estimate_round_data_nbytes(nsb, nob, tb, wb // df)
+            required_factor = 2.2 if overlap else 1.1
+            required_bytes = required_factor * round_nbytes
+            try:
+                free_bytes = shutil.disk_usage(_nearest_existing_ancestor(round_data_dir)).free
+            except OSError as e:
+                logger.warning(
+                    f"Could not check free disk space for --round-data-dir "
+                    f"({round_data_dir}): {e} — skipping the disk-budget check"
+                )
+            else:
+                if free_bytes < required_bytes:
+                    errors.append(
+                        ValidationError(
+                            field="training.round_data_dir",
+                            current=round_data_dir,
+                            message=(
+                                f"--round-data-dir ({round_data_dir}) needs >= "
+                                f"{required_bytes / 1e9:.1f} GB free ({required_factor}x one "
+                                f"round's ~{round_nbytes / 1e9:.1f} GB"
+                                f"{' with data-generation overlap enabled' if overlap else ''}), "
+                                f"but only {free_bytes / 1e9:.1f} GB is available. Free up disk "
+                                f"space, point --round-data-dir at a larger volume, reduce "
+                                f"--num-samples-beta-vae, or pass --no-overlap-data-generation "
+                                f"to halve the requirement"
+                            ),
+                            fix_kind="file_exists",
+                        )
+                    )
 
         # SNR sanity (positivity + curriculum ordering)
         snr_base = _resolve(args, "snr_base", config.training.snr_base)

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -186,7 +186,7 @@ class TrainingConfig:
     data_gen_task_size: int = 256  # Cadences per batched worker task (workers write results straight into the round memmap)
 
     # Round data pipeline params (disk-backed per-round datasets, see round_data.py)
-    round_data_dir: str | None = None  # Defaults to <output_path>/round_data at runtime
+    round_data_dir: str | None = None  # Defaults to get_training_file_path("round_data") at runtime
     overlap_data_generation: bool = (
         True  # Generate round k+1's data in a background process while round k trains
     )

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -183,6 +183,7 @@ class TrainingConfig:
     signal_injection_chunk_size: int = (
         50000  # Maximum cadences to process at once during data generation
     )
+    # NOTE: is this the optimal size?
     data_gen_task_size: int = 256  # Cadences per batched worker task (workers write results straight into the round memmap)
 
     # Round data pipeline params (disk-backed per-round datasets, see round_data.py)

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -183,6 +183,16 @@ class TrainingConfig:
     signal_injection_chunk_size: int = (
         50000  # Maximum cadences to process at once during data generation
     )
+    data_gen_task_size: int = 256  # Cadences per batched worker task (workers write results straight into the round memmap)
+
+    # Round data pipeline params (disk-backed per-round datasets, see round_data.py)
+    round_data_dir: str | None = None  # Defaults to <output_path>/round_data at runtime
+    overlap_data_generation: bool = (
+        True  # Generate round k+1's data in a background process while round k trains
+    )
+    keep_round_data: bool = (
+        False  # Retain each round's on-disk data after its training completes (debugging)
+    )
     # TODO: tune to include sufficient info without bottlenecking training
     plot_injection_subsampling_count: int = (
         100000  # Max points per series in injection_stats scatter plots
@@ -526,6 +536,10 @@ class Config:
                 "effective_batch_size": self.training.effective_batch_size,
                 "per_replica_val_batch_size": self.training.per_replica_val_batch_size,
                 "signal_injection_chunk_size": self.training.signal_injection_chunk_size,
+                "data_gen_task_size": self.training.data_gen_task_size,
+                "round_data_dir": self.training.round_data_dir,
+                "overlap_data_generation": self.training.overlap_data_generation,
+                "keep_round_data": self.training.keep_round_data,
                 "plot_injection_subsampling_count": self.training.plot_injection_subsampling_count,
                 "plot_injection_outlier_percentile": self.training.plot_injection_outlier_percentile,
                 "latent_viz_num_cadences_per_type": self.training.latent_viz_num_cadences_per_type,

--- a/src/aetherscan/data_generation.py
+++ b/src/aetherscan/data_generation.py
@@ -45,22 +45,24 @@ _GLOBAL_SHAPE = None
 _GLOBAL_DTYPE = None
 
 
-def _init_worker(shm_name, shape, dtype):
+def _init_worker(shm_name, shape, dtype, log_queue=None):
     """
     Worker pool initializer: attach to the named shared-memory block holding the background
     plates, seed numpy/random from the worker PID so each process gets a distinct RNG state, and
     set up logging.
 
     Passing shm_name/shape/dtype through the pool initializer (rather than per-task args) avoids
-    re-serializing the array on every map() call. The worker installs a SIGTERM handler that
-    closes its shared-memory file descriptor before letting the signal kill the process; the
-    main process is responsible for unlinking shared memory afterwards (handled by
-    ResourceManager).
+    re-serializing the array on every map() call. `log_queue` must be passed explicitly for
+    pools whose parent process was spawn-started (the RoundDataProducer's — no inherited Logger
+    singleton there); fork-started pools omit it and inherit the singleton's queue. The worker
+    installs a SIGTERM handler that closes its shared-memory file descriptor before letting the
+    signal kill the process; the main process is responsible for unlinking shared memory
+    afterwards (handled by ResourceManager).
     """
     global _GLOBAL_SHM, _GLOBAL_BACKGROUNDS, _GLOBAL_SHAPE, _GLOBAL_DTYPE
 
     # Initialize worker logging
-    init_worker_logging()
+    init_worker_logging(log_queue)
 
     # Seed processes with process IDs so each worker gets a different random state
     random.seed(os.getpid())

--- a/src/aetherscan/data_generation.py
+++ b/src/aetherscan/data_generation.py
@@ -2,6 +2,11 @@
 Synthetic data generation for Aetherscan Pipeline
 Handles signal injection & log-normalization for training
 Uses multiprocessing and shared memory to process data in parallel
+
+Generated rounds are written straight into disk-backed .npy memmaps (see
+aetherscan.round_data): each pool task generates a batch of cadences and writes them
+into its slice of the round's memmap in-place, returning only the small per-sample
+stats dicts — no more per-sample IPC pickling or ~294 GB in-RAM round arrays.
 """
 
 from __future__ import annotations
@@ -11,9 +16,11 @@ import gc
 import logging
 import os
 import random
+import shutil
 import signal
 import time
-from multiprocessing import Pool, cpu_count
+from dataclasses import dataclass
+from multiprocessing import Pool
 from multiprocessing.shared_memory import SharedMemory
 
 import numpy as np
@@ -25,23 +32,17 @@ from aetherscan.config import get_config
 from aetherscan.db import get_db
 from aetherscan.logger import init_worker_logging
 from aetherscan.manager import get_manager
+from aetherscan.round_data import RoundDataPaths, build_manifest, write_done_manifest
 
 logger = logging.getLogger(__name__)
 
 # NOTE: find a way to avoid using global refs (store under manager.py maybe?)
-# NOTE: is there any room to use asyncio & load all chunks simultaneously?
 # Global variables to store background data for multiprocessing workers
 # This avoids serialization overhead when passing data between workers
 _GLOBAL_SHM = None
 _GLOBAL_BACKGROUNDS = None
 _GLOBAL_SHAPE = None
 _GLOBAL_DTYPE = None
-
-# NOTE: come back to this later
-# # NEW: Output shared memory for zero-copy results
-# _GLOBAL_OUTPUT_SHM = None
-# _GLOBAL_OUTPUT_ARRAY = None
-# _GLOBAL_OUTPUT_SHAPE = None
 
 
 def _init_worker(shm_name, shape, dtype):
@@ -56,25 +57,7 @@ def _init_worker(shm_name, shape, dtype):
     main process is responsible for unlinking shared memory afterwards (handled by
     ResourceManager).
     """
-    # NOTE: come back to this later
-    # def _init_worker(shm_name, shape, dtype, output_shm_name=None, output_shape=None):
-    #     """
-    #     Initialize worker process with shared memory references.
-    #
-    #     Args:
-    #         shm_name: Name of the shared memory block containing background plates
-    #         shape: Shape of the background array
-    #         dtype: Data type of the background array
-    #         output_shm_name: Name of shared memory for output results (optional)
-    #         output_shape: Shape of the output array (optional)
-    #
-    #     Why this change:
-    #         Adding output_shm_name and output_shape parameters allows workers to write
-    #         results directly to shared memory instead of returning them through IPC.
-    #         This eliminates ~23GB of pickle serialization per training round.
-    #     """
     global _GLOBAL_SHM, _GLOBAL_BACKGROUNDS, _GLOBAL_SHAPE, _GLOBAL_DTYPE
-    # global _GLOBAL_OUTPUT_SHM, _GLOBAL_OUTPUT_ARRAY, _GLOBAL_OUTPUT_SHAPE
 
     # Initialize worker logging
     init_worker_logging()
@@ -90,15 +73,6 @@ def _init_worker(shm_name, shape, dtype):
     _GLOBAL_BACKGROUNDS = np.ndarray(shape, dtype=dtype, buffer=_GLOBAL_SHM.buf)
     _GLOBAL_SHAPE = shape
     _GLOBAL_DTYPE = dtype
-
-    # NOTE: come back to this later
-    # # NEW: Attach to output shared memory if provided
-    # if output_shm_name is not None and output_shape is not None:
-    #     _GLOBAL_OUTPUT_SHM = SharedMemory(name=output_shm_name)
-    #     _GLOBAL_OUTPUT_ARRAY = np.ndarray(
-    #         output_shape, dtype=np.float32, buffer=_GLOBAL_OUTPUT_SHM.buf
-    #     )
-    #     _GLOBAL_OUTPUT_SHAPE = output_shape
 
     # Ignore SIGINT (Ctrl+C) in workers - let manager from parent handle cleanup coordination
     signal.signal(signal.SIGINT, signal.SIG_IGN)
@@ -565,18 +539,138 @@ def create_true_double(
     return final, sample_info
 
 
-def _single_cadence_wrapper(args):
-    """
-    Multiprocessing worker: unpack the per-task args tuple (function, snr_base, snr_range,
-    width_bin, freq_resolution, time_resolution, inject, dynamic_range) and call the chosen
-    create_* generator against _GLOBAL_BACKGROUNDS. Returns the (cadence, sample_info) pair from
-    the generator.
+# Cadence generator functions addressable by name, so batched tasks stay picklable-cheap
+# (workers resolve the callable locally instead of unpickling a function reference per task)
+_CREATE_FUNCTIONS = {
+    "create_false": create_false,
+    "create_true_single": create_true_single,
+    "create_true_double": create_true_double,
+}
 
-    Pulling backgrounds from the global rather than passing them per-task avoids pickling the
-    full plate on every dispatch.
+
+@dataclass(frozen=True)
+class ChunkSegment:
+    """
+    One contiguous class-segment of a chunk: `count` cadences of a single signal type written
+    at rows [start_idx, start_idx + count) of the round's `array_name` memmap. Each chunk is
+    made of 8 segments (4 quarters for main, 2 halves each for false/true) — the same
+    contiguous per-chunk layout the in-RAM generator used, so the labels array preserves the
+    row -> signal-type mapping and the stratified split downstream keeps working unchanged.
+    """
+
+    array_name: str  # "main" | "false" | "true"
+    signal_class: str  # "main" | "false" | "true" (DB signal_class)
+    signal_type: str  # e.g. "false_no_signal"
+    create_fn_name: str  # key into _CREATE_FUNCTIONS
+    inject: bool | None
+    dynamic_range: float | None
+    start_idx: int  # absolute row offset into the round array
+    count: int
+
+
+# The 4 signal types in main-array (and labels) order within each chunk
+_SIGNAL_TYPES = ("false_no_signal", "false_with_rfi", "true_only_eti", "true_eti_rfi")
+
+
+def build_chunk_segments(chunk_start: int, chunk_size: int) -> list[ChunkSegment]:
+    """
+    Lay out the 8 class-segments for one chunk starting at absolute row `chunk_start`.
+
+    Requires chunk_size % 4 == 0 (validated for signal_injection_chunk_size in cli.py), so
+    quarter = chunk_size // 4 and half = chunk_size // 2 are exact — no oversample/subsample
+    dance and no post-hoc stats filtering.
+    """
+    if chunk_size % 4 != 0:
+        raise ValueError(f"chunk_size must be divisible by 4, got {chunk_size}")
+
+    quarter = chunk_size // 4
+    half = chunk_size // 2
+
+    def seg(array_name, signal_class, signal_type, fn, inject, dyn, offset, count):
+        return ChunkSegment(
+            array_name=array_name,
+            signal_class=signal_class,
+            signal_type=signal_type,
+            create_fn_name=fn,
+            inject=inject,
+            dynamic_range=dyn,
+            start_idx=chunk_start + offset,
+            count=count,
+        )
+
+    return [
+        # main: 4-way balanced quarters (order matches _SIGNAL_TYPES / the labels array)
+        seg("main", "main", "false_no_signal", "create_false", False, None, 0, quarter),
+        seg("main", "main", "false_with_rfi", "create_false", True, None, quarter, quarter),
+        seg(
+            "main", "main", "true_only_eti", "create_true_single", None, None, 2 * quarter, quarter
+        ),
+        seg("main", "main", "true_eti_rfi", "create_true_double", None, 1.0, 3 * quarter, quarter),
+        # false: 2-way balanced halves
+        seg("false", "false", "false_no_signal", "create_false", False, None, 0, half),
+        seg("false", "false", "false_with_rfi", "create_false", True, None, half, half),
+        # true: 2-way balanced halves
+        seg("true", "true", "true_only_eti", "create_true_single", None, None, 0, half),
+        seg("true", "true", "true_eti_rfi", "create_true_double", None, 1.0, half, half),
+    ]
+
+
+def build_segment_tasks(
+    segment: ChunkSegment,
+    array_path: str,
+    task_size: int,
+    snr_base: float,
+    snr_range: float,
+    width_bin: int,
+    freq_resolution: float,
+    time_resolution: float,
+    seed_rng: np.random.Generator,
+) -> list[tuple]:
+    """
+    Partition one segment into batched worker tasks of at most `task_size` cadences each.
+    Together the tasks cover rows [segment.start_idx, segment.start_idx + segment.count)
+    exactly once. Each task carries a fresh RNG seed drawn from `seed_rng` so results don't
+    depend on which persistent worker picks the task up.
+    """
+    if task_size < 1:
+        raise ValueError(f"task_size must be >= 1, got {task_size}")
+
+    tasks = []
+    for offset in range(0, segment.count, task_size):
+        count = min(task_size, segment.count - offset)
+        seed = int(seed_rng.integers(0, 2**31 - 1))
+        tasks.append(
+            (
+                array_path,
+                segment.start_idx + offset,
+                count,
+                segment.create_fn_name,
+                snr_base,
+                snr_range,
+                width_bin,
+                freq_resolution,
+                time_resolution,
+                segment.inject,
+                segment.dynamic_range,
+                seed,
+            )
+        )
+    return tasks
+
+
+def _run_memmap_task(args: tuple, backgrounds: np.ndarray) -> tuple[float, list[dict]]:
+    """
+    Execute one batched generation task against `backgrounds`: open the target .npy r+ (like
+    preprocessing._extract_stamps_worker), generate `count` cadences with the chosen create_*
+    function, and write each result row straight into the memmap. Tasks address disjoint row
+    ranges, so concurrent pool writes never collide. Returns (elapsed_seconds,
+    [sample_info, ...]) — the only data that crosses the IPC boundary.
     """
     (
-        function,
+        array_path,
+        start_idx,
+        count,
+        create_fn_name,
         snr_base,
         snr_range,
         width_bin,
@@ -584,147 +678,25 @@ def _single_cadence_wrapper(args):
         time_resolution,
         inject,
         dynamic_range,
+        seed,
     ) = args
-    return function(
-        # NOTE:
-        # is _GLOBAL_BACKGROUNDS a reference to the shared memory, or the entire data array itself?
-        # is this method of doing things slower due to pickling costs?
-        # should we move the index selection into _single_cadence_wrapper so only one background plate is sent at a time?
-        # how can we benchmark this?
-        # # # Select random background from plate
-        # # background_index = int(plate.shape[0] * random.random())
-        # # base = plate[background_index, :, :, :]
-        _GLOBAL_BACKGROUNDS,
-        snr_base=snr_base,
-        snr_range=snr_range,
-        width_bin=width_bin,
-        freq_resolution=freq_resolution,
-        time_resolution=time_resolution,
-        inject=inject,
-        dynamic_range=dynamic_range,
-    )
 
+    task_start = time.time()
 
-# NOTE: come back to this later
-# def _batch_cadence_worker(args):
-#     """
-#     Process a batch of cadences and write results directly to shared memory.
-#
-#     Args:
-#         args: Tuple of (start_idx, end_idx, function, snr_base, snr_range,
-#                        width_bin, freq_resolution, time_resolution, inject, dynamic_range)
-#
-#     Returns:
-#         None - results written directly to _GLOBAL_OUTPUT_ARRAY
-#
-#     Why this approach:
-#         Instead of returning 192KB per cadence through IPC (which requires pickle
-#         serialization), workers write directly to pre-allocated shared memory.
-#         This eliminates the dominant bottleneck: ~23GB of IPC data transfer per round.
-#
-#         Processing cadences in batches (e.g., 500-1000 per task) also reduces
-#         task scheduling overhead from 120,000 dispatches to ~120-240 dispatches.
-#     """
-#     (
-#         start_idx,
-#         end_idx,
-#         function,
-#         snr_base,
-#         snr_range,
-#         width_bin,
-#         freq_resolution,
-#         time_resolution,
-#         inject,
-#         dynamic_range,
-#     ) = args
-#
-#     # Process each cadence in this batch
-#     for i in range(start_idx, end_idx):
-#         result = function(
-#             _GLOBAL_BACKGROUNDS,
-#             snr_base=snr_base,
-#             snr_range=snr_range,
-#             width_bin=width_bin,
-#             freq_resolution=freq_resolution,
-#             time_resolution=time_resolution,
-#             inject=inject,
-#             dynamic_range=dynamic_range,
-#         )
-#
-#         # Write directly to shared memory output array - NO IPC!
-#         _GLOBAL_OUTPUT_ARRAY[i, :, :, :] = result
-#
-#     # Return None - no data through IPC
+    # Per-task seeding keeps results independent of worker scheduling (workers are
+    # persistent, so PID-only seeding from _init_worker would tie the stream to which
+    # worker happens to pick the task up).
+    random.seed(seed)
+    np.random.seed(seed % (2**32))
 
-
-def batch_create_cadence(
-    function,
-    samples: int,
-    plate: np.ndarray,
-    snr_base: int = 10,
-    snr_range: float = 40,
-    width_bin: int = 512,
-    freq_resolution: float = 2.7939677238464355,
-    time_resolution: float = 18.25361108,
-    inject: bool | None = None,
-    dynamic_range: float | None = None,
-    pool: Pool | None = None,
-    n_processes: int | None = cpu_count(),
-    chunks_per_worker: int | None = 4,
-) -> tuple[np.ndarray, list[dict]]:
-    """
-    Batch-generate `samples` cadences with the chosen `function` (create_false /
-    create_true_single / create_true_double), returning (cadence_array of shape
-    (samples, 6, 16, width_bin), all_sample_info: list of per-sample dicts).
-
-    When `pool` is provided, work is dispatched via _single_cadence_wrapper against the worker
-    pool's shared-memory background plate; otherwise the loop runs sequentially against `plate`
-    in-process. chunks_per_worker controls map() chunksize to balance scheduling overhead vs.
-    parallelism. dynamic_range only applies to create_true_double; inject only to create_false.
-    """
-    # Pre-allocate output array
-    cadence = np.zeros((samples, 6, 16, width_bin))
+    create_fn = _CREATE_FUNCTIONS[create_fn_name]
     all_sample_info = []
 
-    if pool:
-        # Parallel execution using provided pool
-        # Prepare arguments for each parallel task (no plate - uses global)
-        args_list = [
-            (
-                function,
-                snr_base,
-                snr_range,
-                width_bin,
-                freq_resolution,
-                time_resolution,
-                inject,
-                dynamic_range,
-            )
-            for _ in range(samples)
-        ]
-
-        # Calculate optimal chunksize for load balancing
-        try:
-            n_workers = pool._processes
-        except AttributeError:
-            n_workers = n_processes
-        # NOTE: should we use separate chunks_per_worker? how to benchmark?
-        chunksize = max(1, samples // (n_workers * chunks_per_worker))
-
-        # Use pool to generate cadences in parallel
-        for i, (result, sample_info) in enumerate(
-            # TEST: does return order matter?
-            pool.map(_single_cadence_wrapper, args_list, chunksize=chunksize)
-            # pool.imap(_single_cadence_wrapper, args_list, chunksize=chunksize)
-            # pool.imap_unordered(_single_cadence_wrapper, args_list, chunksize=chunksize)
-        ):
-            cadence[i, :, :, :] = result
-            all_sample_info.append(sample_info)
-    else:
-        # Fallback to sequential execution
-        for i in range(samples):
-            result, sample_info = function(
-                plate,
+    out = np.lib.format.open_memmap(array_path, mode="r+")
+    try:
+        for i in range(count):
+            cadence, sample_info = create_fn(
+                backgrounds,
                 snr_base=snr_base,
                 snr_range=snr_range,
                 width_bin=width_bin,
@@ -733,161 +705,283 @@ def batch_create_cadence(
                 inject=inject,
                 dynamic_range=dynamic_range,
             )
-            cadence[i, :, :, :] = result
+            out[start_idx + i] = cadence
             all_sample_info.append(sample_info)
+        out.flush()
+    finally:
+        del out
 
-    return cadence, all_sample_info
+    return time.time() - task_start, all_sample_info
 
 
-# NOTE: come back to this later
-# def batch_create_cadence(
-#     function,
-#     samples: int,
-#     plate: np.ndarray,
-#     snr_base: int = 10,
-#     snr_range: float = 40,
-#     width_bin: int = 512,
-#     freq_resolution: float = 2.7939677238464355,
-#     time_resolution: float = 18.25361108,
-#     inject: bool | None = None,
-#     dynamic_range: float | None = None,
-#     pool: Pool | None = None,
-#     output_shm: SharedMemory | None = None,
-#     output_array: np.ndarray | None = None,
-#     output_offset: int = 0,
-#     n_processes: int | None = cpu_count(),
-#     chunks_per_worker: int | None = 4,
-#     # NOTE: parametrize this in config
-#     batch_size: int = 500,  # cadences per task
-# ) -> np.ndarray:
-#     """
-#     Batch wrapper for creating multiple cadences using multiprocessing.
-#
-#     Key changes from original:
-#     1. Workers write directly to shared memory (output_array) instead of returning results
-#     2. Tasks are batched (batch_size cadences per task) to reduce scheduling overhead
-#     3. output_offset allows writing to a specific slice of the output array
-#
-#     Args:
-#         function: Cadence generation function (create_false, create_true_single, create_true_double)
-#         samples: Number of cadences to generate
-#         plate: Background plate array (only used if pool is None)
-#         snr_base: Base SNR value
-#         snr_range: SNR range for randomization
-#         width_bin: Number of frequency bins
-#         freq_resolution: Frequency resolution in Hz
-#         time_resolution: Time resolution in seconds
-#         inject: Whether to inject signals (for create_false)
-#         dynamic_range: Dynamic range for signal injection (for create_true_double)
-#         pool: Pre-initialized multiprocessing Pool with shared memory
-#         output_shm: SharedMemory object for output (used for cleanup tracking)
-#         output_array: numpy array view of output shared memory
-#         output_offset: Starting index in output_array for this batch
-#         n_processes: Number of processes in multiprocessing Pool
-#         chunks_per_worker: Used to calculate optimal chunksize for load balancing
-#         batch_size: Number of cadences per worker task (default 500)
-#
-#     Returns:
-#         Array of shape (samples, 6, 16, width_bin) containing generated cadences
-#         (either from shared memory or newly allocated)
-#     """
-#     if pool and output_array is not None:
-#         # OPTIMIZED PATH: Use shared memory output
-#
-#         # Create batched task arguments
-#         # Instead of 1 task per cadence, create 1 task per batch_size cadences
-#         tasks = []
-#         for batch_start in range(0, samples, batch_size):
-#             batch_end = min(batch_start + batch_size, samples)
-#             # Indices are relative to output_offset in the shared memory
-#             tasks.append(
-#                 (
-#                     output_offset + batch_start,  # start_idx in output array
-#                     output_offset + batch_end,  # end_idx in output array
-#                     function,
-#                     snr_base,
-#                     snr_range,
-#                     width_bin,
-#                     freq_resolution,
-#                     time_resolution,
-#                     inject,
-#                     dynamic_range,
-#                 )
-#             )
-#
-#         # Calculate chunksize for pool.map
-#         # With batched tasks, we have far fewer tasks, so chunksize can be smaller
-#         n_tasks = len(tasks)
-#         try:
-#             n_workers = pool._processes
-#         except AttributeError:
-#             n_workers = n_processes
-#
-#         # Aim for ~4 chunks per worker for load balancing
-#         chunksize = max(1, n_tasks // (n_workers * 4))
-#
-#         logger.debug(
-#             f"Dispatching {n_tasks} batched tasks (batch_size={batch_size}, chunksize={chunksize})"
-#         )
-#
-#         # Execute - results are written directly to shared memory
-#         # We use pool.map which blocks until complete, but returns None for each task
-#         list(pool.map(_batch_cadence_worker, tasks, chunksize=chunksize))
-#
-#         # Return view of the shared memory output for this batch
-#         return output_array[output_offset : output_offset + samples]
-#
-#     elif pool:
-#         # LEGACY PATH: Pool exists but no shared memory output
-#         # Fall back to original IPC-based approach (for backward compatibility)
-#         cadence = np.zeros((samples, 6, 16, width_bin), dtype=np.float32)
-#
-#         args_list = [
-#             (
-#                 function,
-#                 snr_base,
-#                 snr_range,
-#                 width_bin,
-#                 freq_resolution,
-#                 time_resolution,
-#                 inject,
-#                 dynamic_range,
-#             )
-#             for _ in range(samples)
-#         ]
-#
-#         try:
-#             n_workers = pool._processes
-#         except AttributeError:
-#             n_workers = n_processes
-#
-#         # FIX: Use reasonable chunksize instead of always 1
-#         chunksize = max(50, samples // (n_workers * 4))
-#
-#         for i, result in enumerate(
-#             pool.imap(_single_cadence_wrapper, args_list, chunksize=chunksize)
-#         ):
-#             cadence[i, :, :, :] = result
-#
-#         return cadence
-#
-#     else:
-#         # Sequential execution (no pool)
-#         cadence = np.zeros((samples, 6, 16, width_bin), dtype=np.float32)
-#
-#         for i in range(samples):
-#             cadence[i, :, :, :] = function(
-#                 plate,
-#                 snr_base=snr_base,
-#                 snr_range=snr_range,
-#                 width_bin=width_bin,
-#                 freq_resolution=freq_resolution,
-#                 time_resolution=time_resolution,
-#                 inject=inject,
-#                 dynamic_range=dynamic_range,
-#             )
-#
-#         return cadence
+def _memmap_task_worker(args: tuple) -> tuple[float, list[dict]]:
+    """Pool entry point for batched memmap tasks: run against the shared-memory backgrounds."""
+    return _run_memmap_task(args, _GLOBAL_BACKGROUNDS)
+
+
+def write_segment_stats(db, tag: str, segment: dict) -> None:
+    """
+    Write one class-segment's injection stats to the DB (main-process only — the DB queue is
+    a thread queue.Queue, not process-safe). `segment` is the dict emitted by
+    generate_round_to_memmap's stats_cb.
+
+    Per-sample writes: 6 intensity stats x 3 stages = 18 rows, plus 0-12 signal-characteristic
+    rows depending on signal_type. Segment-level writes: 4 metadata rows.
+    """
+    if db is None:
+        raise RuntimeError("No database instance detected - cannot write injection stats")
+
+    round_number = segment["round_number"]
+    chunk_number = segment["chunk_number"]
+    signal_class = segment["signal_class"]
+    signal_type = segment["signal_type"]
+    timestamp = segment["timestamp"]
+
+    for sample_idx, sample_info in enumerate(segment["stats_list"]):
+        background_index = sample_info["background_index"]
+        intensity_stats = sample_info["intensity_stats"]
+        signal_info = sample_info["signal_info"]
+        slope_was_clamped = sample_info.get("slope_was_clamped", False)
+
+        # Intensity stats for each stage
+        for stage in ["A", "B", "C"]:
+            stage_stats = intensity_stats[stage]
+
+            for stat_name in [
+                "global_mean",
+                "global_median",
+                "global_std",
+                "global_mad",
+                "global_skew",
+                "global_kurtosis",
+            ]:
+                db.write_injection_stat(
+                    stat_name=stat_name,
+                    value=stage_stats[stat_name],
+                    round_number=round_number,
+                    chunk_number=chunk_number,
+                    sample_index=sample_idx,
+                    background_index=background_index,
+                    signal_class=signal_class,
+                    signal_type=signal_type,
+                    injection_stage=stage,
+                    slope_clamped=slope_was_clamped,
+                    tag=tag,
+                    timestamp=timestamp,
+                )
+
+        # NOTE: what happens when signal_info is empty for false_no_rfi signal types?
+        # Signal characteristics (eti_snr, rfi_drift_rate, etc.)
+        # injection_stage=None since these describe the injection itself
+        for stat_name, value in signal_info.items():
+            db.write_injection_stat(
+                stat_name=stat_name,
+                value=float(value),
+                round_number=round_number,
+                chunk_number=chunk_number,
+                sample_index=sample_idx,
+                background_index=background_index,
+                signal_class=signal_class,
+                signal_type=signal_type,
+                injection_stage=None,
+                slope_clamped=slope_was_clamped,
+                tag=tag,
+                timestamp=timestamp,
+            )
+
+    # Segment-level metadata stats (once per segment, not per sample)
+    metadata_stats = [
+        ("snr_range_floor", segment["snr_range_floor"]),
+        ("snr_range_ceil", segment["snr_range_ceil"]),
+        ("num_samples", float(segment["num_samples"])),
+        ("inject_duration", segment["inject_duration"]),
+    ]
+
+    for stat_name, value in metadata_stats:
+        db.write_injection_stat(
+            stat_name=stat_name,
+            value=value,
+            round_number=round_number,
+            chunk_number=chunk_number,
+            sample_index=None,
+            background_index=None,
+            signal_class=signal_class,
+            signal_type=signal_type,
+            injection_stage=None,
+            tag=tag,
+            timestamp=timestamp,
+        )
+
+
+def generate_round_to_memmap(
+    paths: RoundDataPaths,
+    n_samples: int,
+    snr_base: float,
+    snr_range: float,
+    *,
+    width_bin: int,
+    num_observations: int,
+    time_bins: int,
+    chunk_size: int,
+    task_size: int,
+    freq_resolution: float,
+    time_resolution: float,
+    pool: Pool | None = None,
+    backgrounds: np.ndarray | None = None,
+    round_num: int | None = None,
+    stats_cb=None,
+    progress_cb=None,
+) -> dict:
+    """
+    Generate one round's triplet dataset straight into disk-backed .npy memmaps.
+
+    main: collapsed cadences, 1/4 balanced across the 4 signal types (labels array tracks the
+    per-row type); false: 1/2 false_no_signal + 1/2 false_with_rfi; true: 1/2 true_only_eti +
+    1/2 true_eti_rfi — each of shape (n_samples, num_observations, time_bins, width_bin)
+    float32, laid out contiguously per chunk (see build_chunk_segments).
+
+    Work is dispatched as one unified batched task list per chunk through a single pool.map
+    barrier (instead of the old 8 sequential per-class barriers); workers write rows in-place
+    and return only stats dicts. With `pool` None, tasks run sequentially in-process against
+    `backgrounds`. On success the labels array is saved and an atomic .done manifest is
+    written (a crash mid-generation leaves no manifest, so the dir reads as garbage).
+
+    stats_cb(segment_dict) fires once per class-segment per chunk; progress_cb(chunk,
+    n_chunks) once per chunk. Returns the manifest dict.
+    """
+    if n_samples % 4 != 0:
+        raise ValueError(f"n_samples must be divisible by 4, got {n_samples}")
+    if chunk_size % 4 != 0:
+        raise ValueError(f"chunk_size must be divisible by 4, got {chunk_size}")
+    if pool is None and backgrounds is None:
+        raise ValueError("backgrounds must be provided when no pool is given")
+
+    wall_start = time.time()
+
+    # Start from a clean slate: a previous partial generation (no .done manifest) may have
+    # left stale arrays behind.
+    shutil.rmtree(paths.round_dir, ignore_errors=True)
+    os.makedirs(paths.round_dir, exist_ok=True)
+
+    # Pre-create the three destination memmaps; workers reopen them r+ per task
+    shape = (n_samples, num_observations, time_bins, width_bin)
+    array_paths = paths.array_paths
+    for path in array_paths.values():
+        mm = np.lib.format.open_memmap(path, mode="w+", dtype=np.float32, shape=shape)
+        del mm  # Close immediately: creation only reserves the file; workers do the writing
+
+    labels = np.empty(n_samples, dtype="U20")
+
+    n_chunks = max(1, (n_samples + chunk_size - 1) // chunk_size)
+    seed_rng = np.random.default_rng()  # OS entropy; per-task seeds are drawn from this
+
+    logger.info(
+        f"Generating {n_samples} samples into {paths.round_dir} "
+        f"({n_chunks} chunks of max {chunk_size}, task size {task_size})"
+    )
+
+    for chunk_idx in range(n_chunks):
+        chunk_start = chunk_idx * chunk_size
+        this_chunk_size = min(chunk_size, n_samples - chunk_start)
+        if this_chunk_size <= 0:
+            break
+
+        # Capture single timestamp for all stats in this chunk
+        chunk_timestamp = time.time()
+
+        segments = build_chunk_segments(chunk_start, this_chunk_size)
+
+        # One unified task list across all 8 class-segments -> one pool.map barrier per chunk
+        tasks: list[tuple] = []
+        task_owners: list[int] = []  # task index -> segment index (map preserves order)
+        for segment_idx, segment in enumerate(segments):
+            segment_tasks = build_segment_tasks(
+                segment,
+                array_paths[segment.array_name],
+                task_size,
+                snr_base,
+                snr_range,
+                width_bin,
+                freq_resolution,
+                time_resolution,
+                seed_rng,
+            )
+            tasks.extend(segment_tasks)
+            task_owners.extend([segment_idx] * len(segment_tasks))
+
+        # Labels mirror the main array's contiguous per-chunk layout
+        quarter = this_chunk_size // 4
+        chunk_labels: list[str] = []
+        for signal_type in _SIGNAL_TYPES:
+            chunk_labels.extend([signal_type] * quarter)
+        labels[chunk_start : chunk_start + this_chunk_size] = chunk_labels
+
+        logger.info(
+            f"Generating chunk {chunk_idx + 1}/{n_chunks} "
+            f"({this_chunk_size} samples, {len(tasks)} tasks)"
+        )
+
+        if pool is not None:
+            # chunksize=1: each task is already a coarse unit of work (task_size cadences),
+            # so per-task scheduling overhead is negligible and load balance is best
+            results = pool.map(_memmap_task_worker, tasks, chunksize=1)
+        else:
+            results = [_run_memmap_task(task, backgrounds) for task in tasks]
+
+        # Group returned stats by segment. inject_duration is the sum of the segment's
+        # per-task wall times (aggregate worker time, not the barrier wall time — tasks from
+        # all segments run interleaved across the pool, so per-segment barrier walls no
+        # longer exist).
+        segment_stats: list[list[dict]] = [[] for _ in segments]
+        segment_durations = [0.0] * len(segments)
+        for owner, (task_duration, task_stats) in zip(task_owners, results, strict=True):
+            segment_stats[owner].extend(task_stats)
+            segment_durations[owner] += task_duration
+
+        if stats_cb is not None:
+            for segment, stats_list, duration in zip(
+                segments, segment_stats, segment_durations, strict=True
+            ):
+                stats_cb(
+                    {
+                        "round_number": round_num,
+                        "chunk_number": chunk_idx + 1,
+                        "signal_class": segment.signal_class,
+                        "signal_type": segment.signal_type,
+                        "snr_range_floor": snr_base,
+                        "snr_range_ceil": snr_base + snr_range,
+                        "num_samples": len(stats_list),
+                        "inject_duration": duration,
+                        "timestamp": chunk_timestamp,
+                        "stats_list": stats_list,
+                    }
+                )
+
+        del results, segment_stats
+        gc.collect()
+
+        if progress_cb is not None:
+            progress_cb(chunk_idx + 1, n_chunks)
+        logger.info(f"Chunk {chunk_idx + 1}/{n_chunks} complete")
+
+    np.save(paths.labels_path, labels)
+
+    # The .done manifest is only written after every chunk has finished — the same atomicity
+    # idea as preprocessing's .tmp -> os.replace stamp extraction
+    manifest = build_manifest(
+        paths,
+        n_samples=n_samples,
+        snr_base=snr_base,
+        snr_range=snr_range,
+        wall_time_s=time.time() - wall_start,
+        chunk_count=n_chunks,
+    )
+    write_done_manifest(paths, manifest)
+
+    logger.info(
+        f"Round data generation complete: {paths.round_dir} ({manifest['wall_time_s']:.1f}s wall)"
+    )
+    return manifest
 
 
 class DataGenerator:
@@ -900,7 +994,10 @@ class DataGenerator:
         """
         Initialize the generator. background_plates is an array of preprocessed background
         observations with shape (n_backgrounds, 6, 16, 512). Plates are copied into shared memory
-        for worker access and a persistent multiprocessing pool is set up here.
+        for worker access; the worker pool itself is created lazily on the first in-process
+        generate_round() call (when overlap_data_generation is on, the RoundDataProducer process
+        owns its own pool against the same shared memory, and this one is never needed for the
+        beta-VAE rounds).
         """
         self.config = get_config()
         if self.config is None:
@@ -914,11 +1011,11 @@ class DataGenerator:
         if self.manager is None:
             raise ValueError("get_manager() returned None")
 
+        # Pool is created on demand by _ensure_pool()
+        self.pool = None
+
         # Load background plates into shared memory
         self._load_backgrounds(background_plates)
-
-        # Setup persistent process pool for efficient parallel execution
-        self._setup_managed_pool()
 
     def _load_backgrounds(self, background_plates: np.ndarray):
         """Load background plates into shared memory"""
@@ -945,7 +1042,6 @@ class DataGenerator:
 
         # Get multiprocessing params from config
         self.n_processes = self.config.manager.n_processes
-        self.chunks_per_worker = self.config.manager.chunks_per_worker
 
         # Setup shared memory to avoid duplicating background data across workers
         if self.n_processes > 1:
@@ -972,53 +1068,25 @@ class DataGenerator:
         logger.info(f"  Background shape: {self._background_shape}")
         logger.info(f"  Background dtype: {self._background_dtype}")
 
-    def _setup_managed_pool(self):
+    def _ensure_pool(self):
         """
-        Stand up a persistent ResourceManager-owned multiprocessing pool whose workers attach to
-        the shared-memory background block at init time, so per-task dispatches don't have to
-        re-serialize the plates. Falls back to sequential mode (self.pool = None) when
-        n_processes == 1.
+        Lazily stand up the persistent ResourceManager-owned multiprocessing pool whose workers
+        attach to the shared-memory background block at init time, so per-task dispatches don't
+        have to re-serialize the plates. No-op in sequential mode (n_processes == 1, no shared
+        memory) — generate_round() then runs tasks in-process.
 
         The pool must be released via _free_managed_pool() or close() — the ResourceManager
         won't reap it automatically.
         """
         # NOTE: should we explicitly guarantee only 1 shm & 1 pool can exist at a time?
-        # If shared memory exists, then create pool using shared memory reference
-        if self.shm:
-            self.pool = self.manager.create_pool(
-                n_processes=self.n_processes,
-                name=f"DataGen_pool_{id(self)}",  # NOTE: come back to this later
-                initializer=_init_worker,
-                initargs=(self.shm.name, self._background_shape, self._background_dtype),
-            )
-        # Else run in sequential mode (no pool)
-        else:
-            self.pool = None
-            logger.info("DataGenerator running in sequential mode (n_processes=1)")
-
-    # NOTE: come back to this later
-    # def _setup_managed_pool(self):
-    #     """
-    #     Setup managed multiprocessing pool with shared memory.
-    #
-    #     Why we don't create output shared memory here:
-    #         Output shared memory size depends on the batch size requested in generate_triplet_batch(),
-    #         which varies between calls. We create output shared memory on-demand in generate_triplet_batch()
-    #         and pass references to workers via the task arguments.
-    #
-    #         The pool is initialized with background shared memory only. Workers will attach to
-    #         output shared memory when provided via _batch_cadence_worker args.
-    #     """
-    #     if self.shm:
-    #         self.pool = self.manager.create_pool(
-    #             n_processes=self.n_processes,
-    #             name=f"DataGen_pool_{id(self)}",
-    #             initializer=_init_worker,
-    #             initargs=(self.shm.name, self._background_shape, self._background_dtype),
-    #         )
-    #     else:
-    #         self.pool = None
-    #         logger.info("DataGenerator running in sequential mode (n_processes=1)")
+        if self.pool is not None or not self.shm:
+            return
+        self.pool = self.manager.create_pool(
+            n_processes=self.n_processes,
+            name=f"DataGen_pool_{id(self)}",  # NOTE: come back to this later
+            initializer=_init_worker,
+            initargs=(self.shm.name, self._background_shape, self._background_dtype),
+        )
 
     def _free_managed_pool(self):
         """Close multiprocessing pool"""
@@ -1032,13 +1100,13 @@ class DataGenerator:
 
         Should be called between training rounds, since workers can accumulate memory through
         memory fragmentation in long-lived processes, python's reference counter leaking in workers,
-        and caches / global state accumulating in workers.
+        and caches / global state accumulating in workers. The pool is re-created lazily by
+        _ensure_pool() on the next generate_round() call.
         """
         if hasattr(self, "pool") and self.pool is not None:
             try:
                 self._free_managed_pool()
                 gc.collect()  # Garbage collect between resets
-                self._setup_managed_pool()
             except Exception as e:
                 logger.warning(f"Error resetting DataGenerator pool: {e}")
 
@@ -1054,674 +1122,41 @@ class DataGenerator:
         self._free_managed_shared_memory()
         logger.info("DataGenerator closed")
 
-    # NOTE: update docstring values when more stats are added
-    def _write_batch_stats(
+    def generate_round(
         self,
-        stats_list: list[dict],
-        round_number: int | None,
-        chunk_number: int,
-        signal_class: str,
-        signal_type: str,
-        snr_range_floor: float,
-        snr_range_ceil: float,
-        num_samples: int,
-        inject_duration: float,
-        timestamp: float,
-    ):
+        paths,
+        n_samples: int,
+        snr_base: float,
+        snr_range: float,
+        round_num: int | None = None,
+    ) -> dict:
         """
-        Write per-sample stats to DB.
-
-        Per-sample writes:
-        - Intensity stats: 6 stats × 3 stages = 18 writes per sample
-        - Signal characteristics: 0-12 writes depending on signal_type
-        - background_index is included with each write
-
-        Batch-level writes:
-        - 4 metadata stats written once per batch
+        Generate one round's triplet dataset into the disk-backed memmaps at `paths`
+        (a round_data.RoundDataPaths), writing injection stats to the DB as chunks complete.
+        Used for the sequential (non-overlapped) generation path — the RF dataset, and beta-VAE
+        rounds when overlap_data_generation is disabled. Returns the .done manifest dict.
         """
+        self._ensure_pool()
+
         tag = self.config.checkpoint.save_tag
 
-        if self.db is None:
-            raise RuntimeError(
-                "No database instance detected - cannot generate training progress plot"
-            )
+        def _stats_cb(segment: dict) -> None:
+            write_segment_stats(self.db, tag, segment)
 
-        # Write per-sample stats
-        for sample_idx, sample_info in enumerate(stats_list):
-            background_index = sample_info["background_index"]
-            intensity_stats = sample_info["intensity_stats"]
-            signal_info = sample_info["signal_info"]
-            slope_was_clamped = sample_info.get("slope_was_clamped", False)
-
-            # Write intensity stats for each stage
-            for stage in ["A", "B", "C"]:
-                stage_stats = intensity_stats[stage]
-
-                for stat_name in [
-                    "global_mean",
-                    "global_median",
-                    "global_std",
-                    "global_mad",
-                    "global_skew",
-                    "global_kurtosis",
-                ]:
-                    self.db.write_injection_stat(
-                        stat_name=stat_name,
-                        value=stage_stats[stat_name],
-                        round_number=round_number,
-                        chunk_number=chunk_number,
-                        sample_index=sample_idx,
-                        background_index=background_index,
-                        signal_class=signal_class,
-                        signal_type=signal_type,
-                        injection_stage=stage,
-                        slope_clamped=slope_was_clamped,
-                        tag=tag,
-                        timestamp=timestamp,
-                    )
-
-            # NOTE: what happens when signal_info is empty for false_no_rfi signal types?
-            # Write signal characteristics (eti_snr, rfi_drift_rate, etc.)
-            # injection_stage=None since these describe the injection itself
-            for stat_name, value in signal_info.items():
-                self.db.write_injection_stat(
-                    stat_name=stat_name,
-                    value=float(value),
-                    round_number=round_number,
-                    chunk_number=chunk_number,
-                    sample_index=sample_idx,
-                    background_index=background_index,
-                    signal_class=signal_class,
-                    signal_type=signal_type,
-                    injection_stage=None,
-                    slope_clamped=slope_was_clamped,
-                    tag=tag,
-                    timestamp=timestamp,
-                )
-
-        # Write batch-level metadata stats (once per batch, not per sample)
-        metadata_stats = [
-            ("snr_range_floor", snr_range_floor),
-            ("snr_range_ceil", snr_range_ceil),
-            ("num_samples", float(num_samples)),
-            ("inject_duration", inject_duration),
-        ]
-
-        for stat_name, value in metadata_stats:
-            self.db.write_injection_stat(
-                stat_name=stat_name,
-                value=value,
-                round_number=round_number,
-                chunk_number=chunk_number,
-                sample_index=None,
-                background_index=None,
-                signal_class=signal_class,
-                signal_type=signal_type,
-                injection_stage=None,
-                tag=tag,
-                timestamp=timestamp,
-            )
-
-    def generate_triplet_batch(
-        self, n_samples: int, snr_base: int, snr_range: int, round_num: int | None = None
-    ) -> dict[str, np.ndarray]:
-        """
-        Generate triplet batch using chunking & multiprocessing
-
-        main: collapsed cadences
-          - total: n_samples
-          - split: 1/4 balanced between false-no-signal, false-with-rfi, true-single, true-double
-        false: non-collapsed false cadences
-          - total: n_samples
-          - split: 1/2 balanced between false-no-signal, false-with-rfi
-        true: non-collapsed true cadences
-          - total: n_samples
-          - split: 1/2 balanced between true-single, true-double
-        """
-        max_chunk_size = self.config.training.signal_injection_chunk_size
-        n_chunks = max(1, (n_samples + max_chunk_size - 1) // max_chunk_size)
-
-        logger.info(f"Generating {n_samples} samples in {n_chunks} chunks of max {max_chunk_size}")
-
-        # NOTE: freq & time dims hard-coded here
-        # Pre-allocate output arrays
-        all_main = np.empty((n_samples, 6, 16, self.width_bin), dtype=np.float32)
-        all_labels = np.empty(n_samples, dtype="U20")
-        all_false = np.empty((n_samples, 6, 16, self.width_bin), dtype=np.float32)
-        all_true = np.empty((n_samples, 6, 16, self.width_bin), dtype=np.float32)
-
-        for chunk_idx in range(n_chunks):
-            chunk_size = min(max_chunk_size, n_samples - chunk_idx * max_chunk_size)
-            if chunk_size <= 0:
-                break
-
-            start_idx = chunk_idx * max_chunk_size
-            end_idx = start_idx + chunk_size
-
-            logger.info(f"Generating chunk {chunk_idx + 1}/{n_chunks} with {chunk_size} samples")
-
-            # Capture single timestamp for all stats in this chunk
-            chunk_timestamp = time.time()
-
-            # Split chunk into equal partitions (for balanced classes)
-            # Ceiling division ensures 4*quarter >= chunk_size and 2*half >= chunk_size,
-            # so we always generate enough samples. Excess is randomly discarded after concat.
-            quarter = max(1, -(-chunk_size // 4))
-            half = max(1, -(-chunk_size // 2))
-
-            # Pure background (main)
-            batch_start = time.time()
-            quarter_false_no_signal, stats_main_false_no_signal = batch_create_cadence(
-                create_false,
-                quarter,
-                self.backgrounds,
-                snr_base=snr_base,
-                snr_range=snr_range,
-                width_bin=self.width_bin,
-                freq_resolution=self.freq_resolution,
-                time_resolution=self.time_resolution,
-                inject=False,
-                pool=self.pool,
-                n_processes=self.n_processes,
-                chunks_per_worker=self.chunks_per_worker,
-            )
-            duration_main_false_no_signal = time.time() - batch_start
-
-            # RFI only (main)
-            batch_start = time.time()
-            quarter_false_with_rfi, stats_main_false_with_rfi = batch_create_cadence(
-                create_false,
-                quarter,
-                self.backgrounds,
-                snr_base=snr_base,
-                snr_range=snr_range,
-                width_bin=self.width_bin,
-                freq_resolution=self.freq_resolution,
-                time_resolution=self.time_resolution,
-                inject=True,
-                pool=self.pool,
-                n_processes=self.n_processes,
-                chunks_per_worker=self.chunks_per_worker,
-            )
-            duration_main_false_with_rfi = time.time() - batch_start
-
-            # ETI only (main)
-            batch_start = time.time()
-            quarter_true_single, stats_main_true_only_eti = batch_create_cadence(
-                create_true_single,
-                quarter,
-                self.backgrounds,
-                snr_base=snr_base,
-                snr_range=snr_range,
-                width_bin=self.width_bin,
-                freq_resolution=self.freq_resolution,
-                time_resolution=self.time_resolution,
-                pool=self.pool,
-                n_processes=self.n_processes,
-                chunks_per_worker=self.chunks_per_worker,
-            )
-            duration_main_true_only_eti = time.time() - batch_start
-
-            # ETI + RFI (main)
-            batch_start = time.time()
-            quarter_true_double, stats_main_true_eti_rfi = batch_create_cadence(
-                create_true_double,
-                quarter,
-                self.backgrounds,
-                snr_base=snr_base,
-                snr_range=snr_range,
-                width_bin=self.width_bin,
-                freq_resolution=self.freq_resolution,
-                time_resolution=self.time_resolution,
-                dynamic_range=1,
-                pool=self.pool,
-                n_processes=self.n_processes,
-                chunks_per_worker=self.chunks_per_worker,
-            )
-            duration_main_true_eti_rfi = time.time() - batch_start
-
-            # Concatenate for main training data (collapsed cadences)
-            chunk_main = np.concatenate(
-                [
-                    quarter_false_no_signal,
-                    quarter_false_with_rfi,
-                    quarter_true_single,
-                    quarter_true_double,
-                ],
-                axis=0,
-            )
-
-            # Build per-cadence labels for this chunk
-            chunk_labels = np.array(
-                ["false_no_signal"] * quarter
-                + ["false_with_rfi"] * quarter
-                + ["true_only_eti"] * quarter
-                + ["true_eti_rfi"] * quarter,
-                dtype="U20",
-            )
-
-            # Subsample to chunk_size if we generated more than needed (ceiling division remainder)
-            n_generated_main = 4 * quarter
-            if n_generated_main > chunk_size:
-                keep_main = np.sort(
-                    np.random.choice(n_generated_main, size=chunk_size, replace=False)
-                )
-                chunk_main = chunk_main[keep_main]
-                chunk_labels = chunk_labels[keep_main]
-
-                # Filter stats to only include kept samples
-                main_stats_groups = [
-                    (stats_main_false_no_signal, 0),
-                    (stats_main_false_with_rfi, quarter),
-                    (stats_main_true_only_eti, 2 * quarter),
-                    (stats_main_true_eti_rfi, 3 * quarter),
-                ]
-                for stats_ref, offset in main_stats_groups:
-                    type_mask = (keep_main >= offset) & (keep_main < offset + quarter)
-                    kept_indices = keep_main[type_mask] - offset
-                    stats_ref[:] = [stats_ref[i] for i in kept_indices]
-
-            # Write main batch stats (deferred to after subsampling so only kept samples are written)
-            for stats_list, signal_type, duration in [
-                (stats_main_false_no_signal, "false_no_signal", duration_main_false_no_signal),
-                (stats_main_false_with_rfi, "false_with_rfi", duration_main_false_with_rfi),
-                (stats_main_true_only_eti, "true_only_eti", duration_main_true_only_eti),
-                (stats_main_true_eti_rfi, "true_eti_rfi", duration_main_true_eti_rfi),
-            ]:
-                self._write_batch_stats(
-                    stats_list=stats_list,
-                    round_number=round_num,
-                    chunk_number=chunk_idx + 1,
-                    signal_class="main",
-                    signal_type=signal_type,
-                    snr_range_floor=snr_base,
-                    snr_range_ceil=snr_base + snr_range,
-                    num_samples=len(stats_list),
-                    inject_duration=duration,
-                    timestamp=chunk_timestamp,
-                )
-
-            # Generate separate true/false non-collapsed cadences for training set diversity
-            # Used to calculate clustering loss & train RF
-
-            # Pure background (false)
-            batch_start = time.time()
-            half_false_no_signal, stats_false_no_signal = batch_create_cadence(
-                create_false,
-                half,
-                self.backgrounds,
-                snr_base=snr_base,
-                snr_range=snr_range,
-                width_bin=self.width_bin,
-                freq_resolution=self.freq_resolution,
-                time_resolution=self.time_resolution,
-                inject=False,
-                pool=self.pool,
-                n_processes=self.n_processes,
-                chunks_per_worker=self.chunks_per_worker,
-            )
-            duration_false_no_signal = time.time() - batch_start
-
-            # RFI only (false)
-            batch_start = time.time()
-            half_false_with_rfi, stats_false_with_rfi = batch_create_cadence(
-                create_false,
-                half,
-                self.backgrounds,
-                snr_base=snr_base,
-                snr_range=snr_range,
-                width_bin=self.width_bin,
-                freq_resolution=self.freq_resolution,
-                time_resolution=self.time_resolution,
-                inject=True,
-                pool=self.pool,
-                n_processes=self.n_processes,
-                chunks_per_worker=self.chunks_per_worker,
-            )
-            duration_false_with_rfi = time.time() - batch_start
-
-            # ETI only (true)
-            batch_start = time.time()
-            half_true_single, stats_true_only_eti = batch_create_cadence(
-                create_true_single,
-                half,
-                self.backgrounds,
-                snr_base=snr_base,
-                snr_range=snr_range,
-                width_bin=self.width_bin,
-                freq_resolution=self.freq_resolution,
-                time_resolution=self.time_resolution,
-                pool=self.pool,
-                n_processes=self.n_processes,
-                chunks_per_worker=self.chunks_per_worker,
-            )
-            duration_true_only_eti = time.time() - batch_start
-
-            # ETI + RFI (true)
-            batch_start = time.time()
-            half_true_double, stats_true_eti_rfi = batch_create_cadence(
-                create_true_double,
-                half,
-                self.backgrounds,
-                snr_base=snr_base,
-                snr_range=snr_range,
-                width_bin=self.width_bin,
-                freq_resolution=self.freq_resolution,
-                time_resolution=self.time_resolution,
-                dynamic_range=1,
-                pool=self.pool,
-                n_processes=self.n_processes,
-                chunks_per_worker=self.chunks_per_worker,
-            )
-            duration_true_eti_rfi = time.time() - batch_start
-
-            chunk_false = np.concatenate([half_false_no_signal, half_false_with_rfi], axis=0)
-
-            chunk_true = np.concatenate([half_true_single, half_true_double], axis=0)
-
-            # Subsample to chunk_size if we generated more than needed (ceiling division remainder)
-            n_generated_half = 2 * half
-            if n_generated_half > chunk_size:
-                keep_false = np.sort(
-                    np.random.choice(n_generated_half, size=chunk_size, replace=False)
-                )
-                keep_true = np.sort(
-                    np.random.choice(n_generated_half, size=chunk_size, replace=False)
-                )
-                chunk_false = chunk_false[keep_false]
-                chunk_true = chunk_true[keep_true]
-
-                # Filter stats to only include kept samples
-                # chunk_false layout: [0, half) = no_signal, [half, 2*half) = with_rfi
-                stats_false_no_signal[:] = [
-                    stats_false_no_signal[i] for i in keep_false[keep_false < half]
-                ]
-                stats_false_with_rfi[:] = [
-                    stats_false_with_rfi[i - half] for i in keep_false[keep_false >= half]
-                ]
-                # chunk_true layout: [0, half) = only_eti, [half, 2*half) = eti_rfi
-                stats_true_only_eti[:] = [
-                    stats_true_only_eti[i] for i in keep_true[keep_true < half]
-                ]
-                stats_true_eti_rfi[:] = [
-                    stats_true_eti_rfi[i - half] for i in keep_true[keep_true >= half]
-                ]
-
-            # Write false/true batch stats (deferred to after subsampling)
-            for stats_list, signal_class, signal_type, duration in [
-                (stats_false_no_signal, "false", "false_no_signal", duration_false_no_signal),
-                (stats_false_with_rfi, "false", "false_with_rfi", duration_false_with_rfi),
-                (stats_true_only_eti, "true", "true_only_eti", duration_true_only_eti),
-                (stats_true_eti_rfi, "true", "true_eti_rfi", duration_true_eti_rfi),
-            ]:
-                self._write_batch_stats(
-                    stats_list=stats_list,
-                    round_number=round_num,
-                    chunk_number=chunk_idx + 1,
-                    signal_class=signal_class,
-                    signal_type=signal_type,
-                    snr_range_floor=snr_base,
-                    snr_range_ceil=snr_base + snr_range,
-                    num_samples=len(stats_list),
-                    inject_duration=duration,
-                    timestamp=chunk_timestamp,
-                )
-
-            # Store chunks directly into output array
-            all_main[start_idx:end_idx] = chunk_main
-            all_labels[start_idx:end_idx] = chunk_labels
-            all_false[start_idx:end_idx] = chunk_false
-            all_true[start_idx:end_idx] = chunk_true
-
-            # Clean up chunk data immediately
-            del (
-                quarter_false_no_signal,
-                quarter_false_with_rfi,
-                quarter_true_single,
-                quarter_true_double,
-            )
-            del half_false_no_signal, half_false_with_rfi, half_true_single, half_true_double
-            del chunk_main, chunk_labels, chunk_false, chunk_true
-            del stats_main_false_no_signal, stats_main_false_with_rfi
-            del stats_main_true_only_eti, stats_main_true_eti_rfi
-            del stats_false_no_signal, stats_false_with_rfi
-            del stats_true_only_eti, stats_true_eti_rfi
-            gc.collect()
-
-            logger.info(f"Chunk {chunk_idx + 1} complete, memory cleared")
-
-        # Create result dictionary with references to pre-allocated arrays
-        result = {
-            "concatenated": all_main,
-            "labels": all_labels,
-            "false": all_false,
-            "true": all_true,
-        }
-
-        # NOTE: is there a more efficient way to do this? these checks currently take a few minutes to complete. should we comment this portion out?
-        # # Sanity check: verify post-injection data normalization
-        # for key in ["concatenated", "false", "true"]:
-        #     min_val = np.min(result[key])
-        #     max_val = np.max(result[key])
-        #     mean_val = np.mean(result[key])
-        #     logger.info(
-        #         f"Post-injection {key} stats: min={min_val:.6f}, max={max_val:.6f}, mean={mean_val:.6f}"
-        #     )
-        #     if max_val > 1.0:
-        #         logger.error(f"Post-injection {key} values too large! Max: {max_val}")
-        #         raise ValueError(f"Post-injection {key} normalization check failed")
-        #     elif min_val < 0.0:
-        #         logger.error(f"Post-injection {key} values too small! Min: {min_val}")
-        #         raise ValueError(f"Post-injection {key} normalization check failed")
-        #     elif np.isnan(result[key]).any():
-        #         logger.error(f"Post-injection {key} contains NaN values!")
-        #         raise ValueError(f"Post-injection {key} normalization check failed")
-        #     elif np.isinf(result[key]).any():
-        #         logger.error(f"Post-injection {key} contains Inf values!")
-        #         raise ValueError(f"Post-injection {key} normalization check failed")
-        #     else:
-        #         logger.info(f"Post-injection {key} data properly normalized")
-
-        return result
-
-    # NOTE: come back to this later
-    # def generate_triplet_batch(
-    #     self, n_samples: int, snr_base: int, snr_range: int
-    # ) -> dict[str, np.ndarray]:
-    #     """
-    #     Generate triplet batch using unified task submission and shared memory outputs.
-    #
-    #     Key optimizations:
-    #     1. Single shared memory allocation for all outputs
-    #     2. All 8 batch types submitted as unified task queue
-    #     3. Workers write directly to shared memory (no IPC returns)
-    #     4. Single synchronization point instead of 8
-    #
-    #     Output structure:
-    #         main: collapsed cadences (n_samples total)
-    #           - 1/4 false-no-signal, 1/4 false-with-rfi, 1/4 true-single, 1/4 true-double
-    #         false: non-collapsed false cadences (n_samples total)
-    #           - 1/2 false-no-signal, 1/2 false-with-rfi
-    #         true: non-collapsed true cadences (n_samples total)
-    #           - 1/2 true-single, 1/2 true-double
-    #     """
-    #     max_chunk_size = self.config.training.signal_injection_chunk_size
-    #     n_chunks = max(1, (n_samples + max_chunk_size - 1) // max_chunk_size)
-    #
-    #     logger.info(f"Generating {n_samples} samples in {n_chunks} chunks of max {max_chunk_size}")
-    #
-    #     # Pre-allocate output arrays
-    #     all_main = np.empty((n_samples, 6, 16, self.width_bin), dtype=np.float32)
-    #     all_false = np.empty((n_samples, 6, 16, self.width_bin), dtype=np.float32)
-    #     all_true = np.empty((n_samples, 6, 16, self.width_bin), dtype=np.float32)
-    #
-    #     for chunk_idx in range(n_chunks):
-    #         chunk_size = min(max_chunk_size, n_samples - chunk_idx * max_chunk_size)
-    #         if chunk_size <= 0:
-    #             break
-    #
-    #         start_idx = chunk_idx * max_chunk_size
-    #         end_idx = start_idx + chunk_size
-    #
-    #         logger.info(f"Generating chunk {chunk_idx + 1}/{n_chunks} with {chunk_size} samples")
-    #
-    #         # Calculate sample counts for this chunk
-    #         quarter = max(1, chunk_size // 4)
-    #         half = max(1, chunk_size // 2)
-    #
-    #         # Total outputs needed for this chunk:
-    #         # - main: 4 * quarter = chunk_size
-    #         # - false: 2 * half = chunk_size
-    #         # - true: 2 * half = chunk_size
-    #         # Total: 3 * chunk_size
-    #         total_outputs = 3 * chunk_size
-    #
-    #         # Create output shared memory for this chunk
-    #         output_shape = (total_outputs, 6, 16, self.width_bin)
-    #         output_nbytes = int(np.prod(output_shape) * np.float32().nbytes)
-    #
-    #         output_shm = self.manager.create_shared_memory(
-    #             size=output_nbytes,
-    #             name=f"DataGen_output_chunk_{chunk_idx}_{id(self)}",
-    #         )
-    #
-    #         # Create numpy view of output shared memory
-    #         output_array = np.ndarray(output_shape, dtype=np.float32, buffer=output_shm.buf)
-    #
-    #         # Reinitialize pool with output shared memory reference
-    #         # Workers need to attach to the new output shared memory
-    #         if self.pool is not None:
-    #             self._free_managed_pool()
-    #
-    #         self.pool = self.manager.create_pool(
-    #             n_processes=self.n_processes,
-    #             name=f"DataGen_pool_chunk_{chunk_idx}_{id(self)}",
-    #             initializer=_init_worker,
-    #             initargs=(
-    #                 self.shm.name,
-    #                 self._background_shape,
-    #                 self._background_dtype,
-    #                 output_shm.name,  # NEW: output shared memory
-    #                 output_shape,  # NEW: output shape
-    #             ),
-    #         )
-    #
-    #         # Define output layout in shared memory:
-    #         # [0:quarter]                          -> main: false_no_signal
-    #         # [quarter:2*quarter]                  -> main: false_with_rfi
-    #         # [2*quarter:3*quarter]                -> main: true_single
-    #         # [3*quarter:4*quarter]                -> main: true_double
-    #         # [chunk_size:chunk_size+half]         -> false: no_signal
-    #         # [chunk_size+half:chunk_size+2*half]  -> false: with_rfi
-    #         # [2*chunk_size:2*chunk_size+half]     -> true: single
-    #         # [2*chunk_size+half:3*chunk_size]     -> true: double
-    #
-    #         # Build unified task list for all 8 batch types
-    #         batch_size = 500  # Cadences per task
-    #         all_tasks = []
-    #
-    #         # Helper to create batched tasks for a given output range
-    #         def add_tasks(
-    #             output_start,
-    #             count,
-    #             function,
-    #             inject=None,
-    #             dynamic_range=None,
-    #             _batch_size=batch_size,
-    #             _all_tasks=all_tasks,
-    #         ):
-    #             for batch_start in range(0, count, _batch_size):
-    #                 batch_end = min(batch_start + _batch_size, count)
-    #                 _all_tasks.append(
-    #                     (
-    #                         output_start + batch_start,
-    #                         output_start + batch_end,
-    #                         function,
-    #                         snr_base,
-    #                         snr_range,
-    #                         self.width_bin,
-    #                         self.freq_resolution,
-    #                         self.time_resolution,
-    #                         inject,
-    #                         dynamic_range,
-    #                     )
-    #                 )
-    #
-    #         # Main outputs (quarters)
-    #         add_tasks(0, quarter, create_false, inject=False)
-    #         add_tasks(quarter, quarter, create_false, inject=True)
-    #         add_tasks(2 * quarter, quarter, create_true_single)
-    #         add_tasks(3 * quarter, quarter, create_true_double, dynamic_range=1)
-    #
-    #         # False outputs (halves)
-    #         add_tasks(chunk_size, half, create_false, inject=False)
-    #         add_tasks(chunk_size + half, half, create_false, inject=True)
-    #
-    #         # True outputs (halves)
-    #         add_tasks(2 * chunk_size, half, create_true_single)
-    #         add_tasks(2 * chunk_size + half, half, create_true_double, dynamic_range=1)
-    #
-    #         logger.info(f"Submitting {len(all_tasks)} unified tasks to pool")
-    #
-    #         # Execute ALL tasks in single pool.map call
-    #         # This is the key optimization: one sync barrier instead of 8
-    #         n_workers = self.n_processes
-    #         chunksize = max(1, len(all_tasks) // (n_workers * 4))
-    #
-    #         list(self.pool.map(_batch_cadence_worker, all_tasks, chunksize=chunksize))
-    #
-    #         logger.info("All tasks complete, extracting results from shared memory")
-    #
-    #         # Extract results from shared memory into output arrays
-    #         # Main outputs
-    #         chunk_main = np.concatenate(
-    #             [
-    #                 output_array[0:quarter],
-    #                 output_array[quarter : 2 * quarter],
-    #                 output_array[2 * quarter : 3 * quarter],
-    #                 output_array[3 * quarter : 4 * quarter],
-    #             ],
-    #             axis=0,
-    #         )
-    #
-    #         # False outputs
-    #         chunk_false = np.concatenate(
-    #             [
-    #                 output_array[chunk_size : chunk_size + half],
-    #                 output_array[chunk_size + half : chunk_size + 2 * half],
-    #             ],
-    #             axis=0,
-    #         )
-    #
-    #         # True outputs
-    #         chunk_true = np.concatenate(
-    #             [
-    #                 output_array[2 * chunk_size : 2 * chunk_size + half],
-    #                 output_array[2 * chunk_size + half : 3 * chunk_size],
-    #             ],
-    #             axis=0,
-    #         )
-    #
-    #         # Store chunks in pre-allocated arrays
-    #         all_main[start_idx:end_idx] = chunk_main
-    #         all_false[start_idx:end_idx] = chunk_false
-    #         all_true[start_idx:end_idx] = chunk_true
-    #
-    #         # Cleanup chunk resources
-    #         del chunk_main, chunk_false, chunk_true
-    #         del output_array
-    #
-    #         # Close pool before closing shared memory (workers have references)
-    #         self._free_managed_pool()
-    #         self.manager.close_shared_memory(output_shm)
-    #
-    #         gc.collect()
-    #
-    #         logger.info(f"Chunk {chunk_idx + 1} complete, memory cleared")
-    #
-    #     # Recreate pool for next generate_triplet_batch call
-    #     self._setup_managed_pool()
-    #
-    #     result = {"concatenated": all_main, "false": all_false, "true": all_true}
-    #
-    #     return result
+        return generate_round_to_memmap(
+            paths=paths,
+            n_samples=n_samples,
+            snr_base=snr_base,
+            snr_range=snr_range,
+            width_bin=self.width_bin,
+            num_observations=self._background_shape[1],
+            time_bins=self._background_shape[2],
+            chunk_size=self.config.training.signal_injection_chunk_size,
+            task_size=self.config.training.data_gen_task_size,
+            freq_resolution=self.freq_resolution,
+            time_resolution=self.time_resolution,
+            pool=self.pool,
+            backgrounds=self.backgrounds if self.pool is None else None,
+            round_num=round_num,
+            stats_cb=_stats_cb,
+        )

--- a/src/aetherscan/data_generation.py
+++ b/src/aetherscan/data_generation.py
@@ -485,6 +485,10 @@ def create_true_double(
     snr = random.random() * snr_range + snr_base
 
     # Note, small but nonzero probability for "infinite" (long-running) loops
+    # NOTE: quantified in #118 — acceptance is i.i.d. geometric with p~=0.42, so the worst
+    # sample over a full 499200-round is ~25 retries (~3s); a >100-retry sample is effectively
+    # impossible (P~1e-24). This loop is therefore NOT the ~10-min single-worker stall seen in
+    # the #117 smoke (that is gc/IO/scheduling, see #118). #118 tracks a defensive retry cap.
     # Retry signal injection until we get valid non-intersecting signals
     while True:
         # Inject RFI
@@ -692,7 +696,13 @@ def _run_memmap_task(args: tuple, backgrounds: np.ndarray) -> tuple[float, list[
     # random.random() and the np.random.* module API. The determinism therefore holds only
     # as long as nothing else mutates the global RNG state between cadences within a task;
     # threading an explicit np.random.Generator through the create_* functions would remove
-    # that coupling if it ever matters.
+    # that coupling if it ever matters. In practice the coupling is not exposed: pool workers
+    # are single-threaded processes, and the only in-process (pool=None) generation is the RF
+    # dataset, which runs after the training datasets/iterators are torn down (train_round's
+    # finally: holder.clear() -> del datasets -> clear_session -> gc), so no tf.data generator
+    # thread is alive mutating global RNG state during it. Note per-task seeds come from OS
+    # entropy (round_data seed_rng) and are not persisted, so runs are not reproducible anyway;
+    # what this guarantees is independence of results from worker scheduling within a run.
     random.seed(seed)
     np.random.seed(seed % (2**32))
 

--- a/src/aetherscan/data_generation.py
+++ b/src/aetherscan/data_generation.py
@@ -688,6 +688,11 @@ def _run_memmap_task(args: tuple, backgrounds: np.ndarray) -> tuple[float, list[
     # Per-task seeding keeps results independent of worker scheduling (workers are
     # persistent, so PID-only seeding from _init_worker would tie the stream to which
     # worker happens to pick the task up).
+    # NOTE: this seeds the LEGACY global RNGs because new_cadence/create_* draw from
+    # random.random() and the np.random.* module API. The determinism therefore holds only
+    # as long as nothing else mutates the global RNG state between cadences within a task;
+    # threading an explicit np.random.Generator through the create_* functions would remove
+    # that coupling if it ever matters.
     random.seed(seed)
     np.random.seed(seed % (2**32))
 
@@ -709,8 +714,11 @@ def _run_memmap_task(args: tuple, backgrounds: np.ndarray) -> tuple[float, list[
             )
             out[start_idx + i] = cadence
             all_sample_info.append(sample_info)
-        out.flush()
     finally:
+        # Flush in the finally so rows written before a mid-task exception still reach disk
+        # deterministically (a failed round has no .done manifest and reads as garbage either
+        # way, but not all filesystems are guaranteed to write back dirty pages on munmap)
+        out.flush()
         del out
 
     return time.time() - task_start, all_sample_info

--- a/src/aetherscan/logger/logger.py
+++ b/src/aetherscan/logger/logger.py
@@ -293,24 +293,30 @@ def init_logger() -> Logger:
     return logger_instance
 
 
-def init_worker_logging():
+def init_worker_logging(log_queue=None):
     """
     Initialize logging in a multiprocessing worker: reset stdout/stderr to the original streams
     (so the inherited StreamToLogger from the parent doesn't fire), then attach a QueueHandler
-    pointing at the main process's shared log queue. If no Logger singleton has been initialized
-    in the parent, falls back to a NullHandler to avoid noise.
+    pointing at the main process's shared log queue.
+
+    `log_queue` defaults to the Logger singleton's queue, which fork-started workers inherit.
+    Spawn-started processes (e.g. the RoundDataProducer and its pool workers) run a fresh
+    interpreter where the singleton doesn't exist — they must pass the queue explicitly
+    (a multiprocessing.Queue survives the spawn pickling boundary). Without either, falls back
+    to a NullHandler to avoid noise.
     """
-    logger_instance = Logger._instance
+    if log_queue is None:
+        logger_instance = Logger._instance
 
-    if logger_instance is None:
-        logger.warning(
-            "No logger instance initialized - disabling worker logging to avoid conflicts"
-        )
-        logging.getLogger().handlers.clear()
-        logging.getLogger().addHandler(logging.NullHandler())
-        return
+        if logger_instance is None:
+            logger.warning(
+                "No logger instance initialized - disabling worker logging to avoid conflicts"
+            )
+            logging.getLogger().handlers.clear()
+            logging.getLogger().addHandler(logging.NullHandler())
+            return
 
-    log_queue = logger_instance.log_queue
+        log_queue = logger_instance.log_queue
 
     # Reset stdout/stderr to avoid inherited StreamToLogger from parent
     sys.stdout = sys.__stdout__

--- a/src/aetherscan/manager/manager.py
+++ b/src/aetherscan/manager/manager.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import atexit
 import contextlib
 import logging
+import multiprocessing
 import os
 import signal
 import sys
@@ -35,10 +36,64 @@ class ResourceStats:
 
     pools_active: int = 0
     pools_closed: int = 0
+    processes_active: int = 0
+    processes_closed: int = 0
     shared_memories_active: int = 0
     shared_memories_cleaned: int = 0
     total_memory_freed_gb: float = 0.0
     cleanup_time_seconds: float = 0.0
+
+
+@dataclass
+class ManagedProcess:
+    """Wrapper for a tracked multiprocessing.Process (e.g. the RoundDataProducer)"""
+
+    process: multiprocessing.Process
+    name: str
+    created_at: float
+    closed: bool = False
+
+    def close(self, timeout):
+        """Close the process with terminate -> join -> kill escalation (mirrors ManagedPool.close)"""
+        if self.closed:
+            return
+
+        try:
+            if self.process.is_alive():
+                logger.info(f"Terminating process '{self.name}' (PID {self.process.pid})")
+
+                # SIGTERM first: the process's handler gets a chance to clean up (e.g. the
+                # producer terminates its own worker pool before dying)
+                self.process.terminate()
+                self.process.join(timeout)
+
+                if self.process.is_alive():
+                    logger.warning(f"Process '{self.name}' survived SIGTERM, escalating to SIGKILL")
+                    # SIGKILL gives the process no chance to reap its own children (e.g. the
+                    # producer's pool workers), so kill any survivors in its subtree first —
+                    # otherwise they'd be orphaned and keep running
+                    with contextlib.suppress(Exception):
+                        for child in psutil.Process(self.process.pid).children(recursive=True):
+                            with contextlib.suppress(psutil.NoSuchProcess):
+                                child.kill()
+                    self.process.kill()
+                    self.process.join(timeout)
+
+                    if self.process.is_alive():
+                        # Surviving SIGKILL is extremely rare (uninterruptible sleep state 'D').
+                        # Log and proceed — the OS will clean up on exit
+                        logger.error(
+                            f"Process '{self.name}' survived SIGKILL (uninterruptible state?)"
+                        )
+
+            self.closed = True
+            logger.info(f"Process '{self.name}' closed")
+
+        except Exception as e:
+            logger.warning(f"Error terminating process '{self.name}': {e}")
+            with contextlib.suppress(Exception):
+                self.process.kill()
+            self.closed = True
 
 
 @dataclass
@@ -305,6 +360,7 @@ class ResourceManager:
         # NOTE: should these be strong or weak references? import weakref ...
         # Track resources
         self._pools: list[ManagedPool] = []
+        self._processes: list[ManagedProcess] = []
         self._shared_memories: list[ManagedSharedMemory] = []
 
         # Track threads
@@ -409,11 +465,13 @@ class ResourceManager:
         """
         Unified cleanup of all resources.
         Strict order:
-            1. Pools
-            2. SharedMemory
-            3. Monitor
-            4. DB
-            5. Logger
+            1. Processes (before shared memory — e.g. the producer's workers attach to the
+               background-plate block)
+            2. Pools
+            3. SharedMemory
+            4. Monitor
+            5. DB
+            6. Logger
         """
         # Skip if not main process
         if os.getpid() != self._main_process_pid:
@@ -438,6 +496,12 @@ class ResourceManager:
         # Log initial stats
         start_time = time.time()
         initial_memory = self._get_memory_usage()
+
+        # Close managed processes
+        logger.info("Closing managed processes...")
+        for managed in list(self._processes):
+            if not managed.closed:
+                self._close_managed_process(managed)
 
         # Close managed pools
         logger.info("Closing multiprocessing pools...")
@@ -486,6 +550,7 @@ class ResourceManager:
         logger.info("=" * 60)
         logger.info("ResourceManager cleanup complete:")
         logger.info(f"  Pools closed: {self.stats.pools_closed}")
+        logger.info(f"  Processes closed: {self.stats.processes_closed}")
         logger.info(f"  Shared memories cleaned: {self.stats.shared_memories_cleaned}")
         logger.info(f"  Memory freed: {self.stats.total_memory_freed_gb:.2f} GB")
         logger.info(f"  Cleanup time: {self.stats.cleanup_time_seconds:.2f} seconds")
@@ -547,6 +612,35 @@ class ResourceManager:
         self._pools.remove(managed)
         self.stats.pools_active -= 1
         self.stats.pools_closed += 1
+
+    def register_process(self, process: multiprocessing.Process, name: str = "unnamed"):
+        """
+        Register an externally-created multiprocessing.Process (e.g. the RoundDataProducer)
+        for lifecycle tracking, so cleanup_all() can escalate terminate -> join -> kill on it.
+        """
+        managed = ManagedProcess(process=process, name=name, created_at=time.time())
+
+        self._processes.append(managed)
+        self.stats.processes_active += 1
+
+        logger.info(f"Registered process '{name}' (PID {process.pid})")
+        logger.info(f"  Current total active: {self.stats.processes_active}")
+
+    def close_process(self, process: multiprocessing.Process):
+        """Explicitly close a specific tracked process by reference"""
+        for managed in self._processes:
+            if managed.process is process and not managed.closed:
+                self._close_managed_process(managed)
+                return
+        logger.warning("ResourceManager.close_process(): Process not found in managed processes")
+
+    def _close_managed_process(self, managed: ManagedProcess):
+        """Internal method to close a ManagedProcess"""
+        managed.close(timeout=self.config.manager.pool_terminate_timeout)
+        # Remove from tracking list to allow garbage collection of the Process object
+        self._processes.remove(managed)
+        self.stats.processes_active -= 1
+        self.stats.processes_closed += 1
 
     def create_shared_memory(self, size: int, name: str = "unnamed") -> SharedMemory:
         """

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -511,7 +511,7 @@ class DataPreprocessor:
                 # Load chunk into memory
                 chunk_data = np.array(raw_data[chunk_start:chunk_end])
 
-                # NOTE: is this access pattern the most efficient (least pickling)? see comments in _single_cadence_wrapper() from data_generation.py for more details
+                # NOTE: is this access pattern the most efficient (least pickling)? see _downsample_worker()'s docstring on pulling the cadence from the shared-memory global to avoid per-cadence pickling
                 # NOTE: currently, loading the backgrounds takes WAY more time than processing the backgrounds
                 # Prepare arguments for downsampling (just indices, not data - data is in global state)
                 n_cadences = min(chunk_data.shape[0], num_target_backgrounds - len(all_backgrounds))
@@ -704,7 +704,7 @@ class DataPreprocessor:
                 # Load chunk into memory
                 chunk_data = np.array(raw_data[chunk_start:chunk_end])
 
-                # NOTE: is this access pattern the most efficient (least pickling)? see comments in _single_cadence_wrapper() from data_generation.py for more details
+                # NOTE: is this access pattern the most efficient (least pickling)? see _downsample_worker()'s docstring on pulling the cadence from the shared-memory global to avoid per-cadence pickling
                 # NOTE: currently, loading the backgrounds takes WAY more time than processing the backgrounds
                 # Prepare arguments for downsampling (just indices, not data - data is in global state)
                 n_cadences = chunk_data.shape[0]

--- a/src/aetherscan/round_data.py
+++ b/src/aetherscan/round_data.py
@@ -99,6 +99,15 @@ def _array_checksum(arr: np.ndarray) -> dict:
     Cheap, sha-less checksum for a (possibly huge) memmap: total element count plus a few
     deterministically-sampled flat-index values. Positions are derived from the element count,
     so validation re-samples the same spots without storing an RNG state.
+
+    NOTE: this is a smoke test, not integrity protection. It reliably catches truncation and
+    gross corruption (wrong element count, shape, swapped arrays), but sub-threshold damage
+    slips through: a randomly corrupted fraction f of one array is only detected with
+    probability 1-(1-f)^_MANIFEST_SAMPLE_COUNT (e.g. a single lost page in a ~90 GB array is
+    ~never sampled). That is acceptable because a crash leaves NO manifest at all (the dir is
+    then treated as garbage and regenerated), so the checksum only guards against same-run
+    disk/NFS corruption between writing .done and reading it back — not power-loss/torn-page
+    scenarios. If stronger guarantees are ever needed, upgrade to a full content hash.
     """
     # NOTE: reshape(-1) is a zero-copy view here (and in validate_done_manifest) because
     # open_memmap/np.save arrays are always C-contiguous; on a non-contiguous array it would
@@ -168,6 +177,15 @@ def validate_done_manifest(
     Validate a round dir's .done manifest against the arrays on disk. Returns the manifest
     dict when everything checks out (round index, optional expected sample count, per-array
     existence, shape, element count, and the sampled checksum values), else None.
+
+    NOTE: validation does NOT compare the manifest's snr_base/snr_range against what the caller
+    wants — it only proves the arrays match the manifest that was written with them. Reusing a
+    validated round dir is safe TODAY only because _setup_directories deletes every round dir
+    >= start_round before generation begins, so a reused dir is always one written earlier in
+    THIS run's curriculum. If cross-run round reuse is ever added (the obvious ~295 GB-saving
+    optimization), a dir generated under a different SNR curriculum would validate and be
+    silently trained on — add an expected_snr guard here (and at the _producer_main reuse
+    short-circuit) before relaxing the delete-on-startup policy.
     """
     try:
         if not os.path.isfile(paths.done_path):

--- a/src/aetherscan/round_data.py
+++ b/src/aetherscan/round_data.py
@@ -33,10 +33,11 @@ import threading
 import time
 import traceback
 from dataclasses import dataclass
+from logging.handlers import QueueListener
 
 import numpy as np
 
-from aetherscan.logger import get_logger, init_worker_logging
+from aetherscan.logger import init_worker_logging
 from aetherscan.manager import get_manager
 
 logger = logging.getLogger(__name__)
@@ -308,10 +309,11 @@ def _producer_main(
            ("error", round_idx, traceback_str)           on failure (producer keeps serving)
            ("shutdown_ack",)                             right before a graceful exit
 
-    `log_queue` is the main process's multiprocessing log queue — a spawned child has no
-    inherited Logger singleton, so it (and its pool workers) attach QueueHandlers to this queue
-    explicitly. `generate_fn` is a test seam: when provided, no worker pool is created and the
-    stub is called in place of the real memmap generation (see tests/unit/test_round_data.py).
+    `log_queue` is a spawn-context multiprocessing queue relayed into the main process's
+    logging pipeline by RoundDataProducer.start() — a spawned child has no inherited Logger
+    singleton, so it (and its pool workers) attach QueueHandlers to this queue explicitly.
+    `generate_fn` is a test seam: when provided, no worker pool is created and the stub is
+    called in place of the real memmap generation (see tests/unit/test_round_data.py).
     """
     global _PRODUCER_POOL
 
@@ -457,8 +459,13 @@ class RoundDataProducer:
         self._db = db
         self._tag = tag
         # Queues come from the spawn context so they can cross the spawn pickling boundary
+        # (mixing contexts raises "A SemLock created in a fork context is being shared with a
+        # process in a spawn context" — which also rules out handing the child the Logger
+        # singleton's fork-context queue directly; see the relay in start())
         self._request_queue: multiprocessing.Queue = _MP_CONTEXT.Queue()
         self._result_queue: multiprocessing.Queue = _MP_CONTEXT.Queue()
+        self._producer_log_queue: multiprocessing.Queue = _MP_CONTEXT.Queue()
+        self._log_relay: QueueListener | None = None
         self._process: multiprocessing.Process | None = None
         self._drainer: threading.Thread | None = None
         self._drainer_done = False
@@ -467,14 +474,26 @@ class RoundDataProducer:
 
     def start(self) -> None:
         """Spawn the producer process and the main-side result drainer thread."""
-        # Hand the producer the main process's log queue explicitly — a spawned child has no
-        # inherited Logger singleton (multiprocessing.Queue survives Process-args pickling).
-        logger_instance = get_logger()
-        log_queue = logger_instance.log_queue if logger_instance is not None else None
+        # A spawned child has no inherited Logger singleton, and the singleton's fork-context
+        # queue can't cross the spawn boundary — so the producer tree logs into its own
+        # spawn-context queue, and this main-side QueueListener relays each record into the
+        # main process's root handlers (i.e. into the normal file/console/Slack pipeline).
+        self._log_relay = QueueListener(
+            self._producer_log_queue,
+            *logging.getLogger().handlers,
+            respect_handler_level=False,
+        )
+        self._log_relay.start()
 
         self._process = _MP_CONTEXT.Process(
             target=_producer_main,
-            args=(self._request_queue, self._result_queue, self._params, None, log_queue),
+            args=(
+                self._request_queue,
+                self._result_queue,
+                self._params,
+                None,
+                self._producer_log_queue,
+            ),
             name="RoundDataProducer",
         )
 
@@ -548,6 +567,10 @@ class RoundDataProducer:
 
         if self._drainer is not None:
             self._drainer.join(timeout=timeout)
+        if self._log_relay is not None:
+            with contextlib.suppress(Exception):
+                self._log_relay.stop()
+            self._log_relay = None
         self._process = None
         logger.info("RoundDataProducer shut down")
 

--- a/src/aetherscan/round_data.py
+++ b/src/aetherscan/round_data.py
@@ -100,6 +100,9 @@ def _array_checksum(arr: np.ndarray) -> dict:
     deterministically-sampled flat-index values. Positions are derived from the element count,
     so validation re-samples the same spots without storing an RNG state.
     """
+    # NOTE: reshape(-1) is a zero-copy view here (and in validate_done_manifest) because
+    # open_memmap/np.save arrays are always C-contiguous; on a non-contiguous array it would
+    # silently materialize a full in-RAM copy — switch to .ravel()/.flat if the layout ever changes
     flat = arr.reshape(-1)
     n = int(flat.size)
     rng = np.random.default_rng(n)
@@ -499,8 +502,11 @@ class RoundDataProducer:
 
         # The spawned child re-imports the aetherscan module chain, which includes TF; blank
         # out GPU visibility for the child's entire process tree so nothing in the producer
-        # can ever initialize CUDA (generation is pure CPU). The parent's TF read this env at
-        # its own GPU init, so temporarily mutating it here is safe.
+        # can ever initialize CUDA (generation is pure CPU).
+        # NOTE: another thread reading os.environ during this brief window would see the
+        # blanked value — intentionally acceptable ONLY because the parent's TF read the var
+        # once at its own GPU init (long before this point) and nothing else in the pipeline
+        # spawns GPU-visible subprocesses concurrently with training startup.
         original_cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES")
         os.environ["CUDA_VISIBLE_DEVICES"] = ""
         try:
@@ -541,6 +547,9 @@ class RoundDataProducer:
                     raise RuntimeError(
                         f"RoundDataProducer exited before producing round {round_idx} data"
                     )
+                # NOTE: the drainer's notify_all() wakes this immediately on done/error; the
+                # 1 s timeout is not a polling latency, just a liveness re-check so a drainer
+                # that died without notifying can't strand this wait forever
                 self._condition.wait(timeout=1.0)
 
         if kind == "error":

--- a/src/aetherscan/round_data.py
+++ b/src/aetherscan/round_data.py
@@ -36,10 +36,17 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from aetherscan.logger import init_worker_logging
+from aetherscan.logger import get_logger, init_worker_logging
 from aetherscan.manager import get_manager
 
 logger = logging.getLogger(__name__)
+
+# The producer process is started with the SPAWN method, not fork: the training parent holds
+# deep TF / NCCL / gRPC / CUDA thread state whose locks a forked child can inherit in a locked
+# state — an early producer prototype deadlocked on a futex before reaching its own code. A
+# spawned child runs a fresh interpreter with none of that baggage (its own pool workers are
+# then forked from the clean single-threaded producer, which is safe).
+_MP_CONTEXT = multiprocessing.get_context("spawn")
 
 # Directory-name pattern for one round's dataset (1-based, mirrors checkpoint round_XX tags)
 _ROUND_DIR_PATTERN = re.compile(r"^round_(\d+)$")
@@ -284,12 +291,14 @@ def _default_generate(paths, round_idx, snr_base, snr_range, pool, params, stats
     )
 
 
-def _producer_main(request_queue, result_queue, params: dict, generate_fn=None) -> None:
+def _producer_main(
+    request_queue, result_queue, params: dict, generate_fn=None, log_queue=None
+) -> None:
     """
-    Producer process entry point. Owns a private worker pool (workers attach to the
-    background-plate shared memory created by the main process) and generates rounds on
-    request, isolated from the main process's GIL (TF's prefetch threads no longer slow
-    generation down, and generation no longer steals cycles from training).
+    Producer process entry point (spawn-started — see _MP_CONTEXT). Owns a private worker pool
+    (workers attach to the background-plate shared memory created by the main process) and
+    generates rounds on request, isolated from the main process's GIL (TF's prefetch threads no
+    longer slow generation down, and generation no longer steals cycles from training).
 
     Protocol (multiprocessing.Queues):
     - in:  ("generate", round_idx, snr_base, snr_range) | ("shutdown",)
@@ -299,15 +308,17 @@ def _producer_main(request_queue, result_queue, params: dict, generate_fn=None) 
            ("error", round_idx, traceback_str)           on failure (producer keeps serving)
            ("shutdown_ack",)                             right before a graceful exit
 
-    `generate_fn` is a test seam: when provided, no worker pool is created and the stub is
-    called in place of the real memmap generation (see tests/unit/test_round_data.py).
+    `log_queue` is the main process's multiprocessing log queue — a spawned child has no
+    inherited Logger singleton, so it (and its pool workers) attach QueueHandlers to this queue
+    explicitly. `generate_fn` is a test seam: when provided, no worker pool is created and the
+    stub is called in place of the real memmap generation (see tests/unit/test_round_data.py).
     """
     global _PRODUCER_POOL
 
     is_main_thread = threading.current_thread() is threading.main_thread()
     if is_main_thread:
         # The log queue is a multiprocessing.Queue — safe to use from this process.
-        init_worker_logging()
+        init_worker_logging(log_queue)
 
         # Ignore SIGINT: the main process's ResourceManager coordinates Ctrl-C cleanup.
         signal.signal(signal.SIGINT, signal.SIG_IGN)
@@ -333,6 +344,8 @@ def _producer_main(request_queue, result_queue, params: dict, generate_fn=None) 
         # Deferred import (setigen/scipy) — only the real producer needs it.
         from aetherscan.data_generation import _init_worker  # noqa: PLC0415
 
+        # Plain fork-context Pool: this spawned process is single-threaded, so forking its
+        # workers is safe — and they attach to the parent-created background SHM by name.
         pool = multiprocessing.Pool(
             processes=max(1, params["n_processes"]),
             initializer=_init_worker,
@@ -340,6 +353,7 @@ def _producer_main(request_queue, result_queue, params: dict, generate_fn=None) 
                 params["shm_name"],
                 tuple(params["background_shape"]),
                 np.dtype(params["background_dtype"]),
+                log_queue,
             ),
         )
         _PRODUCER_POOL = pool
@@ -442,8 +456,9 @@ class RoundDataProducer:
         }
         self._db = db
         self._tag = tag
-        self._request_queue: multiprocessing.Queue = multiprocessing.Queue()
-        self._result_queue: multiprocessing.Queue = multiprocessing.Queue()
+        # Queues come from the spawn context so they can cross the spawn pickling boundary
+        self._request_queue: multiprocessing.Queue = _MP_CONTEXT.Queue()
+        self._result_queue: multiprocessing.Queue = _MP_CONTEXT.Queue()
         self._process: multiprocessing.Process | None = None
         self._drainer: threading.Thread | None = None
         self._drainer_done = False
@@ -452,12 +467,30 @@ class RoundDataProducer:
 
     def start(self) -> None:
         """Spawn the producer process and the main-side result drainer thread."""
-        self._process = multiprocessing.Process(
+        # Hand the producer the main process's log queue explicitly — a spawned child has no
+        # inherited Logger singleton (multiprocessing.Queue survives Process-args pickling).
+        logger_instance = get_logger()
+        log_queue = logger_instance.log_queue if logger_instance is not None else None
+
+        self._process = _MP_CONTEXT.Process(
             target=_producer_main,
-            args=(self._request_queue, self._result_queue, self._params),
+            args=(self._request_queue, self._result_queue, self._params, None, log_queue),
             name="RoundDataProducer",
         )
-        self._process.start()
+
+        # The spawned child re-imports the aetherscan module chain, which includes TF; blank
+        # out GPU visibility for the child's entire process tree so nothing in the producer
+        # can ever initialize CUDA (generation is pure CPU). The parent's TF read this env at
+        # its own GPU init, so temporarily mutating it here is safe.
+        original_cuda_visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+        os.environ["CUDA_VISIBLE_DEVICES"] = ""
+        try:
+            self._process.start()
+        finally:
+            if original_cuda_visible is None:
+                os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+            else:
+                os.environ["CUDA_VISIBLE_DEVICES"] = original_cuda_visible
 
         manager = get_manager()
         if manager is not None:

--- a/src/aetherscan/round_data.py
+++ b/src/aetherscan/round_data.py
@@ -1,0 +1,569 @@
+"""
+Disk-backed (memmap) round datasets for Aetherscan training.
+
+Each training round's data lives on disk as .npy memmaps under
+{round_data_dir}/{save_tag}/round_{k:02d}/ instead of ~294 GB of main-process RAM:
+workers write generated cadences straight into the memmaps, training reads them back
+through np.load(mmap_mode="r"), and the OS page cache keeps steady-state reads at
+RAM speed while remaining evictable under memory pressure (no more OOM kills).
+
+This module owns:
+- RoundDataPaths: the on-disk layout of one round's dataset.
+- The atomic `.done` manifest protocol (written only after all workers finish, via
+  .tmp -> os.replace like preprocessing's _extract_stamps_worker).
+- Startup archive/reuse/delete semantics for a tag's round-data directory.
+- RoundDataProducer: a dedicated process that generates round k+1 while round k
+  trains, streaming stats back to the main process (DB writes stay in main — the
+  DB queue is a thread queue.Queue, not process-safe).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import math
+import multiprocessing
+import os
+import queue
+import re
+import shutil
+import signal
+import threading
+import time
+import traceback
+from dataclasses import dataclass
+
+import numpy as np
+
+from aetherscan.logger import init_worker_logging
+from aetherscan.manager import get_manager
+
+logger = logging.getLogger(__name__)
+
+# Directory-name pattern for one round's dataset (1-based, mirrors checkpoint round_XX tags)
+_ROUND_DIR_PATTERN = re.compile(r"^round_(\d+)$")
+
+# Number of values sampled per array for the manifest's cheap corruption check
+_MANIFEST_SAMPLE_COUNT = 8
+
+
+@dataclass(frozen=True)
+class RoundDataPaths:
+    """On-disk layout of one round's dataset: {main,true,false,labels}.npy + a .done manifest."""
+
+    round_dir: str
+    round_idx: int
+
+    @classmethod
+    def for_round(cls, base_dir: str, round_idx: int) -> RoundDataPaths:
+        """Build the paths for 1-based round `round_idx` under `base_dir` (round_{k:02d})."""
+        return cls(round_dir=os.path.join(base_dir, f"round_{round_idx:02d}"), round_idx=round_idx)
+
+    @property
+    def main_path(self) -> str:
+        return os.path.join(self.round_dir, "main.npy")
+
+    @property
+    def true_path(self) -> str:
+        return os.path.join(self.round_dir, "true.npy")
+
+    @property
+    def false_path(self) -> str:
+        return os.path.join(self.round_dir, "false.npy")
+
+    @property
+    def labels_path(self) -> str:
+        return os.path.join(self.round_dir, "labels.npy")
+
+    @property
+    def done_path(self) -> str:
+        return os.path.join(self.round_dir, f"round_{self.round_idx:02d}.done")
+
+    @property
+    def array_paths(self) -> dict[str, str]:
+        """Mapping of array name -> .npy path for the three cadence arrays."""
+        return {"main": self.main_path, "true": self.true_path, "false": self.false_path}
+
+
+def _array_checksum(arr: np.ndarray) -> dict:
+    """
+    Cheap, sha-less checksum for a (possibly huge) memmap: total element count plus a few
+    deterministically-sampled flat-index values. Positions are derived from the element count,
+    so validation re-samples the same spots without storing an RNG state.
+    """
+    flat = arr.reshape(-1)
+    n = int(flat.size)
+    rng = np.random.default_rng(n)
+    positions = sorted({int(i) for i in rng.integers(0, n, size=min(_MANIFEST_SAMPLE_COUNT, n))})
+    if arr.dtype.kind in ("U", "S"):
+        samples = [[i, str(flat[i])] for i in positions]
+    else:
+        samples = [[i, float(flat[i])] for i in positions]
+    return {"elements": n, "samples": samples}
+
+
+def _checksum_value_matches(recorded, actual) -> bool:
+    """Compare one manifest sample against the on-disk value (NaN == NaN counts as a match)."""
+    if isinstance(recorded, str):
+        return recorded == str(actual)
+    actual = float(actual)
+    return recorded == actual or (math.isnan(recorded) and math.isnan(actual))
+
+
+def build_manifest(
+    paths: RoundDataPaths,
+    n_samples: int,
+    snr_base: float,
+    snr_range: float,
+    wall_time_s: float,
+    chunk_count: int,
+) -> dict:
+    """Assemble the .done manifest dict by re-opening the finished arrays read-only."""
+    shapes: dict[str, list[int]] = {}
+    checksums: dict[str, dict] = {}
+    for name, path in {**paths.array_paths, "labels": paths.labels_path}.items():
+        arr = np.load(path, mmap_mode="r")
+        shapes[name] = list(arr.shape)
+        checksums[name] = _array_checksum(arr)
+        del arr
+    return {
+        "round_idx": paths.round_idx,
+        "n_samples": int(n_samples),
+        "shapes": shapes,
+        "snr_base": float(snr_base),
+        "snr_range": float(snr_range),
+        "checksums": checksums,
+        "wall_time_s": float(wall_time_s),
+        "chunk_count": int(chunk_count),
+        "created_at": time.time(),
+    }
+
+
+def write_done_manifest(paths: RoundDataPaths, manifest: dict) -> None:
+    """Write the manifest atomically (.tmp -> os.replace) so a crash can't leave a partial
+    .done file — a round dir either has a complete manifest or is treated as garbage."""
+    tmp_path = paths.done_path + ".tmp"
+    with open(tmp_path, "w") as f:
+        json.dump(manifest, f, indent=2)
+    os.replace(tmp_path, paths.done_path)
+    logger.info(f"Wrote round-data manifest: {paths.done_path}")
+
+
+def validate_done_manifest(
+    paths: RoundDataPaths, expected_n_samples: int | None = None
+) -> dict | None:
+    """
+    Validate a round dir's .done manifest against the arrays on disk. Returns the manifest
+    dict when everything checks out (round index, optional expected sample count, per-array
+    existence, shape, element count, and the sampled checksum values), else None.
+    """
+    try:
+        if not os.path.isfile(paths.done_path):
+            return None
+        with open(paths.done_path) as f:
+            manifest = json.load(f)
+
+        if manifest.get("round_idx") != paths.round_idx:
+            logger.warning(f"Manifest round_idx mismatch in {paths.done_path}")
+            return None
+        if expected_n_samples is not None and manifest.get("n_samples") != expected_n_samples:
+            logger.warning(
+                f"Manifest n_samples ({manifest.get('n_samples')}) != expected "
+                f"({expected_n_samples}) in {paths.done_path}"
+            )
+            return None
+
+        all_paths = {**paths.array_paths, "labels": paths.labels_path}
+        for name, path in all_paths.items():
+            if not os.path.isfile(path):
+                logger.warning(f"Manifest array missing on disk: {path}")
+                return None
+            arr = np.load(path, mmap_mode="r")
+            try:
+                if list(arr.shape) != manifest["shapes"][name]:
+                    logger.warning(f"Shape mismatch for {path}")
+                    return None
+                checksum = manifest["checksums"][name]
+                if int(arr.size) != checksum["elements"]:
+                    logger.warning(f"Element-count mismatch for {path}")
+                    return None
+                flat = arr.reshape(-1)
+                for position, recorded in checksum["samples"]:
+                    if not _checksum_value_matches(recorded, flat[position]):
+                        logger.warning(f"Sampled-value mismatch for {path} at {position}")
+                        return None
+            finally:
+                del arr
+
+        return manifest
+    except Exception as e:
+        logger.warning(f"Failed to validate round-data manifest {paths.done_path}: {e}")
+        return None
+
+
+def load_round_arrays(paths: RoundDataPaths) -> dict[str, np.ndarray]:
+    """
+    Open one round's arrays for training. The three cadence arrays come back as read-only
+    memmaps (np.load(mmap_mode="r")) so nothing is pulled into RAM until batches gather it —
+    the OS page cache keeps hot pages resident and evicts them under memory pressure instead
+    of OOM-killing the process. Labels are tiny and loaded eagerly.
+    """
+    return {
+        "concatenated": np.load(paths.main_path, mmap_mode="r"),
+        "true": np.load(paths.true_path, mmap_mode="r"),
+        "false": np.load(paths.false_path, mmap_mode="r"),
+        "labels": np.load(paths.labels_path),
+    }
+
+
+def prepare_round_data_dir(base_dir: str, start_round: int) -> None:
+    """
+    Startup cleanup of a tag's round-data directory, mirroring checkpoint-archiving semantics
+    (train.archive_directory) for resumable runs — except entries are deleted rather than
+    archived (a round is ~295 GB; archiving would silently double the disk budget):
+
+    - round dirs with index >= start_round are deleted (regenerated by this run),
+    - round dirs with index < start_round are kept only if their .done manifest validates
+      (reusable instead of regenerated); .done-less or corrupt dirs are deleted,
+    - any non-round entry (e.g. a stale RF dataset dir) is deleted.
+    """
+    os.makedirs(base_dir, exist_ok=True)
+
+    for entry in sorted(os.listdir(base_dir)):
+        entry_path = os.path.join(base_dir, entry)
+        if not os.path.isdir(entry_path):
+            continue
+        match = _ROUND_DIR_PATTERN.match(entry)
+        if match is None:
+            logger.info(f"Deleting stale round-data entry: {entry_path}")
+            shutil.rmtree(entry_path, ignore_errors=True)
+            continue
+        round_idx = int(match.group(1))
+        if round_idx >= start_round:
+            logger.info(f"Deleting round-data dir for round >= {start_round}: {entry_path}")
+            shutil.rmtree(entry_path, ignore_errors=True)
+        elif validate_done_manifest(RoundDataPaths(entry_path, round_idx)) is None:
+            logger.info(f"Deleting round-data dir with missing/invalid manifest: {entry_path}")
+            shutil.rmtree(entry_path, ignore_errors=True)
+        else:
+            logger.info(f"Keeping validated round-data dir: {entry_path}")
+
+
+# ---------------------------------------------------------------------------
+# RoundDataProducer — background generation process
+# ---------------------------------------------------------------------------
+
+# Producer-process-local handle to its worker pool, so the SIGTERM handler can
+# terminate the pool's children before the producer itself dies.
+_PRODUCER_POOL = None
+
+
+def _default_generate(paths, round_idx, snr_base, snr_range, pool, params, stats_cb, progress_cb):
+    """Real generation entry point for the producer process (test hooks can replace it)."""
+    # Deferred import: data_generation pulls in setigen/scipy, which the parent may not need
+    # at round_data import time (cli.py must stay stdlib-importable via config/cli only).
+    from aetherscan.data_generation import generate_round_to_memmap  # noqa: PLC0415
+
+    return generate_round_to_memmap(
+        paths=paths,
+        n_samples=params["n_samples"],
+        snr_base=snr_base,
+        snr_range=snr_range,
+        width_bin=params["width_bin"],
+        num_observations=params["num_observations"],
+        time_bins=params["time_bins"],
+        chunk_size=params["chunk_size"],
+        task_size=params["task_size"],
+        freq_resolution=params["freq_resolution"],
+        time_resolution=params["time_resolution"],
+        pool=pool,
+        round_num=round_idx,
+        stats_cb=stats_cb,
+        progress_cb=progress_cb,
+    )
+
+
+def _producer_main(request_queue, result_queue, params: dict, generate_fn=None) -> None:
+    """
+    Producer process entry point. Owns a private worker pool (workers attach to the
+    background-plate shared memory created by the main process) and generates rounds on
+    request, isolated from the main process's GIL (TF's prefetch threads no longer slow
+    generation down, and generation no longer steals cycles from training).
+
+    Protocol (multiprocessing.Queues):
+    - in:  ("generate", round_idx, snr_base, snr_range) | ("shutdown",)
+    - out: ("stats", round_idx, segment_dict)            per class-segment per chunk
+           ("progress", round_idx, chunk, n_chunks)      per chunk
+           ("done", round_idx, manifest)                 on success (or valid reuse)
+           ("error", round_idx, traceback_str)           on failure (producer keeps serving)
+           ("shutdown_ack",)                             right before a graceful exit
+
+    `generate_fn` is a test seam: when provided, no worker pool is created and the stub is
+    called in place of the real memmap generation (see tests/unit/test_round_data.py).
+    """
+    global _PRODUCER_POOL
+
+    is_main_thread = threading.current_thread() is threading.main_thread()
+    if is_main_thread:
+        # The log queue is a multiprocessing.Queue — safe to use from this process.
+        init_worker_logging()
+
+        # Ignore SIGINT: the main process's ResourceManager coordinates Ctrl-C cleanup.
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+        # SIGTERM handler mirrors data_generation._init_worker's:
+        # WARN: DO NOT LOG ANYTHING IN THIS HANDLER — the log QueueHandler's feeder thread
+        # needs the GIL, which may be held elsewhere, and a blocked handler deadlocks
+        # termination (see data_generation.py's canonical worker handler).
+        def _cleanup_on_sigterm(signum, frame):
+            with contextlib.suppress(Exception):
+                if _PRODUCER_POOL is not None:
+                    # Forward termination to the pool's children so they don't outlive us
+                    # (SIGKILL on this process would otherwise orphan them).
+                    _PRODUCER_POOL.terminate()
+            signal.signal(signal.SIGTERM, signal.SIG_DFL)
+            os.kill(os.getpid(), signal.SIGTERM)
+
+        signal.signal(signal.SIGTERM, _cleanup_on_sigterm)
+
+    pool = None
+    if generate_fn is None:
+        generate_fn = _default_generate
+        # Deferred import (setigen/scipy) — only the real producer needs it.
+        from aetherscan.data_generation import _init_worker  # noqa: PLC0415
+
+        pool = multiprocessing.Pool(
+            processes=max(1, params["n_processes"]),
+            initializer=_init_worker,
+            initargs=(
+                params["shm_name"],
+                tuple(params["background_shape"]),
+                np.dtype(params["background_dtype"]),
+            ),
+        )
+        _PRODUCER_POOL = pool
+
+    logger.info(f"RoundDataProducer started (PID {os.getpid()})")
+
+    try:
+        while True:
+            message = request_queue.get()
+            if message[0] == "shutdown":
+                logger.info("RoundDataProducer received shutdown request")
+                result_queue.put(("shutdown_ack",))
+                break
+            if message[0] != "generate":
+                logger.warning(f"RoundDataProducer ignoring unknown message: {message[0]!r}")
+                continue
+
+            _, round_idx, snr_base, snr_range = message
+            paths = RoundDataPaths.for_round(params["base_dir"], round_idx)
+
+            existing = validate_done_manifest(paths, expected_n_samples=params["n_samples"])
+            if existing is not None:
+                logger.info(f"RoundDataProducer: reusing validated round {round_idx} data")
+                result_queue.put(("done", round_idx, existing))
+                continue
+
+            try:
+                logger.info(
+                    f"RoundDataProducer: generating round {round_idx} data "
+                    f"(SNR {snr_base}-{snr_base + snr_range})"
+                )
+                manifest = generate_fn(
+                    paths,
+                    round_idx,
+                    snr_base,
+                    snr_range,
+                    pool,
+                    params,
+                    lambda segment, _r=round_idx: result_queue.put(("stats", _r, segment)),
+                    lambda chunk, n_chunks, _r=round_idx: result_queue.put(
+                        ("progress", _r, chunk, n_chunks)
+                    ),
+                )
+                logger.info(f"RoundDataProducer: round {round_idx} data complete")
+                result_queue.put(("done", round_idx, manifest))
+            except Exception:
+                result_queue.put(("error", round_idx, traceback.format_exc()))
+    finally:
+        _PRODUCER_POOL = None
+        if pool is not None:
+            with contextlib.suppress(Exception):
+                pool.terminate()
+                pool.join()
+
+
+class RoundDataProducer:
+    """
+    Main-process handle for the background round-data generation process.
+
+    Lifecycle: start() spawns the producer process (registered with ResourceManager for
+    terminate -> join -> kill cleanup) plus a drainer thread that consumes the result queue —
+    writing streamed injection stats to the DB from the main process (the DB writer queue is
+    a thread queue.Queue, not process-safe) while the GPUs train. request_generation() is
+    fire-and-forget; await_round() blocks until that round's done/error message arrives.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_dir: str,
+        n_samples: int,
+        shm_name: str,
+        background_shape: tuple,
+        background_dtype: str,
+        n_processes: int,
+        width_bin: int,
+        num_observations: int,
+        time_bins: int,
+        chunk_size: int,
+        task_size: int,
+        freq_resolution: float,
+        time_resolution: float,
+        db,
+        tag: str,
+    ):
+        self._params = {
+            "base_dir": base_dir,
+            "n_samples": n_samples,
+            "shm_name": shm_name,
+            "background_shape": tuple(background_shape),
+            "background_dtype": str(background_dtype),
+            "n_processes": n_processes,
+            "width_bin": width_bin,
+            "num_observations": num_observations,
+            "time_bins": time_bins,
+            "chunk_size": chunk_size,
+            "task_size": task_size,
+            "freq_resolution": freq_resolution,
+            "time_resolution": time_resolution,
+        }
+        self._db = db
+        self._tag = tag
+        self._request_queue: multiprocessing.Queue = multiprocessing.Queue()
+        self._result_queue: multiprocessing.Queue = multiprocessing.Queue()
+        self._process: multiprocessing.Process | None = None
+        self._drainer: threading.Thread | None = None
+        self._drainer_done = False
+        self._results: dict[int, tuple[str, object]] = {}
+        self._condition = threading.Condition()
+
+    def start(self) -> None:
+        """Spawn the producer process and the main-side result drainer thread."""
+        self._process = multiprocessing.Process(
+            target=_producer_main,
+            args=(self._request_queue, self._result_queue, self._params),
+            name="RoundDataProducer",
+        )
+        self._process.start()
+
+        manager = get_manager()
+        if manager is not None:
+            manager.register_process(self._process, name="RoundDataProducer")
+
+        self._drainer = threading.Thread(
+            target=self._drain_results, name="RoundDataDrainer", daemon=True
+        )
+        self._drainer.start()
+        logger.info(f"RoundDataProducer process started (PID {self._process.pid})")
+
+    def request_generation(self, round_idx: int, snr_base: float, snr_range: float) -> None:
+        """Queue generation of 1-based round `round_idx` (non-blocking)."""
+        logger.info(f"Requesting background generation of round {round_idx} data")
+        self._request_queue.put(("generate", round_idx, snr_base, snr_range))
+
+    def await_round(self, round_idx: int) -> dict:
+        """
+        Block until round `round_idx`'s done/error message arrives; return the manifest on
+        success, raise RuntimeError (carrying the producer traceback) on generation failure
+        or if the producer died without answering.
+        """
+        while True:
+            with self._condition:
+                if round_idx in self._results:
+                    kind, payload = self._results[round_idx]
+                    break
+                if self._drainer_done:
+                    raise RuntimeError(
+                        f"RoundDataProducer exited before producing round {round_idx} data"
+                    )
+                self._condition.wait(timeout=1.0)
+
+        if kind == "error":
+            raise RuntimeError(f"Round {round_idx} data generation failed in producer:\n{payload}")
+        return payload
+
+    def shutdown(self, timeout: float = 10.0) -> None:
+        """Request a graceful producer exit, escalating to terminate/kill via the manager's
+        ManagedProcess if the producer doesn't wind down in time (e.g. mid-generation)."""
+        if self._process is None:
+            return
+
+        with contextlib.suppress(Exception):
+            self._request_queue.put(("shutdown",))
+        self._process.join(timeout)
+
+        manager = get_manager()
+        if manager is not None:
+            # No-op join if already exited; terminate -> join -> kill escalation otherwise.
+            manager.close_process(self._process)
+        elif self._process.is_alive():
+            self._process.terminate()
+            self._process.join(timeout)
+
+        if self._drainer is not None:
+            self._drainer.join(timeout=timeout)
+        self._process = None
+        logger.info("RoundDataProducer shut down")
+
+    def _handle_message(self, message: tuple) -> None:
+        """Dispatch one producer message (runs on the drainer thread)."""
+        kind = message[0]
+        if kind == "stats":
+            # Deferred import: keep round_data importable without the setigen stack.
+            from aetherscan.data_generation import write_segment_stats  # noqa: PLC0415
+
+            _, _round_idx, segment = message
+            write_segment_stats(self._db, self._tag, segment)
+        elif kind == "progress":
+            _, round_idx, chunk, n_chunks = message
+            logger.info(f"Round {round_idx} data generation: chunk {chunk}/{n_chunks} complete")
+        elif kind in ("done", "error"):
+            _, round_idx, payload = message
+            with self._condition:
+                self._results[round_idx] = (kind, payload)
+                self._condition.notify_all()
+        else:
+            logger.warning(f"RoundDataDrainer ignoring unknown message: {kind!r}")
+
+    def _drain_results(self) -> None:
+        """Drainer thread body: consume producer messages until shutdown-ack or producer death,
+        then sweep any messages still buffered in the queue."""
+        try:
+            while True:
+                try:
+                    message = self._result_queue.get(timeout=1.0)
+                except queue.Empty:
+                    if self._process is None or not self._process.is_alive():
+                        break
+                    continue
+                if message[0] == "shutdown_ack":
+                    break
+                self._handle_message(message)
+
+            # Final sweep: the producer may have exited with messages still in the pipe.
+            while True:
+                try:
+                    message = self._result_queue.get_nowait()
+                except queue.Empty:
+                    break
+                if message[0] != "shutdown_ack":
+                    self._handle_message(message)
+        except Exception as e:
+            logger.error(f"RoundDataDrainer failed: {e}")
+        finally:
+            with self._condition:
+                self._drainer_done = True
+                self._condition.notify_all()

--- a/src/aetherscan/round_data.py
+++ b/src/aetherscan/round_data.py
@@ -540,30 +540,36 @@ class RoundDataProducer:
 
     def _drain_results(self) -> None:
         """Drainer thread body: consume producer messages until shutdown-ack or producer death,
-        then sweep any messages still buffered in the queue."""
-        try:
-            while True:
-                try:
-                    message = self._result_queue.get(timeout=1.0)
-                except queue.Empty:
-                    if self._process is None or not self._process.is_alive():
-                        break
-                    continue
-                if message[0] == "shutdown_ack":
-                    break
-                self._handle_message(message)
+        then sweep any messages still buffered in the queue. A failure handling one message
+        (e.g. a DB hiccup on a stats write) must not kill the drainer — done/error messages
+        for in-flight rounds still need to unblock await_round()."""
 
-            # Final sweep: the producer may have exited with messages still in the pipe.
-            while True:
-                try:
-                    message = self._result_queue.get_nowait()
-                except queue.Empty:
+        def _handle_safely(message: tuple) -> None:
+            try:
+                self._handle_message(message)
+            except Exception as e:
+                logger.error(f"RoundDataDrainer failed to handle {message[0]!r} message: {e}")
+
+        while True:
+            try:
+                message = self._result_queue.get(timeout=1.0)
+            except queue.Empty:
+                if self._process is None or not self._process.is_alive():
                     break
-                if message[0] != "shutdown_ack":
-                    self._handle_message(message)
-        except Exception as e:
-            logger.error(f"RoundDataDrainer failed: {e}")
-        finally:
-            with self._condition:
-                self._drainer_done = True
-                self._condition.notify_all()
+                continue
+            if message[0] == "shutdown_ack":
+                break
+            _handle_safely(message)
+
+        # Final sweep: the producer may have exited with messages still in the pipe.
+        while True:
+            try:
+                message = self._result_queue.get_nowait()
+            except queue.Empty:
+                break
+            if message[0] != "shutdown_ack":
+                _handle_safely(message)
+
+        with self._condition:
+            self._drainer_done = True
+            self._condition.notify_all()

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -53,6 +53,13 @@ from aetherscan.models import (
     create_beta_vae_model,
     prepare_latent_features,
 )
+from aetherscan.round_data import (
+    RoundDataPaths,
+    RoundDataProducer,
+    load_round_arrays,
+    prepare_round_data_dir,
+    validate_done_manifest,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -335,24 +342,22 @@ def check_encoder_trained(encoder, threshold=0.2):
 
 
 # Create data holder objects, to be paired with data generators, for TF's distributed datasets
-# Allows for explicit dereferencing of large arrays using holder.clear(), which lets
+# Allows for explicit dereferencing of the backing arrays using holder.clear(), which lets
 # Python's garbage collector free up memory on-demand
-# Note, holder.clear() is only useful at the end of an epoch, once indices have been exhausted,
-# since the data generators' local caches maintain references to the data until then
-# This is not an issue in our current implementation, where we only clear & reset resources at the
-# end of a round. However, if you require early exit behavior, you may want to remove the _lock and
-# use explicit _cleared() checks instead, which negates the need for local caches (see commit hash
-# 2a404a4). The trade-off being that you're at risk of race conditions if multiple threads attempt
-# to access/clear the holder simultaneously. While this is not the case in our current
-# implementation, we opted for a more defensive approach rather than accomodating future design
-# patterns. As well, the data should not be modified once the holder has been initialized to
-# prevent corrupted state in the holder
-# Note, there's a potential deadlock issue with holder lock contention
-# Since the generators acquire locks at the start of every loop iteration, if TF's prefetch threads
-# (.prefetch(tf.data.AUTOTUNE)) are blocked waiting on this lock while the main thread is trying to
-# call holder.clear() (which also needs the lock), there could be contention.
-# This has not been an issue so far, but if you encounter this in the future, pls update this
-# comment with your findings
+# The holders now hold np.load(mmap_mode="r") memmap references rather than ~294 GB of in-RAM
+# arrays, so clear() drops file mappings (letting the round's directory be deleted and its page
+# cache reclaimed) rather than freeing huge heap allocations — but the semantics are unchanged:
+# clear() is only fully effective at the end of an epoch, once the generators' local caches have
+# been dropped, and the data must not be modified once the holder has been initialized
+# Note, if you require early exit behavior, you may want to remove the _lock and use explicit
+# _cleared() checks instead, which negates the need for local caches (see commit hash 2a404a4).
+# The trade-off being that you're at risk of race conditions if multiple threads attempt to
+# access/clear the holder simultaneously — we opted for the defensive approach
+# Lock contention with TF's prefetch threads is a non-issue in the batched design: each generator
+# acquires the lock exactly once per epoch pass (to snapshot the array references), then yields
+# whole global batches without touching the lock, so a clear() on the main thread can no longer
+# race hundreds of thousands of per-sample lock acquisitions (which the pre-memmap, per-sample
+# generators were at least theoretically exposed to)
 class TrainDataHolder:
     def __init__(self, concat, true, false):
         self._cleared = False
@@ -396,26 +401,42 @@ def prepare_distributed_train_dataset(
     shuffle: bool = True,
 ) -> dict:
     """
-    Build distributed training and validation datasets from the in-memory `data` dict, returning
-    a dict with the two tf.data datasets, sample/step counts, the shared TrainDataHolder, and the
+    Build distributed training and validation datasets from the `data` dict, returning a dict
+    with the two tf.data datasets, sample/step counts, the shared TrainDataHolder, and the
     stratified train/val indices into the original arrays.
 
-    `data` must contain 'concatenated', 'true', 'false', and 'labels' (numpy arrays). The split
-    is stratified across the 4 signal types (false_no_signal, false_with_rfi, true_only_eti,
-    true_eti_rfi) — generate_triplet_batch arranges labels sequentially within chunks, so a naive
-    positional split would over-represent later signal types in val. Each generated batch has the
-    signature ((concat, true, false), concat). Sample counts are trimmed to the global / effective
-    batch size to keep all replicas evenly fed; the holder is shared by both generators so neither
-    pays a memory cost beyond index subsets.
+    `data` must contain 'concatenated', 'true', 'false', and 'labels' — typically the read-only
+    memmaps returned by round_data.load_round_arrays(), though plain in-RAM ndarrays work too.
+    The split is stratified across the 4 signal types (false_no_signal, false_with_rfi,
+    true_only_eti, true_eti_rfi) — generation lays labels out sequentially within chunks, so a
+    naive positional split would over-represent later signal types in val.
+
+    The generators yield whole GLOBAL batches (leading batch dim in the output signature; no
+    .batch() call downstream): each batch gathers sorted fancy indices from the memmaps, cutting
+    the per-sample Python/tf.data boundary crossings by a factor of the global batch size — the
+    per-sample yields were the main source of the 0-14 % GPU utilization. Randomness lives at
+    the epoch level (train_indices are reshuffled each pass); sorting *within* a batch only
+    improves memmap read locality and the model is order-invariant within a batch.
+
+    Page-cache framing: gathering from the memmaps pulls pages through the OS page cache, so
+    after the first epoch a round's ~294 GB (at full-scale defaults) is served at RAM speed from
+    otherwise-free memory on the 503 GB training nodes — but under memory pressure the kernel
+    evicts pages instead of OOM-killing the process, which is exactly the failure mode the old
+    in-RAM arrays hit.
+
+    Each generated batch has the signature ((concat, true, false), concat). Sample counts are
+    trimmed to the global / effective batch size to keep all replicas evenly fed (so every epoch
+    pass yields whole batches exactly); the holder is shared by both generators so neither pays
+    a memory cost beyond index subsets.
     """
     global_train_batch_size = per_replica_batch_size * num_replicas
     global_val_batch_size = per_replica_val_batch_size * num_replicas
 
     # Stratified train/val split to ensure both sets contain proportional representation
     # of all 4 signal types (false_no_signal, false_with_rfi, true_only_eti, true_eti_rfi).
-    # This is necessary because generate_triplet_batch() arranges labels sequentially within
+    # This is necessary because generation arranges labels sequentially within
     # chunks, so a naive positional split would over-represent later signal types in val.
-    labels = data["labels"]
+    labels = np.asarray(data["labels"])
     unique_labels = np.unique(labels)
 
     train_indices = []
@@ -450,15 +471,25 @@ def prepare_distributed_train_dataset(
     if n_val_trimmed < n_val:
         val_indices = np.random.choice(val_indices, size=n_val_trimmed, replace=False)
 
+    # Sort both index sets ascending. For shuffle=False this pins the generators' yield order
+    # to the returned train_indices/val_indices arrays (the alignment contract
+    # train_random_forest depends on) while giving monotone memmap reads; for shuffle=True the
+    # epoch-level reshuffle below supplies the randomness anyway. Stratification is a property
+    # of index *membership*, not order, so sorting doesn't affect it.
+    train_indices = np.sort(train_indices)
+    val_indices = np.sort(val_indices)
+
     logger.info(f"Data alignment: Train {n_train}→{n_train_trimmed}, Val {n_val}→{n_val_trimmed}")
 
     # Share the original arrays between train and val generators via a single data holder.
     # The stratified split requires non-contiguous indices, which would force numpy to create
-    # full copies via fancy indexing (~2x peak memory). Instead, both generators read from the
-    # same original arrays using their respective index subsets — zero extra copies.
+    # full copies via fancy indexing (~2x peak memory). Instead, both generators gather
+    # per-batch slices from the same original arrays using their respective index subsets —
+    # only one global batch is materialized at a time.
     train_holder = TrainDataHolder(data["concatenated"], data["true"], data["false"])
 
-    # Create generator functions for memory-efficient data loading
+    # Create generator functions yielding whole global batches gathered from the (memmap)
+    # arrays — see the docstring for the batching/locality/page-cache rationale
     def train_generator():
         while True:  # Make generators infinite to reset state between epochs
             # Acquire lock to check cleared status and capture data references
@@ -471,14 +502,20 @@ def prepare_distributed_train_dataset(
                 true = train_holder.true
                 false = train_holder.false
 
-            # Work with local references (safe from clearing, no per-sample lock needed)
+            # Work with local references (safe from clearing, no per-batch lock needed)
             # Copy train_indices because np.random.shuffle mutates in-place
             indices = train_indices.copy()
             if shuffle:
                 # Perform global shuffle on each epoch so each pass through the data is unique
                 np.random.shuffle(indices)
-            for idx in indices:
-                yield (concat[idx], true[idx], false[idx]), concat[idx]
+            for start in range(0, len(indices), global_train_batch_size):
+                batch_indices = indices[start : start + global_train_batch_size]
+                if shuffle:
+                    # Within-batch sorted order improves memmap read locality; random batch
+                    # membership is already guaranteed by the epoch-level shuffle above
+                    batch_indices = np.sort(batch_indices)
+                concat_batch = concat[batch_indices]
+                yield (concat_batch, true[batch_indices], false[batch_indices]), concat_batch
 
             # Remove cache references to ensure garbage collection in future
             del concat, true, false
@@ -495,44 +532,40 @@ def prepare_distributed_train_dataset(
                 true = train_holder.true
                 false = train_holder.false
 
-            # Maintain order on each epoch since shuffling provides no benefits (no gradients
-            # are calculated during validation)
-            for idx in val_indices:
-                yield (concat[idx], true[idx], false[idx]), concat[idx]
+            # Maintain val_indices order on each epoch (already sorted above): no gradients are
+            # calculated during validation, and train_random_forest relies on the i-th encoded
+            # val cadence corresponding to val_indices[i]
+            for start in range(0, len(val_indices), global_val_batch_size):
+                batch_indices = val_indices[start : start + global_val_batch_size]
+                concat_batch = concat[batch_indices]
+                yield (concat_batch, true[batch_indices], false[batch_indices]), concat_batch
 
             # Remove cache references to ensure garbage collection in future
             del concat, true, false
 
-    # Determine dataset output signature
+    # Determine dataset output signature: the generators yield whole global batches, so the
+    # specs carry a leading (None) batch dimension and no .batch() call is applied downstream
     sample_shape = data["concatenated"].shape[1:]
-    output_signature = (
-        (
-            tf.TensorSpec(shape=sample_shape, dtype=tf.float32),
-            tf.TensorSpec(shape=sample_shape, dtype=tf.float32),
-            tf.TensorSpec(shape=sample_shape, dtype=tf.float32),
-        ),
-        tf.TensorSpec(shape=sample_shape, dtype=tf.float32),
-    )
+    batch_spec = tf.TensorSpec(shape=(None, *sample_shape), dtype=tf.float32)
+    output_signature = ((batch_spec, batch_spec, batch_spec), batch_spec)
 
     # Create datasets using generators to reduce GPU memory pressure
     # Data is kept on CPU & transferred to GPU in batches on-demand
-    # Note that the datasets yield data in batches before being sharded (distributed) across replicas
-    # Hence, we use global batch sizes here to ensure per replica batch sizes match expectations
+    # Note that the generators yield data in global batches before being sharded (distributed)
+    # across replicas, ensuring per replica batch sizes match expectations
     logger.info(
-        f"Creating infinite datasets from generators with global batch size - "
+        f"Creating infinite batched datasets from generators with global batch size - "
         f"Train: {global_train_batch_size}, Val: {global_val_batch_size}"
     )
 
     train_dataset = (
         tf.data.Dataset.from_generator(train_generator, output_signature=output_signature)
-        .batch(global_train_batch_size, drop_remainder=True)
         .repeat()
         .prefetch(tf.data.AUTOTUNE)
     )
 
     val_dataset = (
         tf.data.Dataset.from_generator(val_generator, output_signature=output_signature)
-        .batch(global_val_batch_size, drop_remainder=True)
         # NOTE: do we need repeat for val dataset? run test without repeat & see if anything breaks?
         .repeat()
         .prefetch(tf.data.AUTOTUNE)
@@ -615,7 +648,9 @@ def prepare_distributed_viz_dataset(
 
     viz_holder = VizDataHolder(padded_data)
 
-    # Create generator function for memory-efficient data loading
+    # Create generator function yielding whole global batches — this feeds
+    # _capture_latent_snapshot every latent_viz_step_interval training steps, so per-sample
+    # yields here used to tax every capture during the epoch loop
     def viz_generator():
         while True:  # Make generator infinite to reset state between passes
             # Acquire lock to check cleared status and capture data references
@@ -627,29 +662,29 @@ def prepare_distributed_viz_dataset(
                 concat = viz_holder.concat
 
             # WARN: DO NOT SHUFFLE viz_generator(), OR ELSE YOU'LL BREAK plot_latent_space_gif()
-            # Maintain order on each epoch since shuffling provides no benefits (no gradients
-            # are calculated during inference)
-            for idx in range(len(concat)):
-                yield concat[idx]
+            # Contiguous in-order slices preserve the original cadence order on every pass
+            # (n_padded is an exact multiple of the global batch size, so slices are whole)
+            for start in range(0, len(concat), global_viz_batch_size):
+                yield concat[start : start + global_viz_batch_size]
 
             # Remove cache references for future garbage collection
             del concat
 
-    # Determine dataset output signature
+    # Determine dataset output signature: the generator yields whole global batches, so the
+    # spec carries a leading (None) batch dimension and no .batch() call is applied downstream
     sample_shape = padded_data.shape[1:]
-    output_signature = tf.TensorSpec(shape=sample_shape, dtype=tf.float32)
+    output_signature = tf.TensorSpec(shape=(None, *sample_shape), dtype=tf.float32)
 
     # Create dataset using generator to reduce GPU memory pressure
     # Data is kept on CPU & transferred to GPU in batches on-demand
-    # Note that the dataset yields data in batches before being sharded (distributed) across replicas
-    # Hence, we use global batch sizes here to ensure per replica batch sizes match expectations
+    # Note that the generator yields data in global batches before being sharded (distributed)
+    # across replicas, ensuring per replica batch sizes match expectations
     logger.info(
-        f"Creating infinite dataset from generator with global batch size: {global_viz_batch_size}"
+        f"Creating infinite batched dataset from generator with global batch size: {global_viz_batch_size}"
     )
 
     viz_dataset = (
         tf.data.Dataset.from_generator(viz_generator, output_signature=output_signature)
-        .batch(global_viz_batch_size, drop_remainder=True)
         # NOTE: do we need repeat for viz dataset? run test without repeat & see if anything breaks?
         .repeat()
         .prefetch(tf.data.AUTOTUNE)
@@ -780,6 +815,10 @@ class TrainingPipeline:
         # Initialize RF model as None
         self.rf_model = None
 
+        # Background round-data producer (created in train_beta_vae when
+        # overlap_data_generation is enabled; None otherwise)
+        self._round_producer: RoundDataProducer | None = None
+
         # In-memory caches for RF eval artifacts and SHAP values, keyed by tag.
         # All ten RF plots consume the same eval-artifact joblib (and the five SHAP
         # plots additionally share a SHAP-values joblib); without these caches each
@@ -866,6 +905,15 @@ class TrainingPipeline:
         plot_checkpoints_dir = os.path.join(self.config.output_path, "plots", "checkpoints")
         archive_directory(plot_checkpoints_dir, target_dirs=None, round_num=start_round)
 
+        # Disk-backed round-data directory for this tag: delete round dirs >= start_round,
+        # keep earlier ones only if their .done manifest validates (round-data mirror of the
+        # checkpoint archiving above, minus the archiving — a round is ~295 GB)
+        round_data_root = self.config.training.round_data_dir or os.path.join(
+            self.config.output_path, "round_data"
+        )
+        self._round_data_base_dir = os.path.join(round_data_root, self.config.checkpoint.save_tag)
+        prepare_round_data_dir(self._round_data_base_dir, start_round)
+
         logger.info("Setup directories complete")
 
     # COMMENTED OUT: Removing TensorBoard support
@@ -920,6 +968,46 @@ class TrainingPipeline:
         # NOTE: this approach doesn't play well with fault tolerance. rethink later
         self.start_time = time.time()
 
+        # Stand up the background round-data producer (a dedicated process owning its own
+        # worker pool against the shared-memory background plates), so round k+1's data
+        # generates while round k trains AND generation escapes this process's GIL — TF's
+        # prefetch/callback threads made round 2+ generation far slower than round 1's.
+        # Falls back to sequential in-process generation when disabled
+        # (--no-overlap-data-generation) or when the DataGenerator has no shared memory for
+        # producer workers to attach to (n_processes == 1).
+        if self.config.training.overlap_data_generation:
+            if self.data_generator.shm is not None:
+                self._round_producer = RoundDataProducer(
+                    base_dir=self._round_data_base_dir,
+                    n_samples=self.config.training.num_samples_beta_vae,
+                    shm_name=self.data_generator.shm.name,
+                    background_shape=self.data_generator._background_shape,
+                    background_dtype=str(self.data_generator._background_dtype),
+                    n_processes=self.data_generator.n_processes,
+                    width_bin=self.data_generator.width_bin,
+                    num_observations=self.config.data.num_observations,
+                    time_bins=self.config.data.time_bins,
+                    chunk_size=self.config.training.signal_injection_chunk_size,
+                    task_size=self.config.training.data_gen_task_size,
+                    freq_resolution=self.data_generator.freq_resolution,
+                    time_resolution=self.data_generator.time_resolution,
+                    db=self.db,
+                    tag=self.config.checkpoint.save_tag,
+                )
+                self._round_producer.start()
+                # Kick off the first round's data right away (nothing to overlap with yet —
+                # the unavoidable serial start)
+                first_snr_base, first_snr_range = self._calculate_curriculum_snr(start_round - 1)
+                self._round_producer.request_generation(
+                    start_round, first_snr_base, first_snr_range
+                )
+            else:
+                logger.warning(
+                    "overlap_data_generation is enabled but DataGenerator is in sequential "
+                    "mode (n_processes=1, no shared memory) — falling back to in-process "
+                    "round data generation"
+                )
+
         try:
             for round_idx in range(start_round - 1, n_rounds):
                 snr_base, snr_range = self._calculate_curriculum_snr(round_idx)
@@ -945,6 +1033,12 @@ class TrainingPipeline:
                     round_idx=round_idx, epochs=epochs, snr_base=snr_base, snr_range=snr_range
                 )
         finally:
+            # Wind down the producer (graceful shutdown message, escalating to
+            # terminate -> kill through the ResourceManager if it's mid-generation)
+            if self._round_producer is not None:
+                self._round_producer.shutdown()
+                self._round_producer = None
+
             # NOTE: this approach doesn't play well with fault tolerance. rethink later
             # Free the latent viz batch once all rounds are complete (or on failure)
             del self._latent_viz_batch, self._latent_viz_labels
@@ -960,10 +1054,37 @@ class TrainingPipeline:
             f"Training round {round_idx + 1} - Epochs: {epochs}, SNR: {snr_base}-{snr_base + snr_range}"
         )
 
-        # Generate training data
-        train_data = self.data_generator.generate_triplet_batch(
-            self.config.training.num_samples_beta_vae, snr_base, snr_range, round_idx + 1
-        )
+        round_number = round_idx + 1
+        n_samples = self.config.training.num_samples_beta_vae
+        paths = RoundDataPaths.for_round(self._round_data_base_dir, round_number)
+        round_trained = False  # Set True once the round fully completes (drives dir deletion)
+
+        # Obtain this round's disk-backed data: reuse a validated on-disk dataset if one
+        # exists, otherwise wait on the background producer (which was asked to generate it
+        # while the previous round trained) or generate in-process (overlap disabled)
+        if validate_done_manifest(paths, expected_n_samples=n_samples) is not None:
+            logger.info(f"Reusing validated round {round_number} data at {paths.round_dir}")
+        elif self._round_producer is not None:
+            logger.info(f"Waiting for round {round_number} data from the background producer")
+            wait_start = time.time()
+            self._round_producer.await_round(round_number)
+            logger.info(f"Round {round_number} data ready (waited {time.time() - wait_start:.1f}s)")
+        else:
+            self.data_generator.generate_round(paths, n_samples, snr_base, snr_range, round_number)
+
+        # Immediately queue generation of the next round's data so it runs in the producer
+        # process while this round's epochs train (curriculum SNR for round k+1 is
+        # deterministic, so it can be computed ahead of time)
+        if (
+            self._round_producer is not None
+            and round_number < self.config.training.num_training_rounds
+        ):
+            next_snr_base, next_snr_range = self._calculate_curriculum_snr(round_idx + 1)
+            self._round_producer.request_generation(round_number + 1, next_snr_base, next_snr_range)
+
+        # Open the round's arrays as read-only memmaps (nothing is loaded into RAM here; the
+        # batched generators gather from the OS page cache during training)
+        train_data = load_round_arrays(paths)
 
         # Extract labels before distributing (prepare_distributed_train_dataset keeps the
         # original arrays alive via a shared train_holder — no copies — so we can free the
@@ -1227,6 +1348,8 @@ class TrainingPipeline:
             # Save checkpoint
             self.save_models(tag=f"round_{round_idx + 1:02d}", dir="checkpoints")
 
+            round_trained = True
+
         except Exception as e:
             logger.error(f"Error in train_round(): {e}")
             raise  # Re-raise to propagate error
@@ -1259,6 +1382,16 @@ class TrainingPipeline:
             logger.info("Reset managed pools")
 
             gc.collect()
+
+            # Delete the round's on-disk data as soon as its training completed (keeps the
+            # disk footprint at ~2 rounds max with overlap). A failed round leaves its data
+            # in place; the retry's _setup_directories() -> prepare_round_data_dir() decides
+            # what survives (dirs >= the resume round are regenerated). Deleting after the
+            # holder.clear()/clear_session() above is safe even if stray memmap handles
+            # linger — POSIX keeps the inodes alive until the mappings drop.
+            if round_trained and not self.config.training.keep_round_data:
+                shutil.rmtree(paths.round_dir, ignore_errors=True)
+                logger.info(f"Deleted round {round_number} data directory: {paths.round_dir}")
 
     def _train_epoch(
         self,
@@ -1827,9 +1960,20 @@ class TrainingPipeline:
         time_bins = self.config.data.time_bins
         width_bin = self.config.data.width_bin // self.config.data.downsample_factor
 
-        # Generate training data (concatenated is 4-way balanced; labels track per-sample subtype)
+        # Generate training data (concatenated is 4-way balanced; labels track per-sample
+        # subtype) into a disk-backed dataset alongside the per-round dirs. Generation is
+        # in-process (sequential with training) — there is nothing left to overlap with, the
+        # beta-VAE producer has already been shut down by train_beta_vae()
         logger.info(f"Preparing training set with SNR: {snr_base}-{snr_base + snr_range}")
-        rf_data = self.data_generator.generate_triplet_batch(n_samples, snr_base, snr_range)
+        rf_paths = RoundDataPaths(
+            round_dir=os.path.join(self._round_data_base_dir, "rf"), round_idx=0
+        )
+        rf_trained = False  # Set True once RF training fully completes (drives dir deletion)
+        if validate_done_manifest(rf_paths, expected_n_samples=n_samples) is not None:
+            logger.info(f"Reusing validated RF dataset at {rf_paths.round_dir}")
+        else:
+            self.data_generator.generate_round(rf_paths, n_samples, snr_base, snr_range)
+        rf_data = load_round_arrays(rf_paths)
 
         # Prepare distributed train+val datasets (stratified split). shuffle=False so the
         # train generator yields in train_indices order, letting us align encoded features
@@ -1983,6 +2127,8 @@ class TrainingPipeline:
             joblib.dump(artifacts, artifact_path)
             logger.info(f"Saved RF eval artifacts to {artifact_path}")
 
+            rf_trained = True
+
             # NOTE: come back to this later (are we dereferencing the correct things? can we instead write things to db instead of storing in memory?)
             del (
                 artifacts,
@@ -2017,6 +2163,13 @@ class TrainingPipeline:
             # Reset multiprocessing pools in DataGenerator to further avoid memory accumulation
             self.data_generator.reset_managed_pool()
             logger.info("Reset managed pools")
+
+            # Delete the RF dataset once RF training fully completed. On failure it stays on
+            # disk for post-mortem; the next run's prepare_round_data_dir() treats it as
+            # stale and regenerates (matching the pre-memmap per-attempt regeneration)
+            if rf_trained and not self.config.training.keep_round_data:
+                shutil.rmtree(rf_paths.round_dir, ignore_errors=True)
+                logger.info(f"Deleted RF data directory: {rf_paths.round_dir}")
 
             # NOTE: is this the right way to check if arrays exist before dereferencing?
             if train_latents is not None:
@@ -2734,7 +2887,7 @@ class TrainingPipeline:
                 )
 
     # TODO: reorder plot methods (def & call sites): train -> latent -> injection
-    # TODO: move injection plots to data_generation.py & call at end of generate_triplet_batch() (instead of at the end of train_round() & run_training_pipeline())
+    # TODO: move injection plots to data_generation.py & call at end of generate_round_to_memmap() (instead of at the end of train_round() & run_training_pipeline())
     # NOTE: there's a ton of improvements we could make to this function (and subsequent _plot functions), but i just care that it works well enough for now
     def plot_injection_stats(self, tag: str | None = None, dir: str | None = None):
         """

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -908,8 +908,8 @@ class TrainingPipeline:
         # Disk-backed round-data directory for this tag: delete round dirs >= start_round,
         # keep earlier ones only if their .done manifest validates (round-data mirror of the
         # checkpoint archiving above, minus the archiving — a round is ~295 GB)
-        round_data_root = self.config.training.round_data_dir or os.path.join(
-            self.config.output_path, "round_data"
+        round_data_root = self.config.training.round_data_dir or self.config.get_training_file_path(
+            "round_data"
         )
         self._round_data_base_dir = os.path.join(round_data_root, self.config.checkpoint.save_tag)
         prepare_round_data_dir(self._round_data_base_dir, start_round)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,9 @@ def _teardown_singletons():
 
     manager = ResourceManager._instance
     if manager is not None:
+        for managed_process in list(manager._processes):
+            with contextlib.suppress(Exception):
+                managed_process.close(timeout=5.0)
         for managed_pool in list(manager._pools):
             with contextlib.suppress(Exception):
                 managed_pool.close(timeout=5.0)

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -5,6 +5,7 @@ apply_saved_config precedence (defaults < saved config < CLI args)."""
 
 from __future__ import annotations
 
+import collections
 import json
 
 import pytest
@@ -47,6 +48,16 @@ def _parse(argv):
 def _cross_param_errors(args, num_replicas):
     errors = collect_validation_errors(args, num_replicas)
     return [e for e in errors if e.fix_kind == "cross_param"]
+
+
+@pytest.fixture(autouse=True)
+def _ample_disk_space(monkeypatch):
+    """The round-data disk-budget check reads the real filesystem via shutil.disk_usage (the
+    full-scale default config needs ~650 GB free — more than CI runners or dev boxes have).
+    Pin it to a huge value so validation tests are machine-independent; tests that exercise
+    the check itself (TestRoundDataFlags) patch their own values on top."""
+    usage = collections.namedtuple("usage", ["total", "used", "free"])
+    monkeypatch.setattr(cli.shutil, "disk_usage", lambda path: usage(2**60, 0, 2**60))
 
 
 class TestTagPattern:
@@ -363,3 +374,90 @@ class TestApplyArgsToConfig:
         config = get_config()
         apply_args_to_config(_parse(["train", "--load-tag", "round_03"]))
         assert config.checkpoint.start_round == 4
+
+
+class TestRoundDataFlags:
+    """Flags and validation for the disk-backed round-data pipeline (round_data.py)."""
+
+    def test_flags_apply_to_config(self):
+        apply_args_to_config(
+            _parse(
+                [
+                    "train",
+                    "--round-data-dir",
+                    "/scratch/rounds",
+                    "--no-overlap-data-generation",
+                    "--keep-round-data",
+                    "--data-gen-task-size",
+                    "128",
+                ]
+            )
+        )
+        config = get_config()
+        assert config.training.round_data_dir == "/scratch/rounds"
+        assert config.training.overlap_data_generation is False
+        assert config.training.keep_round_data is True
+        assert config.training.data_gen_task_size == 128
+
+    def test_defaults_preserved_when_omitted(self):
+        apply_args_to_config(_parse(["train"]))
+        config = get_config()
+        assert config.training.round_data_dir is None
+        assert config.training.overlap_data_generation is True
+        assert config.training.keep_round_data is False
+        assert config.training.data_gen_task_size == 256
+
+    def test_data_gen_task_size_below_one_rejected(self):
+        errors = collect_validation_errors(_parse(["train", "--data-gen-task-size", "0"]), None)
+        assert any(
+            e.field == "training.data_gen_task_size" and e.fix_kind == "clamp_low" for e in errors
+        )
+
+    def _patch_free_bytes(self, monkeypatch, free_bytes):
+        usage = collections.namedtuple("usage", ["total", "used", "free"])
+        monkeypatch.setattr(
+            cli.shutil, "disk_usage", lambda path: usage(free_bytes * 2, free_bytes, free_bytes)
+        )
+
+    def test_disk_budget_error_when_insufficient(self, monkeypatch):
+        config = get_config()
+        round_nbytes = cli._estimate_round_data_nbytes(
+            config.training.num_samples_beta_vae,
+            config.data.num_observations,
+            config.data.time_bins,
+            config.data.width_bin // config.data.downsample_factor,
+        )
+        # Between 1.1x and 2.2x one round: fails with overlap (default), passes without
+        self._patch_free_bytes(monkeypatch, int(1.5 * round_nbytes))
+
+        errors = collect_validation_errors(_parse(["train"]), None)
+        disk_errors = [e for e in errors if e.field == "training.round_data_dir"]
+        assert len(disk_errors) == 1
+        assert "GB free" in disk_errors[0].message
+
+        errors = collect_validation_errors(_parse(["train", "--no-overlap-data-generation"]), None)
+        assert not any(e.field == "training.round_data_dir" for e in errors)
+
+    def test_disk_budget_ok_when_sufficient(self, monkeypatch):
+        config = get_config()
+        round_nbytes = cli._estimate_round_data_nbytes(
+            config.training.num_samples_beta_vae,
+            config.data.num_observations,
+            config.data.time_bins,
+            config.data.width_bin // config.data.downsample_factor,
+        )
+        self._patch_free_bytes(monkeypatch, int(10 * round_nbytes))
+        errors = collect_validation_errors(_parse(["train"]), None)
+        assert not any(e.field == "training.round_data_dir" for e in errors)
+
+    def test_estimate_scales_with_sample_count(self):
+        one = cli._estimate_round_data_nbytes(4, 6, 16, 512)
+        two = cli._estimate_round_data_nbytes(8, 6, 16, 512)
+        assert two == 2 * one
+        # 3 arrays x n x 6 x 16 x 512 float32 + n x U20 labels
+        assert one == 3 * 4 * 6 * 16 * 512 * 4 + 4 * 80
+
+    def test_nearest_existing_ancestor(self, tmp_path):
+        missing = tmp_path / "a" / "b" / "c"
+        assert cli._nearest_existing_ancestor(str(missing)) == str(tmp_path)
+        assert cli._nearest_existing_ancestor(str(tmp_path)) == str(tmp_path)

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -10,7 +10,10 @@ so per-test instances don't accumulate process-global state.
 from __future__ import annotations
 
 import atexit
+import multiprocessing
+import signal
 import sys
+import time
 from multiprocessing.shared_memory import SharedMemory
 
 import pytest
@@ -137,3 +140,62 @@ class TestCleanupAll:
         manager.create_shared_memory(size=512, name="shm")
         manager.cleanup_all()
         assert manager.stats.cleanup_time_seconds >= 0.0
+
+
+def _sleep_target(ready_event):
+    """Process target that just idles (module-level so spawn-based platforms can pickle it)."""
+    ready_event.set()
+    time.sleep(60)
+
+
+def _sigterm_ignoring_target(ready_event):
+    """Process target that ignores SIGTERM, forcing the kill escalation path."""
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    ready_event.set()
+    time.sleep(60)
+
+
+def _start_process(target):
+    ready = multiprocessing.Event()
+    process = multiprocessing.Process(target=target, args=(ready,))
+    process.start()
+    assert ready.wait(timeout=30)  # don't race the target's signal-handler setup
+    return process
+
+
+class TestProcessTracking:
+    def test_register_and_close_process(self, manager):
+        process = _start_process(_sleep_target)
+        manager.register_process(process, name="test-process")
+        assert manager.stats.processes_active == 1
+
+        manager.close_process(process)
+        assert not process.is_alive()
+        assert manager.stats.processes_active == 0
+        assert manager.stats.processes_closed == 1
+        assert manager._processes == []
+
+    def test_close_process_twice_is_safe(self, manager):
+        process = _start_process(_sleep_target)
+        manager.register_process(process, name="test-process")
+        manager.close_process(process)
+        manager.close_process(process)  # logs a warning; must not raise or double-count
+        assert manager.stats.processes_closed == 1
+
+    def test_close_escalates_to_kill_when_sigterm_ignored(self, manager):
+        process = _start_process(_sigterm_ignoring_target)
+        manager.register_process(process, name="stubborn-process")
+        managed = manager._processes[0]
+        managed.close(timeout=1.0)  # SIGTERM is ignored -> join times out -> SIGKILL
+        assert managed.closed is True
+        process.join(timeout=10)
+        assert not process.is_alive()
+
+    def test_managed_process_close_on_dead_process_is_clean(self, manager):
+        process = _start_process(_sleep_target)
+        manager.register_process(process, name="test-process")
+        process.terminate()
+        process.join(timeout=10)
+        # Closing an already-dead process must succeed without escalation
+        manager.close_process(process)
+        assert manager.stats.processes_closed == 1

--- a/tests/unit/test_round_data.py
+++ b/tests/unit/test_round_data.py
@@ -1,0 +1,561 @@
+"""Unit tests for aetherscan.round_data (paths, manifests, startup dir cleanup, producer
+protocol) and the batched memmap generation in aetherscan.data_generation."""
+
+from __future__ import annotations
+
+import os
+import queue
+import random
+import threading
+import time
+
+import numpy as np
+import pytest
+
+from aetherscan.data_generation import (
+    build_chunk_segments,
+    build_segment_tasks,
+    generate_round_to_memmap,
+)
+from aetherscan.round_data import (
+    RoundDataPaths,
+    RoundDataProducer,
+    _producer_main,
+    build_manifest,
+    load_round_arrays,
+    prepare_round_data_dir,
+    validate_done_manifest,
+    write_done_manifest,
+)
+
+# Keep injection fast: small frequency axis, real-ish resolutions (mirrors
+# tests/unit/test_data_generation.py).
+_WIDTH_BIN = 128
+_FREQ_RES = 2.7939677238464355  # Hz
+_TIME_RES = 18.25361108  # seconds
+
+_SIGNAL_TYPES = ["false_no_signal", "false_with_rfi", "true_only_eti", "true_eti_rfi"]
+
+
+@pytest.fixture(autouse=True)
+def _seed_rngs():
+    random.seed(11)
+    np.random.seed(11)
+
+
+def _write_small_round(paths: RoundDataPaths, n_samples=8, width_bin=16, snr_base=10.0):
+    """Write a tiny but structurally-complete round dataset + validated manifest."""
+    os.makedirs(paths.round_dir, exist_ok=True)
+    rng = np.random.default_rng(paths.round_idx + 1)
+    shape = (n_samples, 6, 4, width_bin)
+    for path in paths.array_paths.values():
+        arr = np.lib.format.open_memmap(path, mode="w+", dtype=np.float32, shape=shape)
+        arr[:] = rng.random(shape, dtype=np.float32)
+        del arr
+    labels = np.array(
+        [_SIGNAL_TYPES[i % 4] for i in range(n_samples)],
+        dtype="U20",
+    )
+    np.save(paths.labels_path, labels)
+    manifest = build_manifest(
+        paths,
+        n_samples=n_samples,
+        snr_base=snr_base,
+        snr_range=40.0,
+        wall_time_s=1.0,
+        chunk_count=1,
+    )
+    write_done_manifest(paths, manifest)
+    return manifest
+
+
+class TestRoundDataPaths:
+    def test_for_round_naming(self, tmp_path):
+        paths = RoundDataPaths.for_round(str(tmp_path), 3)
+        assert paths.round_dir == str(tmp_path / "round_03")
+        assert paths.round_idx == 3
+        assert paths.done_path.endswith("round_03.done")
+
+    def test_array_and_label_paths(self, tmp_path):
+        paths = RoundDataPaths.for_round(str(tmp_path), 12)
+        assert set(paths.array_paths.keys()) == {"main", "true", "false"}
+        for name, path in paths.array_paths.items():
+            assert path == os.path.join(paths.round_dir, f"{name}.npy")
+        assert paths.labels_path == os.path.join(paths.round_dir, "labels.npy")
+
+
+class TestManifest:
+    def test_roundtrip_validates(self, tmp_path):
+        paths = RoundDataPaths.for_round(str(tmp_path), 1)
+        written = _write_small_round(paths)
+        manifest = validate_done_manifest(paths, expected_n_samples=8)
+        assert manifest is not None
+        assert manifest["n_samples"] == written["n_samples"] == 8
+        assert manifest["round_idx"] == 1
+        assert set(manifest["checksums"].keys()) == {"main", "true", "false", "labels"}
+
+    def test_missing_done_file_invalid(self, tmp_path):
+        paths = RoundDataPaths.for_round(str(tmp_path), 1)
+        _write_small_round(paths)
+        os.remove(paths.done_path)
+        assert validate_done_manifest(paths) is None
+
+    def test_expected_n_samples_mismatch_invalid(self, tmp_path):
+        paths = RoundDataPaths.for_round(str(tmp_path), 1)
+        _write_small_round(paths, n_samples=8)
+        assert validate_done_manifest(paths, expected_n_samples=16) is None
+
+    def test_round_idx_mismatch_invalid(self, tmp_path):
+        # A manifest written for round 1 dropped into a round-2 dir must not validate.
+        paths_1 = RoundDataPaths.for_round(str(tmp_path), 1)
+        manifest = _write_small_round(paths_1)
+        paths_2 = RoundDataPaths.for_round(str(tmp_path), 2)
+        _write_small_round(paths_2)
+        write_done_manifest(paths_2, manifest)
+        assert validate_done_manifest(paths_2) is None
+
+    def test_missing_array_invalid(self, tmp_path):
+        paths = RoundDataPaths.for_round(str(tmp_path), 1)
+        _write_small_round(paths)
+        os.remove(paths.true_path)
+        assert validate_done_manifest(paths) is None
+
+    def test_shape_mismatch_invalid(self, tmp_path):
+        paths = RoundDataPaths.for_round(str(tmp_path), 1)
+        _write_small_round(paths)
+        np.save(paths.main_path, np.zeros((2, 2), dtype=np.float32))
+        assert validate_done_manifest(paths) is None
+
+    def test_corrupted_values_invalid(self, tmp_path):
+        paths = RoundDataPaths.for_round(str(tmp_path), 1)
+        _write_small_round(paths)
+        # Same shape, different content: the sampled-value checksum must catch it.
+        arr = np.load(paths.false_path, mmap_mode="r+")
+        arr[:] = arr[:] + 7.0
+        arr.flush()
+        del arr
+        assert validate_done_manifest(paths) is None
+
+    def test_corrupted_manifest_json_invalid(self, tmp_path):
+        paths = RoundDataPaths.for_round(str(tmp_path), 1)
+        _write_small_round(paths)
+        with open(paths.done_path, "w") as f:
+            f.write("{not json")
+        assert validate_done_manifest(paths) is None
+
+    def test_load_round_arrays_returns_memmaps(self, tmp_path):
+        paths = RoundDataPaths.for_round(str(tmp_path), 1)
+        _write_small_round(paths, n_samples=8, width_bin=16)
+        data = load_round_arrays(paths)
+        assert set(data.keys()) == {"concatenated", "true", "false", "labels"}
+        for key in ("concatenated", "true", "false"):
+            assert isinstance(data[key], np.memmap)
+            assert data[key].shape == (8, 6, 4, 16)
+            assert data[key].dtype == np.float32
+        assert data["labels"].shape == (8,)
+        assert not isinstance(data["labels"], np.memmap)
+
+
+class TestPrepareRoundDataDir:
+    def test_creates_missing_base_dir(self, tmp_path):
+        base = tmp_path / "round_data" / "test_v1"
+        prepare_round_data_dir(str(base), start_round=1)
+        assert base.is_dir()
+
+    def test_resume_semantics(self, tmp_path):
+        base = str(tmp_path)
+        # round 1: valid manifest (< start_round -> kept)
+        _write_small_round(RoundDataPaths.for_round(base, 1))
+        # round 2: no .done (< start_round -> deleted)
+        paths_2 = RoundDataPaths.for_round(base, 2)
+        _write_small_round(paths_2)
+        os.remove(paths_2.done_path)
+        # round 3: valid manifest but >= start_round -> deleted (regenerated by this run)
+        _write_small_round(RoundDataPaths.for_round(base, 3))
+        # non-round entry (stale RF dataset) -> deleted
+        os.makedirs(os.path.join(base, "rf"))
+        # loose file -> untouched
+        with open(os.path.join(base, "stray.txt"), "w") as f:
+            f.write("x")
+
+        prepare_round_data_dir(base, start_round=3)
+
+        assert os.path.isdir(os.path.join(base, "round_01"))
+        assert not os.path.exists(os.path.join(base, "round_02"))
+        assert not os.path.exists(os.path.join(base, "round_03"))
+        assert not os.path.exists(os.path.join(base, "rf"))
+        assert os.path.isfile(os.path.join(base, "stray.txt"))
+
+    def test_fresh_run_deletes_everything(self, tmp_path):
+        base = str(tmp_path)
+        _write_small_round(RoundDataPaths.for_round(base, 1))
+        _write_small_round(RoundDataPaths.for_round(base, 2))
+        prepare_round_data_dir(base, start_round=1)
+        assert not os.path.exists(os.path.join(base, "round_01"))
+        assert not os.path.exists(os.path.join(base, "round_02"))
+
+
+def _segment_coverage(segments, array_name):
+    """Row indices covered by `array_name`'s segments (with multiplicity)."""
+    covered = []
+    for segment in segments:
+        if segment.array_name == array_name:
+            covered.extend(range(segment.start_idx, segment.start_idx + segment.count))
+    return covered
+
+
+class TestChunkSegmentsAndTasks:
+    def test_segments_cover_each_array_exactly_once(self):
+        segments = build_chunk_segments(chunk_start=8, chunk_size=8)
+        assert len(segments) == 8
+        for array_name in ("main", "false", "true"):
+            covered = _segment_coverage(segments, array_name)
+            assert sorted(covered) == list(range(8, 16))  # exactly once, no gaps/overlaps
+
+    def test_main_segment_order_matches_labels(self):
+        segments = build_chunk_segments(chunk_start=0, chunk_size=8)
+        main_types = [s.signal_type for s in segments if s.array_name == "main"]
+        assert main_types == _SIGNAL_TYPES
+
+    def test_chunk_size_not_divisible_by_4_raises(self):
+        with pytest.raises(ValueError, match="divisible by 4"):
+            build_chunk_segments(chunk_start=0, chunk_size=6)
+
+    def test_task_partitioning_covers_every_row_exactly_once(self):
+        segments = build_chunk_segments(chunk_start=0, chunk_size=40)
+        seed_rng = np.random.default_rng(0)
+        for segment in segments:
+            tasks = build_segment_tasks(
+                segment, "arr.npy", 3, 10.0, 40.0, _WIDTH_BIN, _FREQ_RES, _TIME_RES, seed_rng
+            )
+            covered = []
+            for _, start_idx, count, *_rest in tasks:
+                covered.extend(range(start_idx, start_idx + count))
+            assert sorted(covered) == list(
+                range(segment.start_idx, segment.start_idx + segment.count)
+            )
+            # Every task respects the max size and carries the segment's generation params
+            assert all(task[2] <= 3 for task in tasks)
+            assert all(task[3] == segment.create_fn_name for task in tasks)
+
+    def test_task_size_below_one_raises(self):
+        segment = build_chunk_segments(0, 4)[0]
+        with pytest.raises(ValueError, match="task_size"):
+            build_segment_tasks(
+                segment,
+                "arr.npy",
+                0,
+                10.0,
+                40.0,
+                _WIDTH_BIN,
+                _FREQ_RES,
+                _TIME_RES,
+                np.random.default_rng(0),
+            )
+
+
+class TestGenerateRoundToMemmap:
+    @pytest.fixture
+    def plate(self, make_background_npy):
+        path = make_background_npy("plate.npy", n_cadences=4, width_bin=_WIDTH_BIN)
+        return np.load(path)
+
+    def test_sequential_generation_end_to_end(self, tmp_path, plate):
+        paths = RoundDataPaths.for_round(str(tmp_path), 1)
+        stats_segments = []
+        progress = []
+
+        manifest = generate_round_to_memmap(
+            paths,
+            n_samples=8,
+            snr_base=10.0,
+            snr_range=5.0,
+            width_bin=_WIDTH_BIN,
+            num_observations=6,
+            time_bins=16,
+            chunk_size=4,
+            task_size=3,
+            freq_resolution=_FREQ_RES,
+            time_resolution=_TIME_RES,
+            pool=None,
+            backgrounds=plate,
+            round_num=1,
+            stats_cb=stats_segments.append,
+            progress_cb=lambda chunk, n_chunks: progress.append((chunk, n_chunks)),
+        )
+
+        # Arrays on disk with the right shape/dtype, every row populated & log-normalized
+        data = load_round_arrays(paths)
+        for key in ("concatenated", "true", "false"):
+            arr = data[key]
+            assert arr.shape == (8, 6, 16, _WIDTH_BIN)
+            assert arr.dtype == np.float32
+            row_maxes = arr.max(axis=(1, 2, 3))
+            assert np.all(row_maxes > 0)  # no row was left unwritten
+            assert float(arr.max()) <= 1.0
+            assert float(arr.min()) >= 0.0
+
+        # Labels mirror the contiguous per-chunk layout (chunk_size=4 -> quarter=1)
+        assert list(data["labels"]) == _SIGNAL_TYPES + _SIGNAL_TYPES
+
+        # Manifest validates and matches the generation request
+        assert validate_done_manifest(paths, expected_n_samples=8) is not None
+        assert manifest["chunk_count"] == 2
+        assert manifest["snr_base"] == 10.0
+
+        # Stats: 8 class-segments per chunk x 2 chunks; per-segment sample counts add up
+        assert len(stats_segments) == 16
+        for segment in stats_segments:
+            assert segment["num_samples"] == len(segment["stats_list"])
+            assert segment["round_number"] == 1
+            assert segment["snr_range_ceil"] == 15.0
+        main_total = sum(s["num_samples"] for s in stats_segments if s["signal_class"] == "main")
+        false_total = sum(s["num_samples"] for s in stats_segments if s["signal_class"] == "false")
+        true_total = sum(s["num_samples"] for s in stats_segments if s["signal_class"] == "true")
+        assert main_total == false_total == true_total == 8
+
+        # Signal-info keys match the signal type
+        by_type = {(s["signal_class"], s["signal_type"]): s for s in stats_segments}
+        assert by_type[("main", "false_no_signal")]["stats_list"][0]["signal_info"] == {}
+        double_keys = set(by_type[("true", "true_eti_rfi")]["stats_list"][0]["signal_info"])
+        assert any(k.startswith("eti_") for k in double_keys)
+        assert any(k.startswith("rfi_") for k in double_keys)
+
+        assert progress == [(1, 2), (2, 2)]
+
+    def test_regeneration_clears_stale_dir(self, tmp_path, plate):
+        paths = RoundDataPaths.for_round(str(tmp_path), 1)
+        os.makedirs(paths.round_dir)
+        stale = os.path.join(paths.round_dir, "leftover.npy")
+        with open(stale, "w") as f:
+            f.write("stale")
+        generate_round_to_memmap(
+            paths,
+            n_samples=4,
+            snr_base=10.0,
+            snr_range=5.0,
+            width_bin=_WIDTH_BIN,
+            num_observations=6,
+            time_bins=16,
+            chunk_size=4,
+            task_size=2,
+            freq_resolution=_FREQ_RES,
+            time_resolution=_TIME_RES,
+            backgrounds=plate,
+        )
+        assert not os.path.exists(stale)
+        assert validate_done_manifest(paths, expected_n_samples=4) is not None
+
+    def test_invalid_inputs_raise(self, tmp_path, plate):
+        paths = RoundDataPaths.for_round(str(tmp_path), 1)
+        common = {
+            "width_bin": _WIDTH_BIN,
+            "num_observations": 6,
+            "time_bins": 16,
+            "task_size": 2,
+            "freq_resolution": _FREQ_RES,
+            "time_resolution": _TIME_RES,
+            "backgrounds": plate,
+        }
+        with pytest.raises(ValueError, match="n_samples"):
+            generate_round_to_memmap(paths, 6, 10.0, 5.0, chunk_size=4, **common)
+        with pytest.raises(ValueError, match="chunk_size"):
+            generate_round_to_memmap(paths, 8, 10.0, 5.0, chunk_size=6, **common)
+        with pytest.raises(ValueError, match="backgrounds"):
+            generate_round_to_memmap(
+                paths,
+                8,
+                10.0,
+                5.0,
+                chunk_size=4,
+                **{**common, "backgrounds": None},
+            )
+
+
+def _stub_generate_ok(paths, round_idx, snr_base, snr_range, pool, params, stats_cb, progress_cb):
+    """Producer-protocol stub: emits one stats + one progress message, returns a manifest."""
+    stats_cb({"signal_class": "main", "stats_list": []})
+    progress_cb(1, 1)
+    return {"round_idx": round_idx, "n_samples": params["n_samples"], "stub": True}
+
+
+def _stub_generate_boom(paths, round_idx, snr_base, snr_range, pool, params, stats_cb, progress_cb):
+    raise RuntimeError("stub generation exploded")
+
+
+class TestProducerProtocol:
+    """Drive _producer_main in a thread with plain queues and a stub generate_fn — validates
+    the message protocol without child processes or the setigen generation stack."""
+
+    def _run(self, tmp_path, generate_fn, requests):
+        request_queue: queue.Queue = queue.Queue()
+        result_queue: queue.Queue = queue.Queue()
+        params = {"base_dir": str(tmp_path), "n_samples": 8}
+        for request in requests:
+            request_queue.put(request)
+        request_queue.put(("shutdown",))
+        thread = threading.Thread(
+            target=_producer_main,
+            args=(request_queue, result_queue, params),
+            kwargs={"generate_fn": generate_fn},
+            daemon=True,
+        )
+        thread.start()
+        thread.join(timeout=30)
+        assert not thread.is_alive()
+        messages = []
+        while True:
+            try:
+                messages.append(result_queue.get_nowait())
+            except queue.Empty:
+                break
+        return messages
+
+    def test_generate_emits_stats_progress_done(self, tmp_path):
+        messages = self._run(tmp_path, _stub_generate_ok, [("generate", 1, 10, 40)])
+        kinds = [m[0] for m in messages]
+        assert kinds == ["stats", "progress", "done", "shutdown_ack"]
+        done = messages[2]
+        assert done[1] == 1
+        assert done[2]["stub"] is True
+
+    def test_error_is_reported_and_producer_keeps_serving(self, tmp_path):
+        messages = self._run(
+            tmp_path,
+            _stub_generate_boom,
+            [("generate", 1, 10, 40), ("generate", 2, 10, 40)],
+        )
+        kinds = [m[0] for m in messages]
+        assert kinds == ["error", "error", "shutdown_ack"]
+        assert messages[0][1] == 1
+        assert "stub generation exploded" in messages[0][2]
+        assert messages[1][1] == 2
+
+    def test_existing_valid_round_short_circuits(self, tmp_path):
+        # A validated on-disk round must be reused: done comes back without generate_fn firing.
+        _write_small_round(RoundDataPaths.for_round(str(tmp_path), 1), n_samples=8)
+        messages = self._run(tmp_path, _stub_generate_boom, [("generate", 1, 10, 40)])
+        kinds = [m[0] for m in messages]
+        assert kinds == ["done", "shutdown_ack"]
+        assert messages[0][2]["n_samples"] == 8
+
+    def test_unknown_message_ignored(self, tmp_path):
+        messages = self._run(tmp_path, _stub_generate_ok, [("bogus",)])
+        assert [m[0] for m in messages] == ["shutdown_ack"]
+
+
+class _FakeProcess:
+    """Stand-in for the producer multiprocessing.Process on the main-side handle."""
+
+    def __init__(self):
+        self.alive = True
+        self.pid = 4242
+
+    def is_alive(self):
+        return self.alive
+
+
+class _FakeDB:
+    def __init__(self):
+        self.writes = []
+
+    def write_injection_stat(self, **kwargs):
+        self.writes.append(kwargs)
+
+
+def _minimal_sample_info():
+    stage = dict.fromkeys(
+        [
+            "global_mean",
+            "global_median",
+            "global_std",
+            "global_mad",
+            "global_skew",
+            "global_kurtosis",
+        ],
+        0.5,
+    )
+    return {
+        "background_index": 0,
+        "intensity_stats": {"A": dict(stage), "B": dict(stage), "C": dict(stage)},
+        "signal_info": {},
+        "slope_was_clamped": False,
+    }
+
+
+def _minimal_segment():
+    return {
+        "round_number": 1,
+        "chunk_number": 1,
+        "signal_class": "main",
+        "signal_type": "false_no_signal",
+        "snr_range_floor": 10,
+        "snr_range_ceil": 50,
+        "num_samples": 1,
+        "inject_duration": 0.1,
+        "timestamp": time.time(),
+        "stats_list": [_minimal_sample_info()],
+    }
+
+
+class TestRoundDataProducerDrainer:
+    """Exercise the main-side drainer thread + await_round against a fake process, feeding
+    the result queue directly (no child process involved)."""
+
+    @pytest.fixture
+    def producer(self, tmp_path):
+        producer = RoundDataProducer(
+            base_dir=str(tmp_path),
+            n_samples=8,
+            shm_name="unused",
+            background_shape=(1, 6, 4, 16),
+            background_dtype="float32",
+            n_processes=1,
+            width_bin=16,
+            num_observations=6,
+            time_bins=4,
+            chunk_size=4,
+            task_size=2,
+            freq_resolution=_FREQ_RES,
+            time_resolution=_TIME_RES,
+            db=_FakeDB(),
+            tag="test_v1",
+        )
+        producer._process = _FakeProcess()
+        producer._drainer = threading.Thread(target=producer._drain_results, daemon=True)
+        producer._drainer.start()
+        yield producer
+        producer._process.alive = False
+        producer._drainer.join(timeout=10)
+
+    def test_done_unblocks_await_round(self, producer):
+        producer._result_queue.put(("done", 1, {"n_samples": 8}))
+        assert producer.await_round(1) == {"n_samples": 8}
+
+    def test_error_raises_with_producer_traceback(self, producer):
+        producer._result_queue.put(("error", 2, "Traceback: boom"))
+        with pytest.raises(RuntimeError, match="boom"):
+            producer.await_round(2)
+
+    def test_stats_are_written_to_db_from_main_process(self, producer):
+        producer._result_queue.put(("stats", 1, _minimal_segment()))
+        producer._result_queue.put(("done", 1, {"n_samples": 8}))
+        producer.await_round(1)
+        # 18 per-sample intensity rows (6 stats x 3 stages) + 0 signal rows + 4 metadata rows
+        deadline = time.time() + 10
+        while len(producer._db.writes) < 22 and time.time() < deadline:
+            time.sleep(0.05)
+        assert len(producer._db.writes) == 22
+        metadata_names = {w["stat_name"] for w in producer._db.writes if w["sample_index"] is None}
+        assert metadata_names == {
+            "snr_range_floor",
+            "snr_range_ceil",
+            "num_samples",
+            "inject_duration",
+        }
+        assert all(w["tag"] == "test_v1" for w in producer._db.writes)
+
+    def test_producer_death_unblocks_await_round(self, producer):
+        producer._process.alive = False
+        with pytest.raises(RuntimeError, match="exited before producing"):
+            producer.await_round(5)

--- a/tests/unit/test_round_data.py
+++ b/tests/unit/test_round_data.py
@@ -568,7 +568,14 @@ class TestRoundDataProducerSpawnEndToEnd:
     memory — exercises the spawn pickling boundary, the child's import chain, its pool
     creation, and the stats/done/shutdown protocol for real. Both cluster-smoke failures
     this PR hit (a fork-inherited deadlocked lock; a fork-context SemLock crossing the
-    spawn boundary) were only reachable through a real child process."""
+    spawn boundary) were only reachable through a real child process.
+
+    COVERAGE LIMIT: this validates that spawn WORKS, not the rationale for choosing it. The
+    original fork deadlock needs a thread-laden TF/NCCL parent, which pytest does not have —
+    so a revert to a fork start method would still PASS here (verified: the e2e body passes
+    with _MP_CONTEXT patched to fork in an idle parent). The only guard against re-introducing
+    the fork deadlock is a cluster smoke; gate any change to _MP_CONTEXT / the start method on
+    one. The SemLock/log-relay regression, by contrast, IS caught here (it raises at start)."""
 
     def test_spawned_producer_generates_round(self, tmp_path):
         rng = np.random.default_rng(11)

--- a/tests/unit/test_round_data.py
+++ b/tests/unit/test_round_data.py
@@ -8,6 +8,7 @@ import queue
 import random
 import threading
 import time
+from multiprocessing.shared_memory import SharedMemory
 
 import numpy as np
 import pytest
@@ -559,3 +560,63 @@ class TestRoundDataProducerDrainer:
         producer._process.alive = False
         with pytest.raises(RuntimeError, match="exited before producing"):
             producer.await_round(5)
+
+
+@pytest.mark.slow
+class TestRoundDataProducerSpawnEndToEnd:
+    """Real spawn-started producer process + real (tiny) generation against real shared
+    memory — exercises the spawn pickling boundary, the child's import chain, its pool
+    creation, and the stats/done/shutdown protocol for real. Both cluster-smoke failures
+    this PR hit (a fork-inherited deadlocked lock; a fork-context SemLock crossing the
+    spawn boundary) were only reachable through a real child process."""
+
+    def test_spawned_producer_generates_round(self, tmp_path):
+        rng = np.random.default_rng(11)
+        plate = rng.chisquare(df=4, size=(4, 6, 16, _WIDTH_BIN)).astype(np.float32)
+
+        shm = SharedMemory(create=True, size=plate.nbytes)
+        producer = None
+        try:
+            shared = np.ndarray(plate.shape, dtype=plate.dtype, buffer=shm.buf)
+            shared[:] = plate
+
+            db = _FakeDB()
+            producer = RoundDataProducer(
+                base_dir=str(tmp_path),
+                n_samples=8,
+                shm_name=shm.name,
+                background_shape=plate.shape,
+                background_dtype=str(plate.dtype),
+                n_processes=2,
+                width_bin=_WIDTH_BIN,
+                num_observations=6,
+                time_bins=16,
+                chunk_size=4,
+                task_size=3,
+                freq_resolution=_FREQ_RES,
+                time_resolution=_TIME_RES,
+                db=db,
+                tag="test_v1",
+            )
+            producer.start()
+            producer.request_generation(1, 10, 5)
+            manifest = producer.await_round(1)
+            assert manifest["n_samples"] == 8
+
+            paths = RoundDataPaths.for_round(str(tmp_path), 1)
+            assert validate_done_manifest(paths, expected_n_samples=8) is not None
+
+            # Streamed stats land in the main-process drainer (DB writes stay in main)
+            deadline = time.time() + 30
+            while not db.writes and time.time() < deadline:
+                time.sleep(0.2)
+            assert db.writes
+
+            # A second request for the already-generated round short-circuits via the manifest
+            producer.request_generation(1, 10, 5)
+            assert producer.await_round(1)["n_samples"] == 8
+        finally:
+            if producer is not None:
+                producer.shutdown()
+            shm.close()
+            shm.unlink()

--- a/tests/unit/test_train_datasets.py
+++ b/tests/unit/test_train_datasets.py
@@ -1,0 +1,193 @@
+"""Unit tests for train.py's batched distributed dataset builders: whole-global-batch yields,
+exact index coverage, stratified splits, the shuffle=False alignment contract that
+train_random_forest depends on, and the viz dataset's order guarantee."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import tensorflow as tf
+
+from aetherscan.train import (
+    TrainDataHolder,
+    prepare_distributed_train_dataset,
+    prepare_distributed_viz_dataset,
+)
+
+# Tiny sample shape — the builders never hardcode (6, 16, 512)
+_SAMPLE_SHAPE = (2, 3, 4)
+_SIGNAL_TYPES = ["false_no_signal", "false_with_rfi", "true_only_eti", "true_eti_rfi"]
+
+pytestmark = pytest.mark.slow  # builds TF graphs on CPU
+
+
+def _make_data(n_samples=40):
+    """Arrays whose every sample is a constant equal to (offset + row index), so a yielded
+    batch reveals exactly which rows it gathered."""
+    base = np.arange(n_samples, dtype=np.float32)[:, None, None, None]
+    ones = np.ones((n_samples, *_SAMPLE_SHAPE), dtype=np.float32)
+    labels = np.array([_SIGNAL_TYPES[(4 * i) // n_samples] for i in range(n_samples)], dtype="U20")
+    return {
+        "concatenated": base * ones,
+        "true": (base + 1000.0) * ones,
+        "false": (base + 2000.0) * ones,
+        "labels": labels,
+    }
+
+
+def _build(data, shuffle, train_val_split=0.8, prb=4, eb=8, prvb=4):
+    return prepare_distributed_train_dataset(
+        data=data,
+        train_val_split=train_val_split,
+        per_replica_batch_size=prb,
+        effective_batch_size=eb,
+        per_replica_val_batch_size=prvb,
+        num_replicas=1,
+        strategy=tf.distribute.get_strategy(),
+        shuffle=shuffle,
+    )
+
+
+def _batch_row_ids(batch):
+    """Recover the source row indices a yielded ((c, t, f), y) batch gathered."""
+    (concat, true, false), y = batch
+    concat_ids = concat.numpy()[:, 0, 0, 0]
+    np.testing.assert_array_equal(concat_ids, y.numpy()[:, 0, 0, 0])
+    np.testing.assert_array_equal(concat_ids + 1000.0, true.numpy()[:, 0, 0, 0])
+    np.testing.assert_array_equal(concat_ids + 2000.0, false.numpy()[:, 0, 0, 0])
+    return concat_ids.astype(np.int64)
+
+
+class TestPrepareDistributedTrainDataset:
+    def test_step_counts_and_batched_shapes(self):
+        results = _build(_make_data(), shuffle=True)
+        assert results["n_train_trimmed"] == 32
+        assert results["n_val_trimmed"] == 8
+        assert results["train_steps"] == 4  # 32 / effective(8)
+        assert results["accumulation_steps"] == 2  # effective(8) / global(4)
+        assert results["val_steps"] == 2  # 8 / global val(4)
+
+        iterator = iter(results["train_dataset"])
+        batch = next(iterator)
+        (concat, true, false), y = batch
+        # Whole global batches: leading batch dim is the global batch size (no .batch() op)
+        assert concat.shape == (4, *_SAMPLE_SHAPE)
+        assert true.shape == (4, *_SAMPLE_SHAPE)
+        assert false.shape == (4, *_SAMPLE_SHAPE)
+        assert y.shape == (4, *_SAMPLE_SHAPE)
+        results["_train_holder"].clear()
+
+    def test_epoch_covers_train_indices_exactly_once(self):
+        results = _build(_make_data(), shuffle=True)
+        n_batches_per_epoch = results["train_steps"] * results["accumulation_steps"]
+        iterator = iter(results["train_dataset"])
+        seen = []
+        for _ in range(n_batches_per_epoch):
+            batch_ids = _batch_row_ids(next(iterator))
+            # Within-batch sorted gathers (read locality); membership is epoch-shuffled
+            assert np.all(np.diff(batch_ids) >= 0)
+            seen.extend(batch_ids.tolist())
+        assert sorted(seen) == sorted(results["train_indices"].tolist())
+        results["_train_holder"].clear()
+
+    def test_shuffle_false_yields_train_indices_order(self):
+        """The alignment contract train_random_forest depends on: with shuffle=False the i-th
+        yielded cadence is row train_indices[i], across exactly train_steps x accumulation_steps
+        batches per epoch pass."""
+        results = _build(_make_data(), shuffle=False)
+        n_batches_per_epoch = results["train_steps"] * results["accumulation_steps"]
+        iterator = iter(results["train_dataset"])
+        seen = []
+        for _ in range(n_batches_per_epoch):
+            seen.extend(_batch_row_ids(next(iterator)).tolist())
+        assert seen == results["train_indices"].tolist()
+        # A second epoch pass repeats the same order (.repeat() on an ordered generator)
+        second = []
+        for _ in range(n_batches_per_epoch):
+            second.extend(_batch_row_ids(next(iterator)).tolist())
+        assert second == seen
+        results["_train_holder"].clear()
+
+    def test_val_yields_val_indices_order(self):
+        results = _build(_make_data(), shuffle=True)
+        iterator = iter(results["val_dataset"])
+        seen = []
+        for _ in range(results["val_steps"]):
+            seen.extend(_batch_row_ids(next(iterator)).tolist())
+        assert seen == results["val_indices"].tolist()
+        results["_train_holder"].clear()
+
+    def test_split_is_stratified_and_disjoint(self):
+        data = _make_data()
+        results = _build(data, shuffle=True)
+        train_indices = results["train_indices"]
+        val_indices = results["val_indices"]
+        assert set(train_indices).isdisjoint(set(val_indices))
+        labels = data["labels"]
+        for signal_type in _SIGNAL_TYPES:
+            # 40 samples, 10 per type, 0.8 split -> 8 train / 2 val of each type
+            assert int(np.sum(labels[train_indices] == signal_type)) == 8
+            assert int(np.sum(labels[val_indices] == signal_type)) == 2
+        results["_train_holder"].clear()
+
+    def test_memmap_inputs_supported(self, tmp_path):
+        """Round data arrives as np.load(mmap_mode='r') memmaps — gathers must produce plain
+        in-RAM batches from them."""
+        data = _make_data()
+        mmap_data = {"labels": data["labels"]}
+        for key in ("concatenated", "true", "false"):
+            path = tmp_path / f"{key}.npy"
+            np.save(path, data[key])
+            mmap_data[key] = np.load(path, mmap_mode="r")
+        results = _build(mmap_data, shuffle=False)
+        iterator = iter(results["train_dataset"])
+        batch_ids = _batch_row_ids(next(iterator))
+        assert batch_ids.tolist() == results["train_indices"][:4].tolist()
+        results["_train_holder"].clear()
+
+    def test_holder_clear_drops_references(self):
+        holder = TrainDataHolder(np.zeros(2), np.zeros(2), np.zeros(2))
+        holder.clear()
+        assert holder.concat is None and holder.true is None and holder.false is None
+        holder.clear()  # idempotent
+        assert holder._cleared
+
+
+class TestPrepareDistributedVizDataset:
+    def _build_viz(self, concat, prib=4):
+        return prepare_distributed_viz_dataset(
+            concat_data=concat,
+            per_replica_inf_batch_size=prib,
+            num_replicas=1,
+            strategy=tf.distribute.get_strategy(),
+        )
+
+    def test_order_preserved_with_padding(self):
+        n = 10
+        base = np.arange(n, dtype=np.float32)[:, None, None, None]
+        concat = base * np.ones((n, *_SAMPLE_SHAPE), dtype=np.float32)
+        results = self._build_viz(concat)
+        assert results["n_samples"] == 10
+        assert results["n_padded"] == 12
+        assert results["viz_steps"] == 3
+
+        iterator = iter(results["viz_dataset"])
+        seen = []
+        for _ in range(results["viz_steps"]):
+            batch = next(iterator)
+            assert batch.shape == (4, *_SAMPLE_SHAPE)  # whole global batches
+            seen.extend(batch.numpy()[:, 0, 0, 0].astype(np.int64).tolist())
+        # WARN-comment contract: the first n_samples yields are the original cadence order —
+        # plot_latent_space_gif and _capture_latent_snapshot truncate the padded tail
+        assert seen[:n] == list(range(n))
+        # Padding rows duplicate real cadences
+        assert all(0 <= idx < n for idx in seen[n:])
+        results["_viz_holder"].clear()
+
+    def test_no_padding_when_divisible(self):
+        n = 8
+        concat = np.ones((n, *_SAMPLE_SHAPE), dtype=np.float32)
+        results = self._build_viz(concat)
+        assert results["n_padded"] == n
+        assert results["viz_steps"] == 2
+        results["_viz_holder"].clear()


### PR DESCRIPTION
Closes #114
Stacked on #116 (`feature/test-suite`) — this PR's base is that branch, so the diff shows only this unit's changes.

## Summary

Overhauls the training data pipeline to fix four coupled problems that share one design (full details in #114): the ~294 GB/round in-RAM arrays that OOM-killed full-scale runs, GIL contention that made round 2+ data generation far slower than round 1, strictly serial generate-then-train phases, and per-sample `tf.data` generators that starved the GPUs (0–14 % utilization).

### (a) Memmap-backed round datasets — new `src/aetherscan/round_data.py`

- Each round's `{main,true,false,labels}.npy` live on disk under `{round_data_dir}/{save_tag}/round_XX/` (`round_data_dir` defaults to `get_training_file_path("round_data")` = `<data_path>/training/round_data`), created with `np.lib.format.open_memmap` and read back via `np.load(mmap_mode="r")`.
- A `round_XX.done` manifest (sample counts, shapes, SNR params, element-count + sampled-value checksums, wall time, chunk count) is written atomically (`.tmp` → `os.replace`) only after all workers finish — a crash mid-generation leaves no manifest and the dir reads as garbage.
- `_setup_directories()` prepares the tag's round-data dir with checkpoint-archiving-style resume semantics: delete round dirs ≥ `start_round`, keep earlier dirs only if their manifest validates, delete `.done`-less dirs (deleted rather than archived — a round is ~295 GB).
- Round k's dir is deleted as soon as round k's training completes (`--keep-round-data` retains for debugging), so the steady-state disk footprint is ≤ 2 rounds with overlap.

### (b) Workers write straight into the memmap — `data_generation.py` rewrite

- The 1-task-per-sample dispatch (per-sample IPC pickling + main-process copies + ~20 DB writes/sample on the training thread — the GIL bottleneck) is replaced by batched tasks of `--data-gen-task-size` (default 256) cadences; each worker opens the round memmap `r+` and writes its disjoint row range in place, returning only the small per-sample stats dicts.
- The 8 class-segments per chunk go through **one** unified `pool.map` barrier instead of 8 sequential ones. `signal_injection_chunk_size % 4 == 0` (already CLI-validated) makes quarters/halves exact, removing the ceil-division oversample/subsample dance and its stats-filtering code.
- The old commented-out shared-memory-output redesign blocks are removed — this PR is that redesign.

### (c) Background producer process — overlap + GIL isolation

- A `RoundDataProducer` process (owning its own worker pool attached to the background-plate SHM by name) generates round k+1 while round k trains. Queue protocol: `generate`/`shutdown` in; `stats`/`progress`/`done`/`error` out.
- DB writes stay in the main process: a drainer thread consumes streamed stats and calls `db.write_injection_stat` (the DB queue is a thread `queue.Queue`, not process-safe) — also moving the per-sample DB-write GIL load off the training thread's critical path.
- The producer is **spawn-started**, not forked: the first cluster smoke froze on a futex before the forked child reached its own code — a lock inherited in a locked state from the training parent's deep TF/NCCL/gRPC thread stack. A spawned child runs a fresh interpreter (its own pool workers then fork from the clean single-threaded producer, which is safe). Its logging goes through a spawn-context queue relayed into the main logging pipeline by a `QueueListener` (the Logger singleton's fork-context queue can't cross the spawn boundary), and `CUDA_VISIBLE_DEVICES` is blanked around `Process.start()` so nothing in the producer tree can initialize CUDA.
- Producer + pool workers use `init_worker_logging()` and the canonical no-log SIGTERM handler; the producer is registered with the ResourceManager via a new tracked `ManagedProcess` (terminate → join → kill escalation mirroring `ManagedPool.close`, including killing orphaned pool children before SIGKILL).
- `--no-overlap-data-generation` drops to sequential in-process generation for debugging (also the automatic fallback when `n_processes=1` leaves no SHM to attach to).

### (d) Batched `tf.data` input — `prepare_distributed_train_dataset` rewrite

- Generators yield whole **global** batches gathered from the memmaps (sorted fancy indices per batch; epoch-level shuffle preserved), dropping `.batch()` and keeping `.repeat().prefetch(AUTOTUNE)` — ~global-batch-size× fewer Python/tf.data boundary crossings.
- The stratified split and the `shuffle=False` alignment contract used by `train_random_forest` are preserved (train/val indices are sorted once so yield order matches the returned index arrays); the `train_steps × accumulation_steps` encode-count contract still holds and stays guarded by `_distributed_encode`'s drift check.
- Val and viz datasets get the same batched treatment (viz order guarantee kept — `plot_latent_space_gif` and `_capture_latent_snapshot` depend on it).
- `TrainDataHolder` now holds memmap references; `clear()` semantics unchanged; the stale lock-contention comment is refreshed. Page-cache framing documented in code comments: steady-state reads come from otherwise-free RAM, and the kernel evicts pages under pressure instead of OOM-killing the run.

### Config / CLI

New `TrainingConfig` fields + train-only Pattern A flags (per docs/CONFIG_AND_CLI.md), serialized via `Config.to_dict()`: `--round-data-dir`, `--overlap-data-generation/--no-overlap-data-generation`, `--keep-round-data/--no-keep-round-data`, `--data-gen-task-size` (validated ≥ 1). `collect_validation_errors` gains a train-mode disk-budget check: ≥ 2.2× one round's estimated size free with overlap (two rounds coexist on disk), 1.1× without — a hard ValidationError with the computed numbers. README CLI Reference blocks regenerated with `PYTHONPATH=src python utils/print_cli_help.py all`.

## Verification

**Local (macOS arm64, CPU-only venv: Python 3.12, tensorflow 2.17.1, pins from `requirements-container.txt`):**

```
$ pytest -m "not gpu and not cluster" -q
235 passed, 3 skipped, 2 deselected
```

New tests: `tests/unit/test_round_data.py` — paths/manifest/dir-prep/task-partitioning, end-to-end sequential generation, producer protocol driven with a stub generator fn, drainer + `await_round`, plus a real **spawn-started producer end-to-end test** (which would have caught both cluster failures below); `tests/unit/test_train_datasets.py` — batched yields, exact index coverage, stratification, the `shuffle=False` alignment contract, memmap inputs, viz order; `ManagedProcess` tests in `test_manager.py`; round-data flag/validation tests in `test_cli_validation.py`.

**Cluster smoke (blpc3, NGC 25.02 container, 5× RTX PRO 6000, tag `test_v21`, branch @ 291334f):**

```
./utils/run_container.sh python -m aetherscan.main train --save-tag test_v21 --max-retries 1 \
  --num-training-rounds 3 --epochs-per-round 3 \
  --per-replica-batch-size 4 --per-replica-val-batch-size 4 --effective-batch-size 20 \
  --num-samples-beta-vae 2000 --num-samples-rf 600 --latent-viz-num-cadences-per-type 5
```

(Divisibility pre-validated for 5 replicas with `utils/find_optimal_configs.py --num-gpus 5`; GPUs confirmed idle before launch.) Result: **clean completion, 0 ERROR/Traceback lines**, all artifacts saved, `/dev/shm` clean, round-data dirs auto-deleted.

Acceptance criteria (PLAN §5.4, adapted to blpc3):

- **(i) Data-gen wall time per round (GIL fix)**: 303.6 s / 303.2 s / 280.8 s for rounds 1/2/3 — rounds 2–3 ≈ round 1 (the old pipeline's round-2+ slowdown under a warm TF process is gone; generation now runs in its own process).
- **(ii) Overlap**: log timeline shows round k+1 generating during round k's epochs. Main-thread wait for data: **318.3 s (round 1, unavoidable serial start) → 151.6 s (round 2) → 105.9 s (round 3)**. E.g. `16:16:35 RoundDataProducer: generating round 3 data` runs through round 2's epochs (`16:17:29 Epoch 1 … 16:18:35 Epoch 3`) and completes at `16:21:16`.
- **(iii) RSS bounded**: process-tree RAM mean 7.4 %, max **26.3 %** of 503 GB across the whole run (dominated by the 45.8 GB background-plate SHM + TF runtime); system RAM max 22.7 %. No per-round saw-tooth, no growth across rounds (the resource plot renders flat between rounds).
- **(iv) GPU utilization during epochs**: at this smoke's 5-replica-divisible geometry (batch 4/replica — 1/32 of the full-scale batch), the 1 Hz monitor recorded mean 5.4 % / p90 15 % / max 28 % during train windows. A follow-up probe at the full-scale per-replica batch (`test_v22`: batch 128/replica, effective 640, 3200 samples) sustained **5120 samples/epoch in 7.8 s once warm (~660 samples/s end-to-end)** — the input pipeline is no longer the bottleneck at smoke scale, but per-step GPU compute for this VAE at these sample counts sits far below the 1 Hz sampling interval, so a comparable full-scale GPU-% number must come from the bla0 rehearsal (deferred below).
- **(v) Loss curves sane, RF trains, plots render**: beta-VAE total loss 433.8 → 279.9 (train) and 417.4 → 255.3 (val) monotonically per-round across 3 rounds; RF trained and persisted (`random_forest_test_v21.joblib` + eval/SHAP artifacts); **56 tagged plots** rendered incl. 24 latent-space UMAP GIF variants and the 10 RF diagnostics.

The smoke also exercised: manifest-gated reuse short-circuiting, per-round dir deletion, RF's sequential in-process generation path, producer graceful shutdown, and (via two interrupted runs) the Ctrl-C cleanup path through the new `ManagedProcess`.

**Observation (pre-existing, not a regression)**: the RF dataset generation (`600 samples, 1022.5 s`) was dominated by one worker spinning ~10 min in `create_true_double`'s non-intersection retry loop — the loop predates this PR (see its `Note, small but nonzero probability for "infinite" (long-running) loops`). Batched tasks make such stragglers more visible since one unlucky sample stalls its whole task; a retry cap is worth a follow-up issue.

### Deferred validation

- Full-scale OOM-rehearsal on bla0 (6× A4000, default config — the previous round-2 OOM-killer scenario) is deferred; bla0 is unreachable this session. This is also where the definitive full-scale GPU-utilization comparison against the 0–14 % baseline gets recorded.

## AI assistance disclosure

Implemented with Claude Code (implementation, unit tests, docs/README regeneration, and cluster smoke verification), per AI_POLICY.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

