### PR TITLE
Training fault tolerance: stage-based resume, run manifest, DB supersede semantics

### DIFF
--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -1533,14 +1533,14 @@ def collect_validation_errors(
         # Retries (training-scoped — args.max_retries / args.retry_delay also exist
         # in the inference subparser, so the Pattern C gate on cmd kept this clean).
         mr = _resolve(args, "max_retries", config.training.max_retries)
-        if mr is not None and mr < 0:
+        if mr is not None and mr < 1:
             errors.append(
                 ValidationError(
                     field="training.max_retries",
                     current=mr,
-                    message=f"--max-retries must be >= 0, got {mr}",
+                    message=f"--max-retries must be >= 1 (the run needs at least one attempt), got {mr}",
                     fix_kind="clamp_low",
-                    min_val=0,
+                    min_val=1,
                 )
             )
         rd = _resolve(args, "retry_delay", config.training.retry_delay)

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -644,9 +644,10 @@ class Database:
 
         # Final flush on shutdown
         if self.buffer:
+            flushed_count = len(self.buffer)
             self._flush_buffer()
             self.buffer.clear()
-            logger.info(f"Flushed {len(self.buffer)} remaining data on shutdown")
+            logger.info(f"Flushed {flushed_count} remaining data on shutdown")
 
     # In commit 08fc37d, we switched from using sequential execute() to executemany()
     # The sequential approaches parses SQL statements N times & performs N round trips to the db

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -33,6 +33,16 @@ logger = logging.getLogger(__name__)
 # written
 _FLUSH_SENTINEL = object()
 
+# Command sentinel for mark_superseded() requests routed through the writer thread (same
+# identity-based recognition as _FLUSH_SENTINEL, so single-writer semantics are preserved)
+_MARK_SUPERSEDED_SENTINEL = object()
+
+# Current schema version, stored in SQLite's PRAGMA user_version (0 on any pre-versioning db).
+# Bump this and extend _migrate_schema() with an `if version < N:` block for future changes.
+# v1: added `superseded INTEGER DEFAULT 0` to training_stats, injection_stats,
+#     latent_snapshots, and inference_results (stale-data supersede semantics on retry)
+_SCHEMA_VERSION = 1
+
 
 def get_system_metadata() -> str:
     """
@@ -159,18 +169,9 @@ class Database:
             cls._instance = None
             logger.info("Database singleton instance reset")
 
-    # TODO:
-    # We currently don't support schema versioning or migration scripting for schema changes
-    # This means that while new tables can be easily added using CREATE TABLE IF NOT EXISTS
-    # statements, existing tables cannot be easily modified (i.e. no ALTER TABLE support for adding
-    # new columns to tables, modifying column constraints, renaming columns, or dropping obsolete
-    # columns), and no rollback mechanisms exist
-    # This makes it impossible to evolve existing schema without manual database updates. As well as
-    # having no audit trail of schema changes, or no rollback capability for failed upgrades. It's
-    # also difficult to coordinate deployments across multiple db instances
     # NOTE: should we consider migrating to PostgreSQL? or should we go all in on SQLite?
     def _init_database(self):
-        """Create database tables if they don't exist"""
+        """Create database tables if they don't exist, then run schema migrations"""
         with self._get_connection() as conn:
             cursor = conn.cursor()
 
@@ -222,7 +223,8 @@ class Database:
                     is_finite INTEGER DEFAULT 1,
                     slope_clamped INTEGER DEFAULT 0,
                     tag TEXT,
-                    metadata TEXT
+                    metadata TEXT,
+                    superseded INTEGER DEFAULT 0
                 )
             """)
 
@@ -250,7 +252,8 @@ class Database:
                     round_number INTEGER,
                     epoch_number INTEGER,
                     tag TEXT,
-                    metadata TEXT
+                    metadata TEXT,
+                    superseded INTEGER DEFAULT 0
                 )
             """)
 
@@ -282,7 +285,8 @@ class Database:
                     snr_base INTEGER,
                     snr_range INTEGER,
                     tag TEXT,
-                    metadata TEXT
+                    metadata TEXT,
+                    superseded INTEGER DEFAULT 0
                 )
             """)
 
@@ -310,7 +314,8 @@ class Database:
                     timestamp_observed REAL,
                     h5_path TEXT,
                     tag TEXT,
-                    metadata TEXT
+                    metadata TEXT,
+                    superseded INTEGER DEFAULT 0
                 )
             """)
 
@@ -322,12 +327,50 @@ class Database:
 
             conn.commit()
 
+            # Bring pre-existing databases (older schema) up to the current version
+            self._migrate_schema(conn)
+
             # Enable Write-Ahead Logging (WAL) mode for better concurrent read performance
             # WAL places writes in a separate log file so reads can still go through while writes happen
             # The WAL log is periodically merged back into the main db (i.e. checkpointing)
             cursor.execute("PRAGMA journal_mode=WAL")
 
             logger.info("Database schema initialized with WAL mode")
+
+    def _migrate_schema(self, conn):
+        """
+        Minimal schema migration gated on SQLite's PRAGMA user_version.
+
+        Each block below upgrades one version step via additive ALTER TABLE ... ADD COLUMN
+        statements (the only in-place table change SQLite supports); a per-table column-existence
+        check keeps every step idempotent even if user_version was lost (e.g. a db file copied
+        without its journal). Fresh databases already get the full schema from the CREATE TABLE
+        statements in _init_database(), so migration only stamps their version.
+        """
+        cursor = conn.cursor()
+        version = cursor.execute("PRAGMA user_version").fetchone()[0]
+
+        if version >= _SCHEMA_VERSION:
+            return
+
+        if version < 1:
+            # v1: stale-data supersede semantics — rows from failed/superseded attempts are
+            # flagged (never deleted) so default queries can filter them out
+            for table in (
+                "training_stats",
+                "injection_stats",
+                "latent_snapshots",
+                "inference_results",
+            ):
+                columns = {row[1] for row in cursor.execute(f"PRAGMA table_info({table})")}
+                if "superseded" not in columns:
+                    cursor.execute(f"ALTER TABLE {table} ADD COLUMN superseded INTEGER DEFAULT 0")
+                    logger.info(f"Schema migration: added {table}.superseded")
+
+        # PRAGMA doesn't support parameter binding; _SCHEMA_VERSION is a module-level int constant
+        cursor.execute(f"PRAGMA user_version = {_SCHEMA_VERSION:d}")
+        conn.commit()
+        logger.info(f"Database schema migrated from version {version} to {_SCHEMA_VERSION}")
 
     @contextmanager
     def _get_connection(self):
@@ -411,6 +454,116 @@ class Database:
         logger.warning(f"Database flush timed out after {timeout} seconds")
         return False
 
+    # Tables that support supersede marking, mapped to the optional filters each accepts
+    # (round_ge needs a round_number column; npy_path only exists on inference_results)
+    _SUPERSEDE_TABLES = {
+        "training_stats": frozenset({"round_ge"}),
+        "injection_stats": frozenset({"round_ge"}),
+        "latent_snapshots": frozenset({"round_ge"}),
+        "inference_results": frozenset({"npy_path"}),
+    }
+
+    def mark_superseded(
+        self,
+        table: str,
+        tag: str,
+        *,
+        round_ge: int | None = None,
+        npy_path: str | None = None,
+        timeout: float | None = None,
+    ) -> bool:
+        """
+        Flag existing rows for `tag` as superseded (stale data from a failed attempt) so the
+        default query_* filters ignore them. Rows are never deleted — pass
+        include_superseded=True to a query method to inspect them.
+
+        round_ge narrows the mark to round_number >= round_ge (training_stats /
+        injection_stats / latent_snapshots only); npy_path narrows to one cadence file
+        (inference_results only).
+
+        The command executes on the background writer thread (a command tuple through the
+        write queue, like the flush sentinel) so single-writer semantics are preserved:
+        buffered rows are flushed first, then the UPDATE runs — queue FIFO ordering
+        guarantees every row queued before this call gets marked while later writes keep
+        superseded = 0. Blocks until the mark lands; returns False on timeout or shutdown.
+        When the writer thread isn't running there are no queued rows to order against, so
+        the UPDATE executes synchronously in the caller thread.
+        """
+        if table not in self._SUPERSEDE_TABLES:
+            raise ValueError(
+                f"mark_superseded does not support table {table!r}; "
+                f"expected one of {sorted(self._SUPERSEDE_TABLES)}"
+            )
+        allowed_filters = self._SUPERSEDE_TABLES[table]
+        if round_ge is not None and "round_ge" not in allowed_filters:
+            raise ValueError(f"round_ge is not supported for table {table!r}")
+        if npy_path is not None and "npy_path" not in allowed_filters:
+            raise ValueError("npy_path is only supported for table 'inference_results'")
+        if not tag:
+            raise ValueError("mark_superseded requires a non-empty tag")
+
+        if timeout is None:
+            timeout = self.flush_timeout
+
+        # No writer thread -> nothing queued to order against; run inline
+        if self.writer_thread is None or not self.writer_thread.is_alive():
+            self._execute_mark_superseded(table, tag, round_ge, npy_path)
+            return True
+
+        if self.stop_event.is_set():
+            logger.warning("mark_superseded called during shutdown, skipping")
+            return False
+
+        mark_complete = threading.Event()
+        self.write_queue.put(
+            (_MARK_SUPERSEDED_SENTINEL, (table, tag, round_ge, npy_path), mark_complete)
+        )
+
+        # Block until the writer signals completion, timeout, or shutdown (same loop as flush)
+        wait_interval = 0.1
+        elapsed = 0.0
+        while elapsed < timeout:
+            if mark_complete.wait(timeout=wait_interval):
+                return True
+            if self.stop_event.is_set():
+                logger.warning("Shutdown initiated during mark_superseded, aborting wait")
+                return False
+            elapsed += wait_interval
+
+        logger.warning(f"mark_superseded timed out after {timeout} seconds")
+        return False
+
+    def _execute_mark_superseded(
+        self, table: str, tag: str, round_ge: int | None, npy_path: str | None
+    ) -> None:
+        """Apply the supersede UPDATE (runs on the writer thread, or inline via
+        mark_superseded when no writer thread is running). `table` was already validated
+        against _SUPERSEDE_TABLES, so the f-string interpolation below is safe."""
+        query = f"UPDATE {table} SET superseded = 1 WHERE superseded = 0 AND tag = ?"
+        params: list = [tag]
+
+        if round_ge is not None:
+            query += " AND round_number >= ?"
+            params.append(round_ge)
+
+        if npy_path is not None:
+            query += " AND npy_path = ?"
+            params.append(npy_path)
+
+        try:
+            with self._get_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute(query, params)
+                conn.commit()
+                logger.info(
+                    f"Marked {cursor.rowcount} row(s) superseded in {table} "
+                    f"(tag={tag}, round_ge={round_ge}, npy_path={npy_path})"
+                )
+        except Exception as e:
+            # Mirror _flush_buffer's log-and-continue semantics: a failed mark must not
+            # kill the writer thread (stale rows would then merely reappear in plots)
+            logger.error(f"Error marking rows superseded in {table}: {e}")
+
     def _writer_loop(self):
         """Background loop that consumes data from queue and writes to database"""
         self.buffer = []
@@ -439,6 +592,22 @@ class Database:
                         last_write_time = time.time()
                     # Signal that flush is complete
                     flush_complete_event.set()
+                    continue
+
+                # Check for mark-superseded command. Flush buffered rows first: queue FIFO
+                # guarantees every row enqueued before the command is already in the buffer,
+                # so the UPDATE covers them, while rows enqueued after keep superseded = 0
+                if metric[0] is _MARK_SUPERSEDED_SENTINEL:
+                    _, payload, mark_complete_event = metric
+                    try:
+                        if self.buffer:
+                            self._flush_buffer()
+                            self.buffer.clear()
+                            last_write_time = time.time()
+                        self._execute_mark_superseded(*payload)
+                    finally:
+                        # Always unblock the caller, even if the flush/UPDATE errored
+                        mark_complete_event.set()
                     continue
 
                 self.buffer.append(metric)
@@ -856,6 +1025,7 @@ class Database:
         "slope_clamped",
         "tag",
         "metadata",
+        "superseded",
     }
     _TRAINING_STATS_COLUMNS = {
         "id",
@@ -867,6 +1037,7 @@ class Database:
         "epoch_number",
         "tag",
         "metadata",
+        "superseded",
     }
     _LATENT_SNAPSHOTS_COLUMNS = {
         "id",
@@ -882,6 +1053,7 @@ class Database:
         "snr_range",
         "tag",
         "metadata",
+        "superseded",
     }
     _INFERENCE_RESULTS_COLUMNS = {
         "id",
@@ -900,6 +1072,7 @@ class Database:
         "h5_path",
         "tag",
         "metadata",
+        "superseded",
     }
 
     @staticmethod
@@ -1031,6 +1204,7 @@ class Database:
         start_time: float | None = None,
         end_time: float | None = None,
         columns: list[str] | None = None,
+        include_superseded: bool = False,
     ) -> list[dict[str, Any]]:
         """
         Query rows from injection_stats as a list of dicts.
@@ -1041,8 +1215,9 @@ class Database:
         injection_stage is one of {A=pre-inj pre-norm, B=post-inj pre-norm, C=post-inj post-norm}.
         start_*/end_* pairs bound the corresponding integer column. only_finite (default True)
         drops rows where the stored value was non-finite at write time; only_slope_clamped, when
-        not None, filters by the slope_clamped flag. columns is validated against
-        _INJECTION_STATS_COLUMNS.
+        not None, filters by the slope_clamped flag. include_superseded (default False) controls
+        whether rows flagged stale by mark_superseded() are returned. columns is validated
+        against _INJECTION_STATS_COLUMNS.
         """
         with self._get_connection() as conn:
             cursor = conn.cursor()
