### PR TITLE
Latent-dimension traversal visualization (decoder-based interpretation of latent dims)

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,9 @@ usage: train [-h] [--data-path DATA_PATH] [--model-path MODEL_PATH]
              [--latent-viz-umap-min-dist LATENT_VIZ_UMAP_MIN_DIST [LATENT_VIZ_UMAP_MIN_DIST ...]]
              [--latent-viz-gif-max-frames LATENT_VIZ_GIF_MAX_FRAMES]
              [--latent-viz-gif-duration-ms LATENT_VIZ_GIF_DURATION_MS]
+             [--latent-traversal-every-round | --no-latent-traversal-every-round]
+             [--latent-traversal-num-steps LATENT_TRAVERSAL_NUM_STEPS]
+             [--latent-traversal-max-sigma LATENT_TRAVERSAL_MAX_SIGMA]
              [--snr-base SNR_BASE] [--initial-snr-range INITIAL_SNR_RANGE]
              [--final-snr-range FINAL_SNR_RANGE]
              [--curriculum-schedule CURRICULUM_SCHEDULE]
@@ -614,6 +617,18 @@ options:
                         prioritizing earlier training steps)
   --latent-viz-gif-duration-ms LATENT_VIZ_GIF_DURATION_MS
                         Milliseconds per frame in latent space GIF output
+  --latent-traversal-every-round, --no-latent-traversal-every-round
+                        Render latent-dimension traversal figures at the end
+                        of every training round, in addition to the end-of-
+                        training set (default: disabled)
+  --latent-traversal-num-steps LATENT_TRAVERSAL_NUM_STEPS
+                        Number of traversal steps per latent dimension (must
+                        be odd and >= 3 so the center column is the
+                        unperturbed class-mean decode)
+  --latent-traversal-max-sigma LATENT_TRAVERSAL_MAX_SIGMA
+                        Latent traversal range in per-dimension standard
+                        deviations: steps span [-max_sigma, +max_sigma] (must
+                        be > 0)
   --snr-base SNR_BASE   Base signal-to-noise ratio for curriculum learning
                         (minimum SNR difficulty level)
   --initial-snr-range INITIAL_SNR_RANGE

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -1365,8 +1365,11 @@ def collect_validation_errors(
                     field="training.latent_traversal_num_steps",
                     current=lts,
                     message=f"--latent-traversal-num-steps must be odd and >= 3 so the center column is the unperturbed decode, got {lts}",
+                    # No fix_kind captures "odd and >= 3"; clamp_low is closest and the
+                    # proposal seed is the field's default (7 — odd and valid), matching the
+                    # max_sigma block below. propose_simple_fix only ever suggests this value.
                     fix_kind="clamp_low",
-                    min_val=3,
+                    min_val=7,
                 )
             )
         ltms = _resolve(
@@ -1379,7 +1382,7 @@ def collect_validation_errors(
                     current=ltms,
                     message=f"--latent-traversal-max-sigma must be > 0, got {ltms}",
                     fix_kind="clamp_low",
-                    min_val=3.0,  # Proposal seed: the field's default
+                    min_val=3.0,  # Proposal seed: the field's default (matches num_steps above)
                 )
             )
 

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -1353,7 +1353,9 @@ def collect_validation_errors(
             )
 
         # Latent traversal: odd step count >= 3 (so the center column is the unperturbed
-        # class-mean decode) and a strictly positive sigma range
+        # class-mean decode) and a strictly positive sigma range. No upper step bound:
+        # decode cost scales linearly and stays trivial at any plausible value (99 steps
+        # ~= 800 decoder calls), and an oversized figure is immediately self-evident
         lts = _resolve(
             args, "latent_traversal_num_steps", config.training.latent_traversal_num_steps
         )

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -501,6 +501,24 @@ def _add_train_flags_to(parser):
         default=None,
         help="Milliseconds per frame in latent space GIF output",
     )
+    parser.add_argument(
+        "--latent-traversal-every-round",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Render latent-dimension traversal figures at the end of every training round, in addition to the end-of-training set (default: disabled)",
+    )
+    parser.add_argument(
+        "--latent-traversal-num-steps",
+        type=int,
+        default=None,
+        help="Number of traversal steps per latent dimension (must be odd and >= 3 so the center column is the unperturbed class-mean decode)",
+    )
+    parser.add_argument(
+        "--latent-traversal-max-sigma",
+        type=float,
+        default=None,
+        help="Latent traversal range in per-dimension standard deviations: steps span [-max_sigma, +max_sigma] (must be > 0)",
+    )
 
     parser.add_argument(
         "--snr-base",
@@ -1016,6 +1034,17 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
         config.training.latent_viz_gif_max_frames = args.latent_viz_gif_max_frames
     if hasattr(args, "latent_viz_gif_duration_ms") and args.latent_viz_gif_duration_ms is not None:
         config.training.latent_viz_gif_duration_ms = args.latent_viz_gif_duration_ms
+    # latent_traversal_every_round uses argparse.BooleanOptionalAction with default=None
+    # (same tri-state as overlap_data_generation / keep_round_data above)
+    if (
+        hasattr(args, "latent_traversal_every_round")
+        and args.latent_traversal_every_round is not None
+    ):
+        config.training.latent_traversal_every_round = args.latent_traversal_every_round
+    if hasattr(args, "latent_traversal_num_steps") and args.latent_traversal_num_steps is not None:
+        config.training.latent_traversal_num_steps = args.latent_traversal_num_steps
+    if hasattr(args, "latent_traversal_max_sigma") and args.latent_traversal_max_sigma is not None:
+        config.training.latent_traversal_max_sigma = args.latent_traversal_max_sigma
     if hasattr(args, "snr_base") and args.snr_base is not None:
         config.training.snr_base = args.snr_base
     if hasattr(args, "initial_snr_range") and args.initial_snr_range is not None:
@@ -1320,6 +1349,35 @@ def collect_validation_errors(
                     message=f"--data-gen-task-size must be >= 1, got {dgts}",
                     fix_kind="clamp_low",
                     min_val=1,
+                )
+            )
+
+        # Latent traversal: odd step count >= 3 (so the center column is the unperturbed
+        # class-mean decode) and a strictly positive sigma range
+        lts = _resolve(
+            args, "latent_traversal_num_steps", config.training.latent_traversal_num_steps
+        )
+        if lts is not None and (lts < 3 or lts % 2 == 0):
+            errors.append(
+                ValidationError(
+                    field="training.latent_traversal_num_steps",
+                    current=lts,
+                    message=f"--latent-traversal-num-steps must be odd and >= 3 so the center column is the unperturbed decode, got {lts}",
+                    fix_kind="clamp_low",
+                    min_val=3,
+                )
+            )
+        ltms = _resolve(
+            args, "latent_traversal_max_sigma", config.training.latent_traversal_max_sigma
+        )
+        if ltms is not None and ltms <= 0:
+            errors.append(
+                ValidationError(
+                    field="training.latent_traversal_max_sigma",
+                    current=ltms,
+                    message=f"--latent-traversal-max-sigma must be > 0, got {ltms}",
+                    fix_kind="clamp_low",
+                    min_val=3.0,  # Proposal seed: the field's default
                 )
             )
 

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -243,6 +243,18 @@ class TrainingConfig:
     latent_viz_gif_max_frames: int = 500  # Max frames in output GIF (log-spaced subsampling)
     latent_viz_gif_duration_ms: int = 100  # Milliseconds per frame in output GIF
 
