### PR TITLE
PFB static passband equalization as default bandpass flattener; tag-scoped preprocess output dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,11 @@ PYTHONPATH=src python -m aetherscan.main inference \
     --save-tag run_v1
 ```
 
+> [!NOTE]
+> Energy detection flattens each coarse channel's bandpass before thresholding. The default method (`--bandpass-method pfb`) divides by the instrument's static polyphase-filterbank response — computed once per run — instead of fitting a spline per channel per file (`--bandpass-method spline`). The PFB response is instrument-dependent: `--pfb-taps-per-channel` defaults to 12 (the GBT/Breakthrough Listen backend) and must match the backend that produced the `.h5` files; a warning is logged when the recording's measured bandpass shape disagrees with the static response.
+>
+> Preprocessed per-cadence `.npy` stamps land in a per-CSV, tag-scoped directory by default (`{data_path}/inference/preprocessed/<csv_stem>_<save_tag>/`): retrying with the same `--save-tag` resumes from the existing `.npy` files, while a new tag starts from a clean directory that stale stamps from an older failed attempt can't leak into. To reuse an earlier run's preprocessing instead, pass its directory explicitly via `--preprocess-output-dir`.
+
 **Inference with async-allocator fallbacks (e.g. on a 5-GPU Blackwell topology)**
 
 ```bash
@@ -706,6 +711,9 @@ usage: inference [-h] [--data-path DATA_PATH] [--model-path MODEL_PATH]
                  [--cadence-expected-obs CADENCE_EXPECTED_OBS]
                  [--coarse-channel-width COARSE_CHANNEL_WIDTH]
                  [--parallel-coarse-chans PARALLEL_COARSE_CHANS]
+                 [--bandpass-method BANDPASS_METHOD]
+                 [--pfb-taps-per-channel PFB_TAPS_PER_CHANNEL]
+                 [--bandpass-debug-plot | --no-bandpass-debug-plot]
                  [--spline-order SPLINE_ORDER]
                  [--detection-window-size DETECTION_WINDOW_SIZE]
                  [--detection-step-size DETECTION_STEP_SIZE]
@@ -781,8 +789,25 @@ options:
                         coarse channels per log line (default: the number of
                         worker processes). Parallelism itself comes from the
                         persistent worker pool, not this knob.
+  --bandpass-method BANDPASS_METHOD
+                        Bandpass flattening method for energy detection: 'pfb'
+                        (default) divides each coarse channel by the
+                        instrument's static polyphase-filterbank response;
+                        'spline' fits and subtracts a per-channel spline
+  --pfb-taps-per-channel PFB_TAPS_PER_CHANNEL
+                        PFB prototype-filter taps per coarse channel for
+                        --bandpass-method pfb (default: 12, the
+                        GBT/Breakthrough Listen backend value). INSTRUMENT-
+                        DEPENDENT: must match the backend that produced the
+                        .h5 files
+  --bandpass-debug-plot, --no-bandpass-debug-plot
+                        Save a per-cadence bandpass-flattening overlay debug
+                        plot (raw vs flattened integrated spectrum for a few
+                        sampled coarse channels) under plots/inference/
+                        (default: off)
   --spline-order SPLINE_ORDER
-                        Spline order for bandpass fitting (default: 16)
+                        Spline order for bandpass fitting with --bandpass-
+                        method spline (default: 16)
   --detection-window-size DETECTION_WINDOW_SIZE
                         Sliding window size in fine channels for normality
                         test (default: 256)
@@ -812,7 +837,12 @@ options:
                         overlap-search stamps (default: 0.5)
   --preprocess-output-dir PREPROCESS_OUTPUT_DIR
                         Directory for per-cadence .npy outputs from
-                        preprocessing
+                        preprocessing. Default: a per-CSV, tag-scoped
+                        directory {data_path}/inference/preprocessed/<csv_stem
+                        >_<save_tag>/ — retrying with the same tag resumes
+                        from existing .npy files, while a new tag starts
+                        clean. Pass an old run's directory explicitly to reuse
+                        its preprocessing (shared across CSVs)
   --max-retries MAX_RETRIES
                         Maximum number of retry attempts for inference
                         (including preprocessing) on failure

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -34,6 +34,9 @@ _RF_MAX_FEATURES_STR_VALUES = {"sqrt", "log2"}
 # Allowed values for curriculum_schedule
 _CURRICULUM_SCHEDULES = {"linear", "exponential", "step"}
 
+# Allowed values for bandpass_method (energy-detection bandpass flattening)
+_BANDPASS_METHODS = {"pfb", "spline"}
+
 
 @dataclass
 class ValidationError:
@@ -767,10 +770,28 @@ def _add_inference_flags_to(parser):
         help="Progress-logging chunk size for energy detection, in coarse channels per log line (default: the number of worker processes). Parallelism itself comes from the persistent worker pool, not this knob.",
     )
     parser.add_argument(
+        "--bandpass-method",
+        type=str,
+        default=None,
+        help="Bandpass flattening method for energy detection: 'pfb' (default) divides each coarse channel by the instrument's static polyphase-filterbank response; 'spline' fits and subtracts a per-channel spline",
+    )
+    parser.add_argument(
+        "--pfb-taps-per-channel",
+        type=int,
+        default=None,
+        help="PFB prototype-filter taps per coarse channel for --bandpass-method pfb (default: 12, the GBT/Breakthrough Listen backend value). INSTRUMENT-DEPENDENT: must match the backend that produced the .h5 files",
+    )
+    parser.add_argument(
+        "--bandpass-debug-plot",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Save a per-cadence bandpass-flattening overlay debug plot (raw vs flattened integrated spectrum for a few sampled coarse channels) under plots/inference/ (default: off)",
+    )
+    parser.add_argument(
         "--spline-order",
         type=int,
         default=None,
-        help="Spline order for bandpass fitting (default: 16)",
+        help="Spline order for bandpass fitting with --bandpass-method spline (default: 16)",
     )
     parser.add_argument(
         "--detection-window-size",
@@ -818,7 +839,7 @@ def _add_inference_flags_to(parser):
         "--preprocess-output-dir",
         type=str,
         default=None,
-        help="Directory for per-cadence .npy outputs from preprocessing",
+        help="Directory for per-cadence .npy outputs from preprocessing. Default: a per-CSV, tag-scoped directory {data_path}/inference/preprocessed/<csv_stem>_<save_tag>/ — retrying with the same tag resumes from existing .npy files, while a new tag starts clean. Pass an old run's directory explicitly to reuse its preprocessing (shared across CSVs)",
     )
     parser.add_argument(
         "--max-retries",
@@ -1126,6 +1147,15 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
         config.inference.coarse_channel_width = args.coarse_channel_width
     if hasattr(args, "parallel_coarse_chans") and args.parallel_coarse_chans is not None:
         config.inference.parallel_coarse_chans = args.parallel_coarse_chans
+    if hasattr(args, "bandpass_method") and args.bandpass_method is not None:
+        config.inference.bandpass_method = args.bandpass_method
+    if hasattr(args, "pfb_taps_per_channel") and args.pfb_taps_per_channel is not None:
+        config.inference.pfb_taps_per_channel = args.pfb_taps_per_channel
+    # bandpass_debug_plot uses argparse.BooleanOptionalAction with default=None so the CLI
+    # can express "leave the config default" (omit), "force on" (--bandpass-debug-plot),
+    # and "force off" (--no-bandpass-debug-plot).
+    if hasattr(args, "bandpass_debug_plot") and args.bandpass_debug_plot is not None:
+        config.inference.bandpass_debug_plot = args.bandpass_debug_plot
     if hasattr(args, "spline_order") and args.spline_order is not None:
         config.inference.spline_order = args.spline_order
     if hasattr(args, "detection_window_size") and args.detection_window_size is not None:
@@ -1971,6 +2001,28 @@ def collect_validation_errors(
                     field="inference.spline_order",
                     current=spline_order,
                     message=f"--spline-order must be >= 1, got {spline_order}",
+                    fix_kind="clamp_low",
+                    min_val=1,
+                )
+            )
+        bandpass_method = _resolve(args, "bandpass_method", config.inference.bandpass_method)
+        if bandpass_method is not None and bandpass_method not in _BANDPASS_METHODS:
+            errors.append(
+                ValidationError(
+                    field="inference.bandpass_method",
+                    current=bandpass_method,
+                    message=f"--bandpass-method must be one of {sorted(_BANDPASS_METHODS)}, got {bandpass_method!r}",
+                    fix_kind="enum",
+                    allowed=sorted(_BANDPASS_METHODS),
+                )
+            )
+        pfb_taps = _resolve(args, "pfb_taps_per_channel", config.inference.pfb_taps_per_channel)
+        if pfb_taps is not None and pfb_taps < 1:
+            errors.append(
+                ValidationError(
+                    field="inference.pfb_taps_per_channel",
+                    current=pfb_taps,
+                    message=f"--pfb-taps-per-channel must be >= 1, got {pfb_taps}",
                     fix_kind="clamp_low",
                     min_val=1,
                 )

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -318,6 +318,18 @@ class InferenceConfig:
     # None -> use manager.n_processes. Parallelism itself comes from the persistent worker
     # pool (one fused task per coarse channel), not from this knob.
     parallel_coarse_chans: int | None = None
+    # Bandpass flattening method for energy detection: "pfb" divides each coarse channel by
+    # the instrument's static polyphase-filterbank response (computed once per run); "spline"
+    # fits and subtracts a spline per coarse channel per file (the historical, data-driven
+    # method).
+    bandpass_method: str = "pfb"
+    # PFB prototype-filter taps per coarse channel. Instrument-dependent: 12 is the GBT /
+    # Breakthrough Listen backend default, and it must match the backend that produced the
+    # .h5 files being processed.
+    pfb_taps_per_channel: int = 12
+    # Opt-in debug artifact: save a raw-vs-flattened overlay plot (a few sampled coarse
+    # channels per cadence) under {output_path}/plots/inference/.
+    bandpass_debug_plot: bool = False
     spline_order: int = 16
     detection_window_size: int = 256
     detection_step_size: int = 128
@@ -336,8 +348,11 @@ class InferenceConfig:
     discard_side_channels: bool = False
     side_channel_count: int = 0
 
-    # NOTE: come back to this later (is this consumed properly downstream? how does archiving functionality work with this? is there caching, e.g. if a h5 grouping already preprocessed & written to output dir, just read from it directly instead of wasting compute)
-    preprocess_output_dir: str | None = None  # Defaults to <output_path>/preprocessed at runtime
+    # Per-cadence .npy output directory for energy-detection preprocessing. None (default)
+    # resolves per CSV to {data_path}/inference/preprocessed/<csv_stem>_<save_tag>/ — tag
+    # scoping keeps runs isolated (same-tag retries resume; a new tag starts clean). Set
+    # explicitly to share/reuse one directory across runs and CSVs.
+    preprocess_output_dir: str | None = None
 
     # NOTE: come back to this later (is this implemented correctly?)
     # Fault tolerance
@@ -603,6 +618,9 @@ class Config:
                 "cadence_expected_obs": self.inference.cadence_expected_obs,
                 "coarse_channel_width": self.inference.coarse_channel_width,
                 "parallel_coarse_chans": self.inference.parallel_coarse_chans,
+                "bandpass_method": self.inference.bandpass_method,
+                "pfb_taps_per_channel": self.inference.pfb_taps_per_channel,
+                "bandpass_debug_plot": self.inference.bandpass_debug_plot,
                 "spline_order": self.inference.spline_order,
                 "detection_window_size": self.inference.detection_window_size,
                 "detection_step_size": self.inference.detection_step_size,

--- a/src/aetherscan/pfb.py
+++ b/src/aetherscan/pfb.py
@@ -1,0 +1,124 @@
+"""
+Polyphase filterbank (PFB) static passband equalization for Aetherscan's energy detection.
+
+Radio-telescope backends (e.g. the GBT/Breakthrough Listen digital backend) channelize the
+band with a polyphase filterbank whose prototype filter imprints the same scalloped passband
+shape onto every coarse channel. Because that shape is a static property of the instrument's
+filter design — not of the data — it can be computed once from the filter parameters and
+divided out, instead of fitting a spline to every coarse channel of every file (the historical
+default, and a real per-channel cost inside energy detection).
+
+This is a native NumPy port of the response-generation logic in bliss
+(github.com/n-west/bliss, bliss/preprocess/passband_static_equalize.cpp); it introduces no
+bliss (or TensorFlow) dependency. One intentional deviation: the C++ approximates sinc near
+zero with a truncated cosine product (cos(x/2)*cos(x/4)*cos(x/8) for |x| < 0.01) purely as a
+numerical shortcut, while np.sinc evaluates the same normalized sinc exactly — the unit tests
+pin the two filter designs against each other.
+
+The response depends on (fine_per_coarse, num_coarse_channels, taps_per_channel) only, so
+gen_coarse_channel_response is lru_cached: each process pays the one-time FFT (seconds at
+full GBT resolution), after which equalizing a channel is a single vectorized divide.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# Fraction of a coarse channel treated as the "edge" band (each side) and the "mid" band by
+# edge_mid_power_ratio — the validation statistic used to detect a static-response mismatch.
+_RATIO_BAND_FRACTION = 16
+
+
+def firdes(num_taps: int, fc: float) -> np.ndarray:
+    """
+    Design a windowed-sinc (Hamming) lowpass FIR prototype filter.
+
+    h[n] = sinc(fc * (n - (num_taps - 1) / 2)) * w[n], where w is the Hamming window
+    w[n] = 0.54 - 0.46 * cos(2*pi*n / (num_taps - 1)) (== np.hamming) and np.sinc is the
+    normalized sin(pi*t)/(pi*t). fc is the cutoff as a fraction of the sample rate
+    (1/num_coarse_channels for a critically-sampled PFB). Returns float64 of shape (num_taps,).
+    """
+    n = np.arange(num_taps, dtype=np.float64)
+    return np.sinc(fc * (n - (num_taps - 1) / 2.0)) * np.hamming(num_taps)
+
+
+@functools.cache
+def gen_coarse_channel_response(
+    fine_per_coarse: int, num_coarse_channels: int, taps_per_channel: int
+) -> np.ndarray:
+    """
+    Compute the static per-coarse-channel passband response H of a critically-sampled PFB.
+
+    Steps (mirroring the bliss reference): design the prototype lowpass
+    (taps_per_channel * num_coarse_channels taps, cutoff 1/num_coarse_channels); zero-pad to
+    num_coarse_channels * fine_per_coarse points; take |fftshift(fft(.))|^2; drop half a
+    coarse channel from each end so the remaining band is an integer number of coarse-channel
+    spans centered on channel boundaries; fold those (num_coarse_channels - 1) spans on top of
+    each other (summing in adjacent-channel leakage); normalize to a peak of 1.0.
+
+    Returns H of shape (fine_per_coarse,), float64, read-only (the array is cached and shared
+    across callers — copy before mutating). Cached per argument tuple, so each process pays
+    the FFT cost once per distinct (file resolution, coarse count, taps) combination.
+    """
+    if fine_per_coarse < 2:
+        raise ValueError(f"fine_per_coarse must be >= 2, got {fine_per_coarse}")
+    if num_coarse_channels < 2:
+        # The fold needs at least one full coarse-channel span after edge-slicing.
+        raise ValueError(f"num_coarse_channels must be >= 2, got {num_coarse_channels}")
+    if taps_per_channel < 1:
+        raise ValueError(f"taps_per_channel must be >= 1, got {taps_per_channel}")
+
+    h = firdes(taps_per_channel * num_coarse_channels, 1.0 / num_coarse_channels)
+    full_len = num_coarse_channels * fine_per_coarse
+    padded = np.zeros(full_len, dtype=np.float64)
+    padded[: h.size] = h
+    spectrum = np.abs(np.fft.fftshift(np.fft.fft(padded))) ** 2
+
+    half_fine = fine_per_coarse // 2
+    sliced = spectrum[half_fine : full_len - half_fine]
+    response = sliced.reshape(num_coarse_channels - 1, fine_per_coarse).sum(axis=0)
+    response /= response.max()
+    response.setflags(write=False)
+
+    logger.debug(
+        f"Generated PFB coarse-channel response: fine_per_coarse={fine_per_coarse}, "
+        f"num_coarse_channels={num_coarse_channels}, taps_per_channel={taps_per_channel}"
+    )
+    return response
+
+
+def equalize_passband(channel: np.ndarray, response: np.ndarray) -> np.ndarray:
+    """
+    Divide one coarse channel by the static passband response, broadcasting over time.
+
+    channel has shape (time_bins, fine_per_coarse) and response (fine_per_coarse,) — e.g. the
+    output of gen_coarse_channel_response. Returns the equalized channel (float64 when
+    response is float64); the inputs are not modified.
+    """
+    if channel.shape[-1] != response.shape[0]:
+        raise ValueError(
+            f"channel width {channel.shape[-1]} does not match response length {response.shape[0]}"
+        )
+    return channel / response
+
+
+def edge_mid_power_ratio(spectrum: np.ndarray) -> float:
+    """
+    Mean power in the coarse-channel edge bands relative to the mid band.
+
+    spectrum is a 1-D per-bin power array over one coarse channel (either the theoretical
+    response H or a time-integrated data channel). The edge band is the outermost 1/16 of the
+    bins on each side; the mid band is the central 1/8. Comparing this ratio between H and
+    real data is the cheap sanity check (after the bliss `validate` flag) for whether the
+    configured static response actually matches the recording.
+    """
+    n = spectrum.shape[0]
+    band = max(1, n // _RATIO_BAND_FRACTION)
+    edge = 0.5 * (float(spectrum[:band].mean()) + float(spectrum[-band:].mean()))
+    mid = float(spectrum[n // 2 - band // 2 : n // 2 + band // 2 + 1].mean())
+    return edge / mid

--- a/src/aetherscan/pfb.py
+++ b/src/aetherscan/pfb.py
@@ -69,6 +69,10 @@ def gen_coarse_channel_response(
     """
     if fine_per_coarse < 2:
         raise ValueError(f"fine_per_coarse must be >= 2, got {fine_per_coarse}")
+    if fine_per_coarse % 2 != 0:
+        # Half a coarse channel (fine_per_coarse // 2) is sliced off each end below, so the
+        # remaining band is an exact multiple of fine_per_coarse only when it is even.
+        raise ValueError(f"fine_per_coarse must be even, got {fine_per_coarse}")
     if num_coarse_channels < 2:
         # The fold needs at least one full coarse-channel span after edge-slicing.
         raise ValueError(f"num_coarse_channels must be >= 2, got {num_coarse_channels}")
@@ -118,10 +122,11 @@ def edge_mid_power_ratio(spectrum: np.ndarray) -> float:
     Mean power in the coarse-channel edge bands relative to the mid band.
 
     spectrum is a 1-D per-bin power array over one coarse channel (either the theoretical
-    response H or a time-integrated data channel). The edge band is the outermost 1/16 of the
-    bins on each side; the mid band is the central 1/8. Comparing this ratio between H and
-    real data is the cheap sanity check (after the bliss `validate` flag) for whether the
-    configured static response actually matches the recording.
+    response H or a time-integrated data channel). Both the edge band (outermost n // 16 bins
+    on each side) and the mid band (a central band of the same n // 16 width) use
+    _RATIO_BAND_FRACTION. Comparing this ratio between H and real data is the cheap sanity
+    check (after the bliss `validate` flag) for whether the configured static response
+    actually matches the recording.
     """
     n = spectrum.shape[0]
     band = max(1, n // _RATIO_BAND_FRACTION)

--- a/src/aetherscan/pfb.py
+++ b/src/aetherscan/pfb.py
@@ -47,7 +47,9 @@ def firdes(num_taps: int, fc: float) -> np.ndarray:
     return np.sinc(fc * (n - (num_taps - 1) / 2.0)) * np.hamming(num_taps)
 
 
-@functools.cache
+# maxsize=4 bounds memory if a long-lived process sees several parameter combinations
+# (e.g. a test session); a production run only ever uses one.
+@functools.lru_cache(maxsize=4)
 def gen_coarse_channel_response(
     fine_per_coarse: int, num_coarse_channels: int, taps_per_channel: int
 ) -> np.ndarray:
@@ -104,7 +106,11 @@ def equalize_passband(channel: np.ndarray, response: np.ndarray) -> np.ndarray:
         raise ValueError(
             f"channel width {channel.shape[-1]} does not match response length {response.shape[0]}"
         )
-    return channel / response
+    # Defensive floor: the 12-tap GBT design bottoms out around 0.25-0.5 at channel edges,
+    # but a very high taps_per_channel (sharper rolloff) could push edge bins toward zero
+    # and turn the divide into inf. The floor sits far below any physical response value,
+    # so realistic responses pass through untouched.
+    return channel / np.maximum(response, 1e-10)
 
 
 def edge_mid_power_ratio(spectrum: np.ndarray) -> float:

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -18,6 +18,7 @@ import math
 import os
 import re
 import signal
+import uuid
 from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -1739,7 +1740,10 @@ class DataPreprocessor:
             except Exception as e:
                 logger.warning(f"PFB response cache {path} unreadable ({e}); rewriting")
 
-        tmp_path = path + ".tmp"
+        # Per-writer tmp name (pid + uuid) so two runs sharing this output_path don't clobber
+        # each other's in-progress write on a single shared "{path}.tmp"; os.replace stays
+        # atomic and the content is deterministic, so whichever writer lands last is harmless.
+        tmp_path = f"{path}.{os.getpid()}.{uuid.uuid4().hex}.tmp"
         with open(tmp_path, "wb") as f:
             np.save(f, response)
         os.replace(tmp_path, path)

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -249,16 +249,31 @@ def _spline_flatten_bandpass(channel: np.ndarray, spl_order: int) -> np.ndarray:
     return channel - fit
 
 
-def _pfb_flatten_bandpass(
-    channel: np.ndarray, num_coarse_channels: int, taps_per_channel: int
-) -> np.ndarray:
+@functools.cache
+def _load_pfb_response(response_path: str) -> np.ndarray:
+    """
+    Load (and per-process cache) a PFB passband response written by
+    DataPreprocessor._ensure_pfb_response_file. The array is marked read-only because the
+    cache shares it across every call in the process.
+    """
+    response = np.load(response_path)
+    response.setflags(write=False)
+    return response
+
+
+def _pfb_flatten_bandpass(channel: np.ndarray, response_path: str) -> np.ndarray:
     """
     PFB static-equalization bandpass flattener (--bandpass-method pfb, the default): divide the
     channel by the instrument's precomputed polyphase-filterbank passband response instead of
     fitting a spline per channel per file. channel has shape (time_bins, coarse_channel_width);
-    returns the equalized float64 channel of the same shape. The response is lru_cached per
-    (width, num_coarse_channels, taps_per_channel), so each pool worker pays the one-time FFT
-    cost once and every subsequent channel is a single vectorized divide.
+    returns the equalized float64 channel of the same shape.
+
+    The response is computed ONCE, in the parent process, and shipped to pool workers as the
+    path of a small sidecar .npy (see _ensure_pfb_response_file) rather than as generation
+    parameters: at GBT scale, generating the response is an ~n_chans-point FFT with a
+    tens-of-GB transient, and every pool worker running that concurrently on its first task
+    would exhaust the node's memory. Workers just read the ~8 MB file, cached per process by
+    _load_pfb_response.
 
     # NOTE: the spline path *subtracts* its fit while this path *divides* by H, so equalized
     # channels keep their DC offset and a bin-dependent scale. That asymmetry is fine for
@@ -267,8 +282,7 @@ def _pfb_flatten_bandpass(
     # variance (scale cancels), so flattening the bandpass *shape* is all that matters.
     # The spline-vs-PFB detection comparison in the PR body is the empirical arbiter.
     """
-    response = gen_coarse_channel_response(channel.shape[1], num_coarse_channels, taps_per_channel)
-    return equalize_passband(channel, response)
+    return equalize_passband(channel, _load_pfb_response(response_path))
 
 
 def _sliding_normality_k2(channel: np.ndarray, window_size: int, step_size: int) -> np.ndarray:
@@ -1672,11 +1686,12 @@ class DataPreprocessor:
         method = self.config.inference.bandpass_method
         if method == "pfb":
             if num_coarse_channels >= 2:
-                return functools.partial(
-                    _pfb_flatten_bandpass,
-                    num_coarse_channels=num_coarse_channels,
-                    taps_per_channel=self.config.inference.pfb_taps_per_channel,
+                response_path = self._ensure_pfb_response_file(
+                    self.config.inference.coarse_channel_width,
+                    num_coarse_channels,
+                    self.config.inference.pfb_taps_per_channel,
                 )
+                return functools.partial(_pfb_flatten_bandpass, response_path=response_path)
             logger.warning(
                 "bandpass_method='pfb' requires >= 2 coarse channels to fold adjacent-channel "
                 f"leakage, but this file has {num_coarse_channels}; falling back to the "
@@ -1687,6 +1702,47 @@ class DataPreprocessor:
         return functools.partial(
             _spline_flatten_bandpass, spl_order=self.config.inference.spline_order
         )
+
+    def _ensure_pfb_response_file(
+        self, fine_per_coarse: int, num_coarse_channels: int, taps_per_channel: int
+    ) -> str:
+        """
+        Compute the PFB passband response in the parent process and persist it to a
+        deterministic sidecar .npy under {output_path}/pfb_cache/, returning its path.
+
+        The heavy work (an ~n_chans-point FFT) runs exactly once per parameter combination in
+        the parent — gen_coarse_channel_response is process-cached and the file is reused when
+        its content matches — while pool workers receive only the path and read the ~8 MB
+        array (see _pfb_flatten_bandpass). The file is content-addressed by its parameters, so
+        stale-run leftovers are impossible; a corrupt or mismatched file is rewritten. Writes
+        are atomic (tmp + os.replace), matching the stamp-extraction pattern.
+        """
+        response = gen_coarse_channel_response(
+            fine_per_coarse, num_coarse_channels, taps_per_channel
+        )
+
+        cache_dir = os.path.join(self.config.output_path, "pfb_cache")
+        os.makedirs(cache_dir, exist_ok=True)
+        path = os.path.join(
+            cache_dir,
+            f"pfb_response_w{fine_per_coarse}_c{num_coarse_channels}_t{taps_per_channel}.npy",
+        )
+
+        if os.path.exists(path):
+            try:
+                existing = np.load(path)
+                if np.array_equal(existing, response):
+                    return path
+                logger.warning(f"PFB response cache {path} does not match; rewriting")
+            except Exception as e:
+                logger.warning(f"PFB response cache {path} unreadable ({e}); rewriting")
+
+        tmp_path = path + ".tmp"
+        with open(tmp_path, "wb") as f:
+            np.save(f, response)
+        os.replace(tmp_path, path)
+        logger.info(f"Wrote PFB response cache: {path}")
+        return path
 
     @staticmethod
     def _sample_channel_indices(n_coarse_total: int) -> list[int]:

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -1752,14 +1752,19 @@ class DataPreprocessor:
         spectrum raw vs flattened, overlaying the model being removed (the scaled PFB response
         H, or the spline fit). Saved under {output_path}/plots/inference/. Deliberately
         minimal — PR-08's inference visualization suite formalizes this figure.
+
+        Uses matplotlib's object-oriented Figure API rather than pyplot: _process_cadence runs
+        on the streaming-inference prefetch thread, and pyplot's global figure registry is not
+        thread-safe.
         """
-        import matplotlib.pyplot as plt  # noqa: PLC0415
+        from matplotlib.figure import Figure  # noqa: PLC0415
 
         width = self.config.inference.coarse_channel_width
         pfb_active = bandpass_flatten.func is _pfb_flatten_bandpass
         sampled = self._sample_channel_indices(n_coarse_total)
 
-        fig, axes = plt.subplots(len(sampled), 2, figsize=(14, 3.2 * len(sampled)), squeeze=False)
+        fig = Figure(figsize=(14, 3.2 * len(sampled)))
+        axes = fig.subplots(len(sampled), 2, squeeze=False)
         for row, ch in enumerate(sampled):
             channel = self._read_despiked_channel(h5_path, ch)
             raw = channel.mean(axis=0)
@@ -1796,8 +1801,8 @@ class DataPreprocessor:
         stem = os.path.splitext(os.path.basename(npy_path))[0]
         tag = self.config.checkpoint.save_tag
         out_path = os.path.join(save_dir, f"bandpass_overlay_{stem}_{tag}.png")
+        # No close/registry bookkeeping needed: an OO-API Figure is garbage-collected
         fig.savefig(out_path, dpi=120)
-        plt.close(fig)
         logger.info(f"Saved bandpass overlay debug plot: {out_path}")
 
     # NOTE: come back to this later (what's the trade-off for doing dedup vs not? e.g. lower storage & compute, but higher FNR or lower DR sensitivity?)

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -54,9 +54,11 @@ _GLOBAL_DTYPE = None
 # PFB static-response sanity check: warn when a file's measured edge/mid power ratio
 # disagrees with the theoretical response's by more than this relative tolerance.
 _PFB_RATIO_MISMATCH_TOL = 0.05
-# Coarse channels sampled (evenly across the band) by the PFB sanity check and the opt-in
-# bandpass overlay debug plot.
+# Coarse channels sampled (evenly across the band) by the opt-in bandpass overlay debug plot.
 _BANDPASS_SAMPLE_CHANNELS = 3
+# The PFB static-response sanity check samples more channels and takes a median (not a mean),
+# so a single RFI-heavy channel doesn't skew the statistic.
+_PFB_MISMATCH_SAMPLE_CHANNELS = 9
 
 
 def _init_worker(shm_name, shape, dtype):
@@ -1751,9 +1753,11 @@ class DataPreprocessor:
         return path
 
     @staticmethod
-    def _sample_channel_indices(n_coarse_total: int) -> list[int]:
-        """Pick up to _BANDPASS_SAMPLE_CHANNELS coarse-channel indices evenly across the band."""
-        num = min(_BANDPASS_SAMPLE_CHANNELS, n_coarse_total)
+    def _sample_channel_indices(
+        n_coarse_total: int, num: int = _BANDPASS_SAMPLE_CHANNELS
+    ) -> list[int]:
+        """Pick up to `num` coarse-channel indices evenly across the band."""
+        num = min(num, n_coarse_total)
         return sorted({int(i) for i in np.linspace(0, n_coarse_total - 1, num=num)})
 
     def _read_despiked_channel(self, h5_path: str, channel_index: int) -> np.ndarray:
@@ -1769,24 +1773,41 @@ class DataPreprocessor:
 
     def _warn_on_pfb_response_mismatch(self, h5_path: str, n_coarse_total: int) -> None:
         """
-        Cheap validation of the static PFB response against the recording (after the bliss
-        `validate` flag): compare the file's mean edge/mid power ratio — measured on a few
+        Heuristic sanity check of the static PFB response against the recording (after the bliss
+        `validate` flag): compare the file's median edge/mid power ratio — measured over several
         coarse channels sampled evenly across the band — with the theoretical response's, and
-        warn once per file (never per channel) when they disagree by more than
-        _PFB_RATIO_MISMATCH_TOL. A mismatch means the static response doesn't describe this
-        recording (wrong --pfb-taps-per-channel for the instrument that produced the .h5),
-        in which case the data-driven spline method may be preferable.
+        log an INFORMATIONAL warning once per file (never per channel) when they disagree by
+        more than _PFB_RATIO_MISMATCH_TOL.
+
+        This comparison is deliberately coarse and is EXPECTED to show a moderate mismatch even
+        when the response is correct: the measured ratio is taken on RAW (unflattened) data, so
+        it also carries the analog-frontend passband tilt and edge RFI that the pure response H
+        does not model. A median over several channels resists a single RFI-heavy channel, but
+        the frontend contribution is systematic and does not cancel — so a small disagreement is
+        normal, and only a LARGE or CONSISTENT one (across many files) is diagnostic of a wrong
+        --pfb-taps-per-channel. A principled threshold needs the analog-frontend baseline, which
+        is the deferred pfb_taps-vs-backend characterization.
         """
+        # TODO: replace this raw-vs-pure comparison with a residual-flatness statistic — flatten
+        # the sampled channels with the active response (divide by H) and compare the flattened
+        # edge/mid ratio against ~1.0. That directly measures whether dividing by H flattens the
+        # data and is far less confounded by the frontend tilt / RFI, giving a meaningful
+        # threshold. Land it with the pfb_taps-per-channel backend characterization (which fixes
+        # the legitimate baseline), and read the sampled channels more cheaply (float32/strided)
+        # — the full-resolution float64 reads make this check non-cheap at GBT scale. See #156.
         width = self.config.inference.coarse_channel_width
         taps = self.config.inference.pfb_taps_per_channel
         try:
             response = gen_coarse_channel_response(width, n_coarse_total, taps)
             expected = edge_mid_power_ratio(response)
+            # Median (not mean) so a single RFI-heavy sampled channel doesn't skew the statistic.
             ratios = [
                 edge_mid_power_ratio(self._read_despiked_channel(h5_path, ch).mean(axis=0))
-                for ch in self._sample_channel_indices(n_coarse_total)
+                for ch in self._sample_channel_indices(
+                    n_coarse_total, _PFB_MISMATCH_SAMPLE_CHANNELS
+                )
             ]
-            measured = float(np.mean(ratios))
+            measured = float(np.median(ratios))
         except Exception as e:
             logger.warning(f"PFB static-response sanity check failed for {h5_path}: {e}")
             return
@@ -1794,11 +1815,13 @@ class DataPreprocessor:
         rel_diff = abs(measured - expected) / expected
         if rel_diff > _PFB_RATIO_MISMATCH_TOL:
             logger.warning(
-                f"{h5_path}: measured edge/mid power ratio {measured:.3f} differs from the "
-                f"static PFB response's {expected:.3f} by {rel_diff:.1%} "
-                f"(> {_PFB_RATIO_MISMATCH_TOL:.0%}). The configured response may not match "
-                f"the backend that produced this file — check --pfb-taps-per-channel "
-                f"(currently {taps}), or consider --bandpass-method spline"
+                f"{h5_path}: median edge/mid power ratio {measured:.3f} differs from the static "
+                f"PFB response's {expected:.3f} by {rel_diff:.1%} (heuristic sanity check — "
+                f"informational). The measured ratio is taken on raw data, so it also reflects "
+                f"analog-frontend tilt and edge RFI the pure response does not model; a moderate "
+                f"gap is expected. Investigate only a large or consistent mismatch across many "
+                f"files: it may mean --pfb-taps-per-channel (currently {taps}) is wrong for this "
+                f"backend, in which case --bandpass-method spline is the data-driven fallback."
             )
 
     def _plot_bandpass_overlay(

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -37,6 +37,7 @@ from aetherscan.data_generation import log_norm
 from aetherscan.db import get_db
 from aetherscan.logger import init_worker_logging
 from aetherscan.manager import get_manager
+from aetherscan.pfb import edge_mid_power_ratio, equalize_passband, gen_coarse_channel_response
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,13 @@ _GLOBAL_SHM = None
 _GLOBAL_CHUNK_DATA = None
 _GLOBAL_SHAPE = None
 _GLOBAL_DTYPE = None
+
+# PFB static-response sanity check: warn when a file's measured edge/mid power ratio
+# disagrees with the theoretical response's by more than this relative tolerance.
+_PFB_RATIO_MISMATCH_TOL = 0.05
+# Coarse channels sampled (evenly across the band) by the PFB sanity check and the opt-in
+# bandpass overlay debug plot.
+_BANDPASS_SAMPLE_CHANNELS = 3
 
 
 def _init_worker(shm_name, shape, dtype):
@@ -227,18 +235,40 @@ def _fit_channel_bandpass(
 
 def _spline_flatten_bandpass(channel: np.ndarray, spl_order: int) -> np.ndarray:
     """
-    Default bandpass flattener: fit a spline to the time-integrated coarse channel and subtract
-    it from every time row. channel has shape (time_bins, coarse_channel_width); returns the
-    float64 residuals of the same shape.
+    Spline bandpass flattener (--bandpass-method spline): fit a spline to the time-integrated
+    coarse channel and subtract it from every time row. channel has shape
+    (time_bins, coarse_channel_width); returns the float64 residuals of the same shape.
 
     Bandpass flattening is a pluggable stage: _process_cadence obtains a picklable callable via
-    DataPreprocessor._get_bandpass_flattener() and ships it to the pool workers, so alternative
-    flatteners (e.g. the PFB static equalization planned for a later PR) only need a
-    module-level function with the same (channel) -> residuals contract.
+    DataPreprocessor._get_bandpass_flattener() and ships it to the pool workers, so a flattener
+    only needs to be a module-level function with the same (channel) -> flattened contract
+    (see _pfb_flatten_bandpass for the other implementation).
     """
     integrated_channel = np.mean(channel, axis=0)
     fit = _fit_channel_bandpass(integrated_channel, channel.shape[1], spl_order)
     return channel - fit
+
+
+def _pfb_flatten_bandpass(
+    channel: np.ndarray, num_coarse_channels: int, taps_per_channel: int
+) -> np.ndarray:
+    """
+    PFB static-equalization bandpass flattener (--bandpass-method pfb, the default): divide the
+    channel by the instrument's precomputed polyphase-filterbank passband response instead of
+    fitting a spline per channel per file. channel has shape (time_bins, coarse_channel_width);
+    returns the equalized float64 channel of the same shape. The response is lru_cached per
+    (width, num_coarse_channels, taps_per_channel), so each pool worker pays the one-time FFT
+    cost once and every subsequent channel is a single vectorized divide.
+
+    # NOTE: the spline path *subtracts* its fit while this path *divides* by H, so equalized
+    # channels keep their DC offset and a bin-dependent scale. That asymmetry is fine for
+    # detection: the D'Agostino-Pearson normality statistic is built from skewness and
+    # kurtosis, which are central moments (location cancels) normalized by powers of the
+    # variance (scale cancels), so flattening the bandpass *shape* is all that matters.
+    # The spline-vs-PFB detection comparison in the PR body is the empirical arbiter.
+    """
+    response = gen_coarse_channel_response(channel.shape[1], num_coarse_channels, taps_per_channel)
+    return equalize_passband(channel, response)
 
 
 def _sliding_normality_k2(channel: np.ndarray, window_size: int, step_size: int) -> np.ndarray:
@@ -1163,12 +1193,15 @@ class DataPreprocessor:
             logger.warning("plan_cadences() called with no inference_files configured")
             return []
 
-        # Resolve output directory
-        output_dir = self.config.inference.preprocess_output_dir or os.path.join(
-            self.config.output_path, "preprocessed"
-        )
-        os.makedirs(output_dir, exist_ok=True)
-        logger.info(f"Preprocessing output directory: {output_dir}")
+        # Output directory resolution: an explicit --preprocess-output-dir is used as-is
+        # (shared across CSVs); otherwise each CSV gets its own tag-scoped default,
+        # {data_path}/inference/preprocessed/<csv_stem>_<save_tag>/. Tag scoping trades
+        # cross-run caching for isolation: a retry under the same tag still resumes via the
+        # existing-.npy skip, while a fresh run (new datetime tag) starts from a clean
+        # directory that stale stamps from an older failed attempt can't leak into. To reuse
+        # an old run's preprocessing, pass its directory explicitly.
+        explicit_output_dir = self.config.inference.preprocess_output_dir
+        save_tag = self.config.checkpoint.save_tag
 
         group_by_cols = self.config.inference.cadence_group_by_cols
         h5_path_col = self.config.inference.cadence_h5_path_col
@@ -1196,6 +1229,12 @@ class DataPreprocessor:
             )
 
             csv_stem = os.path.splitext(os.path.basename(csv_path))[0]
+
+            output_dir = explicit_output_dir or self.config.get_inference_file_path(
+                os.path.join("preprocessed", f"{csv_stem}_{save_tag}")
+            )
+            os.makedirs(output_dir, exist_ok=True)
+            logger.info(f"Preprocessing output directory for {csv_filename}: {output_dir}")
 
             for group in valid_groups:
                 npy_filename = self._cadence_npy_filename(csv_stem, group.key)
@@ -1353,8 +1392,6 @@ class DataPreprocessor:
         n_processes = self.config.manager.n_processes
         progress_chunk = max(1, parallel_chans if parallel_chans is not None else n_processes)
 
-        bandpass_flatten = self._get_bandpass_flattener()
-
         # Read header / metadata from the first ON-source file
         on_source_paths = [group.h5_paths[i] for i in (0, 2, 4)]
         primary_h5 = on_source_paths[0]
@@ -1406,6 +1443,17 @@ class DataPreprocessor:
             f"ON-source files={len(on_source_paths)}"
         )
 
+        # The flattener depends on the file's actual coarse count (PFB folds
+        # adjacent-channel leakage), so it can only be built once n_coarse_total is known.
+        bandpass_flatten = self._get_bandpass_flattener(n_coarse_total)
+        pfb_active = bandpass_flatten.func is _pfb_flatten_bandpass
+
+        if self.config.inference.bandpass_debug_plot:
+            try:
+                self._plot_bandpass_overlay(primary_h5, n_coarse_total, bandpass_flatten, npy_path)
+            except Exception as e:
+                logger.error(f"Cadence {group.key}: bandpass overlay plot failed: {e}")
+
         # Aggregate hits across all ON-source files
         all_hits: list[tuple] = []  # (abs_idx, stat, p)
 
@@ -1414,6 +1462,10 @@ class DataPreprocessor:
                 f"Cadence {group.key}: running energy detection on ON-source "
                 f"{on_source_idx + 1}/{len(on_source_paths)}: {on_h5}"
             )
+
+            if pfb_active:
+                # Cheap static-response sanity check (once per file, not per channel)
+                self._warn_on_pfb_response_mismatch(on_h5, n_coarse_total)
 
             tasks = [
                 (
@@ -1601,20 +1653,152 @@ class DataPreprocessor:
             metadata_path=metadata_path,
         )
 
-    def _get_bandpass_flattener(self) -> Callable[[np.ndarray], np.ndarray]:
+    def _get_bandpass_flattener(
+        self, num_coarse_channels: int
+    ) -> Callable[[np.ndarray], np.ndarray]:
         """
         Return the configured bandpass-flattening callable for energy detection.
 
         The callable takes one coarse channel of shape (time_bins, coarse_channel_width) and
-        returns the flattened residuals; it must be picklable (a functools.partial over a
-        module-level function) so pool workers can receive it in their task args. Currently
-        only the spline flattener exists.
+        returns the flattened channel; it must be picklable (a functools.partial over a
+        module-level function) so pool workers can receive it in their task args.
 
-        # NOTE: PR-07 adds a PFB static-equalization flattener here (selected via config)
+        num_coarse_channels is the *file's* actual coarse-channel count
+        (n_chans // coarse_channel_width) — the PFB response folds adjacent-channel leakage,
+        so it depends on how many coarse channels the recording actually has. Files with a
+        single coarse channel can't support the fold and fall back to the spline flattener
+        with a warning.
         """
+        method = self.config.inference.bandpass_method
+        if method == "pfb":
+            if num_coarse_channels >= 2:
+                return functools.partial(
+                    _pfb_flatten_bandpass,
+                    num_coarse_channels=num_coarse_channels,
+                    taps_per_channel=self.config.inference.pfb_taps_per_channel,
+                )
+            logger.warning(
+                "bandpass_method='pfb' requires >= 2 coarse channels to fold adjacent-channel "
+                f"leakage, but this file has {num_coarse_channels}; falling back to the "
+                "spline flattener for this cadence"
+            )
+        elif method != "spline":
+            raise ValueError(f"Unknown bandpass_method {method!r}; expected 'pfb' or 'spline'")
         return functools.partial(
             _spline_flatten_bandpass, spl_order=self.config.inference.spline_order
         )
+
+    @staticmethod
+    def _sample_channel_indices(n_coarse_total: int) -> list[int]:
+        """Pick up to _BANDPASS_SAMPLE_CHANNELS coarse-channel indices evenly across the band."""
+        num = min(_BANDPASS_SAMPLE_CHANNELS, n_coarse_total)
+        return sorted({int(i) for i in np.linspace(0, n_coarse_total - 1, num=num)})
+
+    def _read_despiked_channel(self, h5_path: str, channel_index: int) -> np.ndarray:
+        """Read one coarse channel as float64 with the DC spike interpolated away — the same
+        preparation the energy-detection workers apply before bandpass flattening."""
+        width = self.config.inference.coarse_channel_width
+        time_bins = self.config.data.time_bins
+        start = channel_index * width
+        with h5py.File(h5_path, "r") as hf:
+            channel = hf["data"][:time_bins, 0, start : start + width].astype(np.float64)
+        _remove_dc_spike(channel, width, 1)
+        return channel
+
+    def _warn_on_pfb_response_mismatch(self, h5_path: str, n_coarse_total: int) -> None:
+        """
+        Cheap validation of the static PFB response against the recording (after the bliss
+        `validate` flag): compare the file's mean edge/mid power ratio — measured on a few
+        coarse channels sampled evenly across the band — with the theoretical response's, and
+        warn once per file (never per channel) when they disagree by more than
+        _PFB_RATIO_MISMATCH_TOL. A mismatch means the static response doesn't describe this
+        recording (wrong --pfb-taps-per-channel for the instrument that produced the .h5),
+        in which case the data-driven spline method may be preferable.
+        """
+        width = self.config.inference.coarse_channel_width
+        taps = self.config.inference.pfb_taps_per_channel
+        try:
+            response = gen_coarse_channel_response(width, n_coarse_total, taps)
+            expected = edge_mid_power_ratio(response)
+            ratios = [
+                edge_mid_power_ratio(self._read_despiked_channel(h5_path, ch).mean(axis=0))
+                for ch in self._sample_channel_indices(n_coarse_total)
+            ]
+            measured = float(np.mean(ratios))
+        except Exception as e:
+            logger.warning(f"PFB static-response sanity check failed for {h5_path}: {e}")
+            return
+
+        rel_diff = abs(measured - expected) / expected
+        if rel_diff > _PFB_RATIO_MISMATCH_TOL:
+            logger.warning(
+                f"{h5_path}: measured edge/mid power ratio {measured:.3f} differs from the "
+                f"static PFB response's {expected:.3f} by {rel_diff:.1%} "
+                f"(> {_PFB_RATIO_MISMATCH_TOL:.0%}). The configured response may not match "
+                f"the backend that produced this file — check --pfb-taps-per-channel "
+                f"(currently {taps}), or consider --bandpass-method spline"
+            )
+
+    def _plot_bandpass_overlay(
+        self,
+        h5_path: str,
+        n_coarse_total: int,
+        bandpass_flatten: Callable[[np.ndarray], np.ndarray],
+        npy_path: str,
+    ) -> None:
+        """
+        Opt-in debug artifact (--bandpass-debug-plot): for a few coarse channels sampled evenly
+        across the band of the cadence's primary ON-source file, plot the time-integrated
+        spectrum raw vs flattened, overlaying the model being removed (the scaled PFB response
+        H, or the spline fit). Saved under {output_path}/plots/inference/. Deliberately
+        minimal — PR-08's inference visualization suite formalizes this figure.
+        """
+        import matplotlib.pyplot as plt  # noqa: PLC0415
+
+        width = self.config.inference.coarse_channel_width
+        pfb_active = bandpass_flatten.func is _pfb_flatten_bandpass
+        sampled = self._sample_channel_indices(n_coarse_total)
+
+        fig, axes = plt.subplots(len(sampled), 2, figsize=(14, 3.2 * len(sampled)), squeeze=False)
+        for row, ch in enumerate(sampled):
+            channel = self._read_despiked_channel(h5_path, ch)
+            raw = channel.mean(axis=0)
+            flat = np.asarray(bandpass_flatten(channel)).mean(axis=0)
+            if pfb_active:
+                response = gen_coarse_channel_response(
+                    width, n_coarse_total, self.config.inference.pfb_taps_per_channel
+                )
+                # Least-squares scale so the unit-peak response overlays the raw spectrum
+                overlay = response * (float(raw @ response) / float(response @ response))
+                overlay_label = "scaled PFB response H"
+            else:
+                overlay = _fit_channel_bandpass(raw, width, self.config.inference.spline_order)
+                overlay_label = "spline fit"
+
+            ax_raw, ax_flat = axes[row]
+            ax_raw.plot(raw, lw=0.6, color="tab:blue", label="raw integrated spectrum")
+            ax_raw.plot(overlay, lw=1.2, ls="--", color="tab:orange", label=overlay_label)
+            ax_raw.set_ylabel(f"coarse channel {ch}\nintegrated power")
+            ax_flat.plot(flat, lw=0.6, color="tab:green", label="flattened integrated spectrum")
+            if row == 0:
+                ax_raw.legend(loc="upper right", fontsize=8)
+                ax_flat.legend(loc="upper right", fontsize=8)
+            if row == len(sampled) - 1:
+                ax_raw.set_xlabel("fine channel (within coarse channel)")
+                ax_flat.set_xlabel("fine channel (within coarse channel)")
+
+        method = "pfb" if pfb_active else "spline"
+        fig.suptitle(f"Bandpass flattening overlay ({method}): {os.path.basename(h5_path)}")
+        fig.tight_layout()
+
+        save_dir = os.path.join(self.config.output_path, "plots", "inference")
+        os.makedirs(save_dir, exist_ok=True)
+        stem = os.path.splitext(os.path.basename(npy_path))[0]
+        tag = self.config.checkpoint.save_tag
+        out_path = os.path.join(save_dir, f"bandpass_overlay_{stem}_{tag}.png")
+        fig.savefig(out_path, dpi=120)
+        plt.close(fig)
+        logger.info(f"Saved bandpass overlay debug plot: {out_path}")
 
     # NOTE: come back to this later (what's the trade-off for doing dedup vs not? e.g. lower storage & compute, but higher FNR or lower DR sensitivity?)
     @staticmethod

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -249,7 +249,9 @@ def _spline_flatten_bandpass(channel: np.ndarray, spl_order: int) -> np.ndarray:
     return channel - fit
 
 
-@functools.cache
+# maxsize=4 bounds memory if a long-lived worker sees several response paths (unlikely in
+# production — one per run — but plausible across a long test session).
+@functools.lru_cache(maxsize=4)
 def _load_pfb_response(response_path: str) -> np.ndarray:
     """
     Load (and per-process cache) a PFB passband response written by

--- a/tests/integration/test_inference_smoke.py
+++ b/tests/integration/test_inference_smoke.py
@@ -9,8 +9,11 @@ bind by default — either bind it explicitly:
 
     SINGULARITY_BIND=/datag ./utils/run_container.sh python -m pytest tests/ -m "gpu or cluster" -q
 
-or rely on the resume path: preprocessing skips any cadence whose stamp .npy already exists
-under <output>/preprocessed, so a previously-preprocessed subset runs without /datag.
+or rely on the resume path: preprocessing skips any cadence whose stamp .npy already exists.
+The default stamp directory is tag-scoped ({data_path}/inference/preprocessed/
+<csv_stem>_<save_tag>/), so a fresh-tagged run never resumes on its own — when /datag is not
+mounted and legacy stamps exist under <output>/preprocessed, the test points
+--preprocess-output-dir at them explicitly (the documented reuse escape hatch).
 """
 
 from __future__ import annotations
@@ -46,10 +49,15 @@ def test_inference_smoke(cluster_paths, run_pipeline):
         if not os.path.exists(required):
             pytest.skip(f"required cluster artifact missing: {required}")
 
-    # Raw .h5 reads need /datag; already-preprocessed stamps make it optional.
-    preprocessed = glob.glob(os.path.join(output_path, "preprocessed", "subset_test_*.npy"))
-    if not os.path.exists("/datag") and not preprocessed:
-        pytest.skip("/datag not mounted and no preprocessed subset stamps to resume from")
+    # Raw .h5 reads need /datag; already-preprocessed stamps make it optional, but the
+    # tag-scoped default output dir means a fresh tag never sees them — reuse requires
+    # passing their directory explicitly.
+    extra_flags: list[str] = []
+    if not os.path.exists("/datag"):
+        legacy_dir = os.path.join(output_path, "preprocessed")
+        if not glob.glob(os.path.join(legacy_dir, "subset_test_*.npy")):
+            pytest.skip("/datag not mounted and no preprocessed subset stamps to resume from")
+        extra_flags = ["--preprocess-output-dir", legacy_dir]
 
     tag = datetime.now().strftime("%Y%m%d_%H%M%S")
     proc = run_pipeline(
@@ -67,6 +75,7 @@ def test_inference_smoke(cluster_paths, run_pipeline):
             tag,
             "--max-retries",
             "1",
+            *extra_flags,
         ]
     )
 

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -408,6 +408,34 @@ class TestApplyArgsToConfig:
         apply_args_to_config(_parse(["train", "--load-tag", "round_03"]))
         assert config.checkpoint.start_round == 4
 
+    def test_bandpass_flags_apply_to_inference_config(self):
+        config = get_config()
+        # Preset True so --no-bandpass-debug-plot has something to force off.
+        config.inference.bandpass_debug_plot = True
+        apply_args_to_config(
+            _parse(
+                [
+                    "inference",
+                    "--bandpass-method",
+                    "spline",
+                    "--pfb-taps-per-channel",
+                    "8",
+                    "--no-bandpass-debug-plot",
+                ]
+            )
+        )
+        assert config.inference.bandpass_method == "spline"
+        assert config.inference.pfb_taps_per_channel == 8
+        assert config.inference.bandpass_debug_plot is False
+
+    def test_bandpass_debug_plot_omitted_preserves_default(self):
+        # BooleanOptionalAction default=None: omitting the flag must not clobber the config
+        # value (the "is not None" apply guard is what preserves it).
+        config = get_config()
+        config.inference.bandpass_debug_plot = True
+        apply_args_to_config(_parse(["inference"]))
+        assert config.inference.bandpass_debug_plot is True
+
 
 class TestLatentTraversalFlags:
     """Flags and validation for the latent-dimension traversal plot (PLAN PR-05)."""

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -214,6 +214,23 @@ class TestSemanticChecks:
         errors = collect_validation_errors(_parse(argv), None)
         assert any("divisible by" in e.message and "downsample-factor" in e.message for e in errors)
 
+    def test_bandpass_method_enum(self):
+        errors = collect_validation_errors(
+            _parse(["inference", "--bandpass-method", "median"]), None
+        )
+        assert any(e.field == "inference.bandpass_method" for e in errors)
+
+    @pytest.mark.parametrize("method", ["pfb", "spline"])
+    def test_bandpass_method_valid_values_pass(self, method):
+        errors = collect_validation_errors(_parse(["inference", "--bandpass-method", method]), None)
+        assert [e for e in errors if e.field == "inference.bandpass_method"] == []
+
+    def test_pfb_taps_per_channel_must_be_positive(self):
+        errors = collect_validation_errors(
+            _parse(["inference", "--pfb-taps-per-channel", "0"]), None
+        )
+        assert any(e.field == "inference.pfb_taps_per_channel" for e in errors)
+
 
 class TestCrossParamSolver:
     _VALID_BASE = {

--- a/tests/unit/test_pfb.py
+++ b/tests/unit/test_pfb.py
@@ -1,0 +1,163 @@
+"""Unit tests for aetherscan.pfb: windowed-sinc filter design (cross-checked against a
+transcription of the bliss C++ sinc approximation), the folded coarse-channel response's
+shape properties (symmetry, mid-band peak, edge rolloff), equalization flatness on synthetic
+PFB-shaped noise, and the edge/mid power-ratio validation statistic."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from aetherscan.pfb import (
+    edge_mid_power_ratio,
+    equalize_passband,
+    firdes,
+    gen_coarse_channel_response,
+)
+
+# Small but representative geometry: 4 coarse channels of 512 fine channels, GBT-default taps
+_FINE = 512
+_NUM_COARSE = 4
+_TAPS = 12
+
+
+def _cpp_sinc(t: float) -> float:
+    """Transcription of the bliss C++ sinc helper (passband_static_equalize.cpp): normalized
+    sinc evaluated as sin(pi t)/(pi t), with a truncated cosine-product approximation
+    cos(x/2)*cos(x/4)*cos(x/8) for |pi t| < 0.01. Transcribed here (test-only, no bliss
+    import) to pin our exact np.sinc-based filter against the reference implementation."""
+    x = math.pi * t
+    if abs(x) < 0.01:
+        return math.cos(x / 2.0) * math.cos(x / 4.0) * math.cos(x / 8.0)
+    return math.sin(x) / x
+
+
+def _cpp_firdes(num_taps: int, fc: float) -> np.ndarray:
+    """Reference filter design: C++ sinc transcription x explicit Hamming window."""
+    out = np.empty(num_taps, dtype=np.float64)
+    center = (num_taps - 1) / 2.0
+    for n in range(num_taps):
+        window = 0.54 - 0.46 * math.cos(2.0 * math.pi * n / (num_taps - 1))
+        out[n] = _cpp_sinc(fc * (n - center)) * window
+    return out
+
+
+class TestFirdes:
+    @pytest.mark.parametrize(
+        ("num_taps", "fc"),
+        [(48, 1.0 / 4), (768, 1.0 / 64), (12 * 512, 1.0 / 512)],
+    )
+    def test_matches_cpp_reference_filter(self, num_taps, fc):
+        ours = firdes(num_taps, fc)
+        reference = _cpp_firdes(num_taps, fc)
+        # np.sinc is exact where the C++ approximates; agreement must still be ~1e-6 or better
+        np.testing.assert_allclose(ours, reference, atol=1e-6)
+
+    def test_linear_phase_symmetry(self):
+        # Windowed-sinc design is symmetric about the center tap (linear phase)
+        h = firdes(_TAPS * _NUM_COARSE, 1.0 / _NUM_COARSE)
+        np.testing.assert_allclose(h, h[::-1], atol=1e-15)
+
+
+class TestGenCoarseChannelResponse:
+    def test_shape_dtype_and_readonly(self):
+        response = gen_coarse_channel_response(_FINE, _NUM_COARSE, _TAPS)
+        assert response.shape == (_FINE,)
+        assert response.dtype == np.float64
+        # Cached array is shared across callers; it must be immutable
+        assert not response.flags.writeable
+        with pytest.raises(ValueError):
+            response[0] = 0.0
+
+    def test_symmetric_about_channel_center(self):
+        # The response is even-symmetric excluding bin 0 (the unpaired Nyquist-edge bin of
+        # the even-length spectrum)
+        response = gen_coarse_channel_response(_FINE, _NUM_COARSE, _TAPS)
+        np.testing.assert_allclose(response[1:], response[1:][::-1], atol=1e-12)
+
+    def test_peaks_near_one_mid_band(self):
+        response = gen_coarse_channel_response(_FINE, _NUM_COARSE, _TAPS)
+        assert response.max() == pytest.approx(1.0)
+        assert response[_FINE // 2] > 0.98
+        # The peak sits in the passband, not at the rolled-off edges
+        assert _FINE // 4 < int(response.argmax()) < 3 * _FINE // 4
+
+    def test_rolls_off_at_edges(self):
+        response = gen_coarse_channel_response(_FINE, _NUM_COARSE, _TAPS)
+        # Classic PFB half-power rolloff at the channel boundary
+        assert response[0] < 0.6
+        assert response[-1] < 0.6
+        assert response.min() >= response[0] - 1e-12
+
+    def test_lru_cache_returns_same_object(self):
+        a = gen_coarse_channel_response(_FINE, _NUM_COARSE, _TAPS)
+        b = gen_coarse_channel_response(_FINE, _NUM_COARSE, _TAPS)
+        assert a is b
+        c = gen_coarse_channel_response(_FINE, _NUM_COARSE, _TAPS + 1)
+        assert c is not a
+
+    @pytest.mark.parametrize(
+        ("fine", "num_coarse", "taps"),
+        [(1, 4, 12), (512, 1, 12), (512, 4, 0)],
+    )
+    def test_invalid_arguments_raise(self, fine, num_coarse, taps):
+        with pytest.raises(ValueError):
+            gen_coarse_channel_response(fine, num_coarse, taps)
+
+
+class TestEqualizePassband:
+    def test_deterministic_shaped_input_becomes_exactly_flat(self):
+        response = gen_coarse_channel_response(_FINE, _NUM_COARSE, _TAPS)
+        shaped = np.ones((16, 1)) * response  # noise-free PFB-shaped "spectrum"
+        equalized = equalize_passband(shaped, response)
+        np.testing.assert_allclose(equalized, 1.0, rtol=1e-12)
+
+    def test_synthetic_pfb_noise_integrates_flat(self):
+        # Chi-squared-ish noise with mean 1 imprinted with the PFB shape: after
+        # equalization the time-integrated spectrum must be flat to within a few percent,
+        # while the un-equalized spectrum retains the full ~50% bandpass ripple.
+        rng = np.random.default_rng(3)
+        response = gen_coarse_channel_response(_FINE, 8, _TAPS)
+        noise = rng.chisquare(df=64, size=(4096, _FINE)) / 64.0
+        shaped = noise * response
+
+        integrated_raw = shaped.mean(axis=0)
+        raw_ripple = (integrated_raw.max() - integrated_raw.min()) / integrated_raw.mean()
+        assert raw_ripple > 0.3
+
+        integrated_eq = equalize_passband(shaped, response).mean(axis=0)
+        eq_ripple = (integrated_eq.max() - integrated_eq.min()) / integrated_eq.mean()
+        assert eq_ripple < 0.03
+
+    def test_inputs_not_modified(self):
+        response = gen_coarse_channel_response(_FINE, _NUM_COARSE, _TAPS)
+        channel = np.full((4, _FINE), 2.0)
+        original = channel.copy()
+        equalize_passband(channel, response)
+        np.testing.assert_array_equal(channel, original)
+
+    def test_width_mismatch_raises(self):
+        response = gen_coarse_channel_response(_FINE, _NUM_COARSE, _TAPS)
+        with pytest.raises(ValueError, match="does not match"):
+            equalize_passband(np.ones((4, _FINE + 1)), response)
+
+
+class TestEdgeMidPowerRatio:
+    def test_flat_spectrum_gives_one(self):
+        assert edge_mid_power_ratio(np.ones(_FINE)) == pytest.approx(1.0)
+
+    def test_pfb_response_ratio_reflects_rolloff(self):
+        response = gen_coarse_channel_response(_FINE, _NUM_COARSE, _TAPS)
+        ratio = edge_mid_power_ratio(response)
+        # Edge bands sit on the rolloff, mid band on the passband peak
+        assert 0.3 < ratio < 0.8
+
+    def test_flat_vs_response_disagree_beyond_tolerance(self):
+        # The pair the mismatch warning distinguishes: a recording without the PFB shape
+        # (ratio ~1) vs the theoretical response — far more than 5% apart.
+        response = gen_coarse_channel_response(_FINE, _NUM_COARSE, _TAPS)
+        expected = edge_mid_power_ratio(response)
+        measured = edge_mid_power_ratio(np.ones(_FINE))
+        assert abs(measured - expected) / expected > 0.05

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -21,12 +21,14 @@ from skimage.transform import downscale_local_mean
 
 from aetherscan.config import get_config
 from aetherscan.data_generation import log_norm
+from aetherscan.pfb import edge_mid_power_ratio, gen_coarse_channel_response
 from aetherscan.preprocessing import (
     DataPreprocessor,
     PendingCadence,
     _energy_detect_channel_worker,
     _extract_stamps_worker,
     _fit_channel_bandpass,
+    _pfb_flatten_bandpass,
     _remove_dc_spike,
     _sliding_normality_k2,
     _spline_flatten_bandpass,
@@ -400,10 +402,11 @@ def initialized_runtime():
 
 class TestProcessCadenceEndToEnd:
     """Sequential (no pool) end-to-end run of _process_cadence on synthetic .h5 observations
-    with an injected non-Gaussian feature: exercises fused detection, dedup, overlap stamps,
-    downsample-at-extraction, metadata, and the resume path."""
+    with an injected non-Gaussian feature: exercises fused detection, both bandpass
+    flatteners (spline on flat data, PFB on PFB-shaped data), dedup, overlap stamps,
+    downsample-at-extraction, metadata, the debug overlay plot, and the resume path."""
 
-    def _make_cadence(self, tmp_path, n_chans=2048, inject_at=768):
+    def _make_cadence(self, tmp_path, n_chans=2048, inject_at=768, pfb_shaped=False):
         import h5py  # noqa: PLC0415
 
         rng = np.random.default_rng(23)
@@ -414,6 +417,11 @@ class TestProcessCadenceEndToEnd:
             data = rng.normal(1000.0, 10.0, size=(16, 1, n_chans)).astype(np.float32)
             if obs in (0, 2, 4):
                 data[:, 0, inject_at : inject_at + 4] *= 50.0
+            if pfb_shaped:
+                # Imprint the instrument passband the PFB flattener expects to divide out
+                # (a flat recording would look like a static-response mismatch instead)
+                response = gen_coarse_channel_response(512, n_chans // 512, 12)
+                data *= np.tile(response, n_chans // 512).astype(np.float32)
             path = tmp_path / f"cad_obs_{obs}.h5"
             with h5py.File(path, "w") as hf:
                 dset = hf.create_dataset("data", data=data)
@@ -424,13 +432,14 @@ class TestProcessCadenceEndToEnd:
             h5_paths.append(str(path))
         return h5_paths
 
-    def _configure(self):
+    def _configure(self, bandpass_method="spline"):
         config = get_config()
         config.manager.n_processes = 1  # sequential: no pools/shm in unit tests
         config.data.time_bins = 16
         config.data.width_bin = 256
         config.data.downsample_factor = 8
         config.inference.coarse_channel_width = 512
+        config.inference.bandpass_method = bandpass_method
         config.inference.spline_order = 4
         config.inference.detection_window_size = 64
         config.inference.detection_step_size = 32
@@ -440,11 +449,12 @@ class TestProcessCadenceEndToEnd:
         config.inference.overlap_fraction = 0.5
         return config
 
-    def test_process_and_resume(self, tmp_path, initialized_runtime):
+    @pytest.mark.parametrize(("bandpass_method", "pfb_shaped"), [("spline", False), ("pfb", True)])
+    def test_process_and_resume(self, tmp_path, initialized_runtime, bandpass_method, pfb_shaped):
         from aetherscan.preprocessing import CadenceGroup  # noqa: PLC0415
 
-        config = self._configure()
-        h5_paths = self._make_cadence(tmp_path)
+        config = self._configure(bandpass_method)
+        h5_paths = self._make_cadence(tmp_path, pfb_shaped=pfb_shaped)
         group = CadenceGroup(
             key=("T1", "S1", "L", "7", "2251"),
             h5_paths=h5_paths,
@@ -599,6 +609,176 @@ class TestProcessCadenceEndToEnd:
         result = DataPreprocessor().process_pending_cadence(PendingCadence(group, npy_path))
         assert result is None
         assert not os.path.exists(npy_path)
+
+    def test_bandpass_debug_plot_saved(self, tmp_path, initialized_runtime):
+        from aetherscan.preprocessing import CadenceGroup  # noqa: PLC0415
+
+        config = self._configure("pfb")
+        config.inference.bandpass_debug_plot = True
+        h5_paths = self._make_cadence(tmp_path, pfb_shaped=True)
+        group = CadenceGroup(
+            key=("T3", "S1", "L", "9", "2251"),
+            h5_paths=h5_paths,
+            csv_path="unused.csv",
+            expected_obs=6,
+            is_valid=True,
+        )
+        npy_path = str(tmp_path / "out" / "cadence_dbg.npy")
+        os.makedirs(os.path.dirname(npy_path), exist_ok=True)
+
+        result = DataPreprocessor().process_pending_cadence(PendingCadence(group, npy_path))
+
+        assert result is not None
+        plot_path = os.path.join(
+            config.output_path,
+            "plots",
+            "inference",
+            f"bandpass_overlay_cadence_dbg_{config.checkpoint.save_tag}.png",
+        )
+        assert os.path.exists(plot_path)
+        assert os.path.getsize(plot_path) > 0
+
+
+class TestBandpassFlattenerSelection:
+    """_get_bandpass_flattener must route on config.inference.bandpass_method (pfb default),
+    carry the file's coarse count into the PFB partial, fall back to spline when the fold is
+    impossible, and reject unknown methods."""
+
+    def test_default_is_pfb(self, initialized_runtime):
+        config = get_config()
+        assert config.inference.bandpass_method == "pfb"
+        flattener = DataPreprocessor()._get_bandpass_flattener(num_coarse_channels=4)
+        assert flattener.func is _pfb_flatten_bandpass
+        assert flattener.keywords == {
+            "num_coarse_channels": 4,
+            "taps_per_channel": config.inference.pfb_taps_per_channel,
+        }
+
+    def test_spline_selected_via_config(self, initialized_runtime):
+        config = get_config()
+        config.inference.bandpass_method = "spline"
+        flattener = DataPreprocessor()._get_bandpass_flattener(num_coarse_channels=4)
+        assert flattener.func is _spline_flatten_bandpass
+        assert flattener.keywords == {"spl_order": config.inference.spline_order}
+
+    def test_pfb_single_coarse_channel_falls_back_to_spline(self, initialized_runtime):
+        config = get_config()
+        config.inference.bandpass_method = "pfb"
+        flattener = DataPreprocessor()._get_bandpass_flattener(num_coarse_channels=1)
+        assert flattener.func is _spline_flatten_bandpass
+
+    def test_unknown_method_raises(self, initialized_runtime):
+        config = get_config()
+        config.inference.bandpass_method = "median"
+        with pytest.raises(ValueError, match="bandpass_method"):
+            DataPreprocessor()._get_bandpass_flattener(num_coarse_channels=4)
+
+    def test_pfb_flattener_is_picklable(self, initialized_runtime):
+        # The flattener ships to pool workers inside task tuples
+        import pickle  # noqa: PLC0415
+
+        flattener = DataPreprocessor()._get_bandpass_flattener(num_coarse_channels=4)
+        restored = pickle.loads(pickle.dumps(flattener))
+        channel = np.full((4, 512), 2.0)
+        np.testing.assert_array_equal(restored(channel), flattener(channel))
+
+    def test_pfb_flatten_divides_out_response(self, initialized_runtime):
+        response = gen_coarse_channel_response(512, 4, 12)
+        shaped = np.ones((16, 1)) * response
+        flattened = _pfb_flatten_bandpass(shaped, num_coarse_channels=4, taps_per_channel=12)
+        np.testing.assert_allclose(flattened, 1.0, rtol=1e-12)
+
+
+class TestPfbResponseMismatchWarning:
+    """_warn_on_pfb_response_mismatch compares the file's measured edge/mid power ratio with
+    the static response's, warning once per file when they disagree by more than 5%."""
+
+    def _make_obs(self, tmp_path, shaped: bool, n_chans=1024, width=512):
+        import h5py  # noqa: PLC0415
+
+        rng = np.random.default_rng(51)
+        data = rng.normal(1000.0, 5.0, size=(16, 1, n_chans)).astype(np.float32)
+        if shaped:
+            response = gen_coarse_channel_response(width, n_chans // width, 12)
+            data *= np.tile(response, n_chans // width).astype(np.float32)
+        path = tmp_path / ("shaped.h5" if shaped else "flat.h5")
+        with h5py.File(path, "w") as hf:
+            hf.create_dataset("data", data=data)
+        return str(path)
+
+    def _configure(self):
+        config = get_config()
+        config.data.time_bins = 16
+        config.inference.coarse_channel_width = 512
+        config.inference.pfb_taps_per_channel = 12
+        return config
+
+    def test_flat_recording_warns(self, tmp_path, initialized_runtime, caplog):
+        self._configure()
+        h5_path = self._make_obs(tmp_path, shaped=False)
+        with caplog.at_level("WARNING", logger="aetherscan.preprocessing"):
+            DataPreprocessor()._warn_on_pfb_response_mismatch(h5_path, n_coarse_total=2)
+        mismatch_warnings = [r for r in caplog.records if "edge/mid power ratio" in r.message]
+        assert len(mismatch_warnings) == 1  # once per file, not per channel
+
+    def test_pfb_shaped_recording_does_not_warn(self, tmp_path, initialized_runtime, caplog):
+        self._configure()
+        h5_path = self._make_obs(tmp_path, shaped=True)
+        with caplog.at_level("WARNING", logger="aetherscan.preprocessing"):
+            DataPreprocessor()._warn_on_pfb_response_mismatch(h5_path, n_coarse_total=2)
+        assert [r for r in caplog.records if "edge/mid power ratio" in r.message] == []
+
+    def test_ratio_statistic_separates_the_two(self):
+        # The underlying statistic the check relies on (sanity of the 5% tolerance)
+        response = gen_coarse_channel_response(512, 2, 12)
+        expected = edge_mid_power_ratio(response)
+        assert abs(edge_mid_power_ratio(np.ones(512)) - expected) / expected > 0.05
+
+
+class TestPlanCadencesOutputDir:
+    """plan_cadences resolves the .npy output dir per CSV: tag-scoped default under
+    {data_path}/inference/preprocessed/, with an explicit --preprocess-output-dir shared
+    across CSVs."""
+
+    def test_default_is_per_csv_tag_scoped(self, initialized_runtime, make_inference_csv):
+        config = get_config()
+        make_inference_csv("subset.csv")
+        config.data.inference_files = ["subset.csv"]
+        config.checkpoint.save_tag = "test_v1"
+
+        units = DataPreprocessor().plan_cadences()
+
+        assert len(units) == 1
+        expected_dir = os.path.join(config.data_path, "inference", "preprocessed", "subset_test_v1")
+        assert os.path.dirname(units[0].npy_path) == expected_dir
+        assert os.path.isdir(expected_dir)
+
+    def test_new_tag_gets_clean_directory(self, initialized_runtime, make_inference_csv):
+        config = get_config()
+        make_inference_csv("subset.csv")
+        config.data.inference_files = ["subset.csv"]
+
+        config.checkpoint.save_tag = "test_v1"
+        first = DataPreprocessor().plan_cadences()
+        config.checkpoint.save_tag = "test_v2"
+        second = DataPreprocessor().plan_cadences()
+
+        assert os.path.dirname(first[0].npy_path) != os.path.dirname(second[0].npy_path)
+
+    def test_explicit_override_shared_across_csvs(
+        self, initialized_runtime, make_inference_csv, tmp_path
+    ):
+        config = get_config()
+        make_inference_csv("a.csv")
+        make_inference_csv("b.csv")
+        config.data.inference_files = ["a.csv", "b.csv"]
+        override = str(tmp_path / "shared_preproc")
+        config.inference.preprocess_output_dir = override
+
+        units = DataPreprocessor().plan_cadences()
+
+        assert len(units) == 2
+        assert {os.path.dirname(u.npy_path) for u in units} == {override}
 
 
 class TestLoadInferenceDataPaths:

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -641,18 +641,49 @@ class TestProcessCadenceEndToEnd:
 
 class TestBandpassFlattenerSelection:
     """_get_bandpass_flattener must route on config.inference.bandpass_method (pfb default),
-    carry the file's coarse count into the PFB partial, fall back to spline when the fold is
+    materialize the parent-computed response as a sidecar .npy carried by path in the PFB
+    partial (workers must never generate the response themselves — at GBT scale that is an
+    ~n_chans-point FFT per worker, concurrently), fall back to spline when the fold is
     impossible, and reject unknown methods."""
 
     def test_default_is_pfb(self, initialized_runtime):
         config = get_config()
+        config.inference.coarse_channel_width = 512
         assert config.inference.bandpass_method == "pfb"
         flattener = DataPreprocessor()._get_bandpass_flattener(num_coarse_channels=4)
         assert flattener.func is _pfb_flatten_bandpass
-        assert flattener.keywords == {
-            "num_coarse_channels": 4,
-            "taps_per_channel": config.inference.pfb_taps_per_channel,
-        }
+        response_path = flattener.keywords["response_path"]
+        # The sidecar file lives under the run's output path and holds exactly the response
+        # the parent computed for (width, coarse count, taps)
+        assert response_path.startswith(os.path.join(config.output_path, "pfb_cache"))
+        expected = gen_coarse_channel_response(512, 4, config.inference.pfb_taps_per_channel)
+        np.testing.assert_array_equal(np.load(response_path), expected)
+
+    def test_response_file_reused_across_calls(self, initialized_runtime):
+        config = get_config()
+        config.inference.coarse_channel_width = 512
+        preprocessor = DataPreprocessor()
+        first = preprocessor._get_bandpass_flattener(num_coarse_channels=4)
+        mtime = os.path.getmtime(first.keywords["response_path"])
+        second = preprocessor._get_bandpass_flattener(num_coarse_channels=4)
+        assert second.keywords["response_path"] == first.keywords["response_path"]
+        assert os.path.getmtime(second.keywords["response_path"]) == mtime  # not rewritten
+
+    def test_corrupt_response_file_is_rewritten(self, initialized_runtime):
+        config = get_config()
+        config.inference.coarse_channel_width = 512
+        preprocessor = DataPreprocessor()
+        response_path = preprocessor._get_bandpass_flattener(num_coarse_channels=4).keywords[
+            "response_path"
+        ]
+        with open(response_path, "wb") as f:
+            f.write(b"garbage")
+        response_path_2 = preprocessor._get_bandpass_flattener(num_coarse_channels=4).keywords[
+            "response_path"
+        ]
+        assert response_path_2 == response_path
+        expected = gen_coarse_channel_response(512, 4, config.inference.pfb_taps_per_channel)
+        np.testing.assert_array_equal(np.load(response_path), expected)
 
     def test_spline_selected_via_config(self, initialized_runtime):
         config = get_config()
@@ -677,16 +708,21 @@ class TestBandpassFlattenerSelection:
         # The flattener ships to pool workers inside task tuples
         import pickle  # noqa: PLC0415
 
+        config = get_config()
+        config.inference.coarse_channel_width = 512
         flattener = DataPreprocessor()._get_bandpass_flattener(num_coarse_channels=4)
         restored = pickle.loads(pickle.dumps(flattener))
         channel = np.full((4, 512), 2.0)
         np.testing.assert_array_equal(restored(channel), flattener(channel))
 
     def test_pfb_flatten_divides_out_response(self, initialized_runtime):
+        config = get_config()
+        config.inference.coarse_channel_width = 512
+        config.inference.pfb_taps_per_channel = 12
+        flattener = DataPreprocessor()._get_bandpass_flattener(num_coarse_channels=4)
         response = gen_coarse_channel_response(512, 4, 12)
         shaped = np.ones((16, 1)) * response
-        flattened = _pfb_flatten_bandpass(shaped, num_coarse_channels=4, taps_per_channel=12)
-        np.testing.assert_allclose(flattened, 1.0, rtol=1e-12)
+        np.testing.assert_allclose(flattener(shaped), 1.0, rtol=1e-12)
 
 
 class TestPfbResponseMismatchWarning:


### PR DESCRIPTION
## Summary

Stacked on #120 (`feature/inference-energy-detection-perf` — this PR's base branch; merge that first).

Implements PFB static passband equalization as the **default** bandpass-flattening method inside the fused energy-detection workers, plus a tag-scoped default for the preprocessing output directory. Closes #121.

### PFB static equalization (`src/aetherscan/pfb.py`)

- Pure-NumPy port of bliss's `passband_static_equalize.cpp` (no bliss/TF dependency): `firdes` (windowed-sinc/Hamming prototype), `gen_coarse_channel_response` (zero-pad → |fftshift(fft)|² → edge-slice → fold adjacent-channel leakage → normalize; process-cached, returned read-only), `equalize_passband` (divide, broadcast over time), `edge_mid_power_ratio` (validation statistic).
- The C++ approximates sinc near zero with a truncated cosine product; `np.sinc` is exact. A test-local transcription of the C++ filter design pins the two against each other (they agree to machine precision).

### Integration (`preprocessing.py`, `config.py`, `cli.py`)

- `--bandpass-method {pfb,spline}` (config `bandpass_method`, **pfb default**; spline unchanged and selectable), `--pfb-taps-per-channel` (default 12 = GBT/BL backend; flagged as instrument-dependent in help), `--bandpass-debug-plot` (opt-in overlay artifact under `plots/inference/`; PR-08's viz suite formalizes it).
- `num_coarse_channels` for the response = the file's actual `n_chans // coarse_channel_width`; single-coarse-channel files fall back to spline with a warning.
- Division-only flattening (no mean subtraction) is safe for detection: the D'Agostino–Pearson statistic is built from central, variance-normalized moments, so location and scale both cancel (reasoning kept as a code comment; the comparison below is the empirical arbiter).
- **Static-response sanity check** (after bliss's `validate` flag): once per ON file — never per channel — the measured edge/mid power ratio of a few sampled coarse channels is compared against the response's; >5% disagreement logs a warning suggesting `--pfb-taps-per-channel` review or `--bandpass-method spline`.
- **Memory design, learned the hard way on blpc3**: the first deployment had each pool worker generate the response on its first task — at GBT scale a ~537M-point FFT with a tens-of-GB transient, × 32 concurrent workers, which drove node-available memory from 365 GB to 5 GB before the run was killed. The parent now computes the response exactly once and persists it to a content-addressed sidecar (`{output_path}/pfb_cache/pfb_response_w{width}_c{ncoarse}_t{taps}.npy`, atomic write, verified reuse); workers receive only the path and read the ~8 MB array once per process.

### Tag-scoped preprocessing output dir (`plan_cadences`)

`preprocess_output_dir=None` now resolves **per CSV** to `{data_path}/inference/preprocessed/<csv_stem>_<save_tag>/` instead of one shared directory. Same-tag retries still resume via the existing-`.npy` skip; a new tag starts clean, so stale stamps from an older failed attempt can't leak into a fresh run. Passing `--preprocess-output-dir` explicitly restores deliberate sharing/reuse (documented in help text + README; the cluster smoke test now uses exactly this escape hatch to reuse legacy stamps when `/datag` is unmounted).

## Cluster validation (blpc3, subset_test.csv = 2 cadences, dummy test_v17 model, --max-retries 1)

Two runs at identical config except the bandpass method:

| | spline (tag 20260711_205323) | pfb (tag 20260711_212848) |
|---|---|---|
| End-to-end wall time | 22 m 19 s | 22 m 25 s |
| DDO210: raw hits → dedup → stamps | 815,852 → 24,334 → 73,001 | 815,873 → 24,335 → 73,004 |
| NGC7454: raw hits → dedup → stamps | 191,984 → 7,223 → 21,669 | 191,989 → 7,221 → 21,663 |
| Candidates (dummy model) | 0 | 0 |

**Hit-count assessment.** Raw-hit deltas are +21 (+0.003%) and +5 (+0.003%); dedup deltas +1 / −2; stamp deltas +3 / −6. Different flattening residuals move a handful of borderline windows across the k² threshold — similar but not identical, exactly as expected. Candidate counts identical (0, dummy model).

**Per-stage timing.** Energy detection (3 ON files, fused workers) is I/O-bound after #120, so removing the per-channel spline fit does not shorten ED wall time on this hardware — the win is CPU headroom and flattening consistency, not wall clock:

| Stage | spline | pfb |
|---|---|---|
| DDO210 ED (3 ON files) | 118 s | 120 s |
| NGC7454 ED (3 ON files) | 111 s | 111 s |
| One-time response generation (parent) | — | ~1.3 min, then cached to the sidecar (reused by later runs) |
| Per-file mismatch check (parent) | — | ~0.3 s |

**Stamp frequencies.** Set overlap of stamp start bins between the two runs: DDO210 99.6% Jaccard (69,534 identical of 69,661/69,670 unique starts), NGC7454 99.5% (20,844 of 20,899/20,893); stamp frequency ranges identical to the kHz ([751.578, 2251.458] MHz and [752.924, 2251.204] MHz respectively).

**Debug overlay** (`--bandpass-debug-plot`, left on the cluster at `outputs/aetherscan/plots/inference/bandpass_overlay_subset_test_*_20260711_212848.png`): mid-band coarse channel 255 shows the classic PFB scallop tracked closely by the scaled response, flattening to a uniform noise band across all ~1M fine channels; edge channel 511 flattens well with a slight residual upturn at the channel edges — the visual counterpart of the mismatch warnings below.

**Static-response mismatch warnings** fired exactly once per ON file (6 files, 6 warnings — never per channel): measured edge/mid power ratios 0.495–0.515 vs the response's 0.594, i.e. 13.3–16.7% disagreement. See Deferred validation.

## Local verification

- `PYTHONPATH=src pytest -m "not gpu and not cluster" -q` → **275 passed, 3 skipped (integration), 2 deselected** (arm64 venv, Python 3.12, TF 2.17.1).
- New unit tests: response shape properties (symmetry, ~1.0 mid-band peak, half-power edge rolloff), equalization flatness on synthetic PFB-shaped noise (<3% integrated ripple vs >30% raw), C++ filter cross-check, cache immutability/reuse, sidecar reuse + corrupt-file regeneration, flattener selection/fallback/pickling, mismatch-warning behavior (fires once per file on flat data, silent on PFB-shaped data), debug-plot artifact, per-CSV tag-scoped output dir + explicit override, `--bandpass-method` enum + `--pfb-taps-per-channel` validation.
- `ruff check` / `ruff format` / all pre-commit hooks pass; README CLI Reference regenerated via `PYTHONPATH=src python utils/print_cli_help.py all`.

## Deferred validation

- **`pfb_taps_per_channel=12` must be confirmed against the GBT backend that produced the target `.h5` files before full-scale runs** (plan §16). Notably, the sanity check flagged a 16.7% edge/mid-ratio mismatch on the spliced subset files (`spliced_blc0001020304050607_*.gpuspec.0000.h5`) — plausibly the spliced product's effective response differs from the single-node 12-tap design, exactly the situation the warning exists for. Until confirmed, `--bandpass-method spline` remains one flag away.
- `apply_saved_config` still clobbers `checkpoint.save_tag` from the training config JSON (pre-existing; fix lands in PR-08) — runs that rely on the default datetime tag AND pass `--config-path` will tag-scope their preprocessed dir under the training tag. All documented invocations pass `--save-tag` explicitly.

## AI disclosure

Implemented by Claude Code (Claude Fable 5) end-to-end — design per the maintainer-approved v1 plan, implementation, unit tests, cluster validation runs, and this PR text — under human coordination; all commits GPG-signed and review-gated as usual.