@@ -1107,6 +1282,9 @@ class Database:
                 query += " AND slope_clamped = ?"
                 params.append(1 if only_slope_clamped else 0)
 
+            if not include_superseded:
+                query += " AND superseded = 0"
+
             if tag:
                 query = self._add_str_filter(query, params, "tag", tag)
 
@@ -1136,6 +1314,7 @@ class Database:
         tag: str | list[str] | None = None,
         start_time: float | None = None,
         end_time: float | None = None,
+        include_superseded: bool = False,
     ) -> list[dict[str, Any]]:
         """
         Per-round aggregation of injection_stats for sanitization and clamping rates.
@@ -1177,6 +1356,9 @@ class Database:
                 query += " AND timestamp <= ?"
                 params.append(end_time)
 
+            if not include_superseded:
+                query += " AND superseded = 0"
+
             query += " GROUP BY round_number ORDER BY round_number"
 
             cursor.execute(query, params)
@@ -1200,13 +1382,15 @@ class Database:
         start_time: float | None = None,
         end_time: float | None = None,
         columns: list[str] | None = None,
+        include_superseded: bool = False,
     ) -> list[dict[str, Any]]:
         """
         Query rows from training_stats as a list of dicts.
 
         model_name, stat_name, and tag accept either a single value (= filter) or a list
         (IN filter). start_*/end_* pairs bound the corresponding integer column (inclusive).
-        columns is validated against _TRAINING_STATS_COLUMNS.
+        include_superseded (default False) controls whether rows flagged stale by
+        mark_superseded() are returned. columns is validated against _TRAINING_STATS_COLUMNS.
         """
         with self._get_connection() as conn:
             cursor = conn.cursor()
@@ -1242,6 +1426,9 @@ class Database:
                 query += " AND epoch_number <= ?"
                 params.append(end_epoch_number)
 
+            if not include_superseded:
+                query += " AND superseded = 0"
+
             if tag:
                 query = self._add_str_filter(query, params, "tag", tag)
 
@@ -1276,6 +1463,7 @@ class Database:
         start_time: float | None = None,
         end_time: float | None = None,
         columns: list[str] | None = None,
+        include_superseded: bool = False,
     ) -> list[dict[str, Any]]:
         """
         Query rows from latent_snapshots as a list of dicts.
@@ -1283,7 +1471,8 @@ class Database:
         model_name, signal_type, and tag accept either a single value (= filter) or a list
         (IN filter). round_number/epoch_number/step_number are exact-match filters (no range
         variant). The returned latent_vector field is a JSON string — callers parse it with
-        json.loads. columns is validated against _LATENT_SNAPSHOTS_COLUMNS.
+        json.loads. include_superseded (default False) controls whether rows flagged stale by
+        mark_superseded() are returned. columns is validated against _LATENT_SNAPSHOTS_COLUMNS.
         """
         with self._get_connection() as conn:
             cursor = conn.cursor()
@@ -1326,6 +1515,9 @@ class Database:
                 query += " AND timestamp <= ?"
                 params.append(end_time)
 
+            if not include_superseded:
+                query += " AND superseded = 0"
+
             # NOTE: hard-coded ORDER BY? add template index to init_db
 
             cursor.execute(query, params)
@@ -1340,6 +1532,7 @@ class Database:
         tag: str | list[str] | None = None,
         start_time: float | None = None,
         end_time: float | None = None,
+        include_superseded: bool = False,
     ) -> list[dict[str, Any]]:
         """
         Distinct snapshot keys (model_name, round_number, epoch_number, step_number, snr_base,
@@ -1367,6 +1560,9 @@ class Database:
             if end_time is not None:
                 query += " AND timestamp <= ?"
                 params.append(end_time)
+
+            if not include_superseded:
+                query += " AND superseded = 0"
 
             # This ORDER BY doesn't make full use of idx_latent_snapshots_filter, since the ORDER BY
             # columns don't follow contiguously in the index
@@ -1408,6 +1604,7 @@ class Database:
         start_time: float | None = None,
         end_time: float | None = None,
         columns: list[str] | None = None,
+        include_superseded: bool = False,
     ) -> list[dict[str, Any]]:
         """
         Query rows from inference_results as a list of dicts.
@@ -1416,7 +1613,8 @@ class Database:
         value (= filter) or a list (IN filter). prediction is exact-match (0=RFI, 1=candidate).
         start_*/end_*/min_*/max_* pairs bound the corresponding numeric column (inclusive).
         timestamp_observed is the original observation time (distinct from the write-time
-        timestamp). columns is validated against _INFERENCE_RESULTS_COLUMNS.
+        timestamp). include_superseded (default False) controls whether rows flagged stale by
+        mark_superseded() are returned. columns is validated against _INFERENCE_RESULTS_COLUMNS.
         """
         with self._get_connection() as conn:
             cursor = conn.cursor()
@@ -1497,6 +1695,9 @@ class Database:
             if end_time is not None:
                 query += " AND timestamp <= ?"
                 params.append(end_time)
+
+            if not include_superseded:
+                query += " AND superseded = 0"
 
             # NOTE: hard-coded ORDER BY? add template index to init_db
 

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -30,7 +30,7 @@ from aetherscan.logger import init_logger
 from aetherscan.manager import get_manager, init_manager, register_logger
 from aetherscan.monitor import init_monitor
 from aetherscan.preprocessing import DataPreprocessor
-from aetherscan.train import get_latest_tag, run_training_pipeline
+from aetherscan.train import run_training_pipeline
 
 logger = logging.getLogger(__name__)
 
@@ -203,19 +203,16 @@ def train_command():
 
     max_retries = config.training.max_retries
     retry_delay = config.training.retry_delay
+    pipeline = None
 
     for attempt in range(max_retries):
-        pipeline = None
-
         try:
             logger.info(f"Training attempt: {attempt + 1}/{max_retries}")
 
-            if attempt > 0:
-                logger.info(f"Retrying training from round {config.checkpoint.start_round}")
-            else:
-                logger.info(f"Starting training from round {config.checkpoint.start_round}")
-
-            # Reinitialize training pipeline on each attempt so no corrupted state is persisted
+            # Reinitialize the training pipeline on each attempt so no corrupted state is
+            # persisted. The persisted run manifest (run_state_{save_tag}.json) tells the new
+            # pipeline which rounds/stages already completed, so the attempt resumes exactly
+            # where the previous one died (works identically for a full process relaunch)
             pipeline = run_training_pipeline(background_data=background_data, strategy=strategy)
 
             break  # If we get here, training succeeded
@@ -226,55 +223,18 @@ def train_command():
             logger.info("Training interrupted by user")
             raise
 
-        # NOTE: fault tolerance currently only accounts for beta-vae training failure. what about cases when train_random_forest fails and we wish to resume from there? should we add a check where if new round number is greater than specified rounds, skip directly to train RF? how would this look like? what about when save_models or plot_beta_vae_training_progress fails? should also add a db flag on training retry, such that we can easily filter out "corrupted" data when reading from db (e.g. for plotting). would need to return start_time so we can retain state on retries
         except Exception as e:
             logger.error(f"Training attempt {attempt + 1} failed with error: {e}")
 
             if attempt < max_retries - 1:
-                # Retry training
                 logger.info(
                     f"Attempting to recover from failure: attempt {attempt + 2}/{max_retries}"
                 )
+                logger.info(f"Waiting {retry_delay} seconds before retry...")
 
                 # Collect garbage
-                if pipeline:
-                    del pipeline
                 gc.collect()
-
-                # Save original checkpoint values in case of failure recovery
-                original_dir = config.checkpoint.load_dir
-                original_tag = config.checkpoint.load_tag
-                original_round = config.checkpoint.start_round
-
-                try:
-                    # Find the latest checkpoint & determine where to resume from
-                    config.checkpoint.load_dir = "checkpoints"
-                    config.checkpoint.load_tag = get_latest_tag(
-                        os.path.join(config.model_path, config.checkpoint.load_dir)
-                    )
-                    if config.checkpoint.load_tag.startswith("round_"):
-                        config.checkpoint.infer_start_round()
-                    else:
-                        raise ValueError("No valid checkpoints loaded")
-
-                    logger.info(
-                        f"Found latest checkpoint from round {config.checkpoint.start_round - 1}"
-                    )
-                    logger.info(f"Waiting {retry_delay} seconds before retry...")
-
-                except Exception as recovery_error:
-                    # If no checkpoints loaded, restart from last valid point
-                    config.checkpoint.load_dir = original_dir
-                    config.checkpoint.load_tag = original_tag
-                    config.checkpoint.start_round = original_round
-
-                    logger.error(f"Recovery failed: {recovery_error}")
-                    logger.info(
-                        f"Restarting training from round {config.checkpoint.start_round} in {retry_delay} seconds..."
-                    )
-
-                finally:
-                    time.sleep(retry_delay)
+                time.sleep(retry_delay)
 
             else:
                 # Max retries exceeded
@@ -282,13 +242,25 @@ def train_command():
                 logger.error(f"Final error: {e}")
                 sys.exit(1)
 
-    # Save training configuration
-    config_path = os.path.join(config.output_path, f"config_{config.checkpoint.save_tag}.json")
-    os.makedirs(os.path.dirname(config_path), exist_ok=True)  # Create dir if it doesn't exist
+    # Note, the training configuration JSON is saved by the pipeline's final_save stage
+    # (so it's covered by the retry machinery), not here
 
-    with open(config_path, "w") as f:
-        json.dump(config.to_dict(), f, indent=2)
-    logger.info(f"Training configuration saved to {config_path}")
+    # Plot stages are non-critical (a broken plot mustn't cost a retry cycle including data
+    # regeneration), but their failures are recorded in the run manifest — surface them
+    # loudly and exit nonzero so lost artifacts can't go unnoticed
+    failed_stages = pipeline.run_state.stages_failed if pipeline is not None else []
+    if failed_stages:
+        logger.error("=" * 60)
+        logger.error(
+            f"Training finished, but non-critical stage(s) permanently failed: "
+            f"{', '.join(failed_stages)}"
+        )
+        logger.error(
+            "Re-run the identical command to retry them — completed stages are skipped "
+            "via the run manifest"
+        )
+        logger.error("=" * 60)
+        sys.exit(1)
 
     logger.info("=" * 60)
     logger.info("Training completed successfully!")

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -154,6 +154,44 @@ def setup_gpu_strategy():
         return None
 
 
+def _report_final_training_status(pipeline) -> None:
+    """
+    Emit the terminal training status and exit nonzero on any permanently-failed stage.
+
+    Extracted from train_command so the exit contract is unit-testable: a fully-successful run
+    exits 0, a run with any recorded non-critical stage failure (vae_plots/rf_plots that never
+    recovered across attempts) exits 1, and a missing pipeline exits 1 rather than reporting a
+    false success.
+    """
+    if pipeline is None:
+        # Defensive: the retry loop always sets pipeline or sys.exit(1)s first, and
+        # --max-retries >= 1 is validated, so this is unreachable in practice — but never
+        # report success without a completed pipeline.
+        logger.error("Training produced no pipeline — treating as failure")
+        sys.exit(1)
+
+    # Plot stages are non-critical (a broken plot mustn't cost a retry cycle including data
+    # regeneration), but their failures are recorded in the run manifest — surface them
+    # loudly and exit nonzero so lost artifacts can't go unnoticed.
+    failed_stages = pipeline.run_state.stages_failed
+    if failed_stages:
+        logger.error("=" * 60)
+        logger.error(
+            f"Training finished, but non-critical stage(s) permanently failed: "
+            f"{', '.join(failed_stages)}"
+        )
+        logger.error(
+            "Re-run the identical command to retry them — completed stages are skipped "
+            "via the run manifest"
+        )
+        logger.error("=" * 60)
+        sys.exit(1)
+
+    logger.info("=" * 60)
+    logger.info("Training completed successfully!")
+    logger.info("=" * 60)
+
+
 def train_command():
     """Execute training pipeline with distributed strategy & fault tolerance"""
     logger.info("=" * 60)
@@ -244,27 +282,7 @@ def train_command():
 
     # Note, the training configuration JSON is saved by the pipeline's final_save stage
     # (so it's covered by the retry machinery), not here
-
-    # Plot stages are non-critical (a broken plot mustn't cost a retry cycle including data
-    # regeneration), but their failures are recorded in the run manifest — surface them
-    # loudly and exit nonzero so lost artifacts can't go unnoticed
-    failed_stages = pipeline.run_state.stages_failed if pipeline is not None else []
-    if failed_stages:
-        logger.error("=" * 60)
-        logger.error(
-            f"Training finished, but non-critical stage(s) permanently failed: "
-            f"{', '.join(failed_stages)}"
-        )
-        logger.error(
-            "Re-run the identical command to retry them — completed stages are skipped "
-            "via the run manifest"
-        )
-        logger.error("=" * 60)
-        sys.exit(1)
-
-    logger.info("=" * 60)
-    logger.info("Training completed successfully!")
-    logger.info("=" * 60)
+    _report_final_training_status(pipeline)
 
 
 # NOTE: we need to load the saved config from the corresponding training run, but when/where should we do that, and how does that play with apply_args_to_config()?

--- a/src/aetherscan/run_state.py
+++ b/src/aetherscan/run_state.py
@@ -69,8 +69,7 @@ class TrainingRunState:
             self.stages_failed.remove(stage)
 
     def record_stage_failure(self, stage: str) -> None:
-        """Record a non-critical stage failure (the stage stays out of stages_done, so the
-        next attempt/relaunch retries it)."""
+        """Record a non-critical stage failure; not in stages_done, so relaunches retry it."""
         if stage not in self.stages_failed:
             self.stages_failed.append(stage)
 
@@ -118,6 +117,11 @@ def load_run_state(path: str) -> TrainingRunState | None:
             stages_done=[str(s) for s in payload.get("stages_done", [])],
             stages_failed=[str(s) for s in payload.get("stages_failed", [])],
         )
+    except KeyError as e:
+        logger.warning(
+            f"Run state at {path} is missing required field {e} — treating as a fresh run"
+        )
+        return None
     except Exception as e:
         logger.warning(f"Failed to load run state from {path}: {e} — treating as a fresh run")
         return None

--- a/src/aetherscan/run_state.py
+++ b/src/aetherscan/run_state.py
@@ -20,6 +20,7 @@ or the new one.
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import json
 import logging
 import os
@@ -47,6 +48,47 @@ def run_state_path(output_path: str, tag: str) -> str:
     return os.path.join(output_path, f"run_state_{tag}.json")
 
 
+# Config sections excluded from a run's fingerprint: pure infra/runtime (db, manager, monitor,
+# logger), resume-control (checkpoint), environment paths, and the inference config — none of
+# which change the training result, so a change to any of them must NOT force a fresh run.
+_FINGERPRINT_EXCLUDE_SECTIONS = frozenset(
+    {"db", "manager", "monitor", "logger", "inference", "paths", "checkpoint"}
+)
+# Retry knobs live in the training section but only control the retry loop, not the result.
+_FINGERPRINT_EXCLUDE_TRAINING_KEYS = frozenset({"max_retries", "retry_delay"})
+
+
+def config_fingerprint(config_dict: dict) -> str:
+    """
+    Stable hash of the training-result-affecting config (from Config.to_dict()), used to detect
+    that a run's config changed under a reused --save-tag. Excludes infra/runtime, resume-control,
+    environment paths, the inference config, and the retry knobs (see the constants above) so a
+    change to any of those does not spuriously force a fresh run.
+    """
+    relevant = {
+        section: values
+        for section, values in config_dict.items()
+        if section not in _FINGERPRINT_EXCLUDE_SECTIONS
+    }
+    training = relevant.get("training")
+    if isinstance(training, dict):
+        relevant["training"] = {
+            k: v for k, v in training.items() if k not in _FINGERPRINT_EXCLUDE_TRAINING_KEYS
+        }
+    canonical = json.dumps(relevant, sort_keys=True, default=str)
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def config_changed(state: TrainingRunState | None, current_fingerprint: str) -> bool:
+    """
+    True when a persisted manifest exists but was written under a different config fingerprint —
+    i.e. the resolved training config changed under a reused save tag. The caller downgrades to a
+    fresh run so a stale model is never silently reused/reported as success (a manifest predating
+    fingerprinting carries an empty string, which mismatches any real fingerprint -> fresh run).
+    """
+    return state is not None and state.config_fingerprint != current_fingerprint
+
+
 @dataclass
 class TrainingRunState:
     """Persisted state of one training run (identified by its save tag) across attempts."""
@@ -54,6 +96,7 @@ class TrainingRunState:
     tag: str
     run_start_time: float  # Wall clock of attempt 1 — used by ALL DB queries/plots
     attempt: int = 1  # Incremented per retry (each TrainingPipeline rebuild)
+    config_fingerprint: str = ""  # Hash of the result-affecting config (config_fingerprint())
     completed_rounds: list[int] = field(default_factory=list)
     stages_done: list[str] = field(default_factory=list)
     stages_failed: list[str] = field(default_factory=list)
@@ -113,6 +156,7 @@ def load_run_state(path: str) -> TrainingRunState | None:
             tag=str(payload["tag"]),
             run_start_time=float(payload["run_start_time"]),
             attempt=int(payload.get("attempt", 1)),
+            config_fingerprint=str(payload.get("config_fingerprint", "")),
             completed_rounds=sorted(int(r) for r in payload.get("completed_rounds", [])),
             stages_done=[str(s) for s in payload.get("stages_done", [])],
             stages_failed=[str(s) for s in payload.get("stages_failed", [])],

--- a/src/aetherscan/run_state.py
+++ b/src/aetherscan/run_state.py
@@ -1,0 +1,123 @@
+"""
+Persisted training-run state for fault-tolerant resume.
+
+A TrainingRunState manifest lives at {output_path}/run_state_{save_tag}.json and carries
+everything a retry (in-process or a full relaunch of the identical command) needs to resume
+where the previous attempt died:
+
+- run_start_time: wall clock of attempt 1. TrainingPipeline.__init__ seeds self.start_time
+  from it, so every DB query/plot spans the whole run rather than just the current attempt.
+- completed_rounds: beta-VAE rounds whose checkpoint was saved; resume starts at max + 1.
+- stages_done / stages_failed: drive run_training_pipeline's stage machine — done stages are
+  skipped, failed non-critical stages (plots) are retried on the next run and force a nonzero
+  exit if they never succeed.
+
+Writes are atomic (tmp -> os.replace, mirroring round_data's .done manifest protocol) so a
+crash mid-write can never leave a truncated manifest — the file is either the previous state
+or the new one.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass, field
+
+logger = logging.getLogger(__name__)
+
+# Ordered stage names for run_training_pipeline's stage machine.
+STAGE_VAE_ROUNDS = "vae_rounds"
+STAGE_VAE_PLOTS = "vae_plots"
+STAGE_RF_TRAIN = "rf_train"
+STAGE_RF_PLOTS = "rf_plots"
+STAGE_FINAL_SAVE = "final_save"
+TRAINING_STAGES = (
+    STAGE_VAE_ROUNDS,
+    STAGE_VAE_PLOTS,
+    STAGE_RF_TRAIN,
+    STAGE_RF_PLOTS,
+    STAGE_FINAL_SAVE,
+)
+
+
+def run_state_path(output_path: str, tag: str) -> str:
+    """Manifest location for one training run: {output_path}/run_state_{save_tag}.json."""
+    return os.path.join(output_path, f"run_state_{tag}.json")
+
+
+@dataclass
+class TrainingRunState:
+    """Persisted state of one training run (identified by its save tag) across attempts."""
+
+    tag: str
+    run_start_time: float  # Wall clock of attempt 1 — used by ALL DB queries/plots
+    attempt: int = 1  # Incremented per retry (each TrainingPipeline rebuild)
+    completed_rounds: list[int] = field(default_factory=list)
+    stages_done: list[str] = field(default_factory=list)
+    stages_failed: list[str] = field(default_factory=list)
+
+    def is_stage_done(self, stage: str) -> bool:
+        return stage in self.stages_done
+
+    def mark_stage_done(self, stage: str) -> None:
+        """Record a stage success; a previously recorded failure of the same stage is cleared."""
+        if stage not in self.stages_done:
+            self.stages_done.append(stage)
+        if stage in self.stages_failed:
+            self.stages_failed.remove(stage)
+
+    def record_stage_failure(self, stage: str) -> None:
+        """Record a non-critical stage failure (the stage stays out of stages_done, so the
+        next attempt/relaunch retries it)."""
+        if stage not in self.stages_failed:
+            self.stages_failed.append(stage)
+
+    def mark_round_completed(self, round_number: int) -> None:
+        if round_number not in self.completed_rounds:
+            self.completed_rounds.append(round_number)
+            self.completed_rounds.sort()
+
+    @property
+    def resume_round(self) -> int:
+        """1-based round the beta-VAE loop should (re)start from."""
+        return max(self.completed_rounds) + 1 if self.completed_rounds else 1
+
+
+def save_run_state(state: TrainingRunState, path: str) -> None:
+    """Persist the manifest atomically (tmp -> os.replace): a crash mid-write leaves either
+    the previous manifest or the new one, never a truncated file."""
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    tmp_path = path + ".tmp"
+    try:
+        with open(tmp_path, "w") as f:
+            json.dump(asdict(state), f, indent=2)
+        os.replace(tmp_path, path)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.remove(tmp_path)
+        raise
+
+
+def load_run_state(path: str) -> TrainingRunState | None:
+    """Load a persisted manifest; returns None when the file is missing or unreadable
+    (a corrupt manifest downgrades to a fresh run rather than blocking training)."""
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path) as f:
+            payload = json.load(f)
+        return TrainingRunState(
+            tag=str(payload["tag"]),
+            run_start_time=float(payload["run_start_time"]),
+            attempt=int(payload.get("attempt", 1)),
+            completed_rounds=sorted(int(r) for r in payload.get("completed_rounds", [])),
+            stages_done=[str(s) for s in payload.get("stages_done", [])],
+            stages_failed=[str(s) for s in payload.get("stages_failed", [])],
+        )
+    except Exception as e:
+        logger.warning(f"Failed to load run state from {path}: {e} — treating as a fresh run")
+        return None

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -60,6 +60,17 @@ from aetherscan.round_data import (
     prepare_round_data_dir,
     validate_done_manifest,
 )
+from aetherscan.run_state import (
+    STAGE_FINAL_SAVE,
+    STAGE_RF_PLOTS,
+    STAGE_RF_TRAIN,
+    STAGE_VAE_PLOTS,
+    STAGE_VAE_ROUNDS,
+    TrainingRunState,
+    load_run_state,
+    run_state_path,
+    save_run_state,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -790,6 +801,12 @@ class TrainingPipeline:
         if self.db is None:
             raise ValueError("get_db() returned None")
 
+        # Load (or create) the persisted run manifest for this tag. This resolves
+        # self.start_time (wall clock of attempt 1 — used by every DB query/plot, so retries
+        # see the whole run), self._start_round (where the beta-VAE loop resumes), and marks
+        # stale DB rows from a previously failed attempt as superseded.
+        self._init_run_state()
+
         # Initialize data generator
         self.data_generator = DataGenerator(background_data)
 
@@ -801,8 +818,10 @@ class TrainingPipeline:
             self.vae = create_beta_vae_model()
             self._build_optimizer()
 
-        # NOTE: this approach doesn't play well with fault tolerance. rethink later
-        # Latent viz data (prepared once on first round, persisted across rounds)
+        # Latent viz data (prepared once on first round, persisted across rounds within an
+        # attempt; a resumed attempt rebuilds it from the resumed round's val split — the data
+        # distribution matches by construction, and latent-GIF frames captured before the
+        # failure stay valid in the DB)
         self._latent_viz_batch = None
         self._latent_viz_labels = None
         self._latent_viz_dataset = None
@@ -828,12 +847,17 @@ class TrainingPipeline:
         self._rf_shap_cache: dict[str, dict] = {}
 
         try:
-            # Load models from checkpoints if provided
+            # Load models from checkpoints: explicit user flags win; otherwise a
+            # manifest-driven resume reloads the last completed round's checkpoint
             if self.config.checkpoint.load_tag or self.config.checkpoint.load_dir:
                 logger.info("Resuming from checkpoint")
                 self.load_models(
                     tag=self.config.checkpoint.load_tag, dir=self.config.checkpoint.load_dir
                 )
+            elif self._start_round > 1:
+                resume_tag = f"round_{self._start_round - 1:02d}"
+                logger.info(f"Resuming from checkpoint {resume_tag} (per run manifest)")
+                self.load_models(tag=resume_tag, dir="checkpoints")
 
         except Exception as e:
             logger.error(f"Error loading models from checkpoint: {e}")
@@ -843,7 +867,6 @@ class TrainingPipeline:
             self.config.checkpoint.start_round = 1
             raise  # Re-raise to propagate error
 
-        # NOTE: similar to _setup_directories() & archive_directory(), perhaps we need a flag that gets toggled when fault tolerance is triggered, s.t. future reads from the db know to ignore the flagged rows as "archived" from a previous failed training run?
         finally:
             # Regardless whether checkpoints were loaded or not, we finish the directory setup
             # since fault tolerance expects a clean directory structure
@@ -860,6 +883,108 @@ class TrainingPipeline:
     #         self.train_writer.close()
     #     if hasattr(self, "val_writer"):
     #         self.val_writer.close()
+
+    def _init_run_state(self):
+        """
+        Load or create the persisted run manifest (run_state_{save_tag}.json) and derive all
+        resume state from it:
+
+        - self.start_time: the manifest's run_start_time (wall clock of attempt 1). Setting it
+          here — unconditionally, before any training/plotting can run — fixes the old bug
+          where train_beta_vae()'s already-trained early return skipped the assignment and
+          every subsequent plot raised AttributeError, masking the real failure.
+        - self._start_round: 1-based round the beta-VAE loop starts from. Explicit user
+          checkpoint flags (--load-tag/--load-dir [+ --start-round]) win as an escape hatch;
+          otherwise the manifest's completed_rounds drive resume; a fresh run falls back to
+          config.checkpoint.start_round (default 1).
+        - Supersede marking: on resume of round k, rows for (tag, round >= k) in
+          training_stats / injection_stats / latent_snapshots are stale output of the failed
+          attempt and get flagged before the rerun re-writes them — otherwise duplicated
+          epochs corrupt the loss-curve plots (which sort by (round, epoch)).
+        """
+        tag = self.config.checkpoint.save_tag
+        self._run_state_path = run_state_path(self.config.output_path, tag)
+
+        state = load_run_state(self._run_state_path)
+        self._resumed = state is not None
+
+        if state is None:
+            state = TrainingRunState(tag=tag, run_start_time=time.time())
+            logger.info(f"Starting a fresh training run manifest at {self._run_state_path}")
+        else:
+            state.attempt += 1
+            logger.info(
+                f"Resuming training run from manifest {self._run_state_path} "
+                f"(attempt {state.attempt}, completed rounds: {state.completed_rounds}, "
+                f"stages done: {state.stages_done}, stages failed: {state.stages_failed})"
+            )
+
+        explicit_checkpoint = (
+            self.config.checkpoint.load_tag is not None
+            or self.config.checkpoint.load_dir is not None
+        )
+        if explicit_checkpoint:
+            self._start_round = self.config.checkpoint.start_round
+            if self._resumed:
+                # User override re-runs rounds >= start_round: drop manifest records the
+                # override invalidates (stages_done is cleared wholesale — downstream stages
+                # depend on the re-run rounds and will simply re-execute)
+                logger.info(
+                    f"Explicit checkpoint flags override the manifest: restarting from round "
+                    f"{self._start_round} and re-running all pipeline stages"
+                )
+                state.completed_rounds = [
+                    r for r in state.completed_rounds if r < self._start_round
+                ]
+                state.stages_done = []
+        elif state.completed_rounds:
+            self._start_round = state.resume_round
+        else:
+            self._start_round = self.config.checkpoint.start_round
+
+        self.start_time = state.run_start_time
+        self.run_state = state
+
+        # Flag the failed attempt's partial rows before this attempt re-writes them.
+        # Rows from completed rounds (< _start_round) stay live — they're valid history
+        # (including latent-GIF snapshot frames). No-op on a fresh run (nothing to mark)
+        # and when resuming into post-VAE stages (_start_round > num_training_rounds)
+        if self._resumed:
+            for table in ("training_stats", "injection_stats", "latent_snapshots"):
+                if not self.db.mark_superseded(table, tag, round_ge=self._start_round):
+                    # Non-fatal (matches flush() semantics), but must be loud: unmarked
+                    # stale rows would re-corrupt the loss-curve plots on this attempt
+                    logger.warning(
+                        f"Could not mark stale {table} rows superseded "
+                        f"(tag={tag}, round_ge={self._start_round}); "
+                        f"plots may include rows from the failed attempt"
+                    )
+
+        self._persist_run_state()
+
+    def _persist_run_state(self):
+        """Persist the run manifest (atomic tmp -> replace)."""
+        save_run_state(self.run_state, self._run_state_path)
+
+    def _mark_stage_done(self, stage: str):
+        """Record a pipeline stage success in the manifest and persist it."""
+        self.run_state.mark_stage_done(stage)
+        self._persist_run_state()
+        logger.info(f"Stage '{stage}' complete (recorded in run manifest)")
+
+    def _record_stage_failure(self, stage: str):
+        """Record a non-critical stage failure in the manifest and persist it. The stage
+        stays out of stages_done, so a relaunch retries it; main.py exits nonzero at the very
+        end if any recorded failure never recovers."""
+        self.run_state.record_stage_failure(stage)
+        self._persist_run_state()
+        logger.error(f"Stage '{stage}' failed (recorded in run manifest)")
+
+    def _mark_round_completed(self, round_number: int):
+        """Record a fully-trained round (checkpoint saved) in the manifest and persist it."""
+        self.run_state.mark_round_completed(round_number)
+        self._persist_run_state()
+        logger.info(f"Round {round_number} recorded as completed in run manifest")
 
     def _build_optimizer(self):
         """