+    # Latent traversal params (decoder-based interpretation of the latent dims; see
+    # TrainingPipeline.plot_latent_traversal)
+    latent_traversal_every_round: bool = (
+        False  # Also render traversal figures at the end of every training round
+    )
+    latent_traversal_num_steps: int = (
+        7  # Steps per latent dim (odd & >= 3 so the center column is the unperturbed decode)
+    )
+    latent_traversal_max_sigma: float = (
+        3.0  # Traversal range in per-dim standard deviations: steps span ±max_sigma (> 0)
+    )
+
     # RF visualization params
     shap_max_samples_summary: int = 5000  # Samples for SHAP summary/dependence computation
     shap_max_samples_interaction: int = (
@@ -550,6 +562,9 @@ class Config:
                 "latent_viz_umap_min_dist": self.training.latent_viz_umap_min_dist,
                 "latent_viz_gif_max_frames": self.training.latent_viz_gif_max_frames,
                 "latent_viz_gif_duration_ms": self.training.latent_viz_gif_duration_ms,
+                "latent_traversal_every_round": self.training.latent_traversal_every_round,
+                "latent_traversal_num_steps": self.training.latent_traversal_num_steps,
+                "latent_traversal_max_sigma": self.training.latent_traversal_max_sigma,
                 "shap_max_samples_summary": self.training.shap_max_samples_summary,
                 "shap_max_samples_interaction": self.training.shap_max_samples_interaction,
                 "shap_top_k_features_dependence": self.training.shap_top_k_features_dependence,

--- a/src/aetherscan/data_generation.py
+++ b/src/aetherscan/data_generation.py
@@ -109,19 +109,32 @@ def _init_worker(shm_name, shape, dtype, log_queue=None):
     signal.signal(signal.SIGTERM, cleanup_on_sigterm)
 
 
-def log_norm(data: np.ndarray) -> np.ndarray:
-    """Log-transform `data` (with a 1e-10 epsilon), then shift and rescale into [0, 1]."""
+def log_norm(
+    data: np.ndarray, return_params: bool = False
+) -> np.ndarray | tuple[np.ndarray, tuple[float, float]]:
+    """Log-transform `data` (with a 1e-10 epsilon), then shift and rescale into [0, 1].
+
+    With return_params=True, also returns the (min_log, range_log) normalization parameters,
+    which allow an approximate inversion back to linear intensity:
+    linear ≈ exp(normalized * range_log + min_log). Used by the latent-traversal plot to
+    display decoded reconstructions on a near-physical scale (approximate because the
+    upstream downsampling is lossy).
+    """
     # Add small epsilon to avoid log(0)
     data = data + 1e-10
 
     # Transform data into log-space
     data = np.log(data)
     # Shift data to be >= 0
-    data = data - data.min()
+    min_log = float(data.min())
+    data = data - min_log
     # Normalize data to [0, 1]
-    if data.max() > 0:
-        data = data / data.max()
+    range_log = float(data.max())
+    if range_log > 0:
+        data = data / range_log
 
+    if return_params:
+        return data, (min_log, range_log)
     return data
 
 
@@ -309,7 +322,8 @@ def create_false(
     """
     Create a false-class cadence and return (final, sample_info). final has shape
     (6, 16, width_bin); sample_info carries background_index, per-stage intensity_stats (A/B/C),
-    signal_info (rfi_* keys when inject=True, empty otherwise), and slope_was_clamped.
+    signal_info (rfi_* keys when inject=True, empty otherwise), slope_was_clamped, and the
+    per-observation lognorm_params (shape (6, 2): (min_log, range_log) per observation).
 
     When inject=True, a drifting RFI signal is injected into all 6 observations; when False, the
     background is log-normalized and returned as-is (Stage B = Stage A, signal_info empty).
@@ -328,6 +342,10 @@ def create_false(
 
     # Initialize signal info (will be populated if inject=True)
     signal_info = {}
+
+    # Per-observation log-norm parameters, recorded so the latent-traversal plot can
+    # approximately invert the normalization for display (see log_norm)
+    lognorm_params = np.zeros((n_obs, 2), dtype=np.float32)
 
     # Inject RFI into all 6 observations
     slope_was_clamped = False
@@ -353,7 +371,9 @@ def create_false(
 
         # Reshape stacked data back into original shape & log-normalize after signal injection
         for i in range(n_obs):
-            final[i, :, :] = log_norm(cadence[i * n_time : (i + 1) * n_time, :])
+            final[i, :, :], lognorm_params[i] = log_norm(
+                cadence[i * n_time : (i + 1) * n_time, :], return_params=True
+            )
 
     # Just return background. No signal injection
     else:
@@ -361,7 +381,7 @@ def create_false(
         stats_b = stats_a.copy()
         # Log-normalize base background
         for i in range(n_obs):
-            final[i, :, :] = log_norm(base[i, :, :])
+            final[i, :, :], lognorm_params[i] = log_norm(base[i, :, :], return_params=True)
 
     # STAGE C: Post-injection, post-normalization
     stats_c = _compute_intensity_stats(final)
@@ -372,6 +392,7 @@ def create_false(
         # NOTE: how do we handle db writes & plotting when signal_info is empty?
         "signal_info": signal_info,  # Empty if no injection, rfi_* if injected
         "slope_was_clamped": slope_was_clamped,
+        "lognorm_params": lognorm_params,
     }
 
     return final, sample_info
@@ -390,8 +411,8 @@ def create_true_single(
     """
     Create a true-single-class cadence (ETI injected into ON observations only) and return
     (final, sample_info). final has shape (6, 16, width_bin); sample_info carries
-    background_index, per-stage intensity_stats (A/B/C), eti_*-prefixed signal_info, and
-    slope_was_clamped.
+    background_index, per-stage intensity_stats (A/B/C), eti_*-prefixed signal_info,
+    slope_was_clamped, and per-observation lognorm_params (shape (6, 2)).
     """
     # Select random background from plate
     background_index = int(plate.shape[0] * random.random())
@@ -425,13 +446,18 @@ def create_true_single(
     stats_b = _compute_intensity_stats(cadence)
 
     # Reshape stacked data back into original shape & log-normalize after signal injection
+    lognorm_params = np.zeros((n_obs, 2), dtype=np.float32)
     for i in range(n_obs):
         if i % 2 == 0:
             # ONs: injected signal
-            final[i, :, :] = log_norm(cadence[i * n_time : (i + 1) * n_time, :])
+            final[i, :, :], lognorm_params[i] = log_norm(
+                cadence[i * n_time : (i + 1) * n_time, :], return_params=True
+            )
         else:
             # OFFs: original background
-            final[i, :, :] = log_norm(data[i * n_time : (i + 1) * n_time, :])
+            final[i, :, :], lognorm_params[i] = log_norm(
+                data[i * n_time : (i + 1) * n_time, :], return_params=True
+            )
 
     # STAGE C: Post-injection, post-normalization
     stats_c = _compute_intensity_stats(final)
@@ -441,6 +467,7 @@ def create_true_single(
         "intensity_stats": {"A": stats_a, "B": stats_b, "C": stats_c},
         "signal_info": signal_info,  # eti_* signal characteristics
         "slope_was_clamped": slope_was_clamped,
+        "lognorm_params": lognorm_params,
     }
 
     return final, sample_info
@@ -460,7 +487,8 @@ def create_true_double(
     Create a true-double-class cadence (non-intersecting ETI and RFI signals injected into
     ON-only and ON-OFF respectively) and return (final, sample_info). final has shape
     (6, 16, width_bin); sample_info carries background_index, per-stage intensity_stats (A/B/C),
-    signal_info with both eti_* and rfi_* keys, and slope_was_clamped.
+    signal_info with both eti_* and rfi_* keys, slope_was_clamped, and per-observation
+    lognorm_params (shape (6, 2)).
     """
     # Select random background from plate
     background_index = int(plate.shape[0] * random.random())
@@ -524,13 +552,18 @@ def create_true_double(
     stats_b = _compute_intensity_stats(cadence_2)
 
     # Reshape stacked data back into original shape & log-normalize after signal injection
+    lognorm_params = np.zeros((n_obs, 2), dtype=np.float32)
     for i in range(n_obs):
         if i % 2 == 0:
             # ONs: 2 injected signals (ETI + RFI)
-            final[i, :, :] = log_norm(cadence_2[i * n_time : (i + 1) * n_time, :])
+            final[i, :, :], lognorm_params[i] = log_norm(
+                cadence_2[i * n_time : (i + 1) * n_time, :], return_params=True
+            )
         else:
             # OFFs: 1 injected signal (RFI only)
-            final[i, :, :] = log_norm(cadence_1[i * n_time : (i + 1) * n_time, :])
+            final[i, :, :], lognorm_params[i] = log_norm(
+                cadence_1[i * n_time : (i + 1) * n_time, :], return_params=True
+            )
 
     # STAGE C: Post-injection, post-normalization
     stats_c = _compute_intensity_stats(final)
@@ -540,6 +573,7 @@ def create_true_double(
         "intensity_stats": {"A": stats_a, "B": stats_b, "C": stats_c},
         "signal_info": signal_info,  # Both eti_* and rfi_* signal characteristics
         "slope_was_clamped": slope_was_clamped,
+        "lognorm_params": lognorm_params,
     }
 
     return final, sample_info
@@ -631,12 +665,14 @@ def build_segment_tasks(
     freq_resolution: float,
     time_resolution: float,
     seed_rng: np.random.Generator,
+    lognorm_path: str | None = None,
 ) -> list[tuple]:
     """
     Partition one segment into batched worker tasks of at most `task_size` cadences each.
     Together the tasks cover rows [segment.start_idx, segment.start_idx + segment.count)
     exactly once. Each task carries a fresh RNG seed drawn from `seed_rng` so results don't
-    depend on which persistent worker picks the task up.
+    depend on which persistent worker picks the task up. `lognorm_path`, when given, is the
+    sibling memmap the task writes each cadence's per-observation log-norm parameters into.
     """
     if task_size < 1:
         raise ValueError(f"task_size must be >= 1, got {task_size}")
@@ -659,6 +695,7 @@ def build_segment_tasks(
                 segment.inject,
                 segment.dynamic_range,
                 seed,
+                lognorm_path,
             )
         )
     return tasks
@@ -668,9 +705,10 @@ def _run_memmap_task(args: tuple, backgrounds: np.ndarray) -> tuple[float, list[
     """
     Execute one batched generation task against `backgrounds`: open the target .npy r+ (like
     preprocessing._extract_stamps_worker), generate `count` cadences with the chosen create_*
-    function, and write each result row straight into the memmap. Tasks address disjoint row
-    ranges, so concurrent pool writes never collide. Returns (elapsed_seconds,
-    [sample_info, ...]) — the only data that crosses the IPC boundary.
+    function, and write each result row straight into the memmap (plus its per-observation
+    log-norm parameters into the sibling lognorm memmap). Tasks address disjoint row ranges,
+    so concurrent pool writes never collide. Returns (elapsed_seconds, [sample_info, ...]) —
+    the only data that crosses the IPC boundary.
     """
     (
         array_path,
@@ -685,6 +723,7 @@ def _run_memmap_task(args: tuple, backgrounds: np.ndarray) -> tuple[float, list[
         inject,
         dynamic_range,
         seed,
+        lognorm_path,
     ) = args
 
     task_start = time.time()
@@ -710,6 +749,9 @@ def _run_memmap_task(args: tuple, backgrounds: np.ndarray) -> tuple[float, list[
     all_sample_info = []
 
     out = np.lib.format.open_memmap(array_path, mode="r+")
+    lognorm_out = (
+        np.lib.format.open_memmap(lognorm_path, mode="r+") if lognorm_path is not None else None
+    )
     try:
         for i in range(count):
             cadence, sample_info = create_fn(
@@ -723,6 +765,11 @@ def _run_memmap_task(args: tuple, backgrounds: np.ndarray) -> tuple[float, list[
                 dynamic_range=dynamic_range,
             )
             out[start_idx + i] = cadence
+            # Log-norm params land in the sibling memmap, not the IPC stats payload (they're
+            # per-observation display metadata, not DB-bound injection stats)
+            lognorm_params = sample_info.pop("lognorm_params")
+            if lognorm_out is not None:
+                lognorm_out[start_idx + i] = lognorm_params
             all_sample_info.append(sample_info)
     finally:
         # Flush in the finally so rows written before a mid-task exception still reach disk
@@ -730,6 +777,9 @@ def _run_memmap_task(args: tuple, backgrounds: np.ndarray) -> tuple[float, list[
         # way, but not all filesystems are guaranteed to write back dirty pages on munmap)
         out.flush()
         del out
+        if lognorm_out is not None:
+            lognorm_out.flush()
+            del lognorm_out
 
     return time.time() - task_start, all_sample_info
 
@@ -858,7 +908,9 @@ def generate_round_to_memmap(
     main: collapsed cadences, 1/4 balanced across the 4 signal types (labels array tracks the
     per-row type); false: 1/2 false_no_signal + 1/2 false_with_rfi; true: 1/2 true_only_eti +
     1/2 true_eti_rfi — each of shape (n_samples, num_observations, time_bins, width_bin)
-    float32, laid out contiguously per chunk (see build_chunk_segments).
+    float32, laid out contiguously per chunk (see build_chunk_segments). Each array gets a
+    sibling {name}_lognorm.npy of shape (n_samples, num_observations, 2) carrying the
+    per-observation (min_log, range_log) normalization parameters.
 
     Work is dispatched as one unified batched task list per chunk through a single pool.map
     barrier (instead of the old 8 sequential per-class barriers); workers write rows in-place
@@ -889,6 +941,14 @@ def generate_round_to_memmap(
     for path in array_paths.values():
         mm = np.lib.format.open_memmap(path, mode="w+", dtype=np.float32, shape=shape)
         del mm  # Close immediately: creation only reserves the file; workers do the writing
+
+    # Sibling per-observation log-norm parameter arrays ((min_log, range_log) per obs — tiny),
+    # recorded so the latent-traversal plot can approximately invert the normalization
+    lognorm_paths = paths.lognorm_paths
+    lognorm_shape = (n_samples, num_observations, 2)
+    for path in lognorm_paths.values():
+        mm = np.lib.format.open_memmap(path, mode="w+", dtype=np.float32, shape=lognorm_shape)
+        del mm
 
     labels = np.empty(n_samples, dtype="U20")
 
@@ -925,6 +985,7 @@ def generate_round_to_memmap(
                 freq_resolution,
                 time_resolution,
                 seed_rng,
+                lognorm_path=lognorm_paths[segment.array_name],
             )
             tasks.extend(segment_tasks)
             task_owners.extend([segment_idx] * len(segment_tasks))

--- a/src/aetherscan/data_generation.py
+++ b/src/aetherscan/data_generation.py
@@ -945,8 +945,9 @@ def generate_round_to_memmap(
         mm = np.lib.format.open_memmap(path, mode="w+", dtype=np.float32, shape=shape)
         del mm  # Close immediately: creation only reserves the file; workers do the writing
 
-    # Sibling per-observation log-norm parameter arrays ((min_log, range_log) per obs — tiny),
-    # recorded so the latent-traversal plot can approximately invert the normalization
+    # Sibling per-observation log-norm parameter arrays ((min_log, range_log) per obs —
+    # n_samples x num_observations x 2 float32, so MBs, not GBs, per array), recorded so the
+    # latent-traversal plot can approximately invert the normalization
     lognorm_paths = paths.lognorm_paths
     lognorm_shape = (n_samples, num_observations, 2)
     for path in lognorm_paths.values():

--- a/src/aetherscan/data_generation.py
+++ b/src/aetherscan/data_generation.py
@@ -117,8 +117,11 @@ def log_norm(
     With return_params=True, also returns the (min_log, range_log) normalization parameters,
     which allow an approximate inversion back to linear intensity:
     linear ≈ exp(normalized * range_log + min_log). Used by the latent-traversal plot to
-    display decoded reconstructions on a near-physical scale (approximate because the
-    upstream downsampling is lossy).
+    display decoded reconstructions on a near-physical scale. The inversion is DISPLAY-ONLY
+    and never exact: (1) the upstream frequency downsampling is lossy and cannot be truly
+    undone, and (2) these params are per-observation, so the plot collapses them to a
+    per-class mean over the ON observations while a latent-traversal decode blends
+    observations. Do not treat inverted values as calibrated intensities.
     """
     # Add small epsilon to avoid log(0)
     data = data + 1e-10

--- a/src/aetherscan/round_data.py
+++ b/src/aetherscan/round_data.py
@@ -58,7 +58,8 @@ _MANIFEST_SAMPLE_COUNT = 8
 
 @dataclass(frozen=True)
 class RoundDataPaths:
-    """On-disk layout of one round's dataset: {main,true,false,labels}.npy + a .done manifest."""
+    """On-disk layout of one round's dataset: {main,true,false,labels}.npy, sibling
+    {main,true,false}_lognorm.npy parameter arrays, + a .done manifest."""
 
     round_dir: str
     round_idx: int
@@ -92,6 +93,15 @@ class RoundDataPaths:
     def array_paths(self) -> dict[str, str]:
         """Mapping of array name -> .npy path for the three cadence arrays."""
         return {"main": self.main_path, "true": self.true_path, "false": self.false_path}
+
+    @property
+    def lognorm_paths(self) -> dict[str, str]:
+        """Mapping of array name -> sibling .npy path holding that array's per-observation
+        (min_log, range_log) log-norm parameters, shape (n_samples, num_observations, 2)."""
+        return {
+            name: os.path.join(self.round_dir, f"{name}_lognorm.npy")
+            for name in ("main", "true", "false")
+        }
 
 
 def _array_checksum(arr: np.ndarray) -> dict:
@@ -131,6 +141,15 @@ def _checksum_value_matches(recorded, actual) -> bool:
     return recorded == actual or (math.isnan(recorded) and math.isnan(actual))
 
 
+def _manifest_paths(paths: RoundDataPaths) -> dict[str, str]:
+    """Every array the .done manifest covers: cadence arrays, lognorm siblings, labels."""
+    return {
+        **paths.array_paths,
+        **{f"{name}_lognorm": p for name, p in paths.lognorm_paths.items()},
+        "labels": paths.labels_path,
+    }
+
+
 def build_manifest(
     paths: RoundDataPaths,
     n_samples: int,
@@ -142,7 +161,7 @@ def build_manifest(
     """Assemble the .done manifest dict by re-opening the finished arrays read-only."""
     shapes: dict[str, list[int]] = {}
     checksums: dict[str, dict] = {}
-    for name, path in {**paths.array_paths, "labels": paths.labels_path}.items():
+    for name, path in _manifest_paths(paths).items():
         arr = np.load(path, mmap_mode="r")
         shapes[name] = list(arr.shape)
         checksums[name] = _array_checksum(arr)
@@ -203,8 +222,7 @@ def validate_done_manifest(
             )
             return None
 
-        all_paths = {**paths.array_paths, "labels": paths.labels_path}
-        for name, path in all_paths.items():
+        for name, path in _manifest_paths(paths).items():
             if not os.path.isfile(path):
                 logger.warning(f"Manifest array missing on disk: {path}")
                 return None
@@ -236,13 +254,15 @@ def load_round_arrays(paths: RoundDataPaths) -> dict[str, np.ndarray]:
     Open one round's arrays for training. The three cadence arrays come back as read-only
     memmaps (np.load(mmap_mode="r")) so nothing is pulled into RAM until batches gather it —
     the OS page cache keeps hot pages resident and evicts them under memory pressure instead
-    of OOM-killing the process. Labels are tiny and loaded eagerly.
+    of OOM-killing the process. Labels and the main array's log-norm parameters ("lognorm",
+    consumed by the latent-traversal plot) are tiny and loaded eagerly.
     """
     return {
         "concatenated": np.load(paths.main_path, mmap_mode="r"),
         "true": np.load(paths.true_path, mmap_mode="r"),
         "false": np.load(paths.false_path, mmap_mode="r"),
         "labels": np.load(paths.labels_path),
+        "lognorm": np.load(paths.lognorm_paths["main"]),
     }
 
 

--- a/src/aetherscan/round_data.py
+++ b/src/aetherscan/round_data.py
@@ -255,7 +255,8 @@ def load_round_arrays(paths: RoundDataPaths) -> dict[str, np.ndarray]:
     memmaps (np.load(mmap_mode="r")) so nothing is pulled into RAM until batches gather it —
     the OS page cache keeps hot pages resident and evicts them under memory pressure instead
     of OOM-killing the process. Labels and the main array's log-norm parameters ("lognorm",
-    consumed by the latent-traversal plot) are tiny and loaded eagerly.
+    consumed by the latent-traversal plot) are small (~24 MB for the main array at full scale)
+    and loaded eagerly.
     """
     return {
         "concatenated": np.load(paths.main_path, mmap_mode="r"),

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -374,6 +374,10 @@ def build_traversal_latents(
 
     latent_dim = z_base.shape[0]
     steps = np.linspace(-max_sigma, max_sigma, num_steps).astype(np.float32)
+    if num_steps % 2 == 1:
+        # Snap the center step to exactly 0 — linspace can leave ~1e-16 residue for
+        # non-integral max_sigma, and the center column must be the exact base decode
+        steps[num_steps // 2] = 0.0
     latents = np.tile(z_base, (latent_dim * num_steps, 1))
     for d in range(latent_dim):
         latents[d * num_steps : (d + 1) * num_steps, d] += steps * sigmas[d]
@@ -4748,9 +4752,9 @@ class TrainingPipeline:
                 )
             else:
                 caption = (
-                    "Intensity in normalized log space (log-norm params unavailable); "
-                    f"frequency ×{downsample_factor} nearest-neighbor upsampled. Exact "
-                    "un-preprocessing impossible (lossy downsample)."
+                    "Intensity in normalized log space (log-norm params unavailable or "
+                    f"degenerate); frequency ×{downsample_factor} nearest-neighbor upsampled. "
+                    "Exact un-preprocessing impossible (lossy downsample)."
                 )
 
             self._render_traversal_waterfalls(
@@ -4831,7 +4835,9 @@ class TrainingPipeline:
                 ax.set_xticks([])
                 ax.set_yticks([])
                 if d == 0:
-                    ax.set_title("0σ (base)" if steps[s] == 0 else f"{steps[s]:+.3g}σ", fontsize=10)
+                    # The center column (odd, validated step count) is the unperturbed decode
+                    is_center = num_steps % 2 == 1 and s == num_steps // 2
+                    ax.set_title("0σ (base)" if is_center else f"{steps[s]:+.3g}σ", fontsize=10)
                 if s == 0:
                     ax.set_ylabel(f"dim {d}\n(σ={sigmas[d]:.3f})", fontsize=9)
         axes[-1][num_steps // 2].set_xlabel(

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -4705,10 +4705,21 @@ class TrainingPipeline:
         # Per-dim σ over the whole viz batch (all observations pooled) — sets each dim's
         # traversal scale in units the encoder actually uses
         sigmas = z_mean.reshape(-1, latent_dim).std(axis=0)
+        if np.all(sigmas == 0):
+            # Fully collapsed latents (e.g. a degenerate/untrained encoder): every traversal
+            # step would decode to the same image — skip rather than render 8 blank grids
+            logger.warning(
+                "plot_latent_traversal: all per-dim sigmas are zero (collapsed latents) — "
+                "skipping traversal figures"
+            )
+            return
 
         on_indices = np.arange(0, num_obs, 2)  # ON observations (ABACAD -> indices 0/2/4)
 
         def decode_fn(latents):
+            # Single-shot decode: the batch is bounded by latent_dim * num_steps rows (56 at
+            # defaults; even num_steps=99 is ~800 (16, 512, 1) reconstructions ≈ 26 MB) — no
+            # chunking needed, unlike the cadence-count-scaled encoding loop above
             return np.asarray(self.vae.decoder(tf.convert_to_tensor(latents), training=False))
 
         signal_types = ["false_no_signal", "false_with_rfi", "true_only_eti", "true_eti_rfi"]

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -354,6 +354,88 @@ def check_encoder_trained(encoder, threshold=0.2):
         return False
 
 
+def build_traversal_latents(
+    z_base: np.ndarray, sigmas: np.ndarray, num_steps: int, max_sigma: float
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Build the latent grid for a traversal of every latent dimension around `z_base`.
+
+    Row (d, s) (row-major over dims then steps) is z_base + steps[s] * sigmas[d] * e_d, where
+    steps = linspace(-max_sigma, +max_sigma, num_steps) — with the validated odd num_steps the
+    center step is exactly 0, i.e. the unperturbed base decode. Returns (latents of shape
+    (latent_dim * num_steps, latent_dim) float32, steps of shape (num_steps,)).
+    """
+    z_base = np.asarray(z_base, dtype=np.float32)
+    sigmas = np.asarray(sigmas, dtype=np.float32)
+    if z_base.ndim != 1 or z_base.shape != sigmas.shape:
+        raise ValueError(
+            f"z_base and sigmas must be matching 1-D vectors, got {z_base.shape} and {sigmas.shape}"
+        )
+
+    latent_dim = z_base.shape[0]
+    steps = np.linspace(-max_sigma, max_sigma, num_steps).astype(np.float32)
+    latents = np.tile(z_base, (latent_dim * num_steps, 1))
+    for d in range(latent_dim):
+        latents[d * num_steps : (d + 1) * num_steps, d] += steps * sigmas[d]
+    return latents, steps
+
+
+def compute_traversal_panels(
+    z_base: np.ndarray,
+    sigmas: np.ndarray,
+    num_steps: int,
+    max_sigma: float,
+    decode_fn: Callable[[np.ndarray], np.ndarray],
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Decode a full traversal grid into per-(dim, step) reconstruction panels.
+
+    `decode_fn` maps a (n, latent_dim) latent batch to (n, time, freq) or (n, time, freq, 1)
+    reconstructions (production passes the VAE decoder; unit tests pass a stub). Returns
+    (panels of shape (latent_dim, num_steps, time, freq), steps of shape (num_steps,)).
+    """
+    latents, steps = build_traversal_latents(z_base, sigmas, num_steps, max_sigma)
+    recon = np.asarray(decode_fn(latents))
+    if recon.ndim == 4 and recon.shape[-1] == 1:
+        recon = recon[..., 0]
+    if recon.ndim != 3 or recon.shape[0] != latents.shape[0]:
+        raise ValueError(
+            f"decode_fn must return (n, time, freq[, 1]) reconstructions for n={latents.shape[0]} "
+            f"latents, got shape {recon.shape}"
+        )
+    latent_dim = latents.shape[1]
+    panels = recon.reshape(latent_dim, num_steps, recon.shape[1], recon.shape[2])
+    return panels, steps
+
+
+def unpreprocess_traversal_panels(
+    panels: np.ndarray, lognorm_params: tuple[float, float] | None, downsample_factor: int
+) -> tuple[np.ndarray, bool]:
+    """
+    Approximately undo generation-time preprocessing on decoded panels, for display only.
+
+    Exact inversion is impossible: downsampling is lossy and the log-norm parameters are
+    per-observation while a traversal decode blends many observations — so this is an honest
+    approximation (stated on the figures). Where `lognorm_params` = (min_log, range_log) is
+    available (and non-degenerate), the log-norm is inverted via exp(x * range_log + min_log);
+    otherwise panels stay in normalized log space. Downsampling is undone by nearest-neighbor
+    repetition along the frequency axis so the axis is in true (pre-downsample) bins.
+
+    Returns (display_panels, inverted) — `inverted` says whether the log-norm inversion was
+    applied (drives the figures' intensity-scale caption).
+    """
+    panels = np.asarray(panels)
+    inverted = False
+    if lognorm_params is not None:
+        min_log, range_log = lognorm_params
+        if range_log > 0:
+            panels = np.exp(panels * range_log + min_log)
+            inverted = True
+    if downsample_factor > 1:
+        panels = np.repeat(panels, downsample_factor, axis=-1)
+    return panels, inverted
+
+
 # Create data holder objects, to be paired with data generators, for TF's distributed datasets
 # Allows for explicit dereferencing of the backing arrays using holder.clear(), which lets
 # Python's garbage collector free up memory on-demand
@@ -826,6 +908,7 @@ class TrainingPipeline:
         # failure stay valid in the DB)
         self._latent_viz_batch = None
         self._latent_viz_labels = None
+        self._latent_viz_lognorm_params = None
         self._latent_viz_dataset = None
         self._latent_viz_n_padded = None
         self._latent_viz_n_samples = None
@@ -1180,12 +1263,10 @@ class TrainingPipeline:
                 self._round_producer.shutdown()
                 self._round_producer = None
 
-            # Free the latent viz batch once all rounds are complete (or on failure); a
-            # resumed attempt rebuilds it from the resumed round's val split
-            del self._latent_viz_batch, self._latent_viz_labels
-            self._latent_viz_batch = None
-            self._latent_viz_labels = None
-            gc.collect()
+            # NOTE: the latent viz batch intentionally survives this method — the vae_plots
+            # stage's plot_latent_traversal re-encodes/decodes it. It is freed by
+            # _clear_latent_viz_data(), called from the stage machine after vae_plots (and
+            # from run_training_pipeline's cleanup on any earlier failure)
 
     def train_round(self, round_idx: int, epochs: int, snr_base: int, snr_range: int):
         """
@@ -1227,10 +1308,12 @@ class TrainingPipeline:
         # batched generators gather from the OS page cache during training)
         train_data = load_round_arrays(paths)
 
-        # Extract labels before distributing (prepare_distributed_train_dataset keeps the
-        # original arrays alive via a shared train_holder — no copies — so we can free the
-        # dict reference immediately after)
+        # Extract labels and the (tiny, eagerly-loaded) log-norm parameter array before
+        # distributing (prepare_distributed_train_dataset keeps the original arrays alive via
+        # a shared train_holder — no copies — so we can free the dict reference immediately
+        # after)
         train_labels = train_data.get("labels")
+        train_lognorm = train_data.get("lognorm")
 
         # Distribute training data
         data = prepare_distributed_train_dataset(
@@ -1260,13 +1343,14 @@ class TrainingPipeline:
                     concat_data=data["_train_holder"].concat,
                     labels=train_labels,
                     candidate_indices=data["val_indices"],
+                    lognorm_params=train_lognorm,
                 )
         # On subsequent rounds, the latent viz batch is persisted,
         # but the distributed dataset needs to be rebuilt
         elif self._latent_viz_batch is not None and self._latent_viz_dataset is None:
             self._build_latent_viz_dataset()
 
-        del train_labels
+        del train_labels, train_lognorm
         gc.collect()
 
         train_dataset = data["train_dataset"]
@@ -1481,6 +1565,18 @@ class TrainingPipeline:
                 tag=f"round_{round_idx + 1:02d}",
                 dir="checkpoints",
             )
+
+            # Optional per-round latent traversal (config-gated; the canonical set renders
+            # once at end of training in the vae_plots stage). Failures are logged and
+            # swallowed — an optional plot mustn't fail the round and cost a retry cycle
+            # including data regeneration
+            if self.config.training.latent_traversal_every_round:
+                try:
+                    self.plot_latent_traversal(tag=f"round_{round_idx + 1:02d}", dir="checkpoints")
+                except Exception as e:
+                    logger.error(
+                        f"Failed to execute plot_latent_traversal for round {round_idx + 1}: {e}"
+                    )
 
             # NOTE: commented out to save compute. a final latent space gif at the end of training should suffice
             # Generate latent space GIF
@@ -2522,6 +2618,20 @@ class TrainingPipeline:
         if self._rf_shap_cache:
             logger.info(f"Clearing RF SHAP cache ({len(self._rf_shap_cache)} entries)")
             self._rf_shap_cache.clear()
+        gc.collect()
+
+    def _clear_latent_viz_data(self) -> None:
+        """
+        Free the withheld latent viz batch (plus its labels and log-norm parameters).
+
+        Called from the stage machine once the vae_plots stage has run (the traversal plot is
+        the batch's last consumer) and from run_training_pipeline's cleanup on any earlier
+        failure; a resumed attempt rebuilds the batch from the resumed round's val split.
+        Idempotent.
+        """
+        self._latent_viz_batch = None
+        self._latent_viz_labels = None
+        self._latent_viz_lognorm_params = None
         gc.collect()
 
     # TODO: reorder plot methods (def & call sites): train -> latent -> injection
@@ -4530,6 +4640,287 @@ class TrainingPipeline:
         shutil.rmtree(temp_dir, ignore_errors=True)
         gc.collect()
 
+    def plot_latent_traversal(self, tag: str | None = None, dir: str | None = None):
+        """
+        Decoder-based interpretation of the latent dimensions: for each signal type, decode
+        z_t + s·σ_d·e_d for every latent dim d and step s ∈ linspace(-max_sigma, +max_sigma,
+        num_steps), where z_t is the mean encoder z_mean over that type's ON observations
+        (indices 0/2/4) from the withheld latent viz batch and σ_d is the per-dim std of
+        z_mean over the whole batch. Two figures per signal type:
+
+        - latent_traversal_{signal_type}_{tag}.png: latent_dim × num_steps waterfall grid
+          (shared per-row color scale); the center column is the unperturbed class-mean decode.
+        - latent_traversal_spectra_{signal_type}_{tag}.png: per-dim time-integrated spectra,
+          one line per step (step colormap) — brightness/drift/width shifts read off easily.
+
+        Display un-preprocessing is an honest approximation, stated on each figure (see
+        unpreprocess_traversal_panels). Encoding/decoding uses the plain non-distributed
+        models (the viz batch is ≤ ~960 cadences — a trivial single pass, and keeping the
+        plot independent of the distributed dataset plumbing). Requires the in-memory viz
+        batch, which lives from the first trained round through the vae_plots stage; on a
+        resumed run whose beta-VAE rounds were already complete there is nothing to encode
+        and the plot is skipped with a warning.
+        """
+        if tag is None:
+            tag = self.config.checkpoint.save_tag
+
+        if self._latent_viz_batch is None or self._latent_viz_labels is None:
+            logger.warning(
+                "plot_latent_traversal: no latent viz batch available (e.g. a resumed run "
+                "whose beta-VAE rounds were already complete) — skipping traversal figures"
+            )
+            return
+
+        metadata_json = get_system_metadata()
+        machine_name = json.loads(metadata_json).get("machine_name")
+
+        num_steps = self.config.training.latent_traversal_num_steps
+        max_sigma = self.config.training.latent_traversal_max_sigma
+        latent_dim = self.config.beta_vae.latent_dim
+        num_obs = self.config.data.num_observations
+        time_bins = self.config.data.time_bins
+        downsample_factor = self.config.data.downsample_factor
+        width_bin = self.config.data.width_bin // downsample_factor
+
+        batch = np.asarray(self._latent_viz_batch, dtype=np.float32)
+        labels = self._latent_viz_labels
+        n_cadences = batch.shape[0]
+
+        # Encode the whole viz batch in one simple non-distributed pass, chunked by cadence
+        # so a large viz batch can't spike device memory (the encoder was created inside
+        # strategy.scope() but runs fine on the default device)
+        chunk = max(1, self.config.training.per_replica_val_batch_size)
+        z_parts = []
+        for start in range(0, n_cadences, chunk):
+            observations = batch[start : start + chunk].reshape(-1, time_bins, width_bin, 1)
+            z_mean_part, _, _ = self.vae.encoder(tf.convert_to_tensor(observations), training=False)
+            z_parts.append(np.asarray(z_mean_part))
+        z_mean = np.concatenate(z_parts, axis=0).reshape(n_cadences, num_obs, latent_dim)
+        del z_parts
+
+        # Per-dim σ over the whole viz batch (all observations pooled) — sets each dim's
+        # traversal scale in units the encoder actually uses
+        sigmas = z_mean.reshape(-1, latent_dim).std(axis=0)
+
+        on_indices = np.arange(0, num_obs, 2)  # ON observations (ABACAD -> indices 0/2/4)
+
+        def decode_fn(latents):
+            return np.asarray(self.vae.decoder(tf.convert_to_tensor(latents), training=False))
+
+        signal_types = ["false_no_signal", "false_with_rfi", "true_only_eti", "true_eti_rfi"]
+        type_display_names = {
+            "false_no_signal": "No Signal",
+            "false_with_rfi": "RFI Only",
+            "true_only_eti": "ETI Only",
+            "true_eti_rfi": "ETI + RFI",
+        }
+
+        for signal_type in signal_types:
+            mask = labels == signal_type
+            if not mask.any():
+                logger.warning(
+                    f"plot_latent_traversal: no viz cadences for {signal_type} — skipping"
+                )
+                continue
+            display_name = type_display_names[signal_type]
+
+            # Base vector: mean z_mean over this type's ON observations
+            z_t = z_mean[mask][:, on_indices, :].mean(axis=(0, 1))
+
+            # Class-mean log-norm params over the same ON observations, for the approximate
+            # display inversion (None -> plot in normalized log space)
+            lognorm = None
+            if self._latent_viz_lognorm_params is not None:
+                on_params = self._latent_viz_lognorm_params[mask][:, on_indices, :]
+                lognorm = (float(on_params[..., 0].mean()), float(on_params[..., 1].mean()))
+
+            panels, steps = compute_traversal_panels(z_t, sigmas, num_steps, max_sigma, decode_fn)
+            panels, inverted = unpreprocess_traversal_panels(panels, lognorm, downsample_factor)
+
+            # State the approximation on the figure — exact inversion is impossible
+            # (downsampling is lossy; log-norm params are per-observation, a decode blends many)
+            if inverted:
+                caption = (
+                    "Approximate un-preprocessing: log-norm inverted with class-mean ON-obs "
+                    f"params (exp(x·range_log + min_log)); frequency ×{downsample_factor} "
+                    "nearest-neighbor upsampled. Exact inversion impossible (lossy downsample, "
+                    "per-observation params)."
+                )
+            else:
+                caption = (
+                    "Intensity in normalized log space (log-norm params unavailable); "
+                    f"frequency ×{downsample_factor} nearest-neighbor upsampled. Exact "
+                    "un-preprocessing impossible (lossy downsample)."
+                )
+
+            self._render_traversal_waterfalls(
+                panels, steps, sigmas, display_name, signal_type, caption, tag, dir, machine_name
+            )
+            self._render_traversal_spectra(
+                panels,
+                steps,
+                sigmas,
+                inverted,
+                display_name,
+                signal_type,
+                caption,
+                tag,
+                dir,
+                machine_name,
+            )
+
+            del panels
+
+        del batch, z_mean
+        gc.collect()
+
+    def _save_traversal_figure(self, fig, filename: str, dir: str | None, slack_title: str):
+        """Standard plot tail shared by the two traversal renderers: save under the plots
+        directory (optionally nested in `dir`), close the figure, and upload to Slack."""
+        if dir is not None:
+            save_path = os.path.join(self.config.output_path, "plots", dir, filename)
+        else:
+            save_path = os.path.join(self.config.output_path, "plots", filename)
+        os.makedirs(os.path.dirname(save_path), exist_ok=True)
+        fig.savefig(save_path, dpi=300, bbox_inches="tight")
+        plt.close(fig)
+        logger.info(f"Latent traversal plot saved to: {save_path}")
+
+        logger_instance = get_logger()
+        if logger_instance:
+            logger_instance.upload_image_to_slack(save_path, title=slack_title)
+
+    def _render_traversal_waterfalls(
+        self, panels, steps, sigmas, display_name, signal_type, caption, tag, dir, machine_name
+    ):
+        """Primary traversal figure: latent_dim × num_steps grid of decoded waterfalls with a
+        shared color scale per row (per dim), rows labeled dim/σ, columns labeled step
+        multiples. panels has shape (latent_dim, num_steps, time, freq_display)."""
+        latent_dim, num_steps = panels.shape[0], panels.shape[1]
+
+        fig, axes = plt.subplots(
+            latent_dim,
+            num_steps,
+            figsize=(1.9 * num_steps + 1.5, 1.5 * latent_dim + 1.8),
+            squeeze=False,
+        )
+        fig.suptitle(
+            f"Latent Traversal — {display_name} ({tag}, {machine_name})",
+            fontsize=16,
+            fontweight="bold",
+        )
+        fig.text(0.5, 0.955, caption, ha="center", fontsize=8, style="italic", wrap=True)
+
+        for d in range(latent_dim):
+            # Shared color scale per row so intensity changes read across steps
+            vmin = float(panels[d].min())
+            vmax = float(panels[d].max())
+            if vmax <= vmin:
+                vmax = vmin + 1e-12
+            for s in range(num_steps):
+                ax = axes[d][s]
+                ax.imshow(
+                    panels[d, s],
+                    aspect="auto",
+                    origin="lower",
+                    cmap="viridis",
+                    vmin=vmin,
+                    vmax=vmax,
+                    extent=(0, panels.shape[3], 0, panels.shape[2]),
+                )
+                ax.set_xticks([])
+                ax.set_yticks([])
+                if d == 0:
+                    ax.set_title("0σ (base)" if steps[s] == 0 else f"{steps[s]:+.3g}σ", fontsize=10)
+                if s == 0:
+                    ax.set_ylabel(f"dim {d}\n(σ={sigmas[d]:.3f})", fontsize=9)
+        axes[-1][num_steps // 2].set_xlabel(
+            "Frequency bin (full resolution) — each panel: time × frequency", fontsize=10
+        )
+
+        plt.tight_layout(rect=(0, 0, 1, 0.94))
+
+        self._save_traversal_figure(
+            fig,
+            f"latent_traversal_{signal_type}_{tag}.png",
+            dir,
+            slack_title=f"Latent Traversal ({display_name}) - ({tag}, {machine_name})",
+        )
+
+    def _render_traversal_spectra(
+        self,
+        panels,
+        steps,
+        sigmas,
+        inverted,
+        display_name,
+        signal_type,
+        caption,
+        tag,
+        dir,
+        machine_name,
+    ):
+        """Secondary traversal figure: one panel per latent dim showing the time-integrated
+        spectrum of every traversal step (colormap over steps) — brightness/drift/width shifts
+        read off more easily than in the waterfall grid."""
+        latent_dim, num_steps = panels.shape[0], panels.shape[1]
+        ncols = 4
+        nrows = (latent_dim + ncols - 1) // ncols
+
+        fig, axes = plt.subplots(
+            nrows, ncols, figsize=(4.5 * ncols, 3.2 * nrows + 1.0), squeeze=False
+        )
+        fig.suptitle(
+            f"Latent Traversal Spectra — {display_name} ({tag}, {machine_name})",
+            fontsize=16,
+            fontweight="bold",
+        )
+        fig.text(0.5, 0.935, caption, ha="center", fontsize=8, style="italic", wrap=True)
+
+        cmap = plt.cm.coolwarm
+        norm = plt.Normalize(float(steps[0]), float(steps[-1]))
+        freq_bins = np.arange(panels.shape[3])
+        intensity_label = (
+            "Mean intensity (approx. linear)" if inverted else "Mean intensity (normalized log)"
+        )
+
+        for d in range(latent_dim):
+            ax = axes[d // ncols][d % ncols]
+            for s in range(num_steps):
+                ax.plot(
+                    freq_bins,
+                    panels[d, s].mean(axis=0),  # Time-integrated spectrum
+                    color=cmap(norm(float(steps[s]))),
+                    linewidth=1.2,
+                )
+            ax.set_title(f"dim {d} (σ={sigmas[d]:.3f})", fontsize=11)
+            ax.grid(True, alpha=0.3)
+            if d // ncols == nrows - 1:
+                ax.set_xlabel("Frequency bin (full resolution)", fontsize=10)
+            if d % ncols == 0:
+                ax.set_ylabel(intensity_label, fontsize=10)
+
+        # Hide any unused grid slots (latent_dim not divisible by ncols)
+        for idx in range(latent_dim, nrows * ncols):
+            axes[idx // ncols][idx % ncols].axis("off")
+
+        # Step colorbar (skip tight_layout — it doesn't cooperate with a stolen-axes colorbar)
+        mappable = plt.cm.ScalarMappable(cmap=cmap, norm=norm)
+        mappable.set_array([])
+        fig.colorbar(
+            mappable,
+            ax=axes.ravel().tolist(),
+            label="Traversal step (× per-dim σ)",
+            shrink=0.85,
+        )
+
+        self._save_traversal_figure(
+            fig,
+            f"latent_traversal_spectra_{signal_type}_{tag}.png",
+            dir,
+            slack_title=f"Latent Traversal Spectra ({display_name}) - ({tag}, {machine_name})",
+        )
+
     # TODO: implement plot_rf_snr_sensitivity_curve()
     def plot_rf_confusion_matrices(self, tag: str | None = None, dir: str | None = None):
         """
@@ -5778,7 +6169,9 @@ class TrainingPipeline:
         del pts_features, pts_subtype, pts_correct
         gc.collect()
 
-    def _prepare_latent_viz_batch(self, concat_data, labels, candidate_indices=None):
+    def _prepare_latent_viz_batch(
+        self, concat_data, labels, candidate_indices=None, lognorm_params=None
+    ):
         """
         Subsample cadences from concat_data for latent-space visualization, attempting an equal
         distribution across the 4 signal_type values in `labels` (n_per_type per type).
@@ -5788,7 +6181,9 @@ class TrainingPipeline:
         and reusing the same data across rounds removes distribution-shift artifacts from the
         curriculum schedule. concat_data is shape (n_total, 6, 16, width_bin); labels is shape
         (n_total,); candidate_indices, when given, restricts eligible samples (e.g. to validation
-        partition indices) without copying the full partition.
+        partition indices) without copying the full partition. lognorm_params, when given, is the
+        (n_total, 6, 2) per-observation log-norm parameter array recorded at generation time —
+        the selected cadences' rows are kept for plot_latent_traversal's display inversion.
         """
         n_per_type = self.config.training.latent_viz_num_cadences_per_type
         signal_types = ["false_no_signal", "false_with_rfi", "true_only_eti", "true_eti_rfi"]
@@ -5824,12 +6219,16 @@ class TrainingPipeline:
             logger.warning("No cadences found for any signal type — skipping viz batch")
             self._latent_viz_batch = None
             self._latent_viz_labels = None
+            self._latent_viz_lognorm_params = None
             return
 
         # Fancy indexing already creates a new independent array (no .copy() needed)
         all_indices = np.concatenate(selected_indices)
         self._latent_viz_batch = concat_data[all_indices]
         self._latent_viz_labels = np.array(selected_labels, dtype="U20")
+        self._latent_viz_lognorm_params = (
+            lognorm_params[all_indices] if lognorm_params is not None else None
+        )
 
         if len(all_indices) < n_per_type * len(signal_types):
             logger.warning(
@@ -6061,15 +6460,17 @@ class TrainingPipeline:
 
     # NOTE: combine plot_beta_vae_loss_curves(), plot_beta_vae_training_stability(), and plot_latent_space_gif() into plot_training_progress()?
     def plot_vae_diagnostics(self) -> None:
-        """The vae_plots stage: final loss curves, training stability, injection stats, and
-        the latent-space GIF. Attempts every plot even if one fails, then raises listing the
-        failures — the stage machine records them without costing a data regeneration."""
+        """The vae_plots stage: final loss curves, training stability, injection stats, the
+        latent-space GIF, and the latent-dimension traversal. Attempts every plot even if one
+        fails, then raises listing the failures — the stage machine records them without
+        costing a data regeneration."""
         self._run_plot_group(
             [
                 (self.plot_beta_vae_loss_curves, "plot_beta_vae_loss_curves"),
                 (self.plot_beta_vae_training_stability, "plot_beta_vae_training_stability"),
                 (self.plot_injection_stats, "plot_injection_stats"),
                 (self.plot_latent_space_gif, "plot_latent_space_gif"),
+                (self.plot_latent_traversal, "plot_latent_traversal"),
             ]
         )
 
@@ -6153,6 +6554,10 @@ def _execute_training_stages(pipeline) -> None:
         except Exception as e:
             logger.error(f"Stage '{STAGE_VAE_PLOTS}' failed: {e}")
             pipeline._record_stage_failure(STAGE_VAE_PLOTS)
+        finally:
+            # The withheld viz batch's last consumer (plot_latent_traversal) has run —
+            # free it (a few hundred MB at full-scale defaults) before rf_train
+            pipeline._clear_latent_viz_data()
 
     # Stage 3/5: rf_train. On skip, the persisted RF from the attempt that completed the
     # stage is loaded back (rf_plots and final_save need a live model); if that reload
@@ -6225,7 +6630,10 @@ def run_training_pipeline(
         return pipeline
 
     finally:
-        # Free shared resources on exit
+        # Free shared resources on exit. The viz-batch clear matters on the failure path:
+        # a vae_rounds crash skips the vae_plots-stage clear, and the retry loop builds a
+        # fresh pipeline — don't let the dying one pin a few hundred MB of viz data
+        pipeline._clear_latent_viz_data()
         pipeline.data_generator.close()
 
 

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -4691,8 +4691,9 @@ class TrainingPipeline:
         n_cadences = batch.shape[0]
 
         # Encode the whole viz batch in one simple non-distributed pass, chunked by cadence
-        # so a large viz batch can't spike device memory (the encoder was created inside
-        # strategy.scope() but runs fine on the default device)
+        # (each chunk expands to chunk x num_obs observations at the encoder) so a large viz
+        # batch can't spike device memory (the encoder was created inside strategy.scope()
+        # but runs fine on the default device)
         chunk = max(1, self.config.training.per_replica_val_batch_size)
         z_parts = []
         for start in range(0, n_cadences, chunk):
@@ -4915,7 +4916,9 @@ class TrainingPipeline:
                 )
             ax.set_title(f"dim {d} (σ={sigmas[d]:.3f})", fontsize=11)
             ax.grid(True, alpha=0.3)
-            if d // ncols == nrows - 1:
+            # Label the bottom-most panel in each column (no panel d+ncols below it), so a
+            # partial last row (latent_dim not a multiple of ncols) still labels every column
+            if d + ncols >= latent_dim:
                 ax.set_xlabel("Frequency bin (full resolution)", fontsize=10)
             if d % ncols == 0:
                 ax.set_ylabel(intensity_label, fontsize=10)

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -4742,8 +4742,11 @@ class TrainingPipeline:
             # Base vector: mean z_mean over this type's ON observations
             z_t = z_mean[mask][:, on_indices, :].mean(axis=(0, 1))
 
-            # Class-mean log-norm params over the same ON observations, for the approximate
-            # display inversion (None -> plot in normalized log space)
+            # Class-mean log-norm params over this type's ON observations, for the approximate
+            # display inversion. Collapsing the per-observation (6, 2) params to one
+            # (min_log, range_log) pair is itself part of the approximation — a traversal decode
+            # blends observations — and combined with the lossy frequency downsampling the
+            # inverted intensity is DISPLAY-ONLY, never exact. None -> plot in normalized log space.
             lognorm = None
             if self._latent_viz_lognorm_params is not None:
                 on_params = self._latent_viz_lognorm_params[mask][:, on_indices, :]

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -376,6 +376,71 @@ class TestApplyArgsToConfig:
         assert config.checkpoint.start_round == 4
 
 
+class TestLatentTraversalFlags:
+    """Flags and validation for the latent-dimension traversal plot (PLAN PR-05)."""
+
+    def test_flags_apply_to_config(self):
+        apply_args_to_config(
+            _parse(
+                [
+                    "train",
+                    "--latent-traversal-every-round",
+                    "--latent-traversal-num-steps",
+                    "9",
+                    "--latent-traversal-max-sigma",
+                    "2.5",
+                ]
+            )
+        )
+        config = get_config()
+        assert config.training.latent_traversal_every_round is True
+        assert config.training.latent_traversal_num_steps == 9
+        assert config.training.latent_traversal_max_sigma == 2.5
+
+    def test_defaults_preserved_when_omitted(self):
+        apply_args_to_config(_parse(["train"]))
+        config = get_config()
+        assert config.training.latent_traversal_every_round is False
+        assert config.training.latent_traversal_num_steps == 7
+        assert config.training.latent_traversal_max_sigma == 3.0
+
+    def test_no_flag_forces_off(self):
+        apply_args_to_config(_parse(["train", "--no-latent-traversal-every-round"]))
+        assert get_config().training.latent_traversal_every_round is False
+
+    @staticmethod
+    def _traversal_errors(argv):
+        return [
+            e
+            for e in collect_validation_errors(_parse(argv), None)
+            if e.field.startswith("training.latent_traversal")
+        ]
+
+    @pytest.mark.parametrize("steps", [3, 5, 7, 9])
+    def test_odd_step_counts_accepted(self, steps):
+        assert self._traversal_errors(["train", "--latent-traversal-num-steps", str(steps)]) == []
+
+    @pytest.mark.parametrize("steps", [-1, 0, 1, 2, 4, 6, 8])
+    def test_even_or_too_small_step_counts_rejected(self, steps):
+        errors = self._traversal_errors(["train", "--latent-traversal-num-steps", str(steps)])
+        assert len(errors) == 1
+        assert errors[0].field == "training.latent_traversal_num_steps"
+        assert "odd" in errors[0].message
+
+    @pytest.mark.parametrize("max_sigma", ["0.5", "1", "3.0", "10"])
+    def test_positive_max_sigma_accepted(self, max_sigma):
+        assert self._traversal_errors(["train", "--latent-traversal-max-sigma", max_sigma]) == []
+
+    @pytest.mark.parametrize("max_sigma", ["0", "0.0", "-1.5"])
+    def test_nonpositive_max_sigma_rejected(self, max_sigma):
+        errors = self._traversal_errors(["train", "--latent-traversal-max-sigma", max_sigma])
+        assert len(errors) == 1
+        assert errors[0].field == "training.latent_traversal_max_sigma"
+
+    def test_defaults_pass_validation(self):
+        assert self._traversal_errors(["train"]) == []
+
+
 class TestRoundDataFlags:
     """Flags and validation for the disk-backed round-data pipeline (round_data.py)."""
 

--- a/tests/unit/test_data_generation.py
+++ b/tests/unit/test_data_generation.py
@@ -93,6 +93,28 @@ class TestLogNorm:
         assert twice.max() == pytest.approx(1.0)
         assert np.array_equal(np.argsort(once, axis=None), np.argsort(twice, axis=None))
 
+    def test_return_params_matches_default_output(self):
+        rng = np.random.default_rng(2)
+        data = rng.chisquare(df=4, size=(16, 64))
+        with_params, params = log_norm(data, return_params=True)
+        np.testing.assert_array_equal(with_params, log_norm(data))
+        assert len(params) == 2
+
+    def test_return_params_inverts_transform(self):
+        # exp(normalized * range_log + min_log) must recover the epsilon-shifted input.
+        rng = np.random.default_rng(3)
+        data = rng.chisquare(df=4, size=(16, 64))
+        normalized, (min_log, range_log) = log_norm(data, return_params=True)
+        recovered = np.exp(normalized * range_log + min_log)
+        np.testing.assert_allclose(recovered, data + 1e-10, rtol=1e-6)
+
+    def test_return_params_constant_input_degenerate_range(self):
+        # Constant input has zero dynamic range: range_log == 0 flags "no inversion possible".
+        normalized, (min_log, range_log) = log_norm(np.full((4, 4), 3.0), return_params=True)
+        assert np.all(normalized == 0.0)
+        assert range_log == 0.0
+        assert min_log == pytest.approx(np.log(3.0), abs=1e-9)
+
 
 class TestCheckValidIntersection:
     def test_parallel_lines_are_valid(self):
@@ -199,6 +221,10 @@ class TestCreateCadences:
         # Output is log-normalized per observation.
         assert final.min() >= 0.0
         assert final.max() <= 1.0
+        # Per-observation log-norm params are threaded through for display inversion,
+        # with a positive dynamic range for noisy inputs.
+        assert sample_info["lognorm_params"].shape == (6, 2)
+        assert np.all(sample_info["lognorm_params"][:, 1] > 0)
 
     def test_create_false_injected(self, plate):
         final, sample_info = create_false(plate, inject=True, **self._kwargs())
@@ -217,6 +243,12 @@ class TestCreateCadences:
         base = plate[sample_info["background_index"]]
         for obs in range(6):
             np.testing.assert_allclose(final[obs], log_norm(base[obs]))
+        # The recorded per-observation params invert the normalization back to the raw
+        # (epsilon-shifted) background.
+        for obs in range(6):
+            min_log, range_log = sample_info["lognorm_params"][obs]
+            recovered = np.exp(final[obs] * range_log + min_log)
+            np.testing.assert_allclose(recovered, base[obs] + 1e-10, rtol=1e-5)
 
     def test_create_true_single_injects_on_only(self, plate):
         final, sample_info = create_true_single(plate, **self._kwargs())

--- a/tests/unit/test_latent_traversal.py
+++ b/tests/unit/test_latent_traversal.py
@@ -1,0 +1,161 @@
+"""Unit tests for the latent-traversal math in aetherscan.train: the latent grid builder,
+the stub-decodable panel computation, and the display un-preprocessing (log-norm inversion +
+frequency upsampling)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from aetherscan.data_generation import log_norm
+from aetherscan.train import (
+    build_traversal_latents,
+    compute_traversal_panels,
+    unpreprocess_traversal_panels,
+)
+
+_LATENT_DIM = 8
+_NUM_STEPS = 7
+_MAX_SIGMA = 3.0
+
+
+@pytest.fixture
+def z_base():
+    return np.linspace(-1.0, 1.0, _LATENT_DIM).astype(np.float32)
+
+
+@pytest.fixture
+def sigmas():
+    return (0.1 + np.arange(_LATENT_DIM, dtype=np.float32) * 0.05).astype(np.float32)
+
+
+class TestBuildTraversalLatents:
+    def test_shapes_and_steps(self, z_base, sigmas):
+        latents, steps = build_traversal_latents(z_base, sigmas, _NUM_STEPS, _MAX_SIGMA)
+        assert latents.shape == (_LATENT_DIM * _NUM_STEPS, _LATENT_DIM)
+        assert latents.dtype == np.float32
+        assert steps.shape == (_NUM_STEPS,)
+        assert steps[0] == -_MAX_SIGMA
+        assert steps[-1] == _MAX_SIGMA
+        # Odd step count -> the center step is exactly the unperturbed decode.
+        assert steps[_NUM_STEPS // 2] == 0.0
+        np.testing.assert_allclose(steps, -steps[::-1])  # symmetric grid
+
+    def test_center_rows_are_unperturbed(self, z_base, sigmas):
+        latents, _ = build_traversal_latents(z_base, sigmas, _NUM_STEPS, _MAX_SIGMA)
+        for d in range(_LATENT_DIM):
+            center_row = latents[d * _NUM_STEPS + _NUM_STEPS // 2]
+            np.testing.assert_array_equal(center_row, z_base)
+
+    def test_only_target_dim_is_perturbed_by_step_times_sigma(self, z_base, sigmas):
+        latents, steps = build_traversal_latents(z_base, sigmas, _NUM_STEPS, _MAX_SIGMA)
+        for d in range(_LATENT_DIM):
+            for s in range(_NUM_STEPS):
+                row = latents[d * _NUM_STEPS + s]
+                delta = row - z_base
+                expected = np.zeros(_LATENT_DIM, dtype=np.float32)
+                expected[d] = steps[s] * sigmas[d]
+                np.testing.assert_allclose(delta, expected, atol=1e-6)
+
+    def test_mismatched_shapes_raise(self, z_base):
+        with pytest.raises(ValueError, match="matching 1-D"):
+            build_traversal_latents(z_base, np.ones(_LATENT_DIM + 1), _NUM_STEPS, _MAX_SIGMA)
+        with pytest.raises(ValueError, match="matching 1-D"):
+            build_traversal_latents(np.ones((2, _LATENT_DIM)), np.ones(_LATENT_DIM), 3, 1.0)
+
+
+class TestComputeTraversalPanels:
+    """Stub-decoder tests: an identity-ish decoder that paints each latent vector across the
+    panel's frequency axis, so panel content directly reveals which latent was decoded."""
+
+    @staticmethod
+    def _identity_decoder(latents):
+        # (n, latent_dim) -> (n, time, latent_dim): every time row equals the latent vector.
+        return np.repeat(latents[:, None, :], 4, axis=1)
+
+    def test_panels_are_row_major_over_dims_then_steps(self, z_base, sigmas):
+        panels, steps = compute_traversal_panels(
+            z_base, sigmas, _NUM_STEPS, _MAX_SIGMA, self._identity_decoder
+        )
+        assert panels.shape == (_LATENT_DIM, _NUM_STEPS, 4, _LATENT_DIM)
+        for d in range(_LATENT_DIM):
+            for s in range(_NUM_STEPS):
+                expected = z_base.copy()
+                expected[d] += steps[s] * sigmas[d]
+                # Every time row of the identity decode equals the traversal latent.
+                np.testing.assert_allclose(panels[d, s], np.tile(expected, (4, 1)), atol=1e-6)
+
+    def test_center_column_is_base_decode(self, z_base, sigmas):
+        panels, _ = compute_traversal_panels(
+            z_base, sigmas, _NUM_STEPS, _MAX_SIGMA, self._identity_decoder
+        )
+        base_decode = self._identity_decoder(z_base[None, :])[0]
+        for d in range(_LATENT_DIM):
+            np.testing.assert_array_equal(panels[d, _NUM_STEPS // 2], base_decode)
+
+    def test_trailing_channel_axis_is_squeezed(self, z_base, sigmas):
+        def channel_decoder(latents):
+            return self._identity_decoder(latents)[..., None]  # (n, t, f, 1)
+
+        panels, _ = compute_traversal_panels(
+            z_base, sigmas, _NUM_STEPS, _MAX_SIGMA, channel_decoder
+        )
+        assert panels.shape == (_LATENT_DIM, _NUM_STEPS, 4, _LATENT_DIM)
+
+    def test_bad_decoder_output_raises(self, z_base, sigmas):
+        with pytest.raises(ValueError, match="decode_fn"):
+            compute_traversal_panels(
+                z_base,
+                sigmas,
+                _NUM_STEPS,
+                _MAX_SIGMA,
+                lambda latents: latents,  # 2-D output
+            )
+        with pytest.raises(ValueError, match="decode_fn"):
+            compute_traversal_panels(
+                z_base,
+                sigmas,
+                _NUM_STEPS,
+                _MAX_SIGMA,
+                lambda latents: np.zeros((1, 4, 4)),  # wrong leading dim
+            )
+
+
+class TestUnpreprocessTraversalPanels:
+    def test_lognorm_inversion_math(self):
+        rng = np.random.default_rng(0)
+        panels = rng.random((2, 3, 4, 8))
+        min_log, range_log = -2.0, 3.0
+        out, inverted = unpreprocess_traversal_panels(panels, (min_log, range_log), 1)
+        assert inverted is True
+        np.testing.assert_allclose(out, np.exp(panels * range_log + min_log))
+
+    def test_no_params_stays_in_normalized_space(self):
+        panels = np.random.default_rng(1).random((2, 3, 4, 8))
+        out, inverted = unpreprocess_traversal_panels(panels, None, 1)
+        assert inverted is False
+        np.testing.assert_array_equal(out, panels)
+
+    def test_degenerate_range_skips_inversion(self):
+        panels = np.random.default_rng(2).random((2, 3, 4, 8))
+        out, inverted = unpreprocess_traversal_panels(panels, (0.5, 0.0), 1)
+        assert inverted is False
+        np.testing.assert_array_equal(out, panels)
+
+    def test_downsample_undone_by_nearest_neighbor_repeat(self):
+        panels = np.arange(2 * 3 * 4 * 8, dtype=float).reshape(2, 3, 4, 8)
+        out, _ = unpreprocess_traversal_panels(panels, None, 8)
+        assert out.shape == (2, 3, 4, 64)
+        np.testing.assert_array_equal(out, np.repeat(panels, 8, axis=-1))
+        # Nearest-neighbor: each source bin becomes a constant run of 8.
+        assert np.all(out[..., 0:8] == panels[..., 0:1])
+
+    def test_roundtrip_against_log_norm(self):
+        # Un-preprocessing a log_norm'ed observation with its own recorded params recovers
+        # the (epsilon-shifted) linear intensities.
+        rng = np.random.default_rng(3)
+        data = rng.chisquare(df=4, size=(16, 32))
+        normalized, params = log_norm(data, return_params=True)
+        out, inverted = unpreprocess_traversal_panels(normalized[None, None], params, 1)
+        assert inverted is True
+        np.testing.assert_allclose(out[0, 0], data + 1e-10, rtol=1e-6)

--- a/tests/unit/test_latent_traversal.py
+++ b/tests/unit/test_latent_traversal.py
@@ -1,14 +1,18 @@
 """Unit tests for the latent-traversal math in aetherscan.train: the latent grid builder,
-the stub-decodable panel computation, and the display un-preprocessing (log-norm inversion +
-frequency upsampling)."""
+the stub-decodable panel computation, the display un-preprocessing (log-norm inversion +
+frequency upsampling), and plot_latent_traversal's degenerate-input guards."""
 
 from __future__ import annotations
+
+import os
 
 import numpy as np
 import pytest
 
+from aetherscan.config import get_config
 from aetherscan.data_generation import log_norm
 from aetherscan.train import (
+    TrainingPipeline,
     build_traversal_latents,
     compute_traversal_panels,
     unpreprocess_traversal_panels,
@@ -166,3 +170,61 @@ class TestUnpreprocessTraversalPanels:
         out, inverted = unpreprocess_traversal_panels(normalized[None, None], params, 1)
         assert inverted is True
         np.testing.assert_allclose(out[0, 0], data + 1e-10, rtol=1e-6)
+
+
+class TestPlotLatentTraversalGuards:
+    """plot_latent_traversal's degenerate-input guards, driven through a duck-typed pipeline
+    (object.__new__ skips the heavyweight __init__) with stub encoder/decoder."""
+
+    def _stub_pipeline(self, batch, labels):
+        config = get_config()
+        latent_dim = config.beta_vae.latent_dim
+
+        class _CollapsedEncoder:
+            def __call__(self, x, training=False):
+                z = np.zeros((np.asarray(x).shape[0], latent_dim), dtype=np.float32)
+                return z, z, z
+
+        class _ExplodingDecoder:
+            def __call__(self, z, training=False):
+                raise AssertionError("decoder must not be called for a degenerate traversal")
+
+        class _StubVAE:
+            encoder = _CollapsedEncoder()
+            decoder = _ExplodingDecoder()
+
+        pipeline = object.__new__(TrainingPipeline)
+        pipeline.config = config
+        pipeline.vae = _StubVAE()
+        pipeline._latent_viz_batch = batch
+        pipeline._latent_viz_labels = labels
+        pipeline._latent_viz_lognorm_params = None
+        return pipeline
+
+    def _no_traversal_figures(self, config):
+        plots_dir = os.path.join(config.output_path, "plots")
+        return not os.path.isdir(plots_dir) or not any(
+            "latent_traversal" in name for name in os.listdir(plots_dir)
+        )
+
+    def test_collapsed_latents_skip_rendering(self):
+        # An encoder whose latents all collapse to one point yields all-zero per-dim sigmas:
+        # the plot must skip (before touching the decoder) instead of rendering blank grids.
+        config = get_config()
+        time_bins = config.data.time_bins
+        width = config.data.width_bin // config.data.downsample_factor
+        batch = np.random.default_rng(0).random((2, 6, time_bins, width)).astype(np.float32)
+        labels = np.array(["true_only_eti", "false_no_signal"], dtype="U20")
+
+        pipeline = self._stub_pipeline(batch, labels)
+        pipeline.plot_latent_traversal()
+
+        assert self._no_traversal_figures(config)
+
+    def test_missing_viz_batch_skips_rendering(self):
+        # A resumed run whose beta-VAE rounds were already complete never builds the viz
+        # batch — the plot must warn and return, not raise.
+        pipeline = self._stub_pipeline(None, None)
+        pipeline.plot_latent_traversal()
+
+        assert self._no_traversal_figures(get_config())

--- a/tests/unit/test_latent_traversal.py
+++ b/tests/unit/test_latent_traversal.py
@@ -57,6 +57,13 @@ class TestBuildTraversalLatents:
                 expected[d] = steps[s] * sigmas[d]
                 np.testing.assert_allclose(delta, expected, atol=1e-6)
 
+    @pytest.mark.parametrize("max_sigma", [2.5, 3.0, 0.7])
+    def test_center_step_is_exactly_zero_for_any_max_sigma(self, z_base, sigmas, max_sigma):
+        # linspace can leave ~1e-16 residue at the center for non-integral ranges; the
+        # builder must snap it so the center column is the exact base decode.
+        _, steps = build_traversal_latents(z_base, sigmas, _NUM_STEPS, max_sigma)
+        assert steps[_NUM_STEPS // 2] == 0.0
+
     def test_mismatched_shapes_raise(self, z_base):
         with pytest.raises(ValueError, match="matching 1-D"):
             build_traversal_latents(z_base, np.ones(_LATENT_DIM + 1), _NUM_STEPS, _MAX_SIGMA)

--- a/tests/unit/test_round_data.py
+++ b/tests/unit/test_round_data.py
@@ -137,6 +137,13 @@ class TestManifest:
         os.remove(paths.true_path)
         assert validate_done_manifest(paths) is None
 
+    def test_missing_lognorm_sibling_invalid(self, tmp_path):
+        # A round dir predating the lognorm-sibling feature fails validation & regenerates.
+        paths = RoundDataPaths.for_round(str(tmp_path), 1)
+        _write_small_round(paths)
+        os.remove(paths.lognorm_paths["main"])
+        assert validate_done_manifest(paths) is None
+
     def test_shape_mismatch_invalid(self, tmp_path):
         paths = RoundDataPaths.for_round(str(tmp_path), 1)
         _write_small_round(paths)
@@ -318,16 +325,18 @@ class TestGenerateRoundToMemmap:
         # Labels mirror the contiguous per-chunk layout (chunk_size=4 -> quarter=1)
         assert list(data["labels"]) == _SIGNAL_TYPES + _SIGNAL_TYPES
 
-        # Per-observation log-norm params were recorded for every array & every row:
-        # range_log > 0 for chi-squared-noise inputs, and inverting the normalization
-        # recovers strictly positive linear intensities
+        # Per-observation log-norm params were recorded for every array & every row
+        # (range_log > 0 for chi-squared-noise inputs). This asserts the PLUMBING — params
+        # populated, right shape, and a finite inversion — not an exact roundtrip: the raw
+        # pre-normalization data isn't retained at generate time, so the exact
+        # exp(x*range+min) == data check lives at unit level (test_create_false_not_injected).
         for name, lognorm_path in paths.lognorm_paths.items():
             params = np.load(lognorm_path)
             assert params.shape == (8, 6, 2)
             assert np.all(params[..., 1] > 0), f"{name} lognorm range_log not populated"
         main_params = np.load(paths.lognorm_paths["main"])
         recovered = np.exp(data["concatenated"][0, 0] * main_params[0, 0, 1] + main_params[0, 0, 0])
-        assert np.all(recovered > 0)
+        assert np.all(np.isfinite(recovered))  # finite inversion (exp of a finite value is > 0)
 
         # Manifest validates and matches the generation request
         assert validate_done_manifest(paths, expected_n_samples=8) is not None

--- a/tests/unit/test_round_data.py
+++ b/tests/unit/test_round_data.py
@@ -53,6 +53,11 @@ def _write_small_round(paths: RoundDataPaths, n_samples=8, width_bin=16, snr_bas
         arr = np.lib.format.open_memmap(path, mode="w+", dtype=np.float32, shape=shape)
         arr[:] = rng.random(shape, dtype=np.float32)
         del arr
+    lognorm_shape = (n_samples, 6, 2)
+    for path in paths.lognorm_paths.values():
+        arr = np.lib.format.open_memmap(path, mode="w+", dtype=np.float32, shape=lognorm_shape)
+        arr[:] = rng.random(lognorm_shape, dtype=np.float32)
+        del arr
     labels = np.array(
         [_SIGNAL_TYPES[i % 4] for i in range(n_samples)],
         dtype="U20",
@@ -82,6 +87,9 @@ class TestRoundDataPaths:
         assert set(paths.array_paths.keys()) == {"main", "true", "false"}
         for name, path in paths.array_paths.items():
             assert path == os.path.join(paths.round_dir, f"{name}.npy")
+        assert set(paths.lognorm_paths.keys()) == {"main", "true", "false"}
+        for name, path in paths.lognorm_paths.items():
+            assert path == os.path.join(paths.round_dir, f"{name}_lognorm.npy")
         assert paths.labels_path == os.path.join(paths.round_dir, "labels.npy")
 
 
@@ -93,7 +101,15 @@ class TestManifest:
         assert manifest is not None
         assert manifest["n_samples"] == written["n_samples"] == 8
         assert manifest["round_idx"] == 1
-        assert set(manifest["checksums"].keys()) == {"main", "true", "false", "labels"}
+        assert set(manifest["checksums"].keys()) == {
+            "main",
+            "true",
+            "false",
+            "main_lognorm",
+            "true_lognorm",
+            "false_lognorm",
+            "labels",
+        }
 
     def test_missing_done_file_invalid(self, tmp_path):
         paths = RoundDataPaths.for_round(str(tmp_path), 1)
@@ -148,13 +164,16 @@ class TestManifest:
         paths = RoundDataPaths.for_round(str(tmp_path), 1)
         _write_small_round(paths, n_samples=8, width_bin=16)
         data = load_round_arrays(paths)
-        assert set(data.keys()) == {"concatenated", "true", "false", "labels"}
+        assert set(data.keys()) == {"concatenated", "true", "false", "labels", "lognorm"}
         for key in ("concatenated", "true", "false"):
             assert isinstance(data[key], np.memmap)
             assert data[key].shape == (8, 6, 4, 16)
             assert data[key].dtype == np.float32
         assert data["labels"].shape == (8,)
         assert not isinstance(data["labels"], np.memmap)
+        # The main array's log-norm params are tiny and loaded eagerly
+        assert data["lognorm"].shape == (8, 6, 2)
+        assert not isinstance(data["lognorm"], np.memmap)
 
 
 class TestPrepareRoundDataDir:
@@ -298,6 +317,17 @@ class TestGenerateRoundToMemmap:
 
         # Labels mirror the contiguous per-chunk layout (chunk_size=4 -> quarter=1)
         assert list(data["labels"]) == _SIGNAL_TYPES + _SIGNAL_TYPES
+
+        # Per-observation log-norm params were recorded for every array & every row:
+        # range_log > 0 for chi-squared-noise inputs, and inverting the normalization
+        # recovers strictly positive linear intensities
+        for name, lognorm_path in paths.lognorm_paths.items():
+            params = np.load(lognorm_path)
+            assert params.shape == (8, 6, 2)
+            assert np.all(params[..., 1] > 0), f"{name} lognorm range_log not populated"
+        main_params = np.load(paths.lognorm_paths["main"])
+        recovered = np.exp(data["concatenated"][0, 0] * main_params[0, 0, 1] + main_params[0, 0, 0])
+        assert np.all(recovered > 0)
 
         # Manifest validates and matches the generation request
         assert validate_done_manifest(paths, expected_n_samples=8) is not None

--- a/tests/unit/test_train_utils.py
+++ b/tests/unit/test_train_utils.py
@@ -379,6 +379,9 @@ class _StageMachineStub:
     def _clear_rf_caches(self):
         self.calls.append("_clear_rf_caches")
 
+    def _clear_latent_viz_data(self):
+        self.calls.append("_clear_latent_viz_data")
+
     # The real methods also persist the manifest; persistence is covered in test_run_state.
     def _mark_stage_done(self, stage):
         self.run_state.mark_stage_done(stage)
@@ -397,6 +400,7 @@ class TestExecuteTrainingStages:
         assert stub.calls == [
             "train_beta_vae",
             "plot_vae_diagnostics",
+            "_clear_latent_viz_data",
             "train_random_forest",
             "plot_rf_diagnostics",
             "_clear_rf_caches",
@@ -425,6 +429,8 @@ class TestExecuteTrainingStages:
         stub = _StageMachineStub(self._state(), fail={"plot_vae_diagnostics"})
         _execute_training_stages(stub)
         assert "final_save" in stub.calls
+        # The viz batch is freed even when the plot group fails
+        assert "_clear_latent_viz_data" in stub.calls
         assert stub.run_state.stages_failed == [STAGE_VAE_PLOTS]
         assert not stub.run_state.is_stage_done(STAGE_VAE_PLOTS)
         assert stub.run_state.is_stage_done(STAGE_FINAL_SAVE)
@@ -465,6 +471,10 @@ class TestExecuteTrainingStages:
         # reloads the persisted RF — cheap, and by design), and success clears the failure
         second = _StageMachineStub(state)
         _execute_training_stages(second)
-        assert second.calls == ["plot_vae_diagnostics", "try_load_rf_for_resume"]
+        assert second.calls == [
+            "plot_vae_diagnostics",
+            "_clear_latent_viz_data",
+            "try_load_rf_for_resume",
+        ]
         assert state.stages_failed == []
         assert state.stages_done[-1] == STAGE_VAE_PLOTS  # re-marked after the retry


### PR DESCRIPTION
# Description

Latent-dimension traversal visualization: for each signal type, nudge the class-mean latent along every dimension and decode, revealing what each of the beta-VAE's 8 latent dims encodes (brightness, drift, width, ...). Runs once at end of training as part of the `vae_plots` stage, plus optionally at every round's end.

**Stacked PR: base branch is `feature/training-retry-overhaul` (#122).** This PR contains only the traversal commits; review after #122 and rebase onto `master` once #122 merges.

Closes #123

## What changed

- **`data_generation.py` / `round_data.py`** — per-observation log-norm parameters are now recorded at generation time (they were previously discarded, making any un-preprocessing impossible):
  - `log_norm(data, return_params=True)` additionally returns `(min_log, range_log)`; default call unchanged (`preprocessing.py`'s call site unaffected).
  - The `create_*` generators thread a `(6, 2)` `lognorm_params` array through `sample_info`; each batched memmap task writes it into a sibling `{main,true,false}_lognorm.npy` beside the round arrays (popped before the IPC stats payload — nothing new crosses to the DB).
  - The `.done` manifest covers the new arrays (shape + sampled checksums); pre-existing round dirs without them simply fail validation and regenerate, per the established garbage-or-valid semantics. `load_round_arrays()` eagerly loads the main array's params under a new `"lognorm"` key (`n_samples × 6 × 2` float32 — KBs).
- **`train.py`** — `TrainingPipeline.plot_latent_traversal(tag, dir)`:
  - Encodes the existing withheld latent-viz batch in a plain non-distributed pass (≤ ~960 cadences; chunked by `per_replica_val_batch_size`), computes per-type base vectors `z_t` (mean `z_mean` over ON observations 0/2/4) and per-dim σ over the whole batch, then decodes `z_t + s·σ_d·e_d` for every dim d and step s ∈ `linspace(-max_sigma, +max_sigma, num_steps)`.
  - Grid/panel/un-preprocessing math lives in module-level helpers (`build_traversal_latents`, `compute_traversal_panels`, `unpreprocess_traversal_panels`) unit-tested with a stub decoder. The center step is snapped to exactly 0 so the center column is the exact class-mean decode.
  - **Un-preprocessing is an honest approximation, stated on every figure**: log-norm inverted with the class-mean ON-obs params where recorded (`exp(x·range_log + min_log)`), normalized-log axes otherwise; downsampling undone for display via ×`downsample_factor` nearest-neighbor repetition so the frequency axis is in true bins.
  - Two figures per signal type, standard save + Slack-upload tail: `latent_traversal_{type}_{tag}.png` (dim × steps waterfall grid, shared per-row color scale) and `latent_traversal_spectra_{type}_{tag}.png` (per-dim time-integrated spectra under a step colormap).
  - Scheduling: a `vae_plots`-stage entry after the latent GIF (failures recorded via `stages_failed` like the other vae_plots failures — record-and-continue); optional per-round rendering via `--latent-traversal-every-round` (log-and-swallow there: an optional plot must not cost a round retry + data regeneration).
  - Lifecycle: the viz batch now survives `train_beta_vae()` (previously freed in its `finally`) and is released by `_clear_latent_viz_data()` after the `vae_plots` stage, or in `run_training_pipeline()`'s cleanup on an earlier failure. On a resumed run whose beta-VAE rounds were already complete there is nothing to encode, so the plot skips with a warning.
- **`config.py` / `cli.py` / `README.md`** — `latent_traversal_every_round: bool = False` (tri-state `BooleanOptionalAction`), `latent_traversal_num_steps: int = 7`, `latent_traversal_max_sigma: float = 3.0`; validation requires an odd step count ≥ 3 (center column = unperturbed decode) and `max_sigma > 0`; `to_dict()` updated; README CLI Reference blocks regenerated with `utils/print_cli_help.py` and pasted verbatim.

## Verification

### Unit tests (local, arm64 venv w/ TF 2.17.1)

`PYTHONPATH=src pytest -m "not gpu and not cluster" -q` → **310 passed, 3 skipped** (baseline before this PR: 269). New coverage:

- `tests/unit/test_latent_traversal.py` — traversal grid math with a stub decoder (row-major (dim, step) layout, center rows exactly `z_base` for any `max_sigma`, only the target dim perturbed by `step·σ_d`, trailing channel squeeze, bad-decoder shapes raise), and un-preprocessing (inversion math, degenerate `range_log` fallback, nearest-neighbor repeat, roundtrip against `log_norm`'s own recorded params).
- `test_data_generation.py` — `log_norm` param roundtrip (`exp(x·range+min) ≈ data + 1e-10`), default-signature equivalence, degenerate constant input, `lognorm_params` threading through all three `create_*` (including inverting a no-injection cadence back to its raw background).
- `test_round_data.py` — lognorm siblings populated for all three arrays end-to-end, covered by the manifest checksums, loaded by `load_round_arrays`.
- `test_cli_validation.py` — flag application + validation matrix (steps 3/5/7/9 accepted; −1/0/1/2/4/6/8 rejected; `max_sigma` 0/−1.5 rejected).
- `test_train_utils.py` — stage machine ordering updated for the viz-batch clear (fresh run, skip, and vae_plots-failure paths).

### Cluster smoke (blpc3, 5× RTX PRO 6000, singularity)

2-round × 2-epoch train smoke with the known-good blpc3 5-replica config plus `--latent-traversal-every-round` (fresh tag `test_v25`): completed cleanly (`Training completed successfully!`, clean ResourceManager teardown, no failed stages).

Figure inventory — **24/24 rendered with correct filenames**:

- Per-round (`plots/checkpoints/`, tags `round_01`/`round_02`): `latent_traversal_{false_no_signal,false_with_rfi,true_only_eti,true_eti_rfi}_round_0{1,2}.png` + the 8 matching `latent_traversal_spectra_*` — 16 figures.
- End-of-training (`plots/`, tag `test_v25`): the same 8 filenames tagged `test_v25` — 8 figures, rendered in the `vae_plots` stage after the latent GIF.

Eyeball checks on fetched PNGs: waterfall grids show the center column labeled `0σ (base)` equal to the class-mean reconstruction with smooth variation across ±σ columns; spectra panels show clean monotonic step gradients per dim on an approx-linear intensity scale (~1e11 raw power — physically plausible after inversion), captions correctly state the approximate un-preprocessing. (At 4 total epochs the decodes are noise-dominated textures, as expected for a smoke-scale model — the structure, labeling, scales, and inversion are what this smoke validates.)

Slack: handler initialized for the run channel; all 24 uploads fired with zero failure lines in the run log.

Cleanup performed: `round_data/test_v25` removed, `/dev/shm` clean, `/tmp` log removed, cluster repo returned to `master`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project (ruff lint + format)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (README CLI Reference regenerated; deep-dive docs are scoped to the docs-suite PR per the plan)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## AI disclosure

This PR was implemented end-to-end with **Claude Code**: implementation, unit tests, local render verification, the blpc3 cluster smoke (launch, verification, cleanup), and this PR text (design from the maintainer's v1 plan, PLAN.md §7 / PR-05).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