@@ -897,7 +1022,7 @@ class TrainingPipeline:
         """Create necessary directories"""
         logger.info("Setting up directories")
 
-        start_round = self.config.checkpoint.start_round
+        start_round = self._start_round
 
         model_checkpoints_dir = os.path.join(self.config.model_path, "checkpoints")
         archive_directory(model_checkpoints_dir, target_dirs=None, round_num=start_round)
@@ -950,23 +1075,18 @@ class TrainingPipeline:
         """
         n_rounds = self.config.training.num_training_rounds
         epochs = self.config.training.epochs_per_round
-        start_round = self.config.checkpoint.start_round
+        start_round = self._start_round
 
         if start_round > n_rounds:
-            # BUG: returning here skips the `self.start_time = time.time()` assignment below,
-            # so a resume/retry that finds the beta-VAE already trained (start_round > n_rounds)
-            # leaves self.start_time unset. Later plotting reads self.start_time and raises
-            # `'TrainingPipeline' object has no attribute 'start_time'`, which then masks the
-            # original error across retries. Fix by setting start_time in __init__ (or before
-            # this guard) so it always exists regardless of the resume point.
-            return  # Return early if beta-VAE already trained (can occur from fault tolerance)
+            # Every round already has a saved checkpoint (per the run manifest) — nothing to
+            # train. Safe to return early: self.start_time is set in __init__ from the
+            # manifest's run_start_time, so downstream plots still span the whole run.
+            logger.info(f"All {n_rounds} rounds already trained — skipping beta-VAE training")
+            return
         elif start_round > 1:
             logger.info(f"Resuming training from round {start_round}/{n_rounds}")
         else:
             logger.info(f"Starting training for {n_rounds} rounds")
-
-        # NOTE: this approach doesn't play well with fault tolerance. rethink later
-        self.start_time = time.time()
 
         # Stand up the background round-data producer (a dedicated process owning its own
         # worker pool against the shared-memory background plates), so round k+1's data
@@ -1039,8 +1159,8 @@ class TrainingPipeline:
                 self._round_producer.shutdown()
                 self._round_producer = None
 
-            # NOTE: this approach doesn't play well with fault tolerance. rethink later
-            # Free the latent viz batch once all rounds are complete (or on failure)
+            # Free the latent viz batch once all rounds are complete (or on failure); a
+            # resumed attempt rebuilds it from the resumed round's val split
             del self._latent_viz_batch, self._latent_viz_labels
             self._latent_viz_batch = None
             self._latent_viz_labels = None
@@ -1347,6 +1467,10 @@ class TrainingPipeline:
 
             # Save checkpoint
             self.save_models(tag=f"round_{round_idx + 1:02d}", dir="checkpoints")
+
+            # Checkpoint is on disk — record the round in the run manifest so a retry (or a
+            # relaunch of the identical command) resumes at the next round
+            self._mark_round_completed(round_number)
 
             round_trained = True
 
@@ -1909,6 +2033,17 @@ class TrainingPipeline:
         """Train Random Forest"""
         logger.info("Training Random Forest classifier...")
 
+        # Resume path: a previous attempt of this run already trained and persisted the RF
+        # for this tag — load it back instead of regenerating ~num_samples_rf cadences and
+        # retraining. Gated on self._resumed so a fresh run that happens to reuse an old tag
+        # never silently skips training on stale artifacts
+        if self._resumed and self.try_load_rf_for_resume():
+            logger.info(
+                "Loaded existing Random Forest model + eval artifacts for this tag — "
+                "skipping RF data generation and retraining"
+            )
+            return
+
         # Initialize RF model
         if self.rf_model is None:
             self.rf_model = RandomForestModel()
@@ -2127,6 +2262,13 @@ class TrainingPipeline:
             joblib.dump(artifacts, artifact_path)
             logger.info(f"Saved RF eval artifacts to {artifact_path}")
 
+            # Persist the trained RF immediately (final_save re-saves it later): a retry that
+            # resumes into rf_plots/final_save can then reload the model without regenerating
+            # data — see try_load_rf_for_resume()
+            rf_model_path = os.path.join(self.config.model_path, f"random_forest_{tag}.joblib")
+            self.rf_model.save(rf_model_path)
+            logger.info(f"Saved Random Forest to {rf_model_path}")
+
             rf_trained = True
 
             # NOTE: come back to this later (are we dereferencing the correct things? can we instead write things to db instead of storing in memory?)
@@ -2177,6 +2319,30 @@ class TrainingPipeline:
             if val_latents is not None:
                 del val_latents
             gc.collect()
+
+    def try_load_rf_for_resume(self) -> bool:
+        """
+        Attempt to restore the trained Random Forest persisted by a previous attempt of this
+        run: both random_forest_{tag}.joblib and rf_eval_artifacts_{tag}.joblib must exist
+        under model_path (the artifacts joblib is what every RF plot consumes, so resuming
+        into rf_plots without it would be pointless). Returns True when the model is loaded
+        and ready; False falls back to full RF training.
+        """
+        tag = self.config.checkpoint.save_tag
+        rf_model_path = os.path.join(self.config.model_path, f"random_forest_{tag}.joblib")
+        artifact_path = os.path.join(self.config.model_path, f"rf_eval_artifacts_{tag}.joblib")
+
+        if not (os.path.exists(rf_model_path) and os.path.exists(artifact_path)):
+            return False
+
+        try:
+            if self.rf_model is None:
+                self.rf_model = RandomForestModel()
+            self.rf_model.load(rf_model_path)
+            return True
+        except Exception as e:
+            logger.warning(f"Failed to load persisted Random Forest from {rf_model_path}: {e}")
+            return False
 
     def _load_rf_eval_artifacts(self, tag: str | None = None) -> dict:
         """
@@ -5853,14 +6019,165 @@ class TrainingPipeline:
             logger.error(f"Failed to load models: {e}")
             raise  # Re-raise to propagate error
 
+    def _run_plot_group(self, plot_calls: list[tuple[Callable, str]]) -> None:
+        """
+        Run a group of plot methods, attempting every one even when some fail (a single
+        broken plot mustn't block the others), then raise a summary error listing the
+        failures so the stage machine can record the group as failed.
+        """
+        failures = []
+        for func, name in plot_calls:
+            try:
+                func()
+            except Exception as e:
+                logger.error(f"Failed to execute {name}: {e}")
+                failures.append(name)
+        if failures:
+            raise RuntimeError(f"{len(failures)} plot(s) failed: {', '.join(failures)}")
+
+    # NOTE: combine plot_beta_vae_loss_curves(), plot_beta_vae_training_stability(), and plot_latent_space_gif() into plot_training_progress()?
+    def plot_vae_diagnostics(self) -> None:
+        """The vae_plots stage: final loss curves, training stability, injection stats, and
+        the latent-space GIF. Attempts every plot even if one fails, then raises listing the
+        failures — the stage machine records them without costing a data regeneration."""
+        self._run_plot_group(
+            [
+                (self.plot_beta_vae_loss_curves, "plot_beta_vae_loss_curves"),
+                (self.plot_beta_vae_training_stability, "plot_beta_vae_training_stability"),
+                (self.plot_injection_stats, "plot_injection_stats"),
+                (self.plot_latent_space_gif, "plot_latent_space_gif"),
+            ]
+        )
+
+    def plot_rf_diagnostics(self) -> None:
+        """
+        The rf_plots stage: the ten Random Forest visualizations. All plots consume the
+        eval-artifact joblib persisted by train_random_forest() (the five SHAP plots
+        additionally share a SHAP-values joblib); every plot is attempted even when one
+        fails (e.g. an optional dep like SHAP missing), then a summary error is raised for
+        the stage machine to record. plot_rf_latent_decision_boundary relies on the
+        cadence-level UMAP joblibs written by plot_latent_space_gif (vae_plots stage), so
+        stage ordering matters.
+        """
+        self._run_plot_group(
+            [
+                (self.plot_rf_confusion_matrices, "plot_rf_confusion_matrices"),
+                (self.plot_rf_classification_curves, "plot_rf_classification_curves"),
+                (self.plot_rf_shap_summary, "plot_rf_shap_summary"),
+                (self.plot_rf_shap_dependence, "plot_rf_shap_dependence"),
+                (self.plot_rf_shap_interactions, "plot_rf_shap_interactions"),
+                (self.plot_rf_shap_loss_monitoring, "plot_rf_shap_loss_monitoring"),
+                (
+                    self.plot_rf_shap_explanation_clustering,
+                    "plot_rf_shap_explanation_clustering",
+                ),
+                (self.plot_rf_calibration_curve, "plot_rf_calibration_curve"),
+                (self.plot_rf_ensemble_accuracy_curve, "plot_rf_ensemble_accuracy_curve"),
+                (
+                    self.plot_rf_latent_decision_boundary,
+                    "plot_rf_latent_decision_boundary",
+                ),
+            ]
+        )
+
+    def final_save(self) -> None:
+        """The final_save stage: persist the final models plus the resolved config JSON.
+        The config dump used to live in main.py's train_command after the retry loop; doing
+        it here puts it under the stage machine's retry coverage."""
+        self.save_models()
+
+        config_path = os.path.join(
+            self.config.output_path, f"config_{self.config.checkpoint.save_tag}.json"
+        )
+        os.makedirs(os.path.dirname(config_path), exist_ok=True)
+        with open(config_path, "w") as f:
+            json.dump(self.config.to_dict(), f, indent=2)
+        logger.info(f"Training configuration saved to {config_path}")
+
+
+def _execute_training_stages(pipeline) -> None:
+    """
+    The training stage machine: an explicit ordered stage list with skip-if-done and
+    persist-on-success semantics driven by the pipeline's run manifest.
+
+    Critical stages (vae_rounds, rf_train, final_save) raise on failure — the retry loop in
+    main.py rebuilds the pipeline and the manifest resumes it here. Non-critical stages
+    (vae_plots, rf_plots) are recorded in stages_failed and execution continues: a broken
+    plot mustn't cost a retry cycle including data regeneration, but main.py exits nonzero
+    at the very end if any recorded failure never recovers, so lost artifacts stay loud.
+
+    `pipeline` is duck-typed (a TrainingPipeline in production) so unit tests can drive the
+    stage logic with a lightweight stub.
+    """
+    state = pipeline.run_state
+
+    # Stage 1/5: vae_rounds — the beta-VAE round loop (per-round sub-resume happens inside
+    # train_beta_vae via the manifest's completed_rounds)
+    if state.is_stage_done(STAGE_VAE_ROUNDS):
+        logger.info(f"Stage '{STAGE_VAE_ROUNDS}' already complete — skipping")
+    else:
+        pipeline.train_beta_vae()
+        pipeline._mark_stage_done(STAGE_VAE_ROUNDS)
+
+    # Stage 2/5: vae_plots (non-critical)
+    if state.is_stage_done(STAGE_VAE_PLOTS):
+        logger.info(f"Stage '{STAGE_VAE_PLOTS}' already complete — skipping")
+    else:
+        try:
+            pipeline.plot_vae_diagnostics()
+            pipeline._mark_stage_done(STAGE_VAE_PLOTS)
+        except Exception as e:
+            logger.error(f"Stage '{STAGE_VAE_PLOTS}' failed: {e}")
+            pipeline._record_stage_failure(STAGE_VAE_PLOTS)
+
+    # Stage 3/5: rf_train. On skip, the persisted RF from the attempt that completed the
+    # stage is loaded back (rf_plots and final_save need a live model); if that reload
+    # fails (e.g. the joblib was deleted), fall through to a full retrain
+    if state.is_stage_done(STAGE_RF_TRAIN) and pipeline.try_load_rf_for_resume():
+        logger.info(f"Stage '{STAGE_RF_TRAIN}' already complete — loaded persisted RF model")
+    else:
+        try:
+            pipeline.train_random_forest()
+        except Exception as e:
+            logger.error(f"Error in train_random_forest(): {e}")
+            # Attempt to save models on RF training failure
+            pipeline.rf_model = None  # Avoid saving incomplete RF model state
+            _safe_call(pipeline.save_models, "save_models")
+            raise  # Re-raise to propagate error
+        pipeline._mark_stage_done(STAGE_RF_TRAIN)
+
+    # Stage 4/5: rf_plots (non-critical)
+    if state.is_stage_done(STAGE_RF_PLOTS):
+        logger.info(f"Stage '{STAGE_RF_PLOTS}' already complete — skipping")
+    else:
+        try:
+            pipeline.plot_rf_diagnostics()
+            pipeline._mark_stage_done(STAGE_RF_PLOTS)
+        except Exception as e:
+            logger.error(f"Stage '{STAGE_RF_PLOTS}' failed: {e}")
+            pipeline._record_stage_failure(STAGE_RF_PLOTS)
+        finally:
+            # RF plots are done (or abandoned) — drop the shared eval-artifact / SHAP
+            # caches so the (large) features arrays they hold don't hang around through
+            # final_save and teardown
+            pipeline._clear_rf_caches()
+
+    # Stage 5/5: final_save — final models + config JSON
+    if state.is_stage_done(STAGE_FINAL_SAVE):
+        logger.info(f"Stage '{STAGE_FINAL_SAVE}' already complete — skipping")
+    else:
+        pipeline.final_save()
+        pipeline._mark_stage_done(STAGE_FINAL_SAVE)
+
 
 def run_training_pipeline(
     background_data: np.ndarray, strategy: tf.distribute.Strategy = None
 ) -> TrainingPipeline:
     """
     End-to-end training entry point: construct a TrainingPipeline from preprocessed background
-    data (shape (n, 6, 16, 512)) and an optional tf.distribute strategy, then run all rounds
-    and final RF training.
+    data (shape (n, 6, 16, 512)) and an optional tf.distribute strategy, then run the ordered
+    training stages (vae_rounds -> vae_plots -> rf_train -> rf_plots -> final_save), skipping
+    any the persisted run manifest already records as done.
     """
     try:
         # Create pipeline (no cleanup needed on failure)
@@ -5870,75 +6187,13 @@ def run_training_pipeline(
         raise  # Re-raise to propagate error
 
     try:
-        try:
-            # Train beta-VAE
-            pipeline.train_beta_vae()
-        except Exception as e:
-            logger.error(f"Error in train_beta_vae(): {e}")
-            raise  # Re-raise to propagate error
+        _execute_training_stages(pipeline)
 
-        try:
-            # NOTE: combine plot_beta_vae_loss_curves(), plot_beta_vae_training_stability(), and plot_latent_space_gif() into plot_training_progress()?
-            # Plot loss curves
-            pipeline.plot_beta_vae_loss_curves()
-
-            # Plot clipping rate
-            pipeline.plot_beta_vae_training_stability()
-
-            # Plot injection stats
-            pipeline.plot_injection_stats()
-
-            # Plot latent space GIF
-            pipeline.plot_latent_space_gif()
-        except Exception as e:
-            logger.error(f"Error in plotting: {e}")
-            raise  # Re-raise to propagate error
-
-        try:
-            # Train Random Forest
-            pipeline.train_random_forest()
-        except Exception as e:
-            logger.error(f"Error in train_random_forest(): {e}")
-            # Attempt to save models on RF training failure
-            pipeline.rf_model = None  # Avoid saving incomplete RF model state
-            _safe_call(pipeline.save_models, "save_models")
-            raise  # Re-raise to propagate error
-
-        # NOTE: come back to this later
-        # Random Forest visualizations. All plots consume the eval-artifact joblib
-        # persisted by train_random_forest(); each is wrapped in _safe_call so one
-        # failure (e.g. an optional dep like SHAP missing) doesn't kill the others.
-        # plot_rf_latent_decision_boundary relies on the cadence-level UMAP joblibs
-        # written by plot_latent_space_gif above, so ordering matters.
-        _safe_call(pipeline.plot_rf_confusion_matrices, "plot_rf_confusion_matrices")
-        _safe_call(pipeline.plot_rf_classification_curves, "plot_rf_classification_curves")
-        _safe_call(pipeline.plot_rf_shap_summary, "plot_rf_shap_summary")
-        _safe_call(pipeline.plot_rf_shap_dependence, "plot_rf_shap_dependence")
-        _safe_call(pipeline.plot_rf_shap_interactions, "plot_rf_shap_interactions")
-        _safe_call(pipeline.plot_rf_shap_loss_monitoring, "plot_rf_shap_loss_monitoring")
-        _safe_call(
-            pipeline.plot_rf_shap_explanation_clustering,
-            "plot_rf_shap_explanation_clustering",
-        )
-        _safe_call(pipeline.plot_rf_calibration_curve, "plot_rf_calibration_curve")
-        _safe_call(pipeline.plot_rf_ensemble_accuracy_curve, "plot_rf_ensemble_accuracy_curve")
-        _safe_call(
-            pipeline.plot_rf_latent_decision_boundary,
-            "plot_rf_latent_decision_boundary",
-        )
-
-        # All RF plots are done — drop the shared eval-artifact / SHAP caches
-        # so the (large) features arrays they hold don't hang around through
-        # save_models() and final teardown.
-        pipeline._clear_rf_caches()
-
-        try:
-            # Save final models
-            pipeline.save_models()
-        except Exception as e:
-            logger.error(f"Error in save_models(): {e}")
-            raise  # Re-raise to propagate error
-
+        if pipeline.run_state.stages_failed:
+            logger.warning(
+                f"Training pipeline finished, but non-critical stage(s) failed: "
+                f"{', '.join(pipeline.run_state.stages_failed)}"
+            )
         logger.info("Training complete!")
 
         return pipeline
@@ -5952,10 +6207,10 @@ def _safe_call(func: Callable, name: str, args: tuple | None = None) -> None:
     """
     Invoke a callable, log-and-swallow any exception.
 
-    Used as the primary dispatch for the RF diagnostic plot methods so a single
-    failure (e.g. an optional dependency like SHAP missing, an interaction-value
-    fallback) cannot take down the rest of the pipeline. Also used opportunistically
-    during error cleanup where a best-effort call is still worth attempting.
+    Used during error cleanup where a best-effort call is still worth attempting (e.g.
+    saving the VAE weights after an RF-training failure). Plot dispatch uses
+    TrainingPipeline._run_plot_group instead, which also attempts every call but reports
+    the failures so the stage machine can record them.
     """
     try:
         func(*args) if args else func()

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -2325,7 +2325,8 @@ class TrainingPipeline:
         Attempt to restore the trained Random Forest persisted by a previous attempt of this
         run: both random_forest_{tag}.joblib and rf_eval_artifacts_{tag}.joblib must exist
         under model_path (the artifacts joblib is what every RF plot consumes, so resuming
-        into rf_plots without it would be pointless). Returns True when the model is loaded
+        into rf_plots without it would be pointless — but it is loaded lazily by
+        _load_rf_eval_artifacts(), not here). Returns True when the model is loaded
         and ready; False falls back to full RF training.
         """
         tag = self.config.checkpoint.save_tag
@@ -6159,7 +6160,9 @@ def _execute_training_stages(pipeline) -> None:
         finally:
             # RF plots are done (or abandoned) — drop the shared eval-artifact / SHAP
             # caches so the (large) features arrays they hold don't hang around through
-            # final_save and teardown
+            # final_save and teardown. Clearing only in this branch is deliberate: the
+            # caches are populated exclusively by the plot calls above, so the
+            # skip-if-done path never has anything to clear
             pipeline._clear_rf_caches()
 
     # Stage 5/5: final_save — final models + config JSON

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -67,6 +67,8 @@ from aetherscan.run_state import (
     STAGE_VAE_PLOTS,
     STAGE_VAE_ROUNDS,
     TrainingRunState,
+    config_changed,
+    config_fingerprint,
     load_run_state,
     run_state_path,
     save_run_state,
@@ -906,10 +908,29 @@ class TrainingPipeline:
         self._run_state_path = run_state_path(self.config.output_path, tag)
 
         state = load_run_state(self._run_state_path)
+
+        # Config-drift guard: if the manifest was written under a different result-affecting
+        # config (reused --save-tag with changed hyperparameters, or a manifest that predates
+        # fingerprinting), do NOT silently resume/skip and ship the stale model — warn loudly
+        # and downgrade to a fresh run (the previous attempt's outputs get overwritten).
+        current_fingerprint = config_fingerprint(self.config.to_dict())
+        if config_changed(state, current_fingerprint):
+            logger.warning("=" * 60)
+            logger.warning(
+                f"Run manifest at {self._run_state_path} was written under a DIFFERENT "
+                f"training config (fingerprint mismatch) — starting a FRESH run and "
+                f"overwriting the previous attempt's outputs for tag '{tag}'. Use a new "
+                f"--save-tag to keep both, or restore the original config to resume."
+            )
+            logger.warning("=" * 60)
+            state = None
+
         self._resumed = state is not None
 
         if state is None:
-            state = TrainingRunState(tag=tag, run_start_time=time.time())
+            state = TrainingRunState(
+                tag=tag, run_start_time=time.time(), config_fingerprint=current_fingerprint
+            )
             logger.info(f"Starting a fresh training run manifest at {self._run_state_path}")
         else:
             state.attempt += 1
@@ -2033,10 +2054,12 @@ class TrainingPipeline:
         """Train Random Forest"""
         logger.info("Training Random Forest classifier...")
 
-        # Resume path: a previous attempt of this run already trained and persisted the RF
-        # for this tag — load it back instead of regenerating ~num_samples_rf cadences and
-        # retraining. Gated on self._resumed so a fresh run that happens to reuse an old tag
-        # never silently skips training on stale artifacts
+        # Resume path: a previous attempt of THIS run (same tag AND matching config
+        # fingerprint) already trained and persisted the RF — load it back instead of
+        # regenerating ~num_samples_rf cadences and retraining. self._resumed is False for a
+        # fresh run, and for a reused tag whose config changed (the fingerprint guard in
+        # _init_run_state downgraded it to a fresh run), so stale artifacts are never
+        # silently reused.
         if self._resumed and self.try_load_rf_for_resume():
             logger.info(
                 "Loaded existing Random Forest model + eval artifacts for this tag — "

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -461,3 +461,22 @@ class TestRoundDataFlags:
         missing = tmp_path / "a" / "b" / "c"
         assert cli._nearest_existing_ancestor(str(missing)) == str(tmp_path)
         assert cli._nearest_existing_ancestor(str(tmp_path)) == str(tmp_path)
+
+
+class TestMaxRetriesValidation:
+    """--max-retries must be >= 1: 0 would run zero attempts and exit 0 having trained nothing."""
+
+    def test_zero_rejected(self):
+        errors = collect_validation_errors(_parse(["train", "--max-retries", "0"]), None)
+        assert any(
+            e.field == "training.max_retries" and e.fix_kind == "clamp_low" and e.min_val == 1
+            for e in errors
+        )
+
+    def test_negative_rejected(self):
+        errors = collect_validation_errors(_parse(["train", "--max-retries", "-2"]), None)
+        assert any(e.field == "training.max_retries" for e in errors)
+
+    def test_one_accepted(self):
+        errors = collect_validation_errors(_parse(["train", "--max-retries", "1"]), None)
+        assert not any(e.field == "training.max_retries" for e in errors)

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -7,13 +7,15 @@ against a tmp-path SQLite file."""
 from __future__ import annotations
 
 import json
+import os
+import sqlite3
 import time
 
 import numpy as np
 import pytest
 
 from aetherscan.config import get_config
-from aetherscan.db.db import Database
+from aetherscan.db.db import _SCHEMA_VERSION, Database
 
 
 @pytest.fixture
@@ -227,3 +229,256 @@ class TestQueryFiltersAndWhitelists:
         assert [r["confidence"] for r in rows] == [0.99]
         rows = self.db.query_inference_result(tag="test_v9", prediction=0)
         assert [r["confidence"] for r in rows] == [0.42]
+
+
+class TestMarkSuperseded:
+    def _write_rounds(self, db, tag, rounds=(1, 2, 3)):
+        for round_number in rounds:
+            db.write_training_stat("beta_vae", "total_loss", 1.0, round_number, 1, tag=tag)
+            db.write_injection_stat("eti_snr", 12.5, round_number=round_number, tag=tag)
+            db.write_latent_snapshot(
+                "beta_vae", round_number, 1, 10, 0, "true_only_eti", [[0.1] * 4] * 6, tag=tag
+            )
+
+    def test_round_ge_marking_and_default_filtering(self, db):
+        """Marking (tag, round >= k) must hide those rows from every default query while
+        include_superseded=True still returns them — the resume-of-round-k scenario."""
+        tag = "test_v1"
+        self._write_rounds(db, tag)
+
+        for table in ("training_stats", "injection_stats", "latent_snapshots"):
+            assert db.mark_superseded(table, tag, round_ge=2) is True
+
+        assert sorted(r["round_number"] for r in db.query_training_stat(tag=tag)) == [1]
+        assert sorted(r["round_number"] for r in db.query_injection_stat(tag=tag)) == [1]
+        assert sorted(r["round_number"] for r in db.query_latent_snapshots(tag=tag)) == [1]
+
+        everything = db.query_training_stat(tag=tag, include_superseded=True)
+        assert sorted(r["round_number"] for r in everything) == [1, 2, 3]
+        assert {r["round_number"]: r["superseded"] for r in everything} == {1: 0, 2: 1, 3: 1}
+
+    def test_mark_flushes_queued_writes_first(self, db):
+        """Rows still sitting in the write queue when mark_superseded() is called were
+        written before it, so FIFO ordering must land them in the table AND mark them."""
+        tag = "test_v2"
+        db.write_training_stat("beta_vae", "total_loss", 1.0, 2, 1, tag=tag)  # not yet flushed
+        assert db.mark_superseded("training_stats", tag, round_ge=1) is True
+
+        assert db.query_training_stat(tag=tag) == []
+        stale = db.query_training_stat(tag=tag, include_superseded=True)
+        assert len(stale) == 1 and stale[0]["superseded"] == 1
+
+    def test_rows_written_after_mark_stay_live(self, db):
+        tag = "test_v3"
+        db.write_training_stat("beta_vae", "total_loss", 1.0, 2, 1, tag=tag)
+        assert db.mark_superseded("training_stats", tag, round_ge=2) is True
+        db.write_training_stat("beta_vae", "total_loss", 2.0, 2, 1, tag=tag)  # the re-run's row
+        assert db.flush(timeout=10) is True
+
+        live = db.query_training_stat(tag=tag)
+        assert [r["value"] for r in live] == [2.0]
+
+    def test_mark_scoped_to_tag(self, db):
+        self._write_rounds(db, "test_v4", rounds=(1,))
+        self._write_rounds(db, "test_v5", rounds=(1,))
+        assert db.mark_superseded("training_stats", "test_v4", round_ge=1) is True
+        assert db.query_training_stat(tag="test_v4") == []
+        assert len(db.query_training_stat(tag="test_v5")) == 1
+
+    def test_npy_path_marking_on_inference_results(self, db):
+        tag = "test_v6"
+        db.write_inference_result("/a.npy", 0, 1, 0.99, tag=tag)
+        db.write_inference_result("/b.npy", 0, 1, 0.88, tag=tag)
+        assert db.mark_superseded("inference_results", tag, npy_path="/a.npy") is True
+
+        live = db.query_inference_result(tag=tag)
+        assert [r["npy_path"] for r in live] == ["/b.npy"]
+        assert len(db.query_inference_result(tag=tag, include_superseded=True)) == 2
+
+    def test_stability_aggregation_excludes_superseded(self, db):
+        tag = "test_v7"
+        db.write_injection_stat("global_skew", 1.0, round_number=1, tag=tag)
+        db.write_injection_stat("global_skew", 2.0, round_number=2, tag=tag)
+        assert db.mark_superseded("injection_stats", tag, round_ge=2) is True
+
+        rows = db.query_injection_stat_stability(stat_name="global_skew", tag=tag)
+        assert [r["round_number"] for r in rows] == [1]
+        rows = db.query_injection_stat_stability(
+            stat_name="global_skew", tag=tag, include_superseded=True
+        )
+        assert [r["round_number"] for r in rows] == [1, 2]
+
+    def test_snapshot_keys_exclude_superseded(self, db):
+        tag = "test_v8"
+        self._write_rounds(db, tag, rounds=(1, 2))
+        assert db.mark_superseded("latent_snapshots", tag, round_ge=2) is True
+        keys = db.query_latent_snapshot_keys(tag=tag)
+        assert [k["round_number"] for k in keys] == [1]
+
+    def test_mark_without_writer_thread_runs_inline(self):
+        """With no writer thread there is nothing queued to order against, so the UPDATE
+        runs synchronously in the caller thread (unit-test and post-shutdown ergonomics)."""
+        database = Database()
+        database.start()
+        database.write_training_stat("beta_vae", "total_loss", 1.0, 1, 1, tag="test_v9")
+        assert database.flush(timeout=10) is True
+        database.stop()
+
+        assert database.mark_superseded("training_stats", "test_v9", round_ge=1) is True
+        assert database.query_training_stat(tag="test_v9") == []
+        assert len(database.query_training_stat(tag="test_v9", include_superseded=True)) == 1
+
+    def test_invalid_table_rejected(self, db):
+        with pytest.raises(ValueError, match="does not support table"):
+            db.mark_superseded("system_resources", "test_v1")
+
+    def test_invalid_filters_rejected(self, db):
+        with pytest.raises(ValueError, match="round_ge is not supported"):
+            db.mark_superseded("inference_results", "test_v1", round_ge=1)
+        with pytest.raises(ValueError, match="npy_path is only supported"):
+            db.mark_superseded("training_stats", "test_v1", npy_path="/a.npy")
+        with pytest.raises(ValueError, match="non-empty tag"):
+            db.mark_superseded("training_stats", "")
+
+
+class TestSchemaMigration:
+    # The v0 schema (pre-superseded) for the four tables the migration touches, trimmed to
+    # the columns the assertions need plus everything NOT NULL.
+    _V0_SCHEMA = """
+        CREATE TABLE training_stats (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp REAL NOT NULL,
+            model_name TEXT NOT NULL,
+            stat_name TEXT NOT NULL,
+            value REAL NOT NULL,
+            round_number INTEGER,
+            epoch_number INTEGER,
+            tag TEXT,
+            metadata TEXT
+        );
+        CREATE TABLE injection_stats (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp REAL NOT NULL,
+            stat_name TEXT NOT NULL,
+            value REAL NOT NULL,
+            round_number INTEGER,
+            chunk_number INTEGER,
+            sample_index INTEGER,
+            background_index INTEGER,
+            signal_class TEXT,
+            signal_type TEXT,
+            injection_stage TEXT,
+            is_finite INTEGER DEFAULT 1,
+            slope_clamped INTEGER DEFAULT 0,
+            tag TEXT,
+            metadata TEXT
+        );
+        CREATE TABLE latent_snapshots (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp REAL NOT NULL,
+            model_name TEXT NOT NULL,
+            round_number INTEGER NOT NULL,
+            epoch_number INTEGER NOT NULL,
+            step_number INTEGER NOT NULL,
+            cadence_index INTEGER NOT NULL,
+            signal_type TEXT NOT NULL,
+            latent_vector TEXT NOT NULL,
+            snr_base INTEGER,
+            snr_range INTEGER,
+            tag TEXT,
+            metadata TEXT
+        );
+        CREATE TABLE inference_results (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp REAL NOT NULL,
+            npy_path TEXT NOT NULL,
+            snippet_index INTEGER NOT NULL,
+            prediction INTEGER NOT NULL,
+            confidence REAL NOT NULL,
+            latent_vector TEXT,
+            target TEXT,
+            session TEXT,
+            cadence_id INTEGER,
+            band TEXT,
+            frequency_mhz REAL,
+            timestamp_observed REAL,
+            h5_path TEXT,
+            tag TEXT,
+            metadata TEXT
+        );
+    """
+
+    _MIGRATED_TABLES = (
+        "training_stats",
+        "injection_stats",
+        "latent_snapshots",
+        "inference_results",
+    )
+
+    def _create_v0_db(self, config):
+        """Lay down an old-schema (pre-superseded, user_version 0) db file with one row,
+        at the exact path Database will open."""
+        db_path = os.path.join(config.output_path, "db", "aetherscan.db")
+        os.makedirs(os.path.dirname(db_path), exist_ok=True)
+        conn = sqlite3.connect(db_path)
+        conn.executescript(self._V0_SCHEMA)
+        conn.execute(
+            "INSERT INTO training_stats (timestamp, model_name, stat_name, value, round_number,"
+            " epoch_number, tag, metadata) VALUES (1.0, 'beta_vae', 'total_loss', 0.5, 1, 1,"
+            " 'test_v1', NULL)"
+        )
+        conn.commit()
+        conn.close()
+        return db_path
+
+    def _column_names(self, db_path, table):
+        conn = sqlite3.connect(db_path)
+        try:
+            return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+        finally:
+            conn.close()
+
+    def _user_version(self, db_path):
+        conn = sqlite3.connect(db_path)
+        try:
+            return conn.execute("PRAGMA user_version").fetchone()[0]
+        finally:
+            conn.close()
+
+    def test_old_schema_gains_superseded_column(self):
+        db_path = self._create_v0_db(get_config())
+        assert self._user_version(db_path) == 0
+
+        database = Database()  # _init_database() runs the migration
+        try:
+            for table in self._MIGRATED_TABLES:
+                assert "superseded" in self._column_names(db_path, table)
+            assert self._user_version(db_path) == _SCHEMA_VERSION
+
+            # Pre-migration rows default to superseded = 0 and stay visible
+            rows = database.query_training_stat(tag="test_v1")
+            assert len(rows) == 1
+            assert rows[0]["superseded"] == 0
+        finally:
+            database.stop()
+
+    def test_migration_is_idempotent_across_reopens(self):
+        db_path = self._create_v0_db(get_config())
+
+        # First open migrates; second open must be a clean no-op (no duplicate-column error)
+        first = Database()
+        first.stop()
+        Database._reset()
+        second = Database()
+        try:
+            for table in self._MIGRATED_TABLES:
+                assert "superseded" in self._column_names(db_path, table)
+            assert self._user_version(db_path) == _SCHEMA_VERSION
+            assert len(second.query_training_stat(tag="test_v1")) == 1
+        finally:
+            second.stop()
+
+    def test_fresh_db_created_at_current_version(self, db):
+        for table in self._MIGRATED_TABLES:
+            assert "superseded" in self._column_names(db.db_path, table)
+        assert self._user_version(db.db_path) == _SCHEMA_VERSION

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,0 +1,36 @@
+"""Unit tests for main.py glue that isn't reachable through the higher-level commands —
+currently the terminal training-status / exit-code contract (_report_final_training_status)."""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from aetherscan import main
+from aetherscan.run_state import STAGE_RF_PLOTS, STAGE_VAE_PLOTS, TrainingRunState
+
+
+def _pipeline_with(stages_failed):
+    state = TrainingRunState(tag="t", run_start_time=1.0, stages_failed=list(stages_failed))
+    return types.SimpleNamespace(run_state=state)
+
+
+class TestReportFinalTrainingStatus:
+    def test_success_when_no_failed_stages(self):
+        # No permanently-failed stage -> returns normally, no SystemExit.
+        main._report_final_training_status(_pipeline_with([]))
+
+    @pytest.mark.parametrize(
+        "failed", [[STAGE_VAE_PLOTS], [STAGE_RF_PLOTS], [STAGE_VAE_PLOTS, STAGE_RF_PLOTS]]
+    )
+    def test_exits_nonzero_on_failed_plot_stage(self, failed):
+        with pytest.raises(SystemExit) as exc:
+            main._report_final_training_status(_pipeline_with(failed))
+        assert exc.value.code == 1
+
+    def test_exits_nonzero_when_pipeline_is_none(self):
+        # Degenerate no-pipeline path must never report a false success.
+        with pytest.raises(SystemExit) as exc:
+            main._report_final_training_status(None)
+        assert exc.value.code == 1

--- a/tests/unit/test_run_state.py
+++ b/tests/unit/test_run_state.py
@@ -1,0 +1,135 @@
+"""Unit tests for aetherscan.run_state: manifest round-trip, atomic persistence, corrupt-file
+downgrade, and the stage/round bookkeeping helpers that drive the training stage machine."""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest import mock
+
+import pytest
+
+from aetherscan.run_state import (
+    STAGE_FINAL_SAVE,
+    STAGE_RF_PLOTS,
+    STAGE_RF_TRAIN,
+    STAGE_VAE_PLOTS,
+    STAGE_VAE_ROUNDS,
+    TRAINING_STAGES,
+    TrainingRunState,
+    load_run_state,
+    run_state_path,
+    save_run_state,
+)
+
+
+class TestRunStatePath:
+    def test_layout(self, tmp_path):
+        assert run_state_path(str(tmp_path), "test_v1") == str(tmp_path / "run_state_test_v1.json")
+
+
+class TestRoundTrip:
+    def test_save_then_load_preserves_all_fields(self, tmp_path):
+        path = run_state_path(str(tmp_path), "test_v1")
+        state = TrainingRunState(
+            tag="test_v1",
+            run_start_time=1234.5,
+            attempt=3,
+            completed_rounds=[1, 2],
+            stages_done=[STAGE_VAE_ROUNDS],
+            stages_failed=[STAGE_VAE_PLOTS],
+        )
+        save_run_state(state, path)
+        assert load_run_state(path) == state
+
+    def test_save_creates_parent_dirs(self, tmp_path):
+        path = str(tmp_path / "nested" / "deeper" / "run_state_test_v1.json")
+        save_run_state(TrainingRunState(tag="test_v1", run_start_time=1.0), path)
+        assert load_run_state(path) is not None
+
+    def test_missing_file_returns_none(self, tmp_path):
+        assert load_run_state(str(tmp_path / "run_state_missing.json")) is None
+
+    def test_corrupt_file_downgrades_to_none(self, tmp_path):
+        path = str(tmp_path / "run_state_test_v1.json")
+        with open(path, "w") as f:
+            f.write("{ this is not json")
+        assert load_run_state(path) is None
+
+    def test_missing_required_field_downgrades_to_none(self, tmp_path):
+        path = str(tmp_path / "run_state_test_v1.json")
+        with open(path, "w") as f:
+            json.dump({"tag": "test_v1"}, f)  # no run_start_time
+        assert load_run_state(path) is None
+
+    def test_completed_rounds_are_sorted_on_load(self, tmp_path):
+        path = str(tmp_path / "run_state_test_v1.json")
+        with open(path, "w") as f:
+            json.dump({"tag": "test_v1", "run_start_time": 1.0, "completed_rounds": [3, 1, 2]}, f)
+        assert load_run_state(path).completed_rounds == [1, 2, 3]
+
+
+class TestAtomicity:
+    def test_failed_write_leaves_previous_manifest_intact(self, tmp_path):
+        path = run_state_path(str(tmp_path), "test_v1")
+        original = TrainingRunState(tag="test_v1", run_start_time=1.0, completed_rounds=[1])
+        save_run_state(original, path)
+
+        updated = TrainingRunState(tag="test_v1", run_start_time=1.0, completed_rounds=[1, 2])
+        with (
+            mock.patch("aetherscan.run_state.json.dump", side_effect=OSError("disk full")),
+            pytest.raises(OSError, match="disk full"),
+        ):
+            save_run_state(updated, path)
+
+        # The previous manifest survives untouched and no .tmp litter is left behind
+        assert load_run_state(path) == original
+        assert not os.path.exists(path + ".tmp")
+
+    def test_write_goes_through_tmp_then_replace(self, tmp_path):
+        path = run_state_path(str(tmp_path), "test_v1")
+        with mock.patch("aetherscan.run_state.os.replace", wraps=os.replace) as mock_replace:
+            save_run_state(TrainingRunState(tag="test_v1", run_start_time=1.0), path)
+        mock_replace.assert_called_once_with(path + ".tmp", path)
+
+
+class TestBookkeeping:
+    def test_stage_names(self):
+        assert TRAINING_STAGES == (
+            STAGE_VAE_ROUNDS,
+            STAGE_VAE_PLOTS,
+            STAGE_RF_TRAIN,
+            STAGE_RF_PLOTS,
+            STAGE_FINAL_SAVE,
+        )
+
+    def test_mark_stage_done_is_idempotent(self):
+        state = TrainingRunState(tag="test_v1", run_start_time=1.0)
+        state.mark_stage_done(STAGE_VAE_ROUNDS)
+        state.mark_stage_done(STAGE_VAE_ROUNDS)
+        assert state.stages_done == [STAGE_VAE_ROUNDS]
+        assert state.is_stage_done(STAGE_VAE_ROUNDS)
+        assert not state.is_stage_done(STAGE_VAE_PLOTS)
+
+    def test_stage_success_clears_recorded_failure(self):
+        state = TrainingRunState(tag="test_v1", run_start_time=1.0)
+        state.record_stage_failure(STAGE_VAE_PLOTS)
+        state.record_stage_failure(STAGE_VAE_PLOTS)
+        assert state.stages_failed == [STAGE_VAE_PLOTS]
+        state.mark_stage_done(STAGE_VAE_PLOTS)
+        assert state.stages_failed == []
+        assert state.is_stage_done(STAGE_VAE_PLOTS)
+
+    def test_mark_round_completed_sorted_and_deduped(self):
+        state = TrainingRunState(tag="test_v1", run_start_time=1.0)
+        state.mark_round_completed(2)
+        state.mark_round_completed(1)
+        state.mark_round_completed(2)
+        assert state.completed_rounds == [1, 2]
+
+    def test_resume_round(self):
+        state = TrainingRunState(tag="test_v1", run_start_time=1.0)
+        assert state.resume_round == 1
+        state.mark_round_completed(1)
+        state.mark_round_completed(2)
+        assert state.resume_round == 3

--- a/tests/unit/test_run_state.py
+++ b/tests/unit/test_run_state.py
@@ -3,6 +3,7 @@ downgrade, and the stage/round bookkeeping helpers that drive the training stage
 
 from __future__ import annotations
 
+import copy
 import json
 import os
 from unittest import mock
@@ -17,6 +18,8 @@ from aetherscan.run_state import (
     STAGE_VAE_ROUNDS,
     TRAINING_STAGES,
     TrainingRunState,
+    config_changed,
+    config_fingerprint,
     load_run_state,
     run_state_path,
     save_run_state,
@@ -133,3 +136,88 @@ class TestBookkeeping:
         state.mark_round_completed(1)
         state.mark_round_completed(2)
         assert state.resume_round == 3
+
+
+class TestConfigFingerprint:
+    """config_fingerprint() + config_changed(): the config-drift guard that stops a reused
+    --save-tag from silently resuming/skipping under a changed config."""
+
+    BASE = {
+        "paths": {"data_path": "/data", "output_path": "/out", "model_path": "/models"},
+        "db": {"write_interval": 5.0},
+        "manager": {"n_processes": 32, "chunks_per_worker": 4},
+        "logger": {"slack_enabled": True},
+        "beta_vae": {"beta": 1.5, "alpha": 10.0, "latent_dim": 8},
+        "random_forest": {"n_estimators": 1000, "seed": 11},
+        "data": {"num_target_backgrounds": 45000},
+        "training": {"num_samples_beta_vae": 499200, "max_retries": 3, "retry_delay": 60},
+        "gpu": {"num_replicas": None},
+        "inference": {"max_retries": 3, "parallel_coarse_chans": None},
+        "checkpoint": {"save_tag": "final_v1", "load_tag": None, "start_round": 1},
+    }
+
+    def _mutate(self, section, key, value):
+        d = copy.deepcopy(self.BASE)
+        d[section][key] = value
+        return d
+
+    def test_stable_for_identical_config(self):
+        assert config_fingerprint(self.BASE) == config_fingerprint(copy.deepcopy(self.BASE))
+
+    @pytest.mark.parametrize(
+        "section,key,value",
+        [
+            ("beta_vae", "beta", 2.0),
+            ("beta_vae", "latent_dim", 16),
+            ("random_forest", "n_estimators", 500),
+            ("data", "num_target_backgrounds", 30000),
+            ("training", "num_samples_beta_vae", 8192),
+            ("gpu", "num_replicas", 6),
+        ],
+    )
+    def test_result_affecting_change_flips_fingerprint(self, section, key, value):
+        assert config_fingerprint(self._mutate(section, key, value)) != config_fingerprint(
+            self.BASE
+        )
+
+    @pytest.mark.parametrize(
+        "section,key,value",
+        [
+            ("paths", "data_path", "/elsewhere"),
+            ("paths", "output_path", "/other_out"),
+            ("db", "write_interval", 99.0),
+            ("manager", "n_processes", 96),
+            ("logger", "slack_enabled", False),
+            ("inference", "max_retries", 9),
+            ("checkpoint", "load_tag", "round_03"),
+            ("checkpoint", "start_round", 4),
+            ("training", "max_retries", 10),
+            ("training", "retry_delay", 5),
+        ],
+    )
+    def test_excluded_change_keeps_fingerprint(self, section, key, value):
+        assert config_fingerprint(self._mutate(section, key, value)) == config_fingerprint(
+            self.BASE
+        )
+
+    def test_config_changed_none_state_is_false(self):
+        assert config_changed(None, "abc") is False
+
+    def test_config_changed_matching_is_false(self):
+        state = TrainingRunState(tag="t", run_start_time=1.0, config_fingerprint="abc")
+        assert config_changed(state, "abc") is False
+
+    def test_config_changed_mismatch_is_true(self):
+        state = TrainingRunState(tag="t", run_start_time=1.0, config_fingerprint="abc")
+        assert config_changed(state, "xyz") is True
+
+    def test_config_changed_pre_fingerprint_manifest_is_true(self):
+        # A manifest written before fingerprinting has "" and must be treated as changed.
+        state = TrainingRunState(tag="t", run_start_time=1.0, config_fingerprint="")
+        assert config_changed(state, "abc") is True
+
+    def test_fingerprint_round_trips_through_manifest(self, tmp_path):
+        path = run_state_path(str(tmp_path), "final_v1")
+        state = TrainingRunState(tag="final_v1", run_start_time=1.0, config_fingerprint="deadbeef")
+        save_run_state(state, path)
+        assert load_run_state(path).config_fingerprint == "deadbeef"

--- a/tests/unit/test_train_utils.py
+++ b/tests/unit/test_train_utils.py
@@ -1,7 +1,8 @@
 # NOTE: come back to this later
 
 """Unit tests for aetherscan.train pure-logic helpers: checkpoint tag resolution, curriculum
-schedules, directory archiving, encoder-trained heuristics, and SHAP output normalization."""
+schedules, directory archiving, encoder-trained heuristics, SHAP output normalization, and the
+training stage machine (skip-if-done / record-failure semantics against a stub pipeline)."""
 
 from __future__ import annotations
 
@@ -11,8 +12,18 @@ import numpy as np
 import pytest
 
 from aetherscan.config import get_config
+from aetherscan.run_state import (
+    STAGE_FINAL_SAVE,
+    STAGE_RF_PLOTS,
+    STAGE_RF_TRAIN,
+    STAGE_VAE_PLOTS,
+    STAGE_VAE_ROUNDS,
+    TRAINING_STAGES,
+    TrainingRunState,
+)
 from aetherscan.train import (
     TrainingPipeline,
+    _execute_training_stages,
     _select_positive_class_shap,
     archive_directory,
     check_encoder_trained,
@@ -325,3 +336,135 @@ class TestSelectPositiveClassShap:
     def test_log_loss_passthrough(self):
         values = np.arange(self.N * self.F, dtype=float).reshape(self.N, self.F)
         np.testing.assert_array_equal(_select_positive_class_shap(values, log_loss=True), values)
+
+
+class _StageMachineStub:
+    """Duck-typed TrainingPipeline for _execute_training_stages: records the call order,
+    raises inside any method named in `fail`, and reports rf-load success per `rf_load_ok`."""
+
+    def __init__(self, state, fail=(), rf_load_ok=True):
+        self.run_state = state
+        self.calls = []
+        self.rf_model = "trained-rf"
+        self._fail = set(fail)
+        self._rf_load_ok = rf_load_ok
+
+    def _invoke(self, name):
+        self.calls.append(name)
+        if name in self._fail:
+            raise RuntimeError(f"{name} failed")
+
+    def train_beta_vae(self):
+        self._invoke("train_beta_vae")
+
+    def plot_vae_diagnostics(self):
+        self._invoke("plot_vae_diagnostics")
+
+    def train_random_forest(self):
+        self._invoke("train_random_forest")
+
+    def plot_rf_diagnostics(self):
+        self._invoke("plot_rf_diagnostics")
+
+    def final_save(self):
+        self._invoke("final_save")
+
+    def save_models(self):
+        self._invoke("save_models")
+
+    def try_load_rf_for_resume(self):
+        self.calls.append("try_load_rf_for_resume")
+        return self._rf_load_ok
+
+    def _clear_rf_caches(self):
+        self.calls.append("_clear_rf_caches")
+
+    # The real methods also persist the manifest; persistence is covered in test_run_state.
+    def _mark_stage_done(self, stage):
+        self.run_state.mark_stage_done(stage)
+
+    def _record_stage_failure(self, stage):
+        self.run_state.record_stage_failure(stage)
+
+
+class TestExecuteTrainingStages:
+    def _state(self, **kwargs):
+        return TrainingRunState(tag="test_v1", run_start_time=1.0, **kwargs)
+
+    def test_fresh_run_executes_all_stages_in_order(self):
+        stub = _StageMachineStub(self._state())
+        _execute_training_stages(stub)
+        assert stub.calls == [
+            "train_beta_vae",
+            "plot_vae_diagnostics",
+            "train_random_forest",
+            "plot_rf_diagnostics",
+            "_clear_rf_caches",
+            "final_save",
+        ]
+        assert stub.run_state.stages_done == list(TRAINING_STAGES)
+        assert stub.run_state.stages_failed == []
+
+    def test_done_stages_are_skipped(self):
+        state = self._state(
+            completed_rounds=[1, 2],
+            stages_done=[STAGE_VAE_ROUNDS, STAGE_VAE_PLOTS, STAGE_RF_TRAIN],
+        )
+        stub = _StageMachineStub(state)
+        _execute_training_stages(stub)
+        # rf_train skip must reload the persisted RF (rf_plots/final_save need a live model)
+        assert stub.calls == [
+            "try_load_rf_for_resume",
+            "plot_rf_diagnostics",
+            "_clear_rf_caches",
+            "final_save",
+        ]
+        assert state.stages_done == list(TRAINING_STAGES)
+
+    def test_vae_plot_failure_is_recorded_but_does_not_abort(self):
+        stub = _StageMachineStub(self._state(), fail={"plot_vae_diagnostics"})
+        _execute_training_stages(stub)
+        assert "final_save" in stub.calls
+        assert stub.run_state.stages_failed == [STAGE_VAE_PLOTS]
+        assert not stub.run_state.is_stage_done(STAGE_VAE_PLOTS)
+        assert stub.run_state.is_stage_done(STAGE_FINAL_SAVE)
+
+    def test_rf_plot_failure_is_recorded_and_caches_cleared(self):
+        stub = _StageMachineStub(self._state(), fail={"plot_rf_diagnostics"})
+        _execute_training_stages(stub)
+        assert "_clear_rf_caches" in stub.calls
+        assert "final_save" in stub.calls
+        assert stub.run_state.stages_failed == [STAGE_RF_PLOTS]
+
+    def test_rf_train_failure_saves_vae_and_propagates(self):
+        stub = _StageMachineStub(self._state(), fail={"train_random_forest"})
+        with pytest.raises(RuntimeError, match="train_random_forest failed"):
+            _execute_training_stages(stub)
+        assert stub.rf_model is None  # partial RF state dropped before the best-effort save
+        assert stub.calls[-1] == "save_models"
+        assert not stub.run_state.is_stage_done(STAGE_RF_TRAIN)
+        assert "final_save" not in stub.calls
+
+    def test_rf_train_skip_falls_back_to_retrain_when_reload_fails(self):
+        state = self._state(
+            stages_done=[STAGE_VAE_ROUNDS, STAGE_VAE_PLOTS, STAGE_RF_TRAIN],
+        )
+        stub = _StageMachineStub(state, rf_load_ok=False)
+        _execute_training_stages(stub)
+        assert "train_random_forest" in stub.calls
+        assert state.is_stage_done(STAGE_RF_TRAIN)
+
+    def test_relaunch_after_plot_failure_retries_only_failed_stage(self):
+        # First run: vae_plots fails, everything else succeeds
+        state = self._state()
+        first = _StageMachineStub(state, fail={"plot_vae_diagnostics"})
+        _execute_training_stages(first)
+        assert state.stages_failed == [STAGE_VAE_PLOTS]
+
+        # Relaunch with the persisted state: only vae_plots re-runs (the rf_train skip still
+        # reloads the persisted RF — cheap, and by design), and success clears the failure
+        second = _StageMachineStub(state)
+        _execute_training_stages(second)
+        assert second.calls == ["plot_vae_diagnostics", "try_load_rf_for_resume"]
+        assert state.stages_failed == []
+        assert state.stages_done[-1] == STAGE_VAE_PLOTS  # re-marked after the retry


### PR DESCRIPTION
# Description

Training fault-tolerance overhaul: a persisted run manifest + explicit stage machine replace the checkpoint-hunting retry loop, and stale DB rows from failed attempts are flagged (never deleted) so plots stay clean across retries.

**Stacked PR: base branch is `feature/training-data-pipeline` (#117).** This PR contains only the fault-tolerance commits; review after #117 and rebase onto `master` once #117 merges.

Closes #119

## What changed

- **New `src/aetherscan/run_state.py`** — `TrainingRunState` manifest persisted at `{output_path}/run_state_{save_tag}.json` (atomic tmp -> `os.replace`, mirroring `round_data`'s `.done` protocol): `run_start_time` (wall clock of attempt 1), attempt counter, `completed_rounds`, `stages_done`, `stages_failed`. A corrupt manifest downgrades to a fresh run.
- **`train.py`** — `run_training_pipeline()` is now an explicit ordered stage machine (`vae_rounds` -> `vae_plots` -> `rf_train` -> `rf_plots` -> `final_save`) with skip-if-done + persist-on-success semantics (`_execute_training_stages`, duck-typed for unit testing):
  - `TrainingPipeline.__init__` sets `self.start_time` from the manifest's `run_start_time` unconditionally — fixes the documented `# BUG:` at the old `train_beta_vae()` early return (unset `start_time` -> `AttributeError` in every plot, masking the real error). All DB queries/plots now span the whole run, not just the current attempt.
  - Round resume is manifest-driven: `completed_rounds` -> reload the `round_{k:02d}` checkpoint; each round records itself right after its checkpoint saves. Explicit `--load-tag`/`--load-dir` remain as an escape hatch (they override the manifest and clear downstream stage records).
  - `vae_plots` downgraded from raise-and-retry to record-and-continue: all four plots are attempted, failures land in `stages_failed`, and `main.py` exits nonzero at the very end if they never recover — a plot bug no longer costs a data regeneration, but lost artifacts stay loud. `rf_plots` failures are recorded the same way instead of being silently swallowed.
  - `train_random_forest()` persists `random_forest_{tag}.joblib` as soon as training completes; on resume it reloads model + eval artifacts instead of regenerating ~`num_samples_rf` cadences and retraining (gated on an actual resume so a fresh run reusing an old tag never skips training on stale artifacts).
  - The config JSON dump moved from `train_command` into the `final_save` stage (covered by retry).
- **`db/db.py`** — supersede semantics + minimal schema migration:
  - `superseded INTEGER DEFAULT 0` on `training_stats`, `injection_stats`, `latent_snapshots`, `inference_results` (PR-08 in the v1 plan reuses this for inference resume).
  - Migration mechanism in `_init_database` gated on `PRAGMA user_version` with idempotent `ALTER TABLE ... ADD COLUMN` steps — minimally resolves the schema-evolution TODO.
  - `Database.mark_superseded(table, tag, *, round_ge=None, npy_path=None)` runs on the writer thread via a command tuple through the write queue (like the flush sentinel): buffered rows flush first, then the UPDATE — FIFO ordering guarantees rows written before the call are marked while later writes stay live. Runs inline when no writer thread exists.
  - `query_*` methods on those tables gain `include_superseded: bool = False` and filter `superseded = 0` by default.
  - On resume of round k, `(tag, round >= k)` rows in the three training tables are marked before the rerun re-writes them — no duplicated epochs in loss curves.
- **`main.py`** — `train_command` retry loop simplified: no more `get_latest_tag()` checkpoint hunting or `config.checkpoint.{load_dir,load_tag,start_round}` mutation (the resolved `# NOTE:` block is removed); KeyboardInterrupt passthrough and max-retries accounting unchanged; exits nonzero when the manifest records permanently failed plot stages.

No CLI/config surface changed (no README CLI regeneration needed). `preprocessing.py`/`inference.py` untouched apart from the `inference_results` column + query filter (PR-06/08 own inference).

## Deliberate deviations from the plan spec

- §6.2 suggested keeping `get_latest_tag()` as a retry-loop fallback when no manifest exists. The manifest always exists on retries (attempt 1 writes it in `__init__`), and hunting checkpoints without one risks silently resuming another run's `round_XX` checkpoints on a fresh tag — so the manifest is the single resume driver; `get_latest_tag()` remains as `load_models()`'s internal fallback and in `train_random_forest`'s weight recovery.
- `rf_train` additionally persists `random_forest_{tag}.joblib` at stage end — required for the spec's own "load instead of retrain" resume path to have something to load before `final_save` runs.

## Known limitation (deferred)

- RF-dataset injection stats are written with `round_number=NULL`, which `round_ge` marking can't target; an `rf_train` retry that regenerates the RF dataset can leave stale RF-generation rows live. Bounded (partial-generation rows only); PR-08/PR-10 own the follow-up.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How has this been tested?

### Unit tests (local, arm64 venv w/ TF 2.17.1)

`PYTHONPATH=src pytest -m "not gpu and not cluster" -q` -> **269 passed, 3 skipped**. New coverage:

- `tests/unit/test_run_state.py` — manifest round-trip, atomic tmp->replace persistence (failed write leaves the previous manifest intact, no `.tmp` litter), corrupt-manifest downgrade, stage/round bookkeeping.
- `tests/unit/test_db.py` — supersede marking (`round_ge`, `npy_path`, tag scoping), queue-FIFO semantics (queued-before rows get marked, written-after rows stay live), default query filtering incl. aggregation queries, inline execution without a writer thread, filter validation; migration: old-schema (v0) DB fixture gains the column + `user_version` stamp, idempotent across reopens, fresh DBs created at current version.
- `tests/unit/test_train_utils.py` — stage machine against a stub pipeline: full fresh-run order, skip-if-done (incl. RF reload on skip), plot-failure record-and-continue, rf_train failure propagation + best-effort VAE save, reload-failure fallback to retrain, relaunch-retries-only-failed-stage.

### Cluster kill/resume matrix (blpc3, 5 GPU, singularity)

Smoke config: `--per-replica-batch-size 4 --per-replica-val-batch-size 4 --effective-batch-size 20 --num-samples-beta-vae 200 --num-samples-rf 200 --num-training-rounds 2 --epochs-per-round 2 --latent-viz-num-cadences-per-type 5`, tag `test_v23` (one continuous chain, relaunching the identical command after each SIGKILL); in-process retry run on tag `test_v24`.

| # | SIGKILL point (verified in log) | Relaunch behavior (all asserted from logs + manifest + DB) | Result |
|---|---|---|---|
| 1 | Mid-round-2 epochs (3 s after round-2 epoch 1 completed) | Attempt 2: manifest `completed_rounds [1]` -> `Resuming from checkpoint round_01 (per run manifest)`, loop starts at `ROUND 2/2`; `round_ge=2` marked 14432 injection + 20 snapshot rows stale (the 21 round-2 training rows died unbuffered in the write queue — nothing to mark); stale `round_02` data dir deleted + regenerated | PASS |
| 2 | During vae_plots (1 s into latent-GIF generation; 3 of 4 plots saved) | Attempt 3: `vae_rounds` skipped via manifest (`stages_done ['vae_rounds']`, vae_plots correctly unmarked), checkpoint `round_02` reloaded, all four vae_plots re-ran to completion; `round_ge=3` marked 0 rows (nothing stale) | PASS |
| 3 | During rf_train (2 s into RF data generation; kill also reaped the forked pool workers) | Attempt 4: `vae_rounds` + `vae_plots` both skipped; no RF artifacts had been persisted, so rf_train correctly re-ran from scratch; supersede no-op | PASS |
| 4 | During rf_plots (after 3 of 10 RF plots; rf_train had persisted `random_forest_{tag}.joblib` + `rf_eval_artifacts_{tag}.joblib` at stage end) | Attempt 5: `vae_rounds`/`vae_plots` skipped, **`Stage 'rf_train' already complete — loaded persisted RF model`** (no RF data regeneration), all ten rf_plots re-ran to completion, `final_save` wrote encoder/decoder/RF + `config_{tag}.json`, exit 0 with `Training completed successfully!` | PASS |
| 5 | (none — relaunch after clean completion) | Attempt 6: pure no-op — all five stages logged `already complete — skipping` (rf_train via RF reload), clean exit 0 | PASS |
| R | Transient injection: `plots/checkpoints` chmod 555 during round 1, restored during the 60 s retry sleep (`--max-retries 3`, tag `test_v24`) | Attempt 1 died at `PermissionError: .../plots/checkpoints/beta_vae_loss_curves_round_01.png` (20:11:36); permissions restored during the retry sleep; `Training attempt: 2/3` at 20:12:37 resumed via the manifest, marked 42 training / 14432 injection / 40 snapshot rows superseded at `round_ge=1`, re-ran everything, `Training completed successfully!` at 20:45 — exercising the in-process retry + per-attempt producer teardown end to end | PASS |


Final-state assertions (both tags): manifest shows all five stages done with `run_start_time` unchanged since attempt 1 (spans every attempt — `test_v23`'s covered 5 attempts over ~1 h 45 m); exactly **one live `total_loss` row per (round, epoch)** with all stale rows (`superseded=1`) filtered by default queries — the duplicated-epoch corruption is gone; encoder/decoder/RF/eval-artifacts/config all present; 56 final plots per tag; `/dev/shm` clean after every SIGKILL + relaunch cycle.

Bonus real-world validation: the cluster's **live `aetherscan.db` (pre-existing schema, prior tags) was migrated in place** on first open — `user_version 0 -> 1`, `superseded` added to all four tables, old rows visible with `superseded=0`, and every later launch skipped the migration cleanly.

Observed pre-existing quirk (not a regression, noted for PR-10): at smoke scale, `train_random_forest`'s `check_encoder_trained` fallback loaded `test_v21` weights via `get_latest_tag` — the already-documented `# BUG:` block about tag reuse; this PR's tag-scoped RF resume path is unaffected.

### Deferred validation (bla0 unreachable this session)

- §6.3's original bla0 6-GPU smoke variant of the same matrix (`--num-samples-beta-vae 3072 --num-samples-rf 960`, apptainer/conda runtime).
- Migration behavior against bla0's existing `aetherscan.db` (blpc3's live DB was migrated in place during this matrix — see results).
- Full-scale resume rehearsal (default config) after a real OOM kill.

## Checklist

- [x] My code follows the style guidelines of this project (ruff lint + format)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (deferred: DATABASE.md documenting the migration mechanism is scoped to the docs-suite PR per the plan)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## AI disclosure

This PR was implemented end-to-end with **Claude Code**: implementation, unit tests, docs/comments, cluster kill/resume verification, and this PR text (design from the maintainer's v1 plan). All cluster runs and assertions above were executed and checked as part of this session.
