### PR TITLE
Inference: stage-aware retries (run manifest, supersede-on-retry) + visualization suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,6 +722,9 @@ usage: inference [-h] [--data-path DATA_PATH] [--model-path MODEL_PATH]
                  [--overlap-search | --no-overlap-search]
                  [--overlap-fraction OVERLAP_FRACTION]
                  [--preprocess-output-dir PREPROCESS_OUTPUT_DIR]
+                 [--inference-viz | --no-inference-viz]
+                 [--stamp-gallery-top-k STAMP_GALLERY_TOP_K]
+                 [--max-candidate-plots MAX_CANDIDATE_PLOTS]
                  [--max-retries MAX_RETRIES] [--retry-delay RETRY_DELAY]
                  [--save-tag SAVE_TAG]
 
@@ -843,6 +846,23 @@ options:
                         from existing .npy files, while a new tag starts
                         clean. Pass an old run's directory explicitly to reuse
                         its preprocessing (shared across CSVs)
+  --inference-viz, --no-inference-viz
+                        Render the inference visualization suite (energy
+                        detection distributions, hit spectrum, bandpass
+                        overlay, stamp/candidate galleries, confidence
+                        distribution, latent projection, summary card) at the
+                        end of a CSV inference run, saved under
+                        plots/inference/{save_tag}/ and uploaded to Slack
+                        (default: enabled). Pass --no-inference-viz to
+                        disable.
+  --stamp-gallery-top-k STAMP_GALLERY_TOP_K
+                        Number of top-statistic stamps shown in the stamp
+                        gallery figure, each as a 6-observation waterfall grid
+                        (default: 12)
+  --max-candidate-plots MAX_CANDIDATE_PLOTS
+                        Maximum number of per-candidate figures rendered per
+                        run, highest confidence first (default: 50; the
+                        candidate gallery is unaffected)
   --max-retries MAX_RETRIES
                         Maximum number of retry attempts for inference
                         (including preprocessing) on failure

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -841,6 +841,26 @@ def _add_inference_flags_to(parser):
         default=None,
         help="Directory for per-cadence .npy outputs from preprocessing. Default: a per-CSV, tag-scoped directory {data_path}/inference/preprocessed/<csv_stem>_<save_tag>/ — retrying with the same tag resumes from existing .npy files, while a new tag starts clean. Pass an old run's directory explicitly to reuse its preprocessing (shared across CSVs)",
     )
+
+    # Visualization suite
+    parser.add_argument(
+        "--inference-viz",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Render the inference visualization suite (energy detection distributions, hit spectrum, bandpass overlay, stamp/candidate galleries, confidence distribution, latent projection, summary card) at the end of a CSV inference run, saved under plots/inference/{save_tag}/ and uploaded to Slack (default: enabled). Pass --no-inference-viz to disable.",
+    )
+    parser.add_argument(
+        "--stamp-gallery-top-k",
+        type=int,
+        default=None,
+        help="Number of top-statistic stamps shown in the stamp gallery figure, each as a 6-observation waterfall grid (default: 12)",
+    )
+    parser.add_argument(
+        "--max-candidate-plots",
+        type=int,
+        default=None,
+        help="Maximum number of per-candidate figures rendered per run, highest confidence first (default: 50; the candidate gallery is unaffected)",
+    )
     parser.add_argument(
         "--max-retries",
         type=int,
@@ -1191,6 +1211,17 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
         config.inference.overlap_fraction = args.overlap_fraction
     if hasattr(args, "preprocess_output_dir") and args.preprocess_output_dir is not None:
         config.inference.preprocess_output_dir = args.preprocess_output_dir
+
+    # Visualization suite
+    # inference_viz uses argparse.BooleanOptionalAction with default=None so that the CLI
+    # can express "leave the config default" (omit), "force on" (--inference-viz), and
+    # "force off" (--no-inference-viz)
+    if hasattr(args, "inference_viz") and args.inference_viz is not None:
+        config.inference.inference_viz_enabled = args.inference_viz
+    if hasattr(args, "stamp_gallery_top_k") and args.stamp_gallery_top_k is not None:
+        config.inference.stamp_gallery_top_k = args.stamp_gallery_top_k
+    if hasattr(args, "max_candidate_plots") and args.max_candidate_plots is not None:
+        config.inference.max_candidate_plots = args.max_candidate_plots
     if (
         hasattr(args, "max_retries")
         and args.max_retries is not None
@@ -2092,6 +2123,34 @@ def collect_validation_errors(
                     fix_kind="range",
                     min_val=0.0,
                     max_val=1.0,
+                )
+            )
+
+        # Visualization suite
+        stamp_gallery_top_k = _resolve(
+            args, "stamp_gallery_top_k", config.inference.stamp_gallery_top_k
+        )
+        if stamp_gallery_top_k is not None and stamp_gallery_top_k < 1:
+            errors.append(
+                ValidationError(
+                    field="inference.stamp_gallery_top_k",
+                    current=stamp_gallery_top_k,
+                    message=f"--stamp-gallery-top-k must be >= 1, got {stamp_gallery_top_k}",
+                    fix_kind="clamp_low",
+                    min_val=1,
+                )
+            )
+        max_candidate_plots = _resolve(
+            args, "max_candidate_plots", config.inference.max_candidate_plots
+        )
+        if max_candidate_plots is not None and max_candidate_plots < 0:
+            errors.append(
+                ValidationError(
+                    field="inference.max_candidate_plots",
+                    current=max_candidate_plots,
+                    message=f"--max-candidate-plots must be >= 0, got {max_candidate_plots}",
+                    fix_kind="clamp_low",
+                    min_val=0,
                 )
             )
 

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -882,6 +882,12 @@ def apply_saved_config(config_path: str) -> None:
     forward-compat with newer/older saved configs. Top-level scalar entries
     (`data_path`, `model_path`, `output_path`) are applied directly.
 
+    The `checkpoint` section is skipped entirely: a saved *training* config's
+    checkpoint fields (most damagingly `save_tag`) are never what an inference run
+    wants — layering them would make this run masquerade under the training run's
+    tag, corrupting DB provenance and output paths. The CLI `--save-tag` (or the
+    default import-time timestamp) stays authoritative.
+
     Raises `ValueError` if the file is missing or malformed — caught by main.py's
     wrapper alongside `validate_args` failures.
     """
@@ -898,6 +904,10 @@ def apply_saved_config(config_path: str) -> None:
         raise ValueError("get_config() returned None")
 
     for key, value in saved.items():
+        if key == "checkpoint":
+            # Never layer a saved training run's checkpoint section (save_tag/load_tag/
+            # load_dir/start_round) under CLI flags — see docstring.
+            continue
         target = getattr(config, key, None)
         if target is None:
             continue

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -354,6 +354,16 @@ class InferenceConfig:
     # explicitly to share/reuse one directory across runs and CSVs.
     preprocess_output_dir: str | None = None
 
+    # Visualization suite (aetherscan.inference_viz): rendered at the end of a streaming
+    # CSV inference run, saved under {output_path}/plots/inference/{save_tag}/ and uploaded
+    # to Slack. Every figure is individually exception-guarded — a plot bug can never kill
+    # a science run.
+    inference_viz_enabled: bool = True
+    # Number of top-statistic stamps shown in the stamp gallery (6-obs waterfall grids).
+    stamp_gallery_top_k: int = 12
+    # Cap on per-candidate figures (candidate_{i}_{tag}.png), highest confidence first.
+    max_candidate_plots: int = 50
+
     # NOTE: come back to this later (is this implemented correctly?)
     # Fault tolerance
     max_retries: int = 3
@@ -632,6 +642,9 @@ class Config:
                 "discard_side_channels": self.inference.discard_side_channels,
                 "side_channel_count": self.inference.side_channel_count,
                 "preprocess_output_dir": self.inference.preprocess_output_dir,
+                "inference_viz_enabled": self.inference.inference_viz_enabled,
+                "stamp_gallery_top_k": self.inference.stamp_gallery_top_k,
+                "max_candidate_plots": self.inference.max_candidate_plots,
                 "max_retries": self.inference.max_retries,
                 "retry_delay": self.inference.retry_delay,
             },

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -41,7 +41,12 @@ _MARK_SUPERSEDED_SENTINEL = object()
 # Bump this and extend _migrate_schema() with an `if version < N:` block for future changes.
 # v1: added `superseded INTEGER DEFAULT 0` to training_stats, injection_stats,
 #     latent_snapshots, and inference_results (stale-data supersede semantics on retry)
-_SCHEMA_VERSION = 1
+# v2: added the `inference_cadences` table (per-cadence inference run manifest driving
+#     stage-aware retries). New tables need no ALTER step — the CREATE TABLE IF NOT EXISTS
+#     statements in _init_database() run before migration for old and new databases alike —
+#     so the version bump exists to record the change and keep future `if version < N:`
+#     blocks ordered.
+_SCHEMA_VERSION = 2
 
 
 def get_system_metadata() -> str:
@@ -325,6 +330,35 @@ class Database:
                 ON inference_results(tag, timestamp, confidence, prediction)
             """)
 
+            # Inference cadence manifest table (schema v2): one row per (cadence, stage
+            # transition) — status 'preprocessed' when the stamp .npy lands, a superseding
+            # 'inferred' row (with aggregate stats) when inference completes, and 'failed'
+            # when the inference stage of a cadence dies. Drives stage-aware retry resume:
+            # a live 'inferred' row means the cadence is skipped entirely on retry.
+            # cadence_key and confidence_summary are JSON TEXT.
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS inference_cadences (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp REAL NOT NULL,
+                    tag TEXT,
+                    csv_path TEXT,
+                    cadence_key TEXT,
+                    npy_path TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    n_stamps INTEGER,
+                    n_candidates INTEGER,
+                    confidence_summary TEXT,
+                    duration_s REAL,
+                    superseded INTEGER DEFAULT 0
+                )
+            """)
+
+            # Composite index for the resume lookup pattern (tag + npy_path + status)
+            cursor.execute("""
+                CREATE INDEX IF NOT EXISTS idx_inference_cadences_filter
+                ON inference_cadences(tag, npy_path, status)
+            """)
+
             conn.commit()
 
             # Bring pre-existing databases (older schema) up to the current version
@@ -366,6 +400,11 @@ class Database:
                 if "superseded" not in columns:
                     cursor.execute(f"ALTER TABLE {table} ADD COLUMN superseded INTEGER DEFAULT 0")
                     logger.info(f"Schema migration: added {table}.superseded")
+
+        # v2 (inference_cadences table) needs no migration step here: the table is created
+        # for old and new databases alike by the CREATE TABLE IF NOT EXISTS statement in
+        # _init_database(), which always runs before this method. Only the version stamp
+        # below advances.
 
         # PRAGMA doesn't support parameter binding; _SCHEMA_VERSION is a module-level int constant
         cursor.execute(f"PRAGMA user_version = {_SCHEMA_VERSION:d}")
@@ -455,12 +494,14 @@ class Database:
         return False
 
     # Tables that support supersede marking, mapped to the optional filters each accepts
-    # (round_ge needs a round_number column; npy_path only exists on inference_results)
+    # (round_ge needs a round_number column; npy_path exists on inference_results and
+    # inference_cadences)
     _SUPERSEDE_TABLES = {
         "training_stats": frozenset({"round_ge"}),
         "injection_stats": frozenset({"round_ge"}),
         "latent_snapshots": frozenset({"round_ge"}),
         "inference_results": frozenset({"npy_path"}),
+        "inference_cadences": frozenset({"npy_path"}),
     }
 
     def mark_superseded(
@@ -479,7 +520,7 @@ class Database:
 
         round_ge narrows the mark to round_number >= round_ge (training_stats /
         injection_stats / latent_snapshots only); npy_path narrows to one cadence file
-        (inference_results only).
+        (inference_results / inference_cadences only).
 
         The command executes on the background writer thread (a command tuple through the
         write queue, like the flush sentinel) so single-writer semantics are preserved:
@@ -498,7 +539,9 @@ class Database:
         if round_ge is not None and "round_ge" not in allowed_filters:
             raise ValueError(f"round_ge is not supported for table {table!r}")
         if npy_path is not None and "npy_path" not in allowed_filters:
-            raise ValueError("npy_path is only supported for table 'inference_results'")
+            raise ValueError(
+                "npy_path is only supported for tables 'inference_results' and 'inference_cadences'"
+            )
         if not tag:
             raise ValueError("mark_superseded requires a non-empty tag")
 
@@ -683,6 +726,7 @@ class Database:
                 training_stats_records: list[tuple] = []
                 latent_snapshots_records: list[tuple] = []
                 inference_results_records: list[tuple] = []
+                inference_cadences_records: list[tuple] = []
 
                 for table, values in self.buffer:
                     if table == "system_resources":
@@ -695,6 +739,8 @@ class Database:
                         latent_snapshots_records.append(values)
                     elif table == "inference_results":
                         inference_results_records.append(values)
+                    elif table == "inference_cadences":
+                        inference_cadences_records.append(values)
 
                 # Bulk insert each table type
                 if system_resources_records:
@@ -752,6 +798,17 @@ class Database:
                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         inference_results_records,
+                    )
+
+                if inference_cadences_records:
+                    cursor.executemany(
+                        """
+                        INSERT INTO inference_cadences
+                        (timestamp, tag, csv_path, cadence_key, npy_path, status, n_stamps,
+                         n_candidates, confidence_summary, duration_s)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        inference_cadences_records,
                     )
 
                 conn.commit()
@@ -999,6 +1056,57 @@ class Database:
             )
         )
 
+    # TODO: write checks to sanitize values before writing to db. raise error if problematic value passed
+    def write_inference_cadence(
+        self,
+        npy_path: str,
+        status: str,
+        tag: str | None = None,
+        csv_path: str | None = None,
+        cadence_key: tuple | list | None = None,
+        n_stamps: int | None = None,
+        n_candidates: int | None = None,
+        confidence_summary: dict | None = None,
+        duration_s: float | None = None,
+        timestamp: float | None = None,
+    ):
+        """
+        Queue a non-blocking write to the inference_cadences run manifest.
+
+        One row per (cadence, stage transition): status='preprocessed' when the cadence's
+        stamp .npy lands (n_stamps set, aggregates None), status='inferred' when inference
+        completes (aggregates set; the caller supersedes older rows for the same
+        (tag, npy_path) first), status='failed' when the cadence's inference stage died
+        (so the failure is inspectable and the retry pass re-attempts it). cadence_key
+        (the CSV group-by key) and confidence_summary (quantile stats from
+        inference.summarize_confidences) are JSON-serialized for storage. duration_s is
+        the stage's wall-clock duration. Timestamp defaults to current wall time.
+        """
+        cadence_key_json = None
+        if cadence_key is not None:
+            cadence_key_json = json.dumps([str(part) for part in cadence_key])
+        confidence_summary_json = None
+        if confidence_summary is not None:
+            confidence_summary_json = json.dumps(confidence_summary)
+
+        self.write_queue.put(
+            (
+                "inference_cadences",
+                (
+                    timestamp or time.time(),
+                    tag,
+                    csv_path,
+                    cadence_key_json,
+                    npy_path,
+                    status,
+                    n_stamps,
+                    n_candidates,
+                    confidence_summary_json,
+                    duration_s,
+                ),
+            )
+        )
+
     # Column whitelists per table (for SQL injection prevention when using column projection)
     _SYSTEM_RESOURCES_COLUMNS = {
         "id",
@@ -1073,6 +1181,20 @@ class Database:
         "h5_path",
         "tag",
         "metadata",
+        "superseded",
+    }
+    _INFERENCE_CADENCES_COLUMNS = {
+        "id",
+        "timestamp",
+        "tag",
+        "csv_path",
+        "cadence_key",
+        "npy_path",
+        "status",
+        "n_stamps",
+        "n_candidates",
+        "confidence_summary",
+        "duration_s",
         "superseded",
     }
 
@@ -1709,6 +1831,72 @@ class Database:
             # Pair column names with values and return to user as a dict
             return [dict(zip(result_columns, row, strict=False)) for row in cursor.fetchall()]
 
+    def query_inference_cadences(
+        self,
+        npy_path: str | list[str] | None = None,
+        status: str | list[str] | None = None,
+        csv_path: str | list[str] | None = None,
+        tag: str | list[str] | None = None,
+        start_time: float | None = None,
+        end_time: float | None = None,
+        columns: list[str] | None = None,
+        include_superseded: bool = False,
+    ) -> list[dict[str, Any]]:
+        """
+        Query rows from the inference_cadences run manifest as a list of dicts.
+
+        String filters (npy_path, status, csv_path, tag) accept either a single value
+        (= filter) or a list (IN filter); status is one of {'preprocessed', 'inferred',
+        'failed'}. The returned cadence_key and confidence_summary fields are JSON strings —
+        callers parse them with json.loads. include_superseded (default False) controls
+        whether rows flagged stale by mark_superseded() are returned — the resume flow relies
+        on the default so a cadence whose 'inferred' row was superseded is re-attempted.
+        columns is validated against _INFERENCE_CADENCES_COLUMNS.
+        """
+        with self._get_connection() as conn:
+            cursor = conn.cursor()
+
+            select = self._build_select(
+                "inference_cadences", columns, self._INFERENCE_CADENCES_COLUMNS
+            )
+            # WHERE 1=1 is a way of building parametrized queries
+            # Since 1=1 is always true, it does nothing functionally
+            # But it allows us to safely add more conditions by appending AND clauses
+            # While not breaking the query if none are added
+            query = f"{select} WHERE 1=1"
+            params: list = []
+
+            # Build the query dynamically based on user-specified conditions
+            if npy_path:
+                query = self._add_str_filter(query, params, "npy_path", npy_path)
+
+            if status:
+                query = self._add_str_filter(query, params, "status", status)
+
+            if csv_path:
+                query = self._add_str_filter(query, params, "csv_path", csv_path)
+
+            if tag:
+                query = self._add_str_filter(query, params, "tag", tag)
+
+            if start_time is not None:
+                query += " AND timestamp >= ?"
+                params.append(start_time)
+
+            if end_time is not None:
+                query += " AND timestamp <= ?"
+                params.append(end_time)
+
+            if not include_superseded:
+                query += " AND superseded = 0"
+
+            cursor.execute(query, params)
+
+            # Create a list of column names using query result's metadata
+            result_columns = [desc[0] for desc in cursor.description]
+            # Pair column names with values and return to user as a dict
+            return [dict(zip(result_columns, row, strict=False)) for row in cursor.fetchall()]
+
     # NOTE: this call gets expensive as db grows. create a separate schema to track num_rows_added per pipeline run. then count & update as part of db cleanup routine? or use SQLite's dbstat virtual table or periodic ANALYZE?
     def get_db_stats(self) -> dict[str, Any]:
         """Get summary statistics for the database"""
@@ -1732,6 +1920,9 @@ class Database:
 
             cursor.execute("SELECT COUNT(*) FROM inference_results")
             stats["inference_results_row_count"] = cursor.fetchone()[0]
+
+            cursor.execute("SELECT COUNT(*) FROM inference_cadences")
+            stats["inference_cadences_row_count"] = cursor.fetchone()[0]
 
             # Time range
             # Use system_resources as proxy

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -46,7 +46,11 @@ _MARK_SUPERSEDED_SENTINEL = object()
 #     statements in _init_database() run before migration for old and new databases alike —
 #     so the version bump exists to record the change and keep future `if version < N:`
 #     blocks ordered.
-_SCHEMA_VERSION = 2
+# v3: added `inference_cadences.config_fingerprint` so the stage-aware resume only skips a
+#     cadence whose stored 'inferred' row was written under the same inference config — guards
+#     the reused-tag-with-changed-config stale-reuse footgun (the inference counterpart of the
+#     training-side config_fingerprint guard).
+_SCHEMA_VERSION = 3
 
 
 def get_system_metadata() -> str:
@@ -349,6 +353,7 @@ class Database:
                     n_candidates INTEGER,
                     confidence_summary TEXT,
                     duration_s REAL,
+                    config_fingerprint TEXT,
                     superseded INTEGER DEFAULT 0
                 )
             """)
@@ -405,6 +410,15 @@ class Database:
         # for old and new databases alike by the CREATE TABLE IF NOT EXISTS statement in
         # _init_database(), which always runs before this method. Only the version stamp
         # below advances.
+
+        if version < 3:
+            # v3: config_fingerprint on inference_cadences. A fresh db already has the column
+            # from the CREATE TABLE above; this ALTER patches a db that created the v2 table
+            # before the column existed. The column-existence check keeps it idempotent.
+            columns = {row[1] for row in cursor.execute("PRAGMA table_info(inference_cadences)")}
+            if "config_fingerprint" not in columns:
+                cursor.execute("ALTER TABLE inference_cadences ADD COLUMN config_fingerprint TEXT")
+                logger.info("Schema migration: added inference_cadences.config_fingerprint")
 
         # PRAGMA doesn't support parameter binding; _SCHEMA_VERSION is a module-level int constant
         cursor.execute(f"PRAGMA user_version = {_SCHEMA_VERSION:d}")
@@ -805,8 +819,8 @@ class Database:
                         """
                         INSERT INTO inference_cadences
                         (timestamp, tag, csv_path, cadence_key, npy_path, status, n_stamps,
-                         n_candidates, confidence_summary, duration_s)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                         n_candidates, confidence_summary, duration_s, config_fingerprint)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         inference_cadences_records,
                     )
@@ -1068,6 +1082,7 @@ class Database:
         n_candidates: int | None = None,
         confidence_summary: dict | None = None,
         duration_s: float | None = None,
+        config_fingerprint: str | None = None,
         timestamp: float | None = None,
     ):
         """
@@ -1103,6 +1118,7 @@ class Database:
                     n_candidates,
                     confidence_summary_json,
                     duration_s,
+                    config_fingerprint,
                 ),
             )
         )
@@ -1195,6 +1211,7 @@ class Database:
         "n_candidates",
         "confidence_summary",
         "duration_s",
+        "config_fingerprint",
         "superseded",
     }
 

--- a/src/aetherscan/inference.py
+++ b/src/aetherscan/inference.py
@@ -22,6 +22,39 @@ from aetherscan.models import RandomForestModel
 
 logger = logging.getLogger(__name__)
 
+# Quantile levels stored in each cadence's confidence summary (inference_cadences manifest)
+_CONFIDENCE_QUANTILES = (0.01, 0.05, 0.25, 0.5, 0.75, 0.95, 0.99)
+
+
+def summarize_confidences(proba_true: np.ndarray, threshold: float) -> dict:
+    """
+    Aggregate a cadence's P(true) vector into the JSON-serializable confidence summary
+    stored on its inference_cadences manifest row.
+
+    Returns {n, threshold, n_above_threshold, mean, min, max, quantiles} where quantiles maps
+    'p01'/'p05'/.../'p99' to the corresponding quantile of proba_true. Keeping the summary in
+    the manifest means run-level artifacts don't depend on the positives-only
+    inference_results table. Raises ValueError on an empty vector (a cadence with zero
+    snippets never reaches inference).
+    """
+    proba_true = np.asarray(proba_true, dtype=np.float64)
+    if proba_true.size == 0:
+        raise ValueError("summarize_confidences requires at least one confidence value")
+
+    quantiles = np.quantile(proba_true, _CONFIDENCE_QUANTILES)
+    return {
+        "n": int(proba_true.size),
+        "threshold": float(threshold),
+        "n_above_threshold": int((proba_true > threshold).sum()),
+        "mean": float(proba_true.mean()),
+        "min": float(proba_true.min()),
+        "max": float(proba_true.max()),
+        "quantiles": {
+            f"p{int(q * 100):02d}": float(v)
+            for q, v in zip(_CONFIDENCE_QUANTILES, quantiles, strict=True)
+        },
+    }
+
 
 # Create data holder objects, to be paired with data generators, for TF's distributed datasets
 # Allows for explicit dereferencing of large arrays using DataHolder.clear(), which lets
@@ -237,7 +270,12 @@ class InferencePipeline:
     ) -> dict:
         """
         Run inference on preprocessed cadence snippets (shape (n, 6, 16, 512)) sourced from
-        npy_path, and return {n_cadence_snippets, n_processed, n_candidates}.
+        npy_path, and return {n_cadence_snippets, n_processed, n_candidates, proba_true,
+        predictions, latents}. proba_true is the per-snippet P(true) vector, predictions the
+        thresholded 0/1 array, and latents the truncated per-observation latent array of shape
+        (n * num_observations, latent_dim) — callers use them for the per-cadence manifest
+        summary and the visualization suite, then drop them (they are per-cadence transients,
+        never accumulated catalog-wide).
 
         Encodes each snippet through the VAE encoder under the distribution strategy, then runs
         the Random Forest classifier on the latents and writes positive predictions to the
@@ -301,9 +339,16 @@ class InferencePipeline:
             # rows correspond exactly to the real snippets (row order is snippet-major)
             latents = latents[: n_samples * self.num_observations]
 
-            # Run RF classification
+            # Run RF classification. One predict_proba pass (1000 trees per snippet) yields
+            # everything downstream: P(true) for the manifest confidence summary and the
+            # confidence-distribution figure, plus the same predictions / confidences
+            # predict_verbose would have derived from it (probability of the predicted
+            # class, so high for confident negatives too).
             logger.info("Running Random Forest classification")
-            predictions, confidence_scores = self.rf_model.predict_verbose(latents, self.threshold)
+            probas = self.rf_model.predict_proba(latents)
+            proba_true = probas[:, 1]
+            predictions = (proba_true > self.threshold).astype(int)
+            confidence_scores = np.where(predictions, proba_true, probas[:, 0])
 
             # Write results to database
             n_candidates = self._write_inference_results(
@@ -339,6 +384,9 @@ class InferencePipeline:
             "n_cadence_snippets": n_samples,
             "n_processed": n_samples,
             "n_candidates": n_candidates,
+            "proba_true": proba_true,
+            "predictions": predictions,
+            "latents": latents,
         }
 
     def _distributed_encode(
@@ -490,9 +538,9 @@ class InferencePipeline:
         logger.info(f"Wrote {n_candidates} candidates to database")
         return n_candidates
 
-    # TODO: add plotting functions (remember to call when candidate is found) (full workflow when candidate is found: db write, make plot, save plot, send to slack)
-    def plot_candidate(self):
-        pass
+    # NOTE: candidate plotting lives in aetherscan.inference_viz (plot_candidate /
+    # plot_candidate_gallery), rendered at end of run from the inference_results rows +
+    # stamp .npy files so it also covers cadences skipped by the stage-aware resume.
 
 
 # TODO: add try-except switch statements (see run_training_pipeline())
@@ -518,8 +566,8 @@ def run_inference_pipeline(
 
     The optional provenance arguments (target/session/cadence_id/band/frequency_mhz/
     stamp_frequencies_mhz/timestamp_observed/h5_path) are written to the inference_results
-    table for any positive candidates. Returns the {n_cadence_snippets, n_processed,
-    n_candidates} dict from run_inference.
+    table for any positive candidates. Returns run_inference's results dict
+    ({n_cadence_snippets, n_processed, n_candidates, proba_true, predictions, latents}).
     """
     # Create pipeline
     pipeline = InferencePipeline(strategy=strategy)

--- a/src/aetherscan/inference_viz.py
+++ b/src/aetherscan/inference_viz.py
@@ -665,8 +665,12 @@ def plot_candidate(row: dict, index: int) -> str | None:
     _draw_cadence_strip(waterfall_axes, snippet, label_rows=True)
     waterfall_axes[-1].set_xlabel("frequency bin")
 
-    # Right column: latent bar chart on top, provenance text below
-    latent_ax = fig.add_subplot(grid[: n_obs // 2, 1])
+    # Right column: latent bar chart on top, provenance text below. A nested gridspec gives
+    # the two panels a dedicated vertical gap so the bar chart's x-axis label can never
+    # collide with the first metadata line; the text panel takes the taller share so all of
+    # the provenance lines stay clear of the axis label regardless of how many there are.
+    right_grid = grid[:, 1].subgridspec(2, 1, height_ratios=(1.0, 1.3), hspace=0.55)
+    latent_ax = fig.add_subplot(right_grid[0])
     latent_json = row.get("latent_vector")
     if latent_json:
         latent = np.asarray(json.loads(latent_json), dtype=np.float64).ravel()
@@ -681,10 +685,10 @@ def plot_candidate(row: dict, index: int) -> str | None:
         latent_ax.set_axis_off()
         latent_ax.text(0.5, 0.5, "no latent vector stored", ha="center", va="center")
 
-    text_ax = fig.add_subplot(grid[n_obs // 2 :, 1])
+    text_ax = fig.add_subplot(right_grid[1])
     text_ax.set_axis_off()
     text_ax.text(
-        0.0, 0.95, _candidate_annotation(row), va="top", ha="left", fontsize=9, family="monospace"
+        0.0, 1.0, _candidate_annotation(row), va="top", ha="left", fontsize=9, family="monospace"
     )
 
     fig.suptitle(f"Candidate {index} ({tag}) — P(true) = {row.get('confidence', 0):.4f}")

--- a/src/aetherscan/inference_viz.py
+++ b/src/aetherscan/inference_viz.py
@@ -312,7 +312,9 @@ def plot_ed_stat_distributions(
     ax.axvline(
         stat_threshold, color="red", ls="--", lw=1.2, label=f"threshold ({stat_threshold:g})"
     )
-    above = int(per_on_totals.sum(axis=0)[edges[:-1] >= stat_threshold].sum())
+    # Exact above-threshold count from the workers' hit lists (the histogram bins are fixed,
+    # so the threshold generally falls inside a bin — summing bins would be approximate)
+    above = sum(int((metadatas.get(r.npy_path) or {}).get("n_raw_hits") or 0) for r in records)
     total = int(per_on_totals.sum())
     ax.set_xscale("log")
     ax.set_yscale("log")
@@ -446,37 +448,36 @@ def plot_bandpass_flattening(
 def _select_top_stamps(
     records: list[CadenceVizRecord], metadatas: dict[str, dict], top_k: int
 ) -> list[tuple[CadenceVizRecord, int, float, float]]:
-    """Pick the top_k stamps by detection statistic across all cadences, greedily skipping
-    near-duplicates (overlap-search offsets of an already-selected stamp share its statistic
-    and nearly its start, so a plain top-K would show the same hit up to three times).
-    Returns (record, snippet_index, statistic, frequency_mhz) tuples, strongest first."""
-    candidates: list[tuple[float, CadenceVizRecord, int, float, int]] = []
+    """Pick the top_k stamps by detection statistic across all cadences, collapsing
+    overlap-search offset copies first: with overlap_search each hit yields up to three
+    stamps (at -offset/0/+offset) that all carry the hit's statistic, so a plain top-K
+    would show the same hit up to three times. Copies are grouped by their (exact) shared
+    statistic per cadence and represented by the median-start stamp — the offset-0 center
+    for a full triplet. Returns (record, snippet_index, statistic, frequency_mhz) tuples,
+    strongest first."""
+    representatives: list[tuple[float, CadenceVizRecord, int, float]] = []
     for record in records:
         metadata = metadatas.get(record.npy_path) or {}
         stats_list = metadata.get("stamp_statistics") or []
         freqs = metadata.get("stamp_frequencies_mhz") or []
         starts = metadata.get("stamp_starts") or []
+
+        # Group this cadence's stamps by exact statistic value (offset copies of one hit
+        # share the same float64 statistic; distinct hits colliding on the exact value is
+        # vanishingly unlikely, and for a gallery a collision merely hides a duplicate look)
+        by_stat: dict[float, list[tuple[int, int]]] = {}
         for idx, stat in enumerate(stats_list):
-            freq = float(freqs[idx]) if idx < len(freqs) else float("nan")
             start = int(starts[idx]) if idx < len(starts) else 0
-            candidates.append((float(stat), record, idx, freq, start))
+            by_stat.setdefault(float(stat), []).append((start, idx))
 
-    candidates.sort(key=lambda c: c[0], reverse=True)
+        for stat, members in by_stat.items():
+            members.sort()  # by start; median = offset-0 center for a full triplet
+            _, idx = members[len(members) // 2]
+            freq = float(freqs[idx]) if idx < len(freqs) else float("nan")
+            representatives.append((stat, record, idx, freq))
 
-    selected: list[tuple[CadenceVizRecord, int, float, float]] = []
-    taken_starts: dict[str, list[int]] = {}
-    for stat, record, idx, freq, start in candidates:
-        if len(selected) >= top_k:
-            break
-        metadata = metadatas.get(record.npy_path) or {}
-        stamp_width = int(metadata.get("stamp_width") or 0)
-        min_gap = max(1, stamp_width // 2)
-        near = [s for s in taken_starts.get(record.npy_path, []) if abs(s - start) < min_gap]
-        if near:
-            continue
-        taken_starts.setdefault(record.npy_path, []).append(start)
-        selected.append((record, idx, stat, freq))
-    return selected
+    representatives.sort(key=lambda c: c[0], reverse=True)
+    return [(record, idx, stat, freq) for stat, record, idx, freq in representatives[:top_k]]
 
 
 def plot_stamp_gallery(records: list[CadenceVizRecord], metadatas: dict[str, dict]) -> str | None:
@@ -848,7 +849,9 @@ def plot_inference_latent_projection(collector: InferenceVizCollector) -> str | 
     )
 
 
-def plot_inference_summary(records: list[CadenceVizRecord], totals: dict) -> str | None:
+def plot_inference_summary(
+    records: list[CadenceVizRecord], metadatas: dict[str, dict], totals: dict
+) -> str | None:
     """Table-style run summary card: cadence/snippet/candidate counts, per-stage durations
     and throughput from the inference_cadences manifest, and per-target/band candidate
     counts from inference_results."""
@@ -867,7 +870,6 @@ def plot_inference_summary(records: list[CadenceVizRecord], totals: dict) -> str
                 inference_duration += duration
 
     n_snippets = int(totals.get("n_cadence_snippets", 0))
-    metadatas = {r.npy_path: _load_metadata(r) or {} for r in records}
     n_raw_hits = sum(int((m or {}).get("n_raw_hits") or 0) for m in metadatas.values())
     n_merged_hits = sum(int((m or {}).get("n_merged_hits") or 0) for m in metadatas.values())
     storage_gb = 0.0
@@ -957,6 +959,6 @@ def render_inference_visualizations(
     _viz_safe("confidence_distribution", plot_confidence_distribution, records)
     _viz_safe("candidate_gallery", plot_candidate_gallery)
     _viz_safe("inference_latent_projection", plot_inference_latent_projection, collector)
-    _viz_safe("inference_summary", plot_inference_summary, records, totals)
+    _viz_safe("inference_summary", plot_inference_summary, records, metadatas, totals)
 
     logger.info("Inference visualization suite complete")

--- a/src/aetherscan/inference_viz.py
+++ b/src/aetherscan/inference_viz.py
@@ -203,6 +203,11 @@ def _save_and_upload(fig: Figure, filename: str, slack_title: str) -> str:
     tag = get_config().checkpoint.save_tag
     save_path = os.path.join(_plots_dir(tag), filename)
     fig.savefig(save_path, dpi=150, bbox_inches="tight")
+    # Eagerly release the figure's artists/render buffers. OO-API Figures aren't tracked by
+    # a global registry, so this isn't a leak fix — it just frees the backing memory now
+    # instead of at garbage collection (relevant for dense stamp/candidate galleries). The
+    # Slack upload below reads the saved PNG, not the figure.
+    fig.clear()
     logger.info(f"Inference viz saved: {save_path}")
 
     logger_instance = get_logger()
@@ -336,6 +341,11 @@ def plot_ed_hit_spectrum(records: list[CadenceVizRecord], metadatas: dict[str, d
     structure shows up immediately as spikes/picket-fences."""
     tag = get_config().checkpoint.save_tag
 
+    # NOTE: unlike the pre-binned ED stat histograms, hit frequencies are accumulated raw
+    # across every cadence before the histogram call — an asymmetry that is bounded at
+    # current catalog scale (~1e5-1e6 floats) but would warrant pre-binning in the
+    # metadata (fixed frequency grid, like ed_stat_hist) if catalogs grow to hundreds of
+    # RFI-dense cadences.
     raw_freqs: list[float] = []
     merged_freqs: list[float] = []
     for record in records:

--- a/src/aetherscan/inference_viz.py
+++ b/src/aetherscan/inference_viz.py
@@ -1,0 +1,962 @@
+"""
+Inference visualization suite for Aetherscan Pipeline
+
+Renders the end-of-run figures for a streaming CSV inference run: energy-detection statistic
+distributions, hit spectrum (pre/post dedup), bandpass-flattening overlay, top-K stamp
+gallery, preprocessing funnel, confidence distribution, candidate gallery + per-candidate
+plots, latent projection through the persisted training UMAP, and a run summary card.
+
+Data flows in three ways:
+- transient per-cadence state (confidence histograms, subsampled latent features) collected
+  by InferenceVizCollector during the streaming loop in main._run_streaming_csv_inference;
+- durable per-cadence artifacts (the metadata JSON written by preprocessing next to each
+  stamp .npy, and the .npy itself) — these also cover cadences the stage-aware resume
+  skipped this pass;
+- the database (inference_results candidates, inference_cadences manifest aggregates).
+
+Every figure is saved under {output_path}/plots/inference/{save_tag}/ and uploaded to Slack,
+mirroring train.py's plot pattern. render_inference_visualizations wraps each figure in
+_viz_safe: a plot bug logs an error and moves on — it can never kill a science run.
+
+Matplotlib usage is strictly the object-oriented Figure API (never pyplot): the pipeline runs
+background threads, and pyplot's global figure registry is not thread-safe.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import socket
+import time
+from collections import Counter
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+import numpy as np
+from matplotlib.figure import Figure
+
+from aetherscan.config import get_config
+from aetherscan.data_generation import log_norm
+from aetherscan.db import get_db
+from aetherscan.logger import get_logger
+from aetherscan.models import prepare_latent_features
+from aetherscan.pfb import gen_coarse_channel_response
+
+logger = logging.getLogger(__name__)
+
+# Fixed linear bins over [0, 1] for the per-cadence P(true) histograms accumulated by the
+# collector (identical bins everywhere, so per-cadence counts combine by addition).
+CONFIDENCE_HIST_EDGES = np.linspace(0.0, 1.0, 101)
+
+# Cap on latent feature rows kept for the latent-projection figure. Candidates are always
+# kept; non-candidates fill the remaining budget first-come (earlier cadences are slightly
+# over-represented on huge catalogs, which is fine for a qualitative projection).
+_MAX_LATENT_POINTS = 20_000
+
+# Frequency-axis bins for the hit spectrum figure.
+_HIT_SPECTRUM_BINS = 200
+
+# Candidate gallery shows at most this many top-confidence candidates (per-candidate figures
+# are governed separately by config.inference.max_candidate_plots).
+_CANDIDATE_GALLERY_MAX = 12
+
+# ON/OFF row labels for 6-observation ABACAD cadence strips.
+_OBS_ROW_LABELS = ("ON", "OFF", "ON", "OFF", "ON", "OFF")
+
+
+@dataclass
+class CadenceVizRecord:
+    """Per-cadence state the viz suite keeps after the cadence's arrays are dropped."""
+
+    key: tuple
+    npy_path: str
+    metadata_path: str
+    skipped: bool  # True when the stage-aware resume skipped the cadence this pass
+    n_stamps: int
+    n_candidates: int
+    provenance: dict = field(default_factory=dict)
+    confidence_hist: np.ndarray | None = None  # counts over CONFIDENCE_HIST_EDGES
+    inference_duration_s: float | None = None
+
+
+class InferenceVizCollector:
+    """
+    Accumulates bounded per-cadence state during the streaming inference loop.
+
+    Memory stays O(#cadences + _MAX_LATENT_POINTS) regardless of catalog size: confidence
+    vectors are folded into fixed-bin histograms immediately, and latent features are
+    subsampled against a global budget (candidates always kept).
+    """
+
+    def __init__(self, max_latent_points: int = _MAX_LATENT_POINTS):
+        self.records: list[CadenceVizRecord] = []
+        self._max_latent_points = max_latent_points
+        self._latent_chunks: list[np.ndarray] = []  # (k, num_obs * latent_dim) each
+        self._candidate_chunks: list[np.ndarray] = []  # bool masks aligned with chunks
+        self._latent_count = 0
+        self._rng = np.random.default_rng(11)
+
+    def record_skipped(
+        self, key: tuple, npy_path: str, metadata_path: str, manifest_row: dict
+    ) -> None:
+        """Record a cadence the stage-aware resume skipped (aggregates from its manifest row)."""
+        self.records.append(
+            CadenceVizRecord(
+                key=key,
+                npy_path=npy_path,
+                metadata_path=metadata_path,
+                skipped=True,
+                n_stamps=int(manifest_row.get("n_stamps") or 0),
+                n_candidates=int(manifest_row.get("n_candidates") or 0),
+                inference_duration_s=manifest_row.get("duration_s"),
+            )
+        )
+
+    def record_processed(
+        self,
+        key: tuple,
+        npy_path: str,
+        metadata_path: str,
+        provenance: dict,
+        results: dict,
+        duration_s: float,
+    ) -> None:
+        """Record a cadence inferred this pass. `results` is run_inference's dict; its
+        proba_true / predictions / latents arrays are reduced here and not retained."""
+        proba_true = np.asarray(results["proba_true"])
+        predictions = np.asarray(results["predictions"])
+        confidence_hist, _ = np.histogram(np.clip(proba_true, 0.0, 1.0), bins=CONFIDENCE_HIST_EDGES)
+
+        self.records.append(
+            CadenceVizRecord(
+                key=key,
+                npy_path=npy_path,
+                metadata_path=metadata_path,
+                skipped=False,
+                n_stamps=int(results["n_cadence_snippets"]),
+                n_candidates=int(results["n_candidates"]),
+                provenance=provenance,
+                confidence_hist=confidence_hist,
+                inference_duration_s=duration_s,
+            )
+        )
+
+        self._reservoir_add(results["latents"], predictions.astype(bool))
+
+    def _reservoir_add(self, latents: np.ndarray, is_candidate: np.ndarray) -> None:
+        """Fold one cadence's latents into the bounded projection pool: cadence-level
+        features (obs latents concatenated), candidates always kept, non-candidates only
+        while the global budget lasts."""
+        config = get_config()
+        features = prepare_latent_features(
+            np.asarray(latents), config.data.num_observations
+        ).astype(np.float32)
+
+        keep = np.nonzero(is_candidate)[0]
+        budget = self._max_latent_points - self._latent_count - keep.size
+        non_candidates = np.nonzero(~is_candidate)[0]
+        if budget > 0 and non_candidates.size > 0:
+            if non_candidates.size > budget:
+                non_candidates = self._rng.choice(non_candidates, size=budget, replace=False)
+            keep = np.concatenate([keep, non_candidates])
+
+        if keep.size == 0:
+            return
+        self._latent_chunks.append(features[keep])
+        self._candidate_chunks.append(is_candidate[keep])
+        self._latent_count += keep.size
+
+    def latent_pool(self) -> tuple[np.ndarray, np.ndarray]:
+        """Return (features, is_candidate) stacked over everything collected; empty arrays
+        when nothing was processed this pass."""
+        if not self._latent_chunks:
+            return np.empty((0, 0), dtype=np.float32), np.empty(0, dtype=bool)
+        return np.concatenate(self._latent_chunks), np.concatenate(self._candidate_chunks)
+
+
+# ---------------------------------------------------------------------------
+# Shared plumbing
+# ---------------------------------------------------------------------------
+
+
+def _viz_safe(name: str, fn: Callable, *args, **kwargs):
+    """Run one figure function, log-and-swallow any exception: a plot bug must never kill a
+    science run (mirrors train.py's _safe_call, with viz-specific logging)."""
+    try:
+        return fn(*args, **kwargs)
+    except Exception as e:
+        logger.error(f"Inference viz '{name}' failed (run continues without it): {e}")
+        return None
+
+
+def _plots_dir(tag: str) -> str:
+    path = os.path.join(get_config().output_path, "plots", "inference", tag)
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def _save_and_upload(fig: Figure, filename: str, slack_title: str) -> str:
+    """Save a figure under plots/inference/{tag}/ and upload it to Slack (train.py's plot
+    tail, minus pyplot). Returns the saved path."""
+    tag = get_config().checkpoint.save_tag
+    save_path = os.path.join(_plots_dir(tag), filename)
+    fig.savefig(save_path, dpi=150, bbox_inches="tight")
+    logger.info(f"Inference viz saved: {save_path}")
+
+    logger_instance = get_logger()
+    if logger_instance:
+        logger_instance.upload_image_to_slack(
+            save_path, title=f"{slack_title} - ({tag}, {socket.gethostname()})"
+        )
+    return save_path
+
+
+def _load_metadata(record: CadenceVizRecord) -> dict | None:
+    """Best-effort read of a cadence's metadata JSON (durable ED provenance)."""
+    try:
+        with open(record.metadata_path) as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning(f"Viz: could not read metadata {record.metadata_path} ({e}); skipping")
+        return None
+
+
+def _load_display_cadence(npy_path: str, snippet_index: int) -> np.ndarray:
+    """Load one snippet's (num_obs, time_bins, width) stamp from its .npy and log-normalize
+    it for display (the same transform the model input path applies)."""
+    stamps = np.load(npy_path, mmap_mode="r")
+    snippet = np.array(stamps[snippet_index], dtype=np.float32)
+    del stamps
+    return log_norm(snippet)
+
+
+def _draw_cadence_strip(axes_column, snippet: np.ndarray, label_rows: bool) -> None:
+    """Draw one snippet's 6 observation waterfalls down a column of axes."""
+    for obs_idx, ax in enumerate(axes_column):
+        ax.imshow(
+            snippet[obs_idx],
+            aspect="auto",
+            origin="lower",
+            cmap="viridis",
+            vmin=0.0,
+            vmax=1.0,
+            interpolation="nearest",
+        )
+        ax.set_xticks([])
+        ax.set_yticks([])
+        if label_rows:
+            ax.set_ylabel(_OBS_ROW_LABELS[obs_idx], fontsize=8, rotation=0, ha="right", va="center")
+
+
+def _key_label(key: tuple, max_len: int = 28) -> str:
+    label = "/".join(str(part) for part in key)
+    return label if len(label) <= max_len else label[: max_len - 1] + "…"
+
+
+# ---------------------------------------------------------------------------
+# Per-run figures: energy detection / preprocessing
+# ---------------------------------------------------------------------------
+
+
+def plot_ed_stat_distributions(
+    records: list[CadenceVizRecord], metadatas: dict[str, dict]
+) -> str | None:
+    """Histogram of the D'Agostino-Pearson k2 statistic over ALL windows (not just hits),
+    log-log, per-ON-file overlay + total, with the detection threshold marked. Sourced from
+    the fixed-bin histograms the ED workers accumulate into each cadence's metadata."""
+    config = get_config()
+    tag = config.checkpoint.save_tag
+    stat_threshold = config.inference.stat_threshold
+
+    edges: np.ndarray | None = None
+    per_on_totals: np.ndarray | None = None
+    for record in records:
+        metadata = metadatas.get(record.npy_path)
+        ed_hist = (metadata or {}).get("ed_stat_hist")
+        if not ed_hist:
+            continue
+        cadence_edges = np.asarray(ed_hist["bin_edges"], dtype=np.float64)
+        counts = np.asarray(ed_hist["counts_per_on_file"], dtype=np.int64)
+        if edges is None:
+            edges = cadence_edges
+            per_on_totals = np.zeros_like(counts)
+        elif cadence_edges.shape != edges.shape or not np.allclose(cadence_edges, edges):
+            logger.warning(f"Viz: {record.npy_path} has mismatched ED hist bins; skipping it")
+            continue
+        if counts.shape != per_on_totals.shape:
+            logger.warning(f"Viz: {record.npy_path} has unexpected ED hist shape; skipping it")
+            continue
+        per_on_totals += counts
+
+    if edges is None or per_on_totals is None or per_on_totals.sum() == 0:
+        logger.info("Viz: no ED statistic histograms available; skipping ed_stat_distributions")
+        return None
+
+    centers = np.sqrt(edges[:-1] * edges[1:])  # geometric bin centers (log-spaced bins)
+
+    fig = Figure(figsize=(10, 6))
+    ax = fig.subplots()
+    for on_idx in range(per_on_totals.shape[0]):
+        ax.step(
+            centers,
+            per_on_totals[on_idx],
+            where="mid",
+            lw=1.0,
+            label=f"ON file {on_idx + 1}",
+        )
+    ax.step(
+        centers, per_on_totals.sum(axis=0), where="mid", lw=1.6, color="black", label="all ON files"
+    )
+    ax.axvline(
+        stat_threshold, color="red", ls="--", lw=1.2, label=f"threshold ({stat_threshold:g})"
+    )
+    above = int(per_on_totals.sum(axis=0)[edges[:-1] >= stat_threshold].sum())
+    total = int(per_on_totals.sum())
+    ax.set_xscale("log")
+    ax.set_yscale("log")
+    ax.set_xlabel("D'Agostino-Pearson $k^2$ statistic")
+    ax.set_ylabel("window count")
+    ax.set_title(
+        f"Energy-detection statistic distribution ({tag})\n"
+        f"{total:,} windows, {above:,} above threshold "
+        f"({len([r for r in records if metadatas.get(r.npy_path)])} cadence(s))"
+    )
+    ax.legend(fontsize=8)
+    ax.grid(True, which="both", alpha=0.2)
+
+    return _save_and_upload(fig, f"ed_stat_distributions_{tag}.png", "ED Statistic Distribution")
+
+
+def plot_ed_hit_spectrum(records: list[CadenceVizRecord], metadatas: dict[str, dict]) -> str | None:
+    """Hit density vs frequency (MHz) across the band, pre- vs post-deduplication — RFI comb
+    structure shows up immediately as spikes/picket-fences."""
+    tag = get_config().checkpoint.save_tag
+
+    raw_freqs: list[float] = []
+    merged_freqs: list[float] = []
+    for record in records:
+        metadata = metadatas.get(record.npy_path) or {}
+        raw_freqs.extend(metadata.get("raw_hit_frequencies_mhz") or [])
+        merged_freqs.extend(metadata.get("merged_hit_frequencies_mhz") or [])
+
+    if not raw_freqs:
+        logger.info("Viz: no hit frequencies available; skipping ed_hit_spectrum")
+        return None
+
+    lo, hi = float(np.min(raw_freqs)), float(np.max(raw_freqs))
+    if lo == hi:  # single-frequency degenerate range: give the histogram some width
+        lo, hi = lo - 0.5, hi + 0.5
+    bins = np.linspace(lo, hi, _HIT_SPECTRUM_BINS + 1)
+
+    fig = Figure(figsize=(12, 5))
+    ax = fig.subplots()
+    ax.hist(raw_freqs, bins=bins, histtype="stepfilled", alpha=0.35, label="raw hits (pre-dedup)")
+    ax.hist(merged_freqs, bins=bins, histtype="step", lw=1.4, color="crimson", label="merged hits")
+    ax.set_yscale("log")
+    ax.set_xlabel("frequency (MHz)")
+    ax.set_ylabel("hit count")
+    ax.set_title(
+        f"Energy-detection hit spectrum ({tag})\n"
+        f"{len(raw_freqs):,} raw → {len(merged_freqs):,} merged hits"
+    )
+    ax.legend(fontsize=9)
+    ax.grid(True, alpha=0.2)
+
+    return _save_and_upload(fig, f"ed_hit_spectrum_{tag}.png", "ED Hit Spectrum")
+
+
+def plot_bandpass_flattening(
+    preprocessor, records: list[CadenceVizRecord], metadatas: dict[str, dict]
+) -> str | None:
+    """Integrated spectrum raw vs flattened for a few coarse channels sampled across the
+    band of the first cadence's primary ON file, with the removed model (scaled PFB response
+    H or spline fit) overlaid — formalizes PR-07's opt-in debug artifact as a standard
+    per-run figure."""
+    # NOTE: reaches into DataPreprocessor's private helpers on purpose — they are the
+    # single source of truth for how a channel is read/despiked/flattened, and duplicating
+    # that here would let the figure drift from what detection actually does.
+    from aetherscan.preprocessing import (  # noqa: PLC0415
+        _fit_channel_bandpass,
+        _pfb_flatten_bandpass,
+    )
+
+    config = get_config()
+    tag = config.checkpoint.save_tag
+    width = config.inference.coarse_channel_width
+
+    h5_path = None
+    for record in records:
+        metadata = metadatas.get(record.npy_path) or {}
+        h5_paths = metadata.get("h5_paths") or []
+        if h5_paths and os.path.exists(h5_paths[0]):
+            h5_path = h5_paths[0]
+            n_chans = int((metadata.get("header") or {}).get("nchans", 0))
+            break
+    if h5_path is None:
+        logger.info("Viz: no readable ON-source .h5 available; skipping bandpass_flattening")
+        return None
+
+    n_coarse_total = n_chans // width
+    if n_coarse_total == 0:
+        logger.info("Viz: file narrower than one coarse channel; skipping bandpass_flattening")
+        return None
+
+    bandpass_flatten = preprocessor._get_bandpass_flattener(n_coarse_total)
+    pfb_active = bandpass_flatten.func is _pfb_flatten_bandpass
+    sampled = preprocessor._sample_channel_indices(n_coarse_total)
+
+    fig = Figure(figsize=(14, 3.2 * len(sampled)))
+    axes = fig.subplots(len(sampled), 2, squeeze=False)
+    for row, ch in enumerate(sampled):
+        channel = preprocessor._read_despiked_channel(h5_path, ch)
+        raw = channel.mean(axis=0)
+        flat = np.asarray(bandpass_flatten(channel)).mean(axis=0)
+        if pfb_active:
+            response = gen_coarse_channel_response(
+                width, n_coarse_total, config.inference.pfb_taps_per_channel
+            )
+            # Least-squares scale so the unit-peak response overlays the raw spectrum
+            overlay = response * (float(raw @ response) / float(response @ response))
+            overlay_label = "scaled PFB response H"
+        else:
+            overlay = _fit_channel_bandpass(raw, width, config.inference.spline_order)
+            overlay_label = "spline fit"
+
+        ax_raw, ax_flat = axes[row]
+        ax_raw.plot(raw, lw=0.6, color="tab:blue", label="raw integrated spectrum")
+        ax_raw.plot(overlay, lw=1.2, ls="--", color="tab:orange", label=overlay_label)
+        ax_raw.set_ylabel(f"coarse channel {ch}\nintegrated power")
+        ax_flat.plot(flat, lw=0.6, color="tab:green", label="flattened integrated spectrum")
+        if row == 0:
+            ax_raw.legend(loc="upper right", fontsize=8)
+            ax_flat.legend(loc="upper right", fontsize=8)
+        if row == len(sampled) - 1:
+            ax_raw.set_xlabel("fine channel (within coarse channel)")
+            ax_flat.set_xlabel("fine channel (within coarse channel)")
+
+    method = "pfb" if pfb_active else "spline"
+    fig.suptitle(f"Bandpass flattening ({method}, {tag}): {os.path.basename(h5_path)}")
+    fig.tight_layout()
+
+    return _save_and_upload(fig, f"bandpass_flattening_{tag}.png", "Bandpass Flattening")
+
+
+def _select_top_stamps(
+    records: list[CadenceVizRecord], metadatas: dict[str, dict], top_k: int
+) -> list[tuple[CadenceVizRecord, int, float, float]]:
+    """Pick the top_k stamps by detection statistic across all cadences, greedily skipping
+    near-duplicates (overlap-search offsets of an already-selected stamp share its statistic
+    and nearly its start, so a plain top-K would show the same hit up to three times).
+    Returns (record, snippet_index, statistic, frequency_mhz) tuples, strongest first."""
+    candidates: list[tuple[float, CadenceVizRecord, int, float, int]] = []
+    for record in records:
+        metadata = metadatas.get(record.npy_path) or {}
+        stats_list = metadata.get("stamp_statistics") or []
+        freqs = metadata.get("stamp_frequencies_mhz") or []
+        starts = metadata.get("stamp_starts") or []
+        for idx, stat in enumerate(stats_list):
+            freq = float(freqs[idx]) if idx < len(freqs) else float("nan")
+            start = int(starts[idx]) if idx < len(starts) else 0
+            candidates.append((float(stat), record, idx, freq, start))
+
+    candidates.sort(key=lambda c: c[0], reverse=True)
+
+    selected: list[tuple[CadenceVizRecord, int, float, float]] = []
+    taken_starts: dict[str, list[int]] = {}
+    for stat, record, idx, freq, start in candidates:
+        if len(selected) >= top_k:
+            break
+        metadata = metadatas.get(record.npy_path) or {}
+        stamp_width = int(metadata.get("stamp_width") or 0)
+        min_gap = max(1, stamp_width // 2)
+        near = [s for s in taken_starts.get(record.npy_path, []) if abs(s - start) < min_gap]
+        if near:
+            continue
+        taken_starts.setdefault(record.npy_path, []).append(start)
+        selected.append((record, idx, stat, freq))
+    return selected
+
+
+def plot_stamp_gallery(records: list[CadenceVizRecord], metadatas: dict[str, dict]) -> str | None:
+    """Top-K stamps by detection statistic, each rendered as the 6-observation cadence
+    waterfall grid scientists actually inspect (ON/OFF rows, one stamp per column)."""
+    config = get_config()
+    tag = config.checkpoint.save_tag
+    top_k = config.inference.stamp_gallery_top_k
+
+    selected = _select_top_stamps(records, metadatas, top_k)
+    if not selected:
+        logger.info("Viz: no stamps available; skipping stamp_gallery")
+        return None
+
+    n_cols = len(selected)
+    n_rows = len(_OBS_ROW_LABELS)
+    fig = Figure(figsize=(1.9 * n_cols + 1.2, 1.1 * n_rows + 1.6))
+    axes = fig.subplots(n_rows, n_cols, squeeze=False)
+
+    for col, (record, idx, stat, freq) in enumerate(selected):
+        try:
+            snippet = _load_display_cadence(record.npy_path, idx)
+        except Exception as e:
+            logger.warning(f"Viz: failed to load stamp {idx} from {record.npy_path}: {e}")
+            for row in range(n_rows):
+                axes[row][col].set_axis_off()
+            continue
+        _draw_cadence_strip([axes[row][col] for row in range(n_rows)], snippet, label_rows=col == 0)
+        axes[0][col].set_title(
+            f"$k^2$={stat:.3g}\n{freq:.4f} MHz\n{_key_label(record.key, 20)}", fontsize=7
+        )
+
+    fig.suptitle(f"Top-{n_cols} energy-detection stamps by statistic ({tag})")
+
+    return _save_and_upload(fig, f"stamp_gallery_{tag}.png", "Stamp Gallery")
+
+
+def plot_preproc_funnel(records: list[CadenceVizRecord], metadatas: dict[str, dict]) -> str | None:
+    """Per-cadence preprocessing funnel: raw hits → merged hits → stamps (incl. overlap
+    offsets) → snippets inferred, plus per-cadence stamp storage annotated on top."""
+    tag = get_config().checkpoint.save_tag
+
+    labels: list[str] = []
+    stage_counts: list[tuple[int, int, int, int]] = []
+    storage_gb: list[float] = []
+    for record in records:
+        metadata = metadatas.get(record.npy_path) or {}
+        n_raw = int(metadata.get("n_raw_hits") or 0)
+        n_merged = int(metadata.get("n_merged_hits") or 0)
+        n_stamps = len(metadata.get("stamp_starts") or []) or record.n_stamps
+        labels.append(_key_label(record.key))
+        stage_counts.append((n_raw, n_merged, n_stamps, record.n_stamps))
+        try:
+            storage_gb.append(os.path.getsize(record.npy_path) / 1e9)
+        except OSError:
+            storage_gb.append(float("nan"))
+
+    if not stage_counts:
+        logger.info("Viz: no cadences recorded; skipping preproc_funnel")
+        return None
+
+    stages = ("raw hits", "merged hits", "stamps (+overlap)", "snippets inferred")
+    counts = np.asarray(stage_counts, dtype=np.float64)  # (n_cadences, 4)
+    n_cadences = counts.shape[0]
+    x = np.arange(n_cadences)
+    bar_width = 0.8 / len(stages)
+
+    fig = Figure(figsize=(max(8.0, 1.8 * n_cadences), 6))
+    ax = fig.subplots()
+    for stage_idx, stage in enumerate(stages):
+        ax.bar(
+            x + (stage_idx - (len(stages) - 1) / 2) * bar_width,
+            counts[:, stage_idx],
+            width=bar_width,
+            label=stage,
+        )
+    for i in range(n_cadences):
+        top = np.nanmax(counts[i]) if np.any(np.isfinite(counts[i])) else 0
+        ax.annotate(
+            f"{storage_gb[i]:.2f} GB",
+            xy=(x[i], top),
+            xytext=(0, 6),
+            textcoords="offset points",
+            ha="center",
+            fontsize=8,
+        )
+    ax.set_yscale("log")
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels, rotation=20, ha="right", fontsize=8)
+    ax.set_ylabel("count")
+    ax.set_title(f"Preprocessing funnel per cadence ({tag}) — stamp storage annotated")
+    ax.legend(fontsize=8)
+    ax.grid(True, axis="y", alpha=0.2)
+
+    return _save_and_upload(fig, f"preproc_funnel_{tag}.png", "Preprocessing Funnel")
+
+
+# ---------------------------------------------------------------------------
+# Per-run figures: inference / anomaly detection
+# ---------------------------------------------------------------------------
+
+
+def plot_confidence_distribution(records: list[CadenceVizRecord]) -> str | None:
+    """P(true) histogram over all snippets inferred this pass (log-y), classification
+    threshold marked, per-cadence overlay when the pass covered ≤ 10 cadences. Cadences
+    skipped by the resume are excluded (their confidence vectors were transient)."""
+    config = get_config()
+    tag = config.checkpoint.save_tag
+    threshold = config.inference.classification_threshold
+
+    with_hist = [r for r in records if r.confidence_hist is not None]
+    if not with_hist:
+        logger.info("Viz: no confidence histograms collected; skipping confidence_distribution")
+        return None
+
+    centers = (CONFIDENCE_HIST_EDGES[:-1] + CONFIDENCE_HIST_EDGES[1:]) / 2
+    total = np.sum([r.confidence_hist for r in with_hist], axis=0)
+
+    fig = Figure(figsize=(10, 6))
+    ax = fig.subplots()
+    ax.step(centers, total, where="mid", lw=1.8, color="black", label="all snippets")
+    if len(with_hist) <= 10:
+        for record in with_hist:
+            ax.step(
+                centers,
+                record.confidence_hist,
+                where="mid",
+                lw=0.9,
+                alpha=0.7,
+                label=_key_label(record.key, 22),
+            )
+    ax.axvline(threshold, color="red", ls="--", lw=1.2, label=f"threshold ({threshold:g})")
+    ax.set_yscale("log")
+    ax.set_xlabel("P(true) — Random Forest")
+    ax.set_ylabel("snippet count")
+    n_skipped = len(records) - len(with_hist)
+    subtitle = f"{int(total.sum()):,} snippets over {len(with_hist)} cadence(s)"
+    if n_skipped:
+        subtitle += f" ({n_skipped} cadence(s) resumed earlier, not shown)"
+    ax.set_title(f"Snippet confidence distribution ({tag})\n{subtitle}")
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.2)
+
+    return _save_and_upload(fig, f"confidence_distribution_{tag}.png", "Confidence Distribution")
+
+
+def _candidate_annotation(row: dict) -> str:
+    lines = [f"confidence: {row.get('confidence', float('nan')):.4f}"]
+    if row.get("frequency_mhz") is not None:
+        lines.append(f"frequency: {row['frequency_mhz']:.6f} MHz")
+    for label in ("target", "session", "band", "cadence_id"):
+        if row.get(label) is not None:
+            lines.append(f"{label}: {row[label]}")
+    if row.get("timestamp_observed") is not None:
+        lines.append(f"tstart (MJD): {row['timestamp_observed']:.5f}")
+    if row.get("h5_path"):
+        lines.append(f"h5: {os.path.basename(str(row['h5_path']))}")
+    lines.append(f"npy: {os.path.basename(str(row.get('npy_path', '')))}")
+    lines.append(f"snippet: {row.get('snippet_index')}")
+    return "\n".join(lines)
+
+
+def plot_candidate(row: dict, index: int) -> str | None:
+    """One candidate's full picture (implements the long-standing inference.py stub):
+    6-panel cadence waterfall of its stamp, annotated with confidence / frequency /
+    target / session / band, plus the 48-dim latent vector as a bar chart."""
+    tag = get_config().checkpoint.save_tag
+
+    snippet = _load_display_cadence(str(row["npy_path"]), int(row["snippet_index"]))
+    n_obs = snippet.shape[0]
+
+    fig = Figure(figsize=(11, 7))
+    grid = fig.add_gridspec(n_obs, 2, width_ratios=(2.2, 1.6), hspace=0.15, wspace=0.25, right=0.97)
+    waterfall_axes = [fig.add_subplot(grid[i, 0]) for i in range(n_obs)]
+    _draw_cadence_strip(waterfall_axes, snippet, label_rows=True)
+    waterfall_axes[-1].set_xlabel("frequency bin")
+
+    # Right column: latent bar chart on top, provenance text below
+    latent_ax = fig.add_subplot(grid[: n_obs // 2, 1])
+    latent_json = row.get("latent_vector")
+    if latent_json:
+        latent = np.asarray(json.loads(latent_json), dtype=np.float64).ravel()
+        latent_dim = latent.size // n_obs if latent.size % n_obs == 0 else latent.size
+        colors = [f"C{(i // latent_dim) % 10}" for i in range(latent.size)]
+        latent_ax.bar(np.arange(latent.size), latent, color=colors)
+        latent_ax.set_xlabel("latent dimension (colored per observation)", fontsize=8)
+        latent_ax.set_ylabel("z", fontsize=8)
+        latent_ax.tick_params(labelsize=7)
+        latent_ax.grid(True, axis="y", alpha=0.2)
+    else:
+        latent_ax.set_axis_off()
+        latent_ax.text(0.5, 0.5, "no latent vector stored", ha="center", va="center")
+
+    text_ax = fig.add_subplot(grid[n_obs // 2 :, 1])
+    text_ax.set_axis_off()
+    text_ax.text(
+        0.0, 0.95, _candidate_annotation(row), va="top", ha="left", fontsize=9, family="monospace"
+    )
+
+    fig.suptitle(f"Candidate {index} ({tag}) — P(true) = {row.get('confidence', 0):.4f}")
+
+    return _save_and_upload(fig, f"candidate_{index}_{tag}.png", f"Candidate {index}")
+
+
+def plot_candidate_gallery() -> str | None:
+    """Gallery of the top candidates by confidence (6-obs waterfall strips) plus capped
+    per-candidate figures, sourced from the inference_results table so it also covers
+    cadences the resume skipped this pass."""
+    config = get_config()
+    tag = config.checkpoint.save_tag
+    max_candidate_plots = config.inference.max_candidate_plots
+
+    db = get_db()
+    if db is None:
+        logger.info("Viz: no database instance; skipping candidate plots")
+        return None
+    db.flush()
+    rows = db.query_inference_result(tag=tag, prediction=1)
+    if not rows:
+        logger.info("Viz: no candidates recorded; skipping candidate plots")
+        return None
+    rows.sort(key=lambda r: r.get("confidence") or 0.0, reverse=True)
+
+    # Per-candidate figures (highest confidence first, capped)
+    for index, row in enumerate(rows[:max_candidate_plots]):
+        _viz_safe(f"candidate_{index}", plot_candidate, row, index)
+    if len(rows) > max_candidate_plots:
+        logger.info(
+            f"Viz: rendered {max_candidate_plots} of {len(rows)} candidate figures "
+            f"(--max-candidate-plots cap)"
+        )
+
+    gallery_rows = rows[:_CANDIDATE_GALLERY_MAX]
+    n_cols = len(gallery_rows)
+    n_rows = len(_OBS_ROW_LABELS)
+    fig = Figure(figsize=(1.9 * n_cols + 1.2, 1.1 * n_rows + 1.6))
+    axes = fig.subplots(n_rows, n_cols, squeeze=False)
+    for col, row in enumerate(gallery_rows):
+        try:
+            snippet = _load_display_cadence(str(row["npy_path"]), int(row["snippet_index"]))
+        except Exception as e:
+            logger.warning(f"Viz: failed to load candidate stamp ({e})")
+            for r in range(n_rows):
+                axes[r][col].set_axis_off()
+            continue
+        _draw_cadence_strip([axes[r][col] for r in range(n_rows)], snippet, label_rows=col == 0)
+        freq = row.get("frequency_mhz")
+        freq_label = f"{freq:.4f} MHz" if freq is not None else "freq n/a"
+        axes[0][col].set_title(
+            f"P={row.get('confidence', 0):.3f}\n{freq_label}\n{row.get('target') or ''}",
+            fontsize=7,
+        )
+    fig.suptitle(f"Candidate gallery ({tag}): top {n_cols} of {len(rows)} by confidence")
+
+    return _save_and_upload(fig, f"candidate_gallery_{tag}.png", "Candidate Gallery")
+
+
+def plot_inference_latent_projection(collector: InferenceVizCollector) -> str | None:
+    """Project this run's cadence-level latent features through the persisted cadence-level
+    UMAP from the training run (located via the training config JSON's model_path +
+    save_tag), over a faint background of the UMAP's training embedding. Answers "where does
+    real data live relative to the synthetic training classes". Skips gracefully (with a
+    log) when the training config or a persisted UMAP is unavailable."""
+    import joblib  # noqa: PLC0415  # deferred: only this figure needs it
+
+    config = get_config()
+    tag = config.checkpoint.save_tag
+
+    features, is_candidate = collector.latent_pool()
+    if features.size == 0:
+        logger.info("Viz: no latent features collected this pass; skipping latent projection")
+        return None
+
+    training_config_path = config.inference.config_path
+    if not training_config_path or not os.path.exists(training_config_path):
+        logger.info(
+            f"Viz: training config JSON not available ({training_config_path}); "
+            f"skipping latent projection"
+        )
+        return None
+    try:
+        with open(training_config_path) as f:
+            training_config = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.info(f"Viz: could not read training config ({e}); skipping latent projection")
+        return None
+
+    model_path = (training_config.get("paths") or {}).get("model_path")
+    train_tag = (training_config.get("checkpoint") or {}).get("save_tag")
+    training_section = training_config.get("training") or {}
+    nn_values = training_section.get("latent_viz_umap_n_neighbors") or [15]
+    md_values = training_section.get("latent_viz_umap_min_dist") or [0.1]
+    if not model_path or not train_tag:
+        logger.info("Viz: training config lacks model_path/save_tag; skipping latent projection")
+        return None
+
+    umap_path = None
+    nn = md = None
+    for candidate_nn in nn_values:
+        for candidate_md in md_values:
+            path = os.path.join(
+                model_path, f"umap_cadence_nn{candidate_nn}_md{candidate_md}_{train_tag}.joblib"
+            )
+            if os.path.exists(path):
+                umap_path, nn, md = path, candidate_nn, candidate_md
+                break
+        if umap_path:
+            break
+    if umap_path is None:
+        logger.info(
+            f"Viz: no persisted cadence-level UMAP found under {model_path} for tag "
+            f"{train_tag}; skipping latent projection"
+        )
+        return None
+
+    logger.info(f"Viz: projecting {features.shape[0]} latent features through {umap_path}")
+    umap_model = joblib.load(umap_path)
+    embedding = umap_model.transform(features)
+
+    fig = Figure(figsize=(9, 8))
+    ax = fig.subplots()
+    # The training fit pool's class labels are not persisted, so the training embedding is
+    # rendered as an unlabeled backdrop — it still shows where the synthetic classes live.
+    background = getattr(umap_model, "embedding_", None)
+    if background is not None and len(background):
+        ax.scatter(
+            background[:, 0],
+            background[:, 1],
+            s=3,
+            c="lightgray",
+            alpha=0.35,
+            linewidths=0,
+            label=f"training embedding ({train_tag})",
+            rasterized=True,
+        )
+    non_candidates = ~is_candidate
+    if non_candidates.any():
+        ax.scatter(
+            embedding[non_candidates, 0],
+            embedding[non_candidates, 1],
+            s=6,
+            c="tab:blue",
+            alpha=0.5,
+            linewidths=0,
+            label=f"snippets ({int(non_candidates.sum()):,})",
+            rasterized=True,
+        )
+    if is_candidate.any():
+        ax.scatter(
+            embedding[is_candidate, 0],
+            embedding[is_candidate, 1],
+            s=42,
+            c="red",
+            marker="*",
+            edgecolors="black",
+            linewidths=0.4,
+            label=f"candidates ({int(is_candidate.sum())})",
+        )
+    ax.set_xlabel("UMAP 1")
+    ax.set_ylabel("UMAP 2")
+    ax.set_title(
+        f"Inference latents through training cadence-level UMAP ({tag})\n"
+        f"nn={nn}, md={md}, training tag {train_tag}"
+    )
+    ax.legend(fontsize=8, loc="best")
+
+    return _save_and_upload(
+        fig, f"inference_latent_projection_{tag}.png", "Inference Latent Projection"
+    )
+
+
+def plot_inference_summary(records: list[CadenceVizRecord], totals: dict) -> str | None:
+    """Table-style run summary card: cadence/snippet/candidate counts, per-stage durations
+    and throughput from the inference_cadences manifest, and per-target/band candidate
+    counts from inference_results."""
+    config = get_config()
+    tag = config.checkpoint.save_tag
+
+    db = get_db()
+    preproc_duration = inference_duration = 0.0
+    if db is not None:
+        db.flush()
+        for row in db.query_inference_cadences(tag=tag):
+            duration = row.get("duration_s") or 0.0
+            if row.get("status") == "preprocessed":
+                preproc_duration += duration
+            elif row.get("status") == "inferred":
+                inference_duration += duration
+
+    n_snippets = int(totals.get("n_cadence_snippets", 0))
+    metadatas = {r.npy_path: _load_metadata(r) or {} for r in records}
+    n_raw_hits = sum(int((m or {}).get("n_raw_hits") or 0) for m in metadatas.values())
+    n_merged_hits = sum(int((m or {}).get("n_merged_hits") or 0) for m in metadatas.values())
+    storage_gb = 0.0
+    for record in records:
+        with contextlib.suppress(OSError):
+            storage_gb += os.path.getsize(record.npy_path) / 1e9
+
+    summary_rows = [
+        ("run tag", tag),
+        ("rendered", time.strftime("%Y-%m-%d %H:%M:%S")),
+        ("cadences", f"{totals.get('n_cadences', len(records))}"),
+        ("  resumed (skipped this pass)", f"{totals.get('n_skipped', 0)}"),
+        ("raw ED hits", f"{n_raw_hits:,}"),
+        ("merged hits", f"{n_merged_hits:,}"),
+        ("snippets inferred", f"{n_snippets:,}"),
+        ("candidates", f"{totals.get('n_candidates', 0):,}"),
+        ("stamp storage", f"{storage_gb:.2f} GB"),
+        ("preprocessing time", f"{preproc_duration:,.1f} s"),
+        ("inference time", f"{inference_duration:,.1f} s"),
+        (
+            "throughput",
+            f"{n_snippets / inference_duration:,.1f} snippets/s"
+            if inference_duration > 0
+            else "n/a",
+        ),
+    ]
+
+    per_group: Counter = Counter()
+    if db is not None:
+        candidate_rows = db.query_inference_result(
+            tag=tag, prediction=1, columns=["target", "band"]
+        )
+        for row in candidate_rows:
+            per_group[(row.get("target") or "?", row.get("band") or "?")] += 1
+
+    fig = Figure(figsize=(8.5, 0.42 * (len(summary_rows) + min(len(per_group), 10)) + 2.5))
+    ax = fig.subplots()
+    ax.set_axis_off()
+
+    lines = [f"{name:<32} {value}" for name, value in summary_rows]
+    if per_group:
+        lines.append("")
+        lines.append("candidates per target/band:")
+        for (target, band), count in per_group.most_common(10):
+            lines.append(f"  {target} [{band}]: {count}")
+    ax.text(
+        0.02,
+        0.98,
+        "\n".join(lines),
+        va="top",
+        ha="left",
+        fontsize=10,
+        family="monospace",
+        transform=ax.transAxes,
+    )
+    ax.set_title(f"Inference run summary ({tag})", fontsize=13, pad=14)
+
+    return _save_and_upload(fig, f"inference_summary_{tag}.png", "Inference Summary")
+
+
+# ---------------------------------------------------------------------------
+# Suite entry point
+# ---------------------------------------------------------------------------
+
+
+def render_inference_visualizations(
+    collector: InferenceVizCollector, preprocessor, totals: dict
+) -> None:
+    """Render every figure of the suite, each individually exception-guarded. Called by
+    main._run_streaming_csv_inference after a fully successful pass (and gated on
+    config.inference.inference_viz_enabled by the caller)."""
+    tag = get_config().checkpoint.save_tag
+    logger.info(f"Rendering inference visualization suite under plots/inference/{tag}/")
+
+    records = collector.records
+    metadatas: dict[str, dict] = {}
+    for record in records:
+        metadata = _load_metadata(record)
+        if metadata is not None:
+            metadatas[record.npy_path] = metadata
+
+    _viz_safe("ed_stat_distributions", plot_ed_stat_distributions, records, metadatas)
+    _viz_safe("ed_hit_spectrum", plot_ed_hit_spectrum, records, metadatas)
+    _viz_safe("bandpass_flattening", plot_bandpass_flattening, preprocessor, records, metadatas)
+    _viz_safe("stamp_gallery", plot_stamp_gallery, records, metadatas)
+    _viz_safe("preproc_funnel", plot_preproc_funnel, records, metadatas)
+    _viz_safe("confidence_distribution", plot_confidence_distribution, records)
+    _viz_safe("candidate_gallery", plot_candidate_gallery)
+    _viz_safe("inference_latent_projection", plot_inference_latent_projection, collector)
+    _viz_safe("inference_summary", plot_inference_summary, records, totals)
+
+    logger.info("Inference visualization suite complete")

--- a/src/aetherscan/inference_viz.py
+++ b/src/aetherscan/inference_viz.py
@@ -876,7 +876,13 @@ def plot_inference_summary(
     preproc_duration = inference_duration = 0.0
     if db is not None:
         db.flush()
-        for row in db.query_inference_cadences(tag=tag):
+        # NOTE: include_superseded=True is required here: _infer_cadence supersedes a
+        # cadence's 'preprocessed' row before writing its live 'inferred' row, so on a fully
+        # successful run every 'preprocessed' row is superseded and the default query would
+        # hide it (preprocessing time would always read 0.0 s). Summing per status keeps each
+        # metric on its own row — no double-counting between the 'preprocessed' and 'inferred'
+        # rows of the same cadence.
+        for row in db.query_inference_cadences(tag=tag, include_superseded=True):
             duration = row.get("duration_s") or 0.0
             if row.get("status") == "preprocessed":
                 preproc_duration += duration

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -454,7 +454,7 @@ def _run_streaming_csv_inference(
             collector.record_skipped(
                 unit.group.key,
                 unit.npy_path,
-                DataPreprocessor._cadence_metadata_path(unit.npy_path),
+                DataPreprocessor.cadence_metadata_path(unit.npy_path),
                 manifest_row,
             )
         logger.info(
@@ -518,6 +518,10 @@ def _run_streaming_csv_inference(
                             tag=tag,
                             csv_path=unit.group.csv_path,
                             cadence_key=cadence_result.key,
+                            # Despite the historical field name, CadenceResult.n_hits is
+                            # the .npy's stamp-row count — the same quantity as the
+                            # 'preprocessed'/'inferred' rows' n_stamps, so the manifest
+                            # stays consistent across all three statuses.
                             n_stamps=cadence_result.n_hits,
                         )
                         continue

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -32,6 +32,7 @@ from aetherscan.logger import init_logger
 from aetherscan.manager import get_manager, init_manager, register_logger
 from aetherscan.monitor import init_monitor
 from aetherscan.preprocessing import DataPreprocessor, derive_cadence_provenance
+from aetherscan.run_state import inference_config_fingerprint
 from aetherscan.train import run_training_pipeline
 
 logger = logging.getLogger(__name__)
@@ -297,7 +298,11 @@ class NonRetryableInferenceError(RuntimeError):
 
 
 def _infer_cadence(
-    pipeline: InferencePipeline, preprocessor: DataPreprocessor, unit, cadence_result
+    pipeline: InferencePipeline,
+    preprocessor: DataPreprocessor,
+    unit,
+    cadence_result,
+    config_fingerprint: str,
 ) -> dict:
     """
     Run the inference stage for one preprocessed cadence: derive provenance, load its stamps
@@ -370,6 +375,7 @@ def _infer_cadence(
         n_candidates=results["n_candidates"],
         confidence_summary=confidence_summary,
         duration_s=duration_s,
+        config_fingerprint=config_fingerprint,
     )
 
     results["provenance"] = provenance
@@ -429,18 +435,29 @@ def _run_streaming_csv_inference(
     }
     collector = InferenceVizCollector() if config.inference.inference_viz_enabled else None
 
-    # Stage-aware resume: a live 'inferred' manifest row for (tag, npy_path) means the
-    # cadence completed on an earlier attempt — skip it entirely and reuse its aggregates.
+    # Stage-aware resume: a live 'inferred' manifest row for (tag, npy_path) means the cadence
+    # completed on an earlier attempt — skip it and reuse its aggregates, but ONLY when it was
+    # written under the same inference config. The fingerprint guard stops a reused --save-tag
+    # with a changed threshold/model/geometry from silently serving stale results (the inference
+    # counterpart of the training-side config_fingerprint guard).
     # Flush first so rows queued by this process (an in-process retry) are visible.
+    current_fingerprint = inference_config_fingerprint(config.to_dict())
     db.flush()
     inferred_rows = {
         row["npy_path"]: row for row in db.query_inference_cadences(tag=tag, status="inferred")
     }
 
     pending = []
+    stale_config = 0
     for unit in units:
         manifest_row = inferred_rows.get(unit.npy_path)
         if manifest_row is None:
+            pending.append(unit)
+            continue
+        if manifest_row.get("config_fingerprint") != current_fingerprint:
+            # Live 'inferred' row, but written under a different inference config -> don't reuse.
+            # Re-infer; _infer_cadence's supersede step retires the stale row.
+            stale_config += 1
             pending.append(unit)
             continue
         n_snippets = int(manifest_row.get("n_stamps") or 0)
@@ -460,6 +477,14 @@ def _run_streaming_csv_inference(
         logger.info(
             f"Cadence {unit.group.key}: already inferred under tag {tag} "
             f"({n_snippets} snippets, {n_candidates} candidate(s)); skipping"
+        )
+
+    if stale_config:
+        logger.warning(
+            f"{stale_config} cadence(s) under tag {tag} have an 'inferred' manifest row written "
+            f"with a DIFFERENT inference config; re-inferring rather than reusing stale results "
+            f"(a reused --save-tag with a changed threshold/model/geometry is not resumed). Use a "
+            f"fresh --save-tag to keep separate configs' results separate."
         )
 
     logger.info(
@@ -505,7 +530,9 @@ def _run_streaming_csv_inference(
                     # move on — one bad cadence must not abort the catalog. The pass
                     # raises after the loop so the retry loop re-attempts failed cadences.
                     try:
-                        results = _infer_cadence(pipeline, preprocessor, unit, cadence_result)
+                        results = _infer_cadence(
+                            pipeline, preprocessor, unit, cadence_result, current_fingerprint
+                        )
                     except Exception as e:
                         logger.error(
                             f"Cadence {cadence_result.key}: inference stage failed ({e}); "

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -536,12 +536,13 @@ def _run_streaming_csv_inference(
                             results,
                             results["duration_s"],
                         )
-                    del results
 
                     logger.info(
                         f"Cadence {cadence_result.key} ({totals['n_cadences']} done, "
-                        f"{len(pending) - i - 1} to go)"
+                        f"{len(pending) - i - 1} to go): {results['n_processed']} snippets, "
+                        f"{results['n_candidates']} candidate(s)"
                     )
+                    del results
         finally:
             preprocessor.stop_energy_detection_pool()
             # Release TF dataset/iterator state once per run, after the loaded models are done

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -25,8 +25,9 @@ from aetherscan.cli import (
     validate_args,
 )
 from aetherscan.config import get_config, init_config
-from aetherscan.db import init_db
-from aetherscan.inference import InferencePipeline, run_inference_pipeline
+from aetherscan.db import get_db, init_db
+from aetherscan.inference import InferencePipeline, run_inference_pipeline, summarize_confidences
+from aetherscan.inference_viz import InferenceVizCollector, render_inference_visualizations
 from aetherscan.logger import init_logger
 from aetherscan.manager import get_manager, init_manager, register_logger
 from aetherscan.monitor import init_monitor
@@ -295,118 +296,273 @@ class NonRetryableInferenceError(RuntimeError):
     """
 
 
+def _infer_cadence(
+    pipeline: InferencePipeline, preprocessor: DataPreprocessor, unit, cadence_result
+) -> dict:
+    """
+    Run the inference stage for one preprocessed cadence: derive provenance, load its stamps
+    (memmap -> log-norm), encode on the GPUs, classify with the RF, and record the result in
+    both DB tables. Returns run_inference's results dict augmented with the provenance dict
+    and the stage's duration_s. Exceptions propagate to the caller's per-cadence containment.
+
+    Supersede-on-retry ordering (single-writer FIFO makes each step atomic w.r.t. the next):
+    1. mark_superseded(inference_results, tag, npy_path) — partial positives written by a
+       dead attempt can't mix with this attempt's rows;
+    2. run_inference writes the fresh positives;
+    3. mark_superseded(inference_cadences, tag, npy_path) — retires the 'preprocessed' row
+       and any 'failed'/stale 'inferred' rows;
+    4. write_inference_cadence(status='inferred') — the row the stage-aware resume keys on,
+       carrying the aggregate stats (n_stamps/n_candidates/confidence summary) so run-level
+       artifacts don't depend on the positives-only inference_results table.
+    """
+    config = get_config()
+    db = get_db()
+    tag = config.checkpoint.save_tag
+
+    # Per-cadence provenance from the group key + metadata JSON
+    try:
+        with open(cadence_result.metadata_path) as f:
+            metadata = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning(
+            f"Cadence {cadence_result.key}: could not read metadata at "
+            f"{cadence_result.metadata_path} ({e}); provenance will be sparse"
+        )
+        metadata = {"h5_paths": cadence_result.h5_paths}
+    provenance = derive_cadence_provenance(
+        key=cadence_result.key,
+        group_by_cols=config.inference.cadence_group_by_cols,
+        metadata=metadata,
+    )
+
+    stage_start = time.time()
+
+    # copy=False: the loader already returns float32; don't duplicate GBs of stamps
+    cadence_data = preprocessor.load_inference_data(
+        override_filepaths=[cadence_result.npy_path]
+    ).astype(np.float32, copy=False)
+
+    # Step 1: retire any partial rows from a dead attempt before fresh ones land
+    db.mark_superseded("inference_results", tag, npy_path=cadence_result.npy_path)
+
+    results = pipeline.run_inference(
+        data=cadence_data,
+        npy_path=cadence_result.npy_path,
+        **provenance,
+    )
+    del cadence_data
+    gc.collect()
+
+    duration_s = time.time() - stage_start
+
+    # Steps 3 + 4: new-row-plus-supersede on the run manifest
+    confidence_summary = summarize_confidences(
+        results["proba_true"], config.inference.classification_threshold
+    )
+    db.mark_superseded("inference_cadences", tag, npy_path=cadence_result.npy_path)
+    db.write_inference_cadence(
+        npy_path=cadence_result.npy_path,
+        status="inferred",
+        tag=tag,
+        csv_path=unit.group.csv_path,
+        cadence_key=cadence_result.key,
+        n_stamps=results["n_cadence_snippets"],
+        n_candidates=results["n_candidates"],
+        confidence_summary=confidence_summary,
+        duration_s=duration_s,
+    )
+
+    results["provenance"] = provenance
+    results["duration_s"] = duration_s
+    return results
+
+
 def _run_streaming_csv_inference(
     preprocessor: DataPreprocessor, strategy: tf.distribute.Strategy
 ) -> dict:
     """
-    Per-cadence streaming inference over the configured CSV catalogs.
+    Per-cadence streaming inference over the configured CSV catalogs, with stage-aware
+    resume off the inference_cadences run manifest.
 
     Flow (peak memory = one cadence's stamps + the next cadence's in-flight preprocessing,
     independent of catalog size):
 
-        units = plan_cadences()                      # cadence groups + .npy paths, no work yet
-        pipeline = InferencePipeline(strategy)       # models loaded once for the whole run
-        for each cadence (prefetch depth 1):
-            [background thread] preprocess cadence i+1 (energy detection; the persistent pool's
-                                child processes do the real work — the thread mostly waits)
-            [main thread]       load cadence i's stamps (memmap -> log-norm) -> encode on GPUs
-                                -> RF -> write per-cadence results with per-cadence provenance
+        units = plan_cadences()                # cadence groups + .npy paths, no work yet
+        skip units with a live 'inferred' manifest row for this tag (fold their stored
+            aggregates into the totals); for the rest:
+        pipeline = InferencePipeline(strategy) # models loaded once for the whole run
+        for each pending cadence (prefetch depth 1):
+            [background thread] preprocess cadence i+1 (energy detection; skipped when its
+                                stamp .npy already exists — preprocessing-artifact resume)
+            [main thread]       load cadence i's stamps -> encode on GPUs -> RF -> write
+                                per-cadence results + manifest row (_infer_cadence)
 
-    Provenance (target/session/band/cadence_id/per-stamp frequency/timestamp/h5_path) is
-    derived per cadence from its group key + metadata JSON via derive_cadence_provenance.
-    Returns aggregate {n_cadence_snippets, n_processed, n_candidates, n_cadences}. Exceptions
-    from the load/encode stages propagate to the retry loop in inference_command; per-cadence
-    preprocessing failures are logged and skipped inside process_pending_cadence. Raises
-    NonRetryableInferenceError when the catalog yields no work units or no cadence produces a
-    stamp .npy — permanent conditions the retry loop must not retry.
+    Failure containment mirrors preprocessing's: a cadence whose inference stage fails is
+    logged, recorded as status='failed' in the manifest, and the loop continues; the pass
+    raises at the end so inference_command's retry loop re-attempts — and the manifest skip
+    means only the failed cadences re-run. Raises NonRetryableInferenceError when the
+    catalog yields no work units or no cadence produces a stamp .npy — permanent conditions
+    the retry loop must not retry. On a fully successful pass the visualization suite is
+    rendered (config.inference.inference_viz_enabled; every figure is exception-guarded).
+
+    Returns aggregate {n_cadence_snippets, n_processed, n_candidates, n_cadences,
+    n_skipped}, where skipped (resumed) cadences contribute their manifest aggregates.
     """
     config = get_config()
+    db = get_db()
+    if db is None:
+        raise ValueError("get_db() returned None")
+    tag = config.checkpoint.save_tag
 
     units = preprocessor.plan_cadences()
     if not units:
         raise NonRetryableInferenceError(
             "No cadence work units produced from the configured inference CSVs"
         )
-    logger.info(f"Streaming inference over {len(units)} cadence(s)")
 
-    # Load models once; every cadence reuses this pipeline
-    pipeline = InferencePipeline(strategy=strategy)
+    totals = {
+        "n_cadence_snippets": 0,
+        "n_processed": 0,
+        "n_candidates": 0,
+        "n_cadences": 0,
+        "n_skipped": 0,
+    }
+    collector = InferenceVizCollector() if config.inference.inference_viz_enabled else None
 
-    totals = {"n_cadence_snippets": 0, "n_processed": 0, "n_candidates": 0, "n_cadences": 0}
+    # Stage-aware resume: a live 'inferred' manifest row for (tag, npy_path) means the
+    # cadence completed on an earlier attempt — skip it entirely and reuse its aggregates.
+    # Flush first so rows queued by this process (an in-process retry) are visible.
+    db.flush()
+    inferred_rows = {
+        row["npy_path"]: row for row in db.query_inference_cadences(tag=tag, status="inferred")
+    }
 
-    # Start the persistent energy-detection pool from the main thread (forking after
-    # background threads exist risks inheriting mid-operation locks in the children)
-    preprocessor.start_energy_detection_pool()
-    try:
-        with ThreadPoolExecutor(max_workers=1, thread_name_prefix="preproc_prefetch") as prefetch:
-            future = prefetch.submit(preprocessor.process_pending_cadence, units[0])
+    pending = []
+    for unit in units:
+        manifest_row = inferred_rows.get(unit.npy_path)
+        if manifest_row is None:
+            pending.append(unit)
+            continue
+        n_snippets = int(manifest_row.get("n_stamps") or 0)
+        n_candidates = int(manifest_row.get("n_candidates") or 0)
+        totals["n_cadence_snippets"] += n_snippets
+        totals["n_processed"] += n_snippets
+        totals["n_candidates"] += n_candidates
+        totals["n_cadences"] += 1
+        totals["n_skipped"] += 1
+        if collector is not None:
+            collector.record_skipped(
+                unit.group.key,
+                unit.npy_path,
+                DataPreprocessor._cadence_metadata_path(unit.npy_path),
+                manifest_row,
+            )
+        logger.info(
+            f"Cadence {unit.group.key}: already inferred under tag {tag} "
+            f"({n_snippets} snippets, {n_candidates} candidate(s)); skipping"
+        )
 
-            for i, unit in enumerate(units):
-                # NOTE: an exception inside a prefetched preprocessing task surfaces here,
-                # one iteration after it was submitted, when its future is resolved — and
-                # then propagates to inference_command's retry loop. In practice
-                # process_pending_cadence swallows per-cadence failures (returns None), so
-                # only infrastructure-level errors (e.g. a broken worker pool) raise.
-                cadence_result = future.result()
+    logger.info(
+        f"Streaming inference over {len(pending)} cadence(s) "
+        f"({totals['n_skipped']} already inferred, resumed from manifest)"
+    )
 
-                # Prefetch depth 1: kick off cadence i+1's CPU preprocessing while the main
-                # thread loads + encodes cadence i on the GPUs
-                if i + 1 < len(units):
-                    future = prefetch.submit(preprocessor.process_pending_cadence, units[i + 1])
+    failed_keys: list[tuple] = []
+    if pending:
+        # Load models once; every cadence reuses this pipeline
+        pipeline = InferencePipeline(strategy=strategy)
 
-                if cadence_result is None:
-                    logger.info(f"Cadence {unit.group.key}: no stamps produced; skipping")
-                    continue
+        # Start the persistent energy-detection pool from the main thread (forking after
+        # background threads exist risks inheriting mid-operation locks in the children)
+        preprocessor.start_energy_detection_pool()
+        try:
+            with ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix="preproc_prefetch"
+            ) as prefetch:
+                future = prefetch.submit(preprocessor.process_pending_cadence, pending[0])
 
-                # Per-cadence provenance from the group key + metadata JSON
-                try:
-                    with open(cadence_result.metadata_path) as f:
-                        metadata = json.load(f)
-                except (OSError, json.JSONDecodeError) as e:
-                    logger.warning(
-                        f"Cadence {cadence_result.key}: could not read metadata at "
-                        f"{cadence_result.metadata_path} ({e}); provenance will be sparse"
+                for i, unit in enumerate(pending):
+                    # NOTE: an exception inside a prefetched preprocessing task surfaces
+                    # here, one iteration after it was submitted, when its future is
+                    # resolved — and then propagates to inference_command's retry loop. In
+                    # practice process_pending_cadence swallows per-cadence failures
+                    # (returns None), so only infrastructure-level errors (e.g. a broken
+                    # worker pool) raise.
+                    cadence_result = future.result()
+
+                    # Prefetch depth 1: kick off cadence i+1's CPU preprocessing while the
+                    # main thread loads + encodes cadence i on the GPUs
+                    if i + 1 < len(pending):
+                        future = prefetch.submit(
+                            preprocessor.process_pending_cadence, pending[i + 1]
+                        )
+
+                    if cadence_result is None:
+                        logger.info(f"Cadence {unit.group.key}: no stamps produced; skipping")
+                        continue
+
+                    # Inference-stage failure containment: log, record in the manifest,
+                    # move on — one bad cadence must not abort the catalog. The pass
+                    # raises after the loop so the retry loop re-attempts failed cadences.
+                    try:
+                        results = _infer_cadence(pipeline, preprocessor, unit, cadence_result)
+                    except Exception as e:
+                        logger.error(
+                            f"Cadence {cadence_result.key}: inference stage failed ({e}); "
+                            f"continuing with remaining cadences"
+                        )
+                        failed_keys.append(cadence_result.key)
+                        db.write_inference_cadence(
+                            npy_path=cadence_result.npy_path,
+                            status="failed",
+                            tag=tag,
+                            csv_path=unit.group.csv_path,
+                            cadence_key=cadence_result.key,
+                            n_stamps=cadence_result.n_hits,
+                        )
+                        continue
+
+                    totals["n_cadence_snippets"] += results["n_cadence_snippets"]
+                    totals["n_processed"] += results["n_processed"]
+                    totals["n_candidates"] += results["n_candidates"]
+                    totals["n_cadences"] += 1
+
+                    if collector is not None:
+                        collector.record_processed(
+                            cadence_result.key,
+                            cadence_result.npy_path,
+                            cadence_result.metadata_path,
+                            results["provenance"],
+                            results,
+                            results["duration_s"],
+                        )
+                    del results
+
+                    logger.info(
+                        f"Cadence {cadence_result.key} ({totals['n_cadences']} done, "
+                        f"{len(pending) - i - 1} to go)"
                     )
-                    metadata = {"h5_paths": cadence_result.h5_paths}
-                provenance = derive_cadence_provenance(
-                    key=cadence_result.key,
-                    group_by_cols=config.inference.cadence_group_by_cols,
-                    metadata=metadata,
-                )
+        finally:
+            preprocessor.stop_energy_detection_pool()
+            # Release TF dataset/iterator state once per run, after the loaded models are done
+            tf.keras.backend.clear_session()
+            logger.info("Cleared TensorFlow session state")
 
-                # copy=False: the loader already returns float32; don't duplicate GBs of stamps
-                cadence_data = preprocessor.load_inference_data(
-                    override_filepaths=[cadence_result.npy_path]
-                ).astype(np.float32, copy=False)
-
-                results = pipeline.run_inference(
-                    data=cadence_data,
-                    npy_path=cadence_result.npy_path,
-                    **provenance,
-                )
-                del cadence_data
-                gc.collect()
-
-                totals["n_cadence_snippets"] += results["n_cadence_snippets"]
-                totals["n_processed"] += results["n_processed"]
-                totals["n_candidates"] += results["n_candidates"]
-                totals["n_cadences"] += 1
-
-                logger.info(
-                    f"Cadence {cadence_result.key} ({totals['n_cadences']} done, "
-                    f"{len(units) - i - 1} to go): {results['n_processed']} snippets, "
-                    f"{results['n_candidates']} candidate(s)"
-                )
-    finally:
-        preprocessor.stop_energy_detection_pool()
-        # Release TF dataset/iterator state once per run, after the loaded models are done
-        tf.keras.backend.clear_session()
-        logger.info("Cleared TensorFlow session state")
+        if failed_keys:
+            # Whole-pass retry over the remaining failed set: cadences that completed are
+            # skipped via their 'inferred' manifest rows on the next attempt
+            raise RuntimeError(
+                f"Inference stage failed for {len(failed_keys)} cadence(s): {failed_keys}"
+            )
 
     if totals["n_cadences"] == 0:
         # Preserve the historical contract: preprocessing producing no stamp .npy at all is
         # an error (bad paths/catalog), not a legitimate empty result
         raise NonRetryableInferenceError("No cadence results produced by preprocessing")
+
+    if collector is not None:
+        # Every figure is individually exception-guarded — a plot bug can't fail the pass
+        render_inference_visualizations(collector, preprocessor, totals)
 
     return totals
 
@@ -453,23 +609,16 @@ def inference_command():
         logger.error("No GPU strategy available. Inference requires GPU.")
         sys.exit(1)
 
-    # NOTE: come back to this later (does fault tolerance work properly with inference?)
     # Run preprocessing + inference with fault tolerance.
-    # Recovery is state-based, not checkpoint-based: preprocessing writes per-cadence
-    # .npy files as it goes and skips any whose .npy already exists, so simply
-    # retrying resumes from where the last attempt died. No checkpoint metadata
-    # is needed for the preprocessing stage.
+    # Recovery is state-based, not checkpoint-based: preprocessing resumes off each
+    # cadence's on-disk stamp .npy, and the inference stage resumes off the
+    # inference_cadences run manifest in the DB (a live status='inferred' row means the
+    # cadence is skipped entirely) — so a retry, in-process or a full relaunch of the
+    # identical command, re-runs only what the previous attempt didn't finish.
     preprocessor = DataPreprocessor()
     max_retries = config.inference.max_retries
     retry_delay = config.inference.retry_delay
     results = None
-    # Legacy --test-files path only: cache cadence_data across retry attempts so an
-    # inference-only failure doesn't trigger a re-load / re-downsample / re-log-norm
-    # pass. Mirrors how train_command loads background_data once outside its retry
-    # loop. The streaming CSV path holds no catalog-sized state to cache — its
-    # per-cadence .npy files are the resume mechanism.
-    cadence_data: np.ndarray | None = None
-    npy_path_for_logging: str | None = None
 
     for attempt in range(max_retries):
         try:
@@ -487,21 +636,17 @@ def inference_command():
                         "nothing to load for inference"
                     )
                     sys.exit(1)
-                # Load stage. Skipped on retry if a previous attempt already produced
-                # cadence_data (i.e. only the inference stage failed).
-                if cadence_data is None:
-                    cadence_data = preprocessor.load_inference_data().astype(np.float32)
-                    npy_path_for_logging = config.data.test_files[0]
-                else:
-                    logger.info("Reusing cadence_data from previous attempt (skipping load)")
-
-                # NOTE: come back to this later (inference-stage resume should skip cadences already in the DB. not yet implemented)
-                # Inference stage
+                # Legacy --test-files path: load + infer in one shot. The load repeats on
+                # retry (the old cross-attempt cadence_data cache is gone — the manifest
+                # made it obsolete on the streaming path, and holding a catalog-sized
+                # array across attempts was its only remaining use).
+                cadence_data = preprocessor.load_inference_data().astype(np.float32)
                 results = run_inference_pipeline(
                     cadence_data=cadence_data,
-                    npy_path=npy_path_for_logging,  # TODO: handle multiple test_files properly
+                    npy_path=config.data.test_files[0],  # TODO: handle multiple test_files properly
                     strategy=strategy,
                 )
+                del cadence_data
             break  # success
 
         except KeyboardInterrupt:
@@ -539,6 +684,8 @@ def inference_command():
     logger.info("Summary:")
     if "n_cadences" in results:
         logger.info(f"  Total cadences: {results['n_cadences']}")
+    if results.get("n_skipped"):
+        logger.info(f"    Resumed from a previous attempt (skipped): {results['n_skipped']}")
     logger.info(f"  Total cadence snippets: {results['n_cadence_snippets']}")
     logger.info(f"    Processed: {results['n_processed']}")
     logger.info(f"    Candidates found: {results['n_candidates']}")

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -18,6 +18,7 @@ import math
 import os
 import re
 import signal
+import time
 import uuid
 from collections import OrderedDict
 from collections.abc import Callable
@@ -54,6 +55,12 @@ _GLOBAL_DTYPE = None
 # PFB static-response sanity check: warn when a file's measured edge/mid power ratio
 # disagrees with the theoretical response's by more than this relative tolerance.
 _PFB_RATIO_MISMATCH_TOL = 0.05
+# Fixed log-spaced bin edges for the energy-detection statistic summary histograms
+# accumulated by _energy_detect_channel_worker. The edges are identical for every channel /
+# file / cadence, so per-channel counts combine by plain addition; the range spans sub-noise
+# k2 values (~1e-3) through extreme RFI statistics (~1e9) at 10 bins per decade. Consumed by
+# inference_viz.plot_ed_stat_distributions via each cadence's metadata JSON.
+ED_STAT_HIST_EDGES = np.logspace(-3.0, 9.0, 121)
 # Coarse channels sampled (evenly across the band) by the opt-in bandpass overlay debug plot.
 _BANDPASS_SAMPLE_CHANNELS = 3
 # The PFB static-response sanity check samples more channels and takes a median (not a mean),
@@ -429,12 +436,15 @@ def _sliding_normality_k2(channel: np.ndarray, window_size: int, step_size: int)
     return k2
 
 
-def _energy_detect_channel_worker(args: tuple) -> list[tuple]:
+def _energy_detect_channel_worker(args: tuple) -> tuple[list[tuple], np.ndarray]:
     """
     Fused worker: run the complete energy-detection chain for one coarse channel — read the
     channel's h5 slice, remove the DC spike, flatten the bandpass, and threshold the vectorized
-    normality statistic. Returns a small list of (absolute_fine_channel_index, statistic,
-    pvalue) hit tuples; the bulky (time_bins, coarse_channel_width) intermediates never leave
+    normality statistic. Returns (hits, stat_hist): hits is a small list of
+    (absolute_fine_channel_index, statistic, pvalue) tuples; stat_hist is the histogram of
+    *all* finite window statistics (not just hits) over the fixed ED_STAT_HIST_EDGES bins, so
+    the parent can cheaply accumulate the full per-file statistic distribution for the
+    visualization suite. The bulky (time_bins, coarse_channel_width) intermediates never leave
     the worker, so no shared memory or per-block parent arrays are needed.
 
     args is (h5_path, channel_index, coarse_channel_width, time_bins, bandpass_flatten,
@@ -467,16 +477,26 @@ def _energy_detect_channel_worker(args: tuple) -> list[tuple]:
     residuals = bandpass_flatten(channel)
 
     k2 = _sliding_normality_k2(residuals, window_size, step_size)
+
+    # Summary histogram over all finite window statistics — a handful of numpy ops on ~1e4
+    # values, negligible next to the k2 computation itself. Out-of-range values are clipped
+    # onto the fixed edges so counts are never silently dropped.
+    finite = k2[np.isfinite(k2)]
+    stat_hist, _ = np.histogram(
+        np.clip(finite, ED_STAT_HIST_EDGES[0], ED_STAT_HIST_EDGES[-1]), bins=ED_STAT_HIST_EDGES
+    )
+
     hit_windows = np.nonzero(k2 > stat_threshold)[0]
     if hit_windows.size == 0:
-        return []
+        return [], stat_hist
 
     # p-values are only stored in metadata, so chi2.sf runs on the (small) hit subset only
     pvalues = stats.chi2.sf(k2[hit_windows], 2)
-    return [
+    hits = [
         (start + int(j) * step_size, float(k2[j]), float(p))
         for j, p in zip(hit_windows, pvalues, strict=True)
     ]
+    return hits, stat_hist
 
 
 def _extract_stamps_worker(args: tuple) -> None:
@@ -1473,8 +1493,12 @@ class DataPreprocessor:
             except Exception as e:
                 logger.error(f"Cadence {group.key}: bandpass overlay plot failed: {e}")
 
-        # Aggregate hits across all ON-source files
+        cadence_start_time = time.time()
+
+        # Aggregate hits across all ON-source files, plus the per-ON-file summary histogram
+        # of every window statistic (for the ed_stat_distributions figure)
         all_hits: list[tuple] = []  # (abs_idx, stat, p)
+        stat_hists = np.zeros((len(on_source_paths), len(ED_STAT_HIST_EDGES) - 1), dtype=np.int64)
 
         for on_source_idx, on_h5 in enumerate(on_source_paths):
             logger.info(
@@ -1512,8 +1536,9 @@ class DataPreprocessor:
                     )
                 channel_hits_iter = map(_energy_detect_channel_worker, tasks)
 
-            for done, channel_hits in enumerate(channel_hits_iter, start=1):
+            for done, (channel_hits, channel_hist) in enumerate(channel_hits_iter, start=1):
                 all_hits.extend(channel_hits)
+                stat_hists[on_source_idx] += channel_hist
                 if done % progress_chunk == 0 or done == n_coarse_total:
                     logger.info(
                         f"  Coarse channel {done}/{n_coarse_total} of ON-source "
@@ -1651,6 +1676,17 @@ class DataPreprocessor:
             "stamp_pvalues": stamp_pvals,
             "overlap_search": overlap_search,
             "overlap_fraction": overlap_fraction if overlap_search else None,
+            # Energy-detection provenance for the visualization suite: the all-window
+            # statistic histograms (per ON file, fixed log-spaced bins) and the hit
+            # frequencies before/after deduplication (hit spectrum + funnel figures)
+            "ed_stat_hist": {
+                "bin_edges": [float(e) for e in ED_STAT_HIST_EDGES],
+                "counts_per_on_file": stat_hists.tolist(),
+            },
+            "n_raw_hits": len(all_hits),
+            "n_merged_hits": len(merged_hits),
+            "raw_hit_frequencies_mhz": [float(fch1 + foff * idx) for idx, _, _ in all_hits],
+            "merged_hit_frequencies_mhz": [float(fch1 + foff * idx) for idx, _, _ in merged_hits],
         }
         tmp_metadata_path = metadata_path + ".tmp"
         with open(tmp_metadata_path, "w") as f:
@@ -1658,6 +1694,20 @@ class DataPreprocessor:
         os.replace(tmp_metadata_path, metadata_path)
 
         gc.collect()
+
+        # Record the stage transition in the inference_cadences run manifest. Written only
+        # when preprocessing actually ran (the resume path never re-writes it); a crash
+        # between the os.replace above and this write just loses an informational row —
+        # resume keys off the .npy's existence, and the 'inferred' row keys off inference.
+        self.db.write_inference_cadence(
+            npy_path=npy_path,
+            status="preprocessed",
+            tag=self.config.checkpoint.save_tag,
+            csv_path=group.csv_path,
+            cadence_key=group.key,
+            n_stamps=n_stamps,
+            duration_s=time.time() - cadence_start_time,
+        )
 
         logger.info(
             f"Cadence {group.key}: wrote {n_stamps} stamps -> "

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -565,6 +565,9 @@ class CadenceResult:
     npy_path: str
     h5_paths: list[str]  # Same as in CadenceGroup
     key: tuple  # Same as in CadenceGroup
+    # Number of stamp rows in the .npy (post-dedup, incl. overlap offsets) — the same
+    # quantity the inference_cadences manifest stores as n_stamps. Historical name: this
+    # is NOT the raw energy-detection hit count (metadata's n_raw_hits carries that).
     n_hits: int
     metadata_path: str  # Sibling .json with hit details
 
@@ -1298,7 +1301,7 @@ class DataPreprocessor:
 
         if os.path.exists(npy_path):
             # Resume path: rebuild a minimal CadenceResult from the existing file
-            metadata_path = self._cadence_metadata_path(npy_path)
+            metadata_path = self.cadence_metadata_path(npy_path)
             try:
                 existing = np.load(npy_path, mmap_mode="r")
                 n_hits = existing.shape[0]
@@ -1376,8 +1379,10 @@ class DataPreprocessor:
         return f"{csv_stem}_{'_'.join(safe_parts)}.npy"
 
     @staticmethod
-    def _cadence_metadata_path(npy_path: str) -> str:
-        """Return the sibling .json path for a cadence's metadata."""
+    def cadence_metadata_path(npy_path: str) -> str:
+        """Return the sibling .json path for a cadence's metadata. Public: the streaming
+        loop (main.py) and the viz suite derive metadata paths for resume-skipped cadences
+        whose CadenceResult was never rebuilt."""
         return os.path.splitext(npy_path)[0] + ".json"
 
     @staticmethod
@@ -1656,7 +1661,7 @@ class DataPreprocessor:
 
         os.replace(tmp_npy_path, npy_path)
 
-        metadata_path = self._cadence_metadata_path(npy_path)
+        metadata_path = self.cadence_metadata_path(npy_path)
         # Per-stamp frequency = center bin's frequency, computed from header's fch1/foff
         stamp_freqs_mhz = [float(fch1 + foff * (start + half)) for start, _, _ in stamp_centers]
         stamp_stats = [float(s) for _, s, _ in stamp_centers]
@@ -1678,7 +1683,11 @@ class DataPreprocessor:
             "overlap_fraction": overlap_fraction if overlap_search else None,
             # Energy-detection provenance for the visualization suite: the all-window
             # statistic histograms (per ON file, fixed log-spaced bins) and the hit
-            # frequencies before/after deduplication (hit spectrum + funnel figures)
+            # frequencies before/after deduplication (hit spectrum + funnel figures).
+            # NOTE: the frequency lists are stored raw (unlike the pre-binned stat
+            # histograms — an asymmetry): tens of thousands of floats per RFI-dense
+            # cadence, bounded at current catalog scale. If metadata JSONs grow unwieldy,
+            # pre-bin these onto a fixed frequency grid the way ed_stat_hist does.
             "ed_stat_hist": {
                 "bin_edges": [float(e) for e in ED_STAT_HIST_EDGES],
                 "counts_per_on_file": stat_hists.tolist(),

--- a/src/aetherscan/run_state.py
+++ b/src/aetherscan/run_state.py
@@ -89,6 +89,53 @@ def config_changed(state: TrainingRunState | None, current_fingerprint: str) -> 
     return state is not None and state.config_fingerprint != current_fingerprint
 
 
+# Inference-result-affecting config for inference_config_fingerprint(). We DENYLIST the inference
+# keys that don't change per-cadence results (I/O paths, batching, retry knobs, and viz/debug
+# toggles) rather than allowlisting the ones that do — a denylist can only over-invalidate (force a
+# harmless re-inference), never under-invalidate (the actual stale-reuse footgun). The data section
+# is the reverse: it is mostly training params, so we ALLOWLIST only the geometry fields that drive
+# stamp extraction and the encoder input.
+_INFERENCE_FINGERPRINT_EXCLUDE_INFERENCE_KEYS = frozenset(
+    {
+        "config_path",  # source-config file path, not a result input
+        "per_replica_batch_size",  # batching only; #120's pad+truncate makes results batch-invariant
+        "parallel_coarse_chans",  # progress-logging chunk size only (inert)
+        "bandpass_debug_plot",  # opt-in debug artifact
+        "preprocess_output_dir",  # where stamps are written (folded into npy_path, not values)
+        "inference_viz_enabled",  # viz toggle
+        "stamp_gallery_top_k",  # viz only
+        "max_candidate_plots",  # viz only
+        "max_retries",  # retry loop only
+        "retry_delay",  # retry loop only
+    }
+)
+_INFERENCE_FINGERPRINT_DATA_KEYS = frozenset(
+    {"downsample_factor", "width_bin", "num_observations", "time_bins"}
+)
+
+
+def inference_config_fingerprint(config_dict: dict) -> str:
+    """
+    Stable hash of the inference-result-affecting config (from Config.to_dict()) — the inference
+    counterpart of config_fingerprint. Used to detect that inference was re-run under a reused
+    --save-tag with a changed config so a stale 'inferred' manifest row is not silently reused as
+    a skip. Covers the inference section minus non-result knobs (see the denylist above) plus the
+    data-section geometry that drives stamp extraction and the encoder input.
+    """
+    inference = config_dict.get("inference") or {}
+    data = config_dict.get("data") or {}
+    relevant = {
+        "inference": {
+            k: v
+            for k, v in inference.items()
+            if k not in _INFERENCE_FINGERPRINT_EXCLUDE_INFERENCE_KEYS
+        },
+        "data": {k: data[k] for k in _INFERENCE_FINGERPRINT_DATA_KEYS if k in data},
+    }
+    canonical = json.dumps(relevant, sort_keys=True, default=str)
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
 @dataclass
 class TrainingRunState:
     """Persisted state of one training run (identified by its save tag) across attempts."""

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -163,6 +163,43 @@ class TestSemanticChecks:
         errors = collect_validation_errors(_parse(argv), None)
         assert any(e.field == "training.initial_snr_range" for e in errors)
 
+    def test_stamp_gallery_top_k_bounds(self):
+        errors = collect_validation_errors(
+            _parse(["inference", "--stamp-gallery-top-k", "0"]), None
+        )
+        assert any(e.field == "inference.stamp_gallery_top_k" for e in errors)
+
+    def test_max_candidate_plots_bounds(self):
+        errors = collect_validation_errors(
+            _parse(["inference", "--max-candidate-plots", "-1"]), None
+        )
+        assert any(e.field == "inference.max_candidate_plots" for e in errors)
+
+    def test_viz_flags_route_to_inference_config(self):
+        config = get_config()
+        apply_args_to_config(
+            _parse(
+                [
+                    "inference",
+                    "--no-inference-viz",
+                    "--stamp-gallery-top-k",
+                    "6",
+                    "--max-candidate-plots",
+                    "10",
+                ]
+            )
+        )
+        assert config.inference.inference_viz_enabled is False
+        assert config.inference.stamp_gallery_top_k == 6
+        assert config.inference.max_candidate_plots == 10
+
+    def test_viz_flags_omitted_keep_defaults(self):
+        config = get_config()
+        apply_args_to_config(_parse(["inference"]))
+        assert config.inference.inference_viz_enabled is True
+        assert config.inference.stamp_gallery_top_k == 12
+        assert config.inference.max_candidate_plots == 50
+
     def test_missing_train_files_reported(self):
         errors = collect_validation_errors(_parse(["train"]), None)
         # Default train_files don't exist under the tmp data path.

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -333,7 +333,6 @@ class TestApplySavedConfigPrecedence:
     def test_saved_config_overrides_defaults(self, tmp_path):
         saved = {
             "training": {"num_training_rounds": 7, "snr_base": 33},
-            "checkpoint": {"save_tag": "final_v9"},
             "data_path": "/saved/data/path",
         }
         path = tmp_path / "saved_config.json"
@@ -343,9 +342,37 @@ class TestApplySavedConfigPrecedence:
         config = get_config()
         assert config.training.num_training_rounds == 7
         assert config.training.snr_base == 33
-        # Documented sharp edge: the saved file clobbers checkpoint.save_tag too.
-        assert config.checkpoint.save_tag == "final_v9"
         assert config.data_path == "/saved/data/path"
+
+    def test_checkpoint_section_is_never_applied(self, tmp_path):
+        """Regression: a saved *training* config's checkpoint section (most damagingly
+        save_tag) must never leak onto the singleton — an inference run layering the
+        training config would otherwise masquerade under the training run's tag."""
+        config = get_config()
+        config.checkpoint.save_tag = "20260712_010203"  # this run's own tag
+        original_load_dir = config.checkpoint.load_dir
+        original_load_tag = config.checkpoint.load_tag
+        original_start_round = config.checkpoint.start_round
+
+        saved = {
+            "checkpoint": {
+                "save_tag": "final_v9",
+                "load_dir": "/somewhere/else",
+                "load_tag": "round_05",
+                "start_round": 6,
+            },
+            "beta_vae": {"latent_dim": 16},
+        }
+        path = tmp_path / "saved_config.json"
+        path.write_text(json.dumps(saved))
+        apply_saved_config(str(path))
+
+        assert config.checkpoint.save_tag == "20260712_010203"
+        assert config.checkpoint.load_dir == original_load_dir
+        assert config.checkpoint.load_tag == original_load_tag
+        assert config.checkpoint.start_round == original_start_round
+        # Non-checkpoint sections still layer normally.
+        assert config.beta_vae.latent_dim == 16
 
     def test_cli_args_override_saved_config(self, tmp_path):
         saved = {"training": {"snr_base": 33, "num_training_rounds": 7}}

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -341,6 +341,101 @@ class TestMarkSuperseded:
             db.mark_superseded("training_stats", "")
 
 
+class TestInferenceCadences:
+    """The per-cadence inference run manifest (schema v2): write/query round-trip, JSON
+    field serialization, status filtering, and the supersede-on-retry flow the stage-aware
+    resume relies on."""
+
+    def test_write_query_round_trip(self, db):
+        tag = "test_v1"
+        summary = {"n": 4, "mean": 0.5, "quantiles": {"p50": 0.5}}
+        db.write_inference_cadence(
+            npy_path="/pre/cad_a.npy",
+            status="inferred",
+            tag=tag,
+            csv_path="/catalog.csv",
+            cadence_key=("HIP110750", "AGBT21B_999_31", "L", "0", "1400"),
+            n_stamps=4,
+            n_candidates=1,
+            confidence_summary=summary,
+            duration_s=12.5,
+        )
+        assert db.flush(timeout=10) is True
+
+        rows = db.query_inference_cadences(tag=tag)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["npy_path"] == "/pre/cad_a.npy"
+        assert row["status"] == "inferred"
+        assert row["csv_path"] == "/catalog.csv"
+        assert json.loads(row["cadence_key"]) == ["HIP110750", "AGBT21B_999_31", "L", "0", "1400"]
+        assert row["n_stamps"] == 4
+        assert row["n_candidates"] == 1
+        assert json.loads(row["confidence_summary"]) == summary
+        assert row["duration_s"] == 12.5
+        assert row["superseded"] == 0
+
+    def test_optional_fields_default_to_none(self, db):
+        db.write_inference_cadence(npy_path="/pre/cad_b.npy", status="preprocessed", tag="test_v1")
+        assert db.flush(timeout=10) is True
+        row = db.query_inference_cadences(tag="test_v1")[0]
+        assert row["cadence_key"] is None
+        assert row["confidence_summary"] is None
+        assert row["n_candidates"] is None
+
+    def test_status_and_npy_path_filters(self, db):
+        tag = "test_v2"
+        db.write_inference_cadence(npy_path="/a.npy", status="preprocessed", tag=tag, n_stamps=3)
+        db.write_inference_cadence(npy_path="/a.npy", status="inferred", tag=tag, n_stamps=3)
+        db.write_inference_cadence(npy_path="/b.npy", status="failed", tag=tag)
+        assert db.flush(timeout=10) is True
+
+        inferred = db.query_inference_cadences(tag=tag, status="inferred")
+        assert [r["npy_path"] for r in inferred] == ["/a.npy"]
+        a_rows = db.query_inference_cadences(tag=tag, npy_path="/a.npy")
+        assert sorted(r["status"] for r in a_rows) == ["inferred", "preprocessed"]
+        multi = db.query_inference_cadences(tag=tag, status=["inferred", "failed"])
+        assert sorted(r["status"] for r in multi) == ["failed", "inferred"]
+
+    def test_supersede_on_retry_flow(self, db):
+        """The manifest state machine on a retried cadence: 'preprocessed' + 'failed' rows
+        from the dead attempt are superseded before the fresh 'inferred' row is written, so
+        the resume query (status='inferred', default superseded filter) flips from empty to
+        exactly one row."""
+        tag = "test_v3"
+        npy = "/pre/cad_c.npy"
+        db.write_inference_cadence(npy_path=npy, status="preprocessed", tag=tag, n_stamps=7)
+        db.write_inference_cadence(npy_path=npy, status="failed", tag=tag)
+
+        # Before the retry completes: no live 'inferred' row -> the cadence is re-attempted
+        assert db.flush(timeout=10) is True
+        assert db.query_inference_cadences(tag=tag, npy_path=npy, status="inferred") == []
+
+        # Retry succeeds: supersede old rows, then write the fresh 'inferred' row
+        assert db.mark_superseded("inference_cadences", tag, npy_path=npy) is True
+        db.write_inference_cadence(
+            npy_path=npy, status="inferred", tag=tag, n_stamps=7, n_candidates=0
+        )
+        assert db.flush(timeout=10) is True
+
+        live = db.query_inference_cadences(tag=tag, npy_path=npy)
+        assert [r["status"] for r in live] == ["inferred"]
+        all_rows = db.query_inference_cadences(tag=tag, npy_path=npy, include_superseded=True)
+        assert len(all_rows) == 3
+
+    def test_supersede_scoped_to_npy_path(self, db):
+        tag = "test_v4"
+        db.write_inference_cadence(npy_path="/a.npy", status="inferred", tag=tag)
+        db.write_inference_cadence(npy_path="/b.npy", status="inferred", tag=tag)
+        assert db.mark_superseded("inference_cadences", tag, npy_path="/a.npy") is True
+        live = db.query_inference_cadences(tag=tag, status="inferred")
+        assert [r["npy_path"] for r in live] == ["/b.npy"]
+
+    def test_invalid_column_rejected(self, db):
+        with pytest.raises(ValueError, match="Invalid column"):
+            db.query_inference_cadences(columns=["npy_path; DROP TABLE inference_cadences"])
+
+
 class TestSchemaMigration:
     # The v0 schema (pre-superseded) for the four tables the migration touches, trimmed to
     # the columns the assertions need plus everything NOT NULL.
@@ -445,6 +540,16 @@ class TestSchemaMigration:
         finally:
             conn.close()
 
+    def _table_names(self, db_path):
+        conn = sqlite3.connect(db_path)
+        try:
+            return {
+                row[0]
+                for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+            }
+        finally:
+            conn.close()
+
     def test_old_schema_gains_superseded_column(self):
         db_path = self._create_v0_db(get_config())
         assert self._user_version(db_path) == 0
@@ -459,6 +564,23 @@ class TestSchemaMigration:
             rows = database.query_training_stat(tag="test_v1")
             assert len(rows) == 1
             assert rows[0]["superseded"] == 0
+        finally:
+            database.stop()
+
+    def test_old_schema_gains_inference_cadences_table(self):
+        """A pre-versioning database (v0: no inference_cadences table) must come out of
+        _init_database() with the v2 manifest table present and usable."""
+        db_path = self._create_v0_db(get_config())
+        assert "inference_cadences" not in self._table_names(db_path)
+
+        database = Database()
+        database.start()
+        try:
+            assert "inference_cadences" in self._table_names(db_path)
+            assert self._user_version(db_path) == _SCHEMA_VERSION
+            database.write_inference_cadence(npy_path="/a.npy", status="inferred", tag="test_v1")
+            assert database.flush(timeout=10) is True
+            assert len(database.query_inference_cadences(tag="test_v1")) == 1
         finally:
             database.stop()
 

--- a/tests/unit/test_inference.py
+++ b/tests/unit/test_inference.py
@@ -1,6 +1,7 @@
 """Unit tests for aetherscan.inference: the tail-padding fix in
-prepare_distributed_inf_dataset (regression for the silent partial-batch drop) and the
-InfDataHolder clear semantics."""
+prepare_distributed_inf_dataset (regression for the silent partial-batch drop), the
+InfDataHolder clear semantics, and the confidence-summary math backing the
+inference_cadences manifest."""
 
 from __future__ import annotations
 
@@ -8,7 +9,11 @@ import numpy as np
 import pytest
 import tensorflow as tf
 
-from aetherscan.inference import InfDataHolder, prepare_distributed_inf_dataset
+from aetherscan.inference import (
+    InfDataHolder,
+    prepare_distributed_inf_dataset,
+    summarize_confidences,
+)
 
 
 def _collect_batches(result: dict) -> np.ndarray:
@@ -113,3 +118,42 @@ class TestInfDataHolder:
         assert holder.data is None
         holder.clear()  # second clear is a no-op
         assert holder.data is None
+
+
+class TestSummarizeConfidences:
+    def test_summary_math(self):
+        proba = np.linspace(0.0, 1.0, 101)  # p50 = 0.5, p01 = 0.01, ... exactly
+        summary = summarize_confidences(proba, threshold=0.9)
+
+        assert summary["n"] == 101
+        assert summary["threshold"] == 0.9
+        assert summary["n_above_threshold"] == 10  # 0.91 .. 1.00 (strictly above)
+        assert summary["mean"] == pytest.approx(0.5)
+        assert summary["min"] == 0.0
+        assert summary["max"] == 1.0
+        assert summary["quantiles"]["p50"] == pytest.approx(0.5)
+        assert summary["quantiles"]["p01"] == pytest.approx(0.01)
+        assert summary["quantiles"]["p99"] == pytest.approx(0.99)
+        assert list(summary["quantiles"]) == ["p01", "p05", "p25", "p50", "p75", "p95", "p99"]
+
+    def test_single_value(self):
+        summary = summarize_confidences(np.array([0.42]), threshold=0.5)
+        assert summary["n"] == 1
+        assert summary["n_above_threshold"] == 0
+        assert all(v == pytest.approx(0.42) for v in summary["quantiles"].values())
+
+    def test_json_serializable(self):
+        import json  # noqa: PLC0415
+
+        summary = summarize_confidences(np.random.default_rng(1).random(50), threshold=0.99)
+        round_tripped = json.loads(json.dumps(summary))
+        assert round_tripped == summary  # plain floats/ints only, no numpy scalars
+
+    def test_threshold_boundary_is_strict(self):
+        # Matches the RF prediction rule: prediction = proba > threshold, not >=
+        summary = summarize_confidences(np.array([0.99, 0.991]), threshold=0.99)
+        assert summary["n_above_threshold"] == 1
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="at least one confidence"):
+            summarize_confidences(np.array([]), threshold=0.5)

--- a/tests/unit/test_inference_viz.py
+++ b/tests/unit/test_inference_viz.py
@@ -90,7 +90,7 @@ def _write_cadence_artifacts(tmp_path, name, key, n_stamps=N_STAMPS, h5_paths=No
         "raw_hit_frequencies_mhz": list(np.repeat(freqs, 3)),
         "merged_hit_frequencies_mhz": freqs,
     }
-    metadata_path = DataPreprocessor._cadence_metadata_path(npy_path)
+    metadata_path = DataPreprocessor.cadence_metadata_path(npy_path)
     with open(metadata_path, "w") as f:
         json.dump(metadata, f)
     return npy_path, metadata_path, metadata

--- a/tests/unit/test_inference_viz.py
+++ b/tests/unit/test_inference_viz.py
@@ -174,6 +174,33 @@ class TestCollector:
         assert record.confidence_hist is None
 
 
+class TestSelectTopStamps:
+    def test_overlap_offset_duplicates_are_skipped(self, tmp_path):
+        """With overlap_search the same hit yields stamps at ±overlap_fraction*stamp_width
+        (exactly stamp_width // 2 at defaults) sharing one statistic — the gallery selection
+        must keep only one of each triplet (regression: a strict < comparison let all
+        three through)."""
+        from aetherscan.inference_viz import _select_top_stamps  # noqa: PLC0415
+
+        npy_path, metadata_path, metadata = _write_cadence_artifacts(tmp_path, "cad_ov", ("O",))
+        # One hit at start 1000 with its two overlap offsets (stamp_width=256 -> offset 128),
+        # plus one genuinely distinct weaker hit far away
+        metadata["stamp_starts"] = [872, 1000, 1128, 5000]
+        metadata["stamp_statistics"] = [9000.0, 9000.0, 9000.0, 3000.0]
+        metadata["stamp_frequencies_mhz"] = [1400.1, 1400.1, 1400.1, 1405.0]
+        with open(metadata_path, "w") as f:
+            json.dump(metadata, f)
+
+        coll = InferenceVizCollector()
+        coll.record_processed(("O",), npy_path, metadata_path, {}, _fake_results(n=4), 1.0)
+        metadatas = {npy_path: metadata}
+
+        selected = _select_top_stamps(coll.records, metadatas, top_k=4)
+        starts = [metadata["stamp_starts"][idx] for _, idx, _, _ in selected]
+        assert len([s for s in starts if s in (872, 1000, 1128)]) == 1
+        assert 5000 in starts
+
+
 class TestFigureSmoke:
     def test_ed_stat_distributions(self, collector, metadatas):
         _assert_figure(plot_ed_stat_distributions(collector.records, metadatas))
@@ -281,7 +308,7 @@ class TestFigureSmoke:
         config.inference.config_path = str(config_json)
         assert plot_inference_latent_projection(collector) is None
 
-    def test_inference_summary(self, initialized_runtime, collector):
+    def test_inference_summary(self, initialized_runtime, collector, metadatas):
         db = initialized_runtime
         db.write_inference_cadence(
             npy_path=collector.records[0].npy_path,
@@ -305,7 +332,7 @@ class TestFigureSmoke:
             "n_cadences": 2,
             "n_skipped": 0,
         }
-        _assert_figure(plot_inference_summary(collector.records, totals))
+        _assert_figure(plot_inference_summary(collector.records, metadatas, totals))
 
 
 class TestSuiteEntryPoint:

--- a/tests/unit/test_inference_viz.py
+++ b/tests/unit/test_inference_viz.py
@@ -1,0 +1,341 @@
+"""Smoke tests for aetherscan.inference_viz: every figure function runs against small
+synthetic inputs and produces a non-empty PNG under plots/inference/{tag}/, the collector
+keeps bounded state, and the suite entry point never raises (a plot bug must not kill a
+science run)."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import joblib
+import numpy as np
+import pytest
+
+from aetherscan.config import get_config
+from aetherscan.inference_viz import (
+    CONFIDENCE_HIST_EDGES,
+    InferenceVizCollector,
+    plot_bandpass_flattening,
+    plot_candidate,
+    plot_candidate_gallery,
+    plot_confidence_distribution,
+    plot_ed_hit_spectrum,
+    plot_ed_stat_distributions,
+    plot_inference_latent_projection,
+    plot_inference_summary,
+    plot_preproc_funnel,
+    plot_stamp_gallery,
+    render_inference_visualizations,
+)
+from aetherscan.preprocessing import ED_STAT_HIST_EDGES, DataPreprocessor
+
+TAG = "test_v1"
+N_STAMPS = 5
+STORED_WIDTH = 32
+
+
+class FakeUMAP:
+    """Stands in for a persisted umap.UMAP: transform() projects onto the first two feature
+    dims; embedding_ mimics the training fit pool's 2-D embedding."""
+
+    def __init__(self, embedding):
+        self.embedding_ = embedding
+
+    def transform(self, features):
+        return np.asarray(features, dtype=np.float64)[:, :2]
+
+
+@pytest.fixture
+def initialized_runtime():
+    from aetherscan.db import init_db  # noqa: PLC0415
+    from aetherscan.manager import init_manager  # noqa: PLC0415
+
+    init_manager()
+    return init_db()
+
+
+def _write_cadence_artifacts(tmp_path, name, key, n_stamps=N_STAMPS, h5_paths=None):
+    """Write a small stamp .npy + full metadata JSON like _process_cadence would."""
+    rng = np.random.default_rng(hash(name) % 2**31)
+    npy_path = str(tmp_path / f"{name}.npy")
+    stamps = rng.chisquare(df=4, size=(n_stamps, 6, 16, STORED_WIDTH)).astype(np.float32)
+    np.save(npy_path, stamps)
+
+    stat_hist = np.zeros((3, len(ED_STAT_HIST_EDGES) - 1), dtype=np.int64)
+    stat_hist[:, 40:60] = rng.integers(1, 500, size=(3, 20))
+    stat_hist[:, 100] = 3  # a few extreme windows above any threshold
+
+    freqs = list(1400.0 + rng.random(n_stamps) * 10)
+    metadata = {
+        "key": list(key),
+        "csv_path": "catalog.csv",
+        "h5_paths": h5_paths or [f"/data/{name}_{i}.h5" for i in range(6)],
+        "header": {"nchans": 2048, "fch1": 1410.0, "foff": -2.8e-6, "tstart": 58000.5},
+        "stamp_starts": [int(100 + 200 * i) for i in range(n_stamps)],
+        "stamp_width": 256,
+        "stored_width": STORED_WIDTH,
+        "downsample_factor_applied": 8,
+        "stamp_frequencies_mhz": freqs,
+        "stamp_statistics": [float(3000 + 100 * i) for i in range(n_stamps)],
+        "stamp_pvalues": [1e-9] * n_stamps,
+        "overlap_search": False,
+        "overlap_fraction": None,
+        "ed_stat_hist": {
+            "bin_edges": [float(e) for e in ED_STAT_HIST_EDGES],
+            "counts_per_on_file": stat_hist.tolist(),
+        },
+        "n_raw_hits": 3 * n_stamps,
+        "n_merged_hits": n_stamps,
+        "raw_hit_frequencies_mhz": list(np.repeat(freqs, 3)),
+        "merged_hit_frequencies_mhz": freqs,
+    }
+    metadata_path = DataPreprocessor._cadence_metadata_path(npy_path)
+    with open(metadata_path, "w") as f:
+        json.dump(metadata, f)
+    return npy_path, metadata_path, metadata
+
+
+def _fake_results(n=N_STAMPS, n_candidates=1):
+    proba = np.linspace(0.1, 0.999, n)
+    predictions = np.zeros(n, dtype=int)
+    predictions[-n_candidates:] = 1
+    return {
+        "n_cadence_snippets": n,
+        "n_processed": n,
+        "n_candidates": n_candidates,
+        "proba_true": proba,
+        "predictions": predictions,
+        "latents": np.random.default_rng(7).normal(size=(n * 6, 8)).astype(np.float32),
+    }
+
+
+@pytest.fixture
+def collector(tmp_path):
+    """A collector with two processed cadences backed by real on-disk artifacts."""
+    get_config().checkpoint.save_tag = TAG
+    coll = InferenceVizCollector()
+    for name, key in (
+        ("cad_a", ("A", "S1", "L", "0", "1400")),
+        ("cad_b", ("B", "S1", "L", "1", "1400")),
+    ):
+        npy_path, metadata_path, _ = _write_cadence_artifacts(tmp_path, name, key)
+        coll.record_processed(
+            key, npy_path, metadata_path, {"target": key[0]}, _fake_results(), 2.5
+        )
+    return coll
+
+
+@pytest.fixture
+def metadatas(collector):
+    result = {}
+    for record in collector.records:
+        with open(record.metadata_path) as f:
+            result[record.npy_path] = json.load(f)
+    return result
+
+
+def _assert_figure(path):
+    assert path is not None
+    assert os.path.exists(path)
+    assert os.path.getsize(path) > 0
+    tag_dir = os.path.join(get_config().output_path, "plots", "inference", TAG)
+    assert os.path.dirname(path) == tag_dir
+
+
+class TestCollector:
+    def test_confidence_histogram_counts(self, collector):
+        for record in collector.records:
+            assert record.confidence_hist is not None
+            assert record.confidence_hist.sum() == N_STAMPS
+            assert record.confidence_hist.shape == (len(CONFIDENCE_HIST_EDGES) - 1,)
+
+    def test_latent_pool_keeps_candidates_within_budget(self, tmp_path):
+        coll = InferenceVizCollector(max_latent_points=6)
+        npy_path, metadata_path, _ = _write_cadence_artifacts(tmp_path, "cad_pool", ("P",))
+        coll.record_processed(
+            ("P",), npy_path, metadata_path, {}, _fake_results(n=10, n_candidates=2), 1.0
+        )
+        coll.record_processed(
+            ("Q",), npy_path, metadata_path, {}, _fake_results(n=10, n_candidates=2), 1.0
+        )
+        features, is_candidate = coll.latent_pool()
+        assert int(is_candidate.sum()) == 4  # candidates always kept, even past budget
+        assert features.shape[1] == 48
+        # Non-candidates only filled while the budget lasted
+        assert features.shape[0] <= 6 + 4
+
+    def test_record_skipped_uses_manifest_aggregates(self, tmp_path):
+        coll = InferenceVizCollector()
+        coll.record_skipped(("S",), "/x.npy", "/x.json", {"n_stamps": 9, "n_candidates": 3})
+        record = coll.records[0]
+        assert record.skipped is True
+        assert record.n_stamps == 9
+        assert record.confidence_hist is None
+
+
+class TestFigureSmoke:
+    def test_ed_stat_distributions(self, collector, metadatas):
+        _assert_figure(plot_ed_stat_distributions(collector.records, metadatas))
+
+    def test_ed_hit_spectrum(self, collector, metadatas):
+        _assert_figure(plot_ed_hit_spectrum(collector.records, metadatas))
+
+    def test_stamp_gallery(self, collector, metadatas):
+        _assert_figure(plot_stamp_gallery(collector.records, metadatas))
+
+    def test_preproc_funnel(self, collector, metadatas):
+        _assert_figure(plot_preproc_funnel(collector.records, metadatas))
+
+    def test_confidence_distribution(self, collector):
+        _assert_figure(plot_confidence_distribution(collector.records))
+
+    def test_bandpass_flattening(
+        self, tmp_path, initialized_runtime, collector, make_h5_observation
+    ):
+        config = get_config()
+        config.manager.n_processes = 1
+        config.inference.coarse_channel_width = 512
+        config.inference.bandpass_method = "spline"
+        config.inference.spline_order = 4
+        h5_path = make_h5_observation("viz_obs.h5", n_chans=2048)
+        npy_path, metadata_path, _ = _write_cadence_artifacts(
+            tmp_path, "cad_h5", ("H",), h5_paths=[str(h5_path)] * 6
+        )
+        coll = InferenceVizCollector()
+        coll.record_processed(("H",), npy_path, metadata_path, {}, _fake_results(), 1.0)
+        with open(metadata_path) as f:
+            metas = {npy_path: json.load(f)}
+        _assert_figure(plot_bandpass_flattening(DataPreprocessor(), coll.records, metas))
+
+    def test_candidate_gallery_and_per_candidate(self, initialized_runtime, collector):
+        db = initialized_runtime
+        config = get_config()
+        config.inference.max_candidate_plots = 1
+        record = collector.records[0]
+        latent = list(np.random.default_rng(5).normal(size=48))
+        for idx, conf in ((0, 0.995), (1, 0.999)):
+            db.write_inference_result(
+                record.npy_path,
+                idx,
+                1,
+                conf,
+                latent_vector=np.asarray(latent),
+                target="HIP110750",
+                band="L",
+                frequency_mhz=1400.5,
+                tag=TAG,
+            )
+        assert db.flush(timeout=10) is True
+
+        _assert_figure(plot_candidate_gallery())
+        tag_dir = os.path.join(config.output_path, "plots", "inference", TAG)
+        # max_candidate_plots=1 caps the per-candidate figures at the top-confidence one
+        assert os.path.exists(os.path.join(tag_dir, f"candidate_0_{TAG}.png"))
+        assert not os.path.exists(os.path.join(tag_dir, f"candidate_1_{TAG}.png"))
+
+    def test_plot_candidate_without_latent(self, collector):
+        record = collector.records[0]
+        row = {
+            "npy_path": record.npy_path,
+            "snippet_index": 0,
+            "confidence": 0.99,
+            "frequency_mhz": 1400.5,
+            "target": "HIP110750",
+            "latent_vector": None,
+        }
+        _assert_figure(plot_candidate(row, 0))
+
+    def test_latent_projection_with_persisted_umap(self, tmp_path, collector):
+        config = get_config()
+        model_dir = tmp_path / "models"
+        model_dir.mkdir(exist_ok=True)
+        umap_path = model_dir / "umap_cadence_nn15_md0.1_final_v1.joblib"
+        joblib.dump(FakeUMAP(np.random.default_rng(2).normal(size=(30, 2))), umap_path)
+        training_config = {
+            "paths": {"model_path": str(model_dir)},
+            "checkpoint": {"save_tag": "final_v1"},
+            "training": {
+                "latent_viz_umap_n_neighbors": [15],
+                "latent_viz_umap_min_dist": [0.1],
+            },
+        }
+        config_json = tmp_path / "config_final_v1.json"
+        config_json.write_text(json.dumps(training_config))
+        config.inference.config_path = str(config_json)
+
+        _assert_figure(plot_inference_latent_projection(collector))
+
+    def test_latent_projection_skips_without_training_config(self, collector):
+        get_config().inference.config_path = None
+        assert plot_inference_latent_projection(collector) is None
+
+    def test_latent_projection_skips_without_umap(self, tmp_path, collector):
+        config = get_config()
+        training_config = {
+            "paths": {"model_path": str(tmp_path / "empty_models")},
+            "checkpoint": {"save_tag": "final_v1"},
+        }
+        config_json = tmp_path / "config_no_umap.json"
+        config_json.write_text(json.dumps(training_config))
+        config.inference.config_path = str(config_json)
+        assert plot_inference_latent_projection(collector) is None
+
+    def test_inference_summary(self, initialized_runtime, collector):
+        db = initialized_runtime
+        db.write_inference_cadence(
+            npy_path=collector.records[0].npy_path,
+            status="preprocessed",
+            tag=TAG,
+            n_stamps=N_STAMPS,
+            duration_s=12.0,
+        )
+        db.write_inference_cadence(
+            npy_path=collector.records[0].npy_path,
+            status="inferred",
+            tag=TAG,
+            n_stamps=N_STAMPS,
+            n_candidates=1,
+            duration_s=3.0,
+        )
+        totals = {
+            "n_cadence_snippets": 10,
+            "n_processed": 10,
+            "n_candidates": 2,
+            "n_cadences": 2,
+            "n_skipped": 0,
+        }
+        _assert_figure(plot_inference_summary(collector.records, totals))
+
+
+class TestSuiteEntryPoint:
+    def test_render_all_never_raises(self, initialized_runtime, collector):
+        totals = {
+            "n_cadence_snippets": 10,
+            "n_processed": 10,
+            "n_candidates": 2,
+            "n_cadences": 2,
+            "n_skipped": 0,
+        }
+        render_inference_visualizations(collector, DataPreprocessor(), totals)
+        tag_dir = os.path.join(get_config().output_path, "plots", "inference", TAG)
+        rendered = os.listdir(tag_dir)
+        # Core figures render even though the h5s/UMAP/candidates are unavailable
+        # (those figures log and skip instead of failing the suite)
+        for stem in (
+            "ed_stat_distributions",
+            "ed_hit_spectrum",
+            "stamp_gallery",
+            "preproc_funnel",
+            "confidence_distribution",
+            "inference_summary",
+        ):
+            assert f"{stem}_{TAG}.png" in rendered
+
+    def test_render_survives_broken_records(self, initialized_runtime):
+        """Missing .npy/metadata everywhere: every figure must degrade to a logged skip."""
+        coll = InferenceVizCollector()
+        coll.record_skipped(("X",), "/nope/gone.npy", "/nope/gone.json", {"n_stamps": 1})
+        render_inference_visualizations(
+            coll, DataPreprocessor(), {"n_cadence_snippets": 1, "n_cadences": 1}
+        )

--- a/tests/unit/test_inference_viz.py
+++ b/tests/unit/test_inference_viz.py
@@ -334,6 +334,59 @@ class TestFigureSmoke:
         }
         _assert_figure(plot_inference_summary(collector.records, metadatas, totals))
 
+    def test_inference_summary_counts_superseded_preprocessing(
+        self, initialized_runtime, collector, metadatas, monkeypatch
+    ):
+        """Regression: _infer_cadence supersedes each cadence's 'preprocessed' row just before
+        writing its live 'inferred' row, so on a fully successful run every 'preprocessed' row
+        is superseded. The summary aggregation must include superseded rows (else preprocessing
+        time always reads 0.0 s) while summing per status so the preprocessed and inferred rows
+        of the same cadence aren't double-counted."""
+        db = initialized_runtime
+        npy_path = collector.records[0].npy_path
+        # Reproduce the post-success manifest state for one cadence: a 'preprocessed' row
+        # retired by mark_superseded, then the live 'inferred' row (the _infer_cadence order).
+        db.write_inference_cadence(
+            npy_path=npy_path, status="preprocessed", tag=TAG, n_stamps=N_STAMPS, duration_s=12.0
+        )
+        assert db.mark_superseded("inference_cadences", TAG, npy_path=npy_path) is True
+        db.write_inference_cadence(
+            npy_path=npy_path,
+            status="inferred",
+            tag=TAG,
+            n_stamps=N_STAMPS,
+            n_candidates=1,
+            duration_s=3.0,
+        )
+        assert db.flush(timeout=10) is True
+
+        # The 'preprocessed' row is invisible to the default query but must drive the summary.
+        assert db.query_inference_cadences(tag=TAG, status="preprocessed") == []
+
+        # Capture the rendered summary text (patch before _save_and_upload clears the figure).
+        captured: dict[str, str] = {}
+
+        def _capture(fig, filename, slack_title):
+            captured["text"] = "\n".join(t.get_text() for ax in fig.axes for t in ax.texts)
+            return filename
+
+        monkeypatch.setattr("aetherscan.inference_viz._save_and_upload", _capture)
+
+        totals = {
+            "n_cadence_snippets": 10,
+            "n_candidates": 1,
+            "n_cadences": 1,
+            "n_skipped": 0,
+        }
+        plot_inference_summary(collector.records, metadatas, totals)
+
+        lines = captured["text"].splitlines()
+        preproc_line = next(line for line in lines if line.startswith("preprocessing time"))
+        inference_line = next(line for line in lines if line.startswith("inference time"))
+        # Real non-zero value (bug read 0.0 s), summed exactly once (double count -> 24.0 s).
+        assert preproc_line.split()[-2:] == ["12.0", "s"]
+        assert inference_line.split()[-2:] == ["3.0", "s"]
+
 
 class TestSuiteEntryPoint:
     def test_render_all_never_raises(self, initialized_runtime, collector):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,16 +1,21 @@
-"""Unit tests for main.py glue that isn't reachable through the higher-level commands —
-the terminal training-status / exit-code contract (_report_final_training_status) and
-non-retryable streaming-inference failures."""
+"""Unit tests for main.py glue that isn't reachable through the higher-level commands: the
+terminal training-status / exit-code contract (_report_final_training_status), non-retryable
+streaming-inference failures, and the stage-aware inference retry state machine (manifest-driven
+skip, per-cadence failure containment, supersede-on-retry) with the GPU pipeline and
+preprocessing stubbed out."""
 
 from __future__ import annotations
 
+import json
 import types
 
+import numpy as np
 import pytest
 
 from aetherscan import main
+from aetherscan.config import get_config
 from aetherscan.main import NonRetryableInferenceError, _run_streaming_csv_inference
-from aetherscan.preprocessing import DataPreprocessor
+from aetherscan.preprocessing import CadenceGroup, CadenceResult, DataPreprocessor, PendingCadence
 from aetherscan.run_state import STAGE_RF_PLOTS, STAGE_VAE_PLOTS, TrainingRunState
 
 
@@ -41,12 +46,13 @@ class TestReportFinalTrainingStatus:
 
 @pytest.fixture
 def initialized_runtime():
-    """DataPreprocessor needs live db + manager singletons; conftest tears them down."""
+    """DataPreprocessor needs live db + manager singletons; conftest tears them down.
+    Returns the Database so tests can flush/query the run manifest."""
     from aetherscan.db import init_db  # noqa: PLC0415
     from aetherscan.manager import init_manager  # noqa: PLC0415
 
     init_manager()
-    init_db()
+    return init_db()
 
 
 class TestStreamingInferenceNonRetryable:
@@ -63,3 +69,216 @@ class TestStreamingInferenceNonRetryable:
         # Sanity: it must be catchable as a plain Exception (cleanup paths) while being
         # distinguishable from transient failures by the retry loop.
         assert issubclass(NonRetryableInferenceError, RuntimeError)
+
+
+class _StubPreprocessor:
+    """DataPreprocessor stand-in: fixed work units, canned per-cadence stamp arrays, no
+    pools. Writes real .npy/.json artifacts so the resume/viz plumbing sees real files."""
+
+    def __init__(self, tmp_path, keys, n_stamps=4, width=8):
+        self.tmp_path = tmp_path
+        self.n_stamps = n_stamps
+        self.width = width
+        self.units = [self._make_unit(key) for key in keys]
+        self.processed_keys: list[tuple] = []
+        self.loaded_paths: list[str] = []
+
+    def _make_unit(self, key):
+        group = CadenceGroup(
+            key=key,
+            h5_paths=[f"/data/{key[0]}_{i}.h5" for i in range(6)],
+            csv_path="catalog.csv",
+            expected_obs=6,
+            is_valid=True,
+        )
+        return PendingCadence(group=group, npy_path=str(self.tmp_path / f"{key[0]}.npy"))
+
+    def plan_cadences(self):
+        return list(self.units)
+
+    def start_energy_detection_pool(self):
+        pass
+
+    def stop_energy_detection_pool(self):
+        pass
+
+    def process_pending_cadence(self, unit):
+        self.processed_keys.append(unit.group.key)
+        rng = np.random.default_rng(3)
+        stamps = rng.random((self.n_stamps, 6, 16, self.width)).astype(np.float32)
+        np.save(unit.npy_path, stamps)
+        metadata_path = DataPreprocessor._cadence_metadata_path(unit.npy_path)
+        with open(metadata_path, "w") as f:
+            json.dump({"h5_paths": unit.group.h5_paths, "key": list(unit.group.key)}, f)
+        return CadenceResult(
+            npy_path=unit.npy_path,
+            h5_paths=unit.group.h5_paths,
+            key=unit.group.key,
+            n_hits=self.n_stamps,
+            metadata_path=metadata_path,
+        )
+
+    def load_inference_data(self, override_filepaths):
+        self.loaded_paths.extend(override_filepaths)
+        return np.load(override_filepaths[0])
+
+
+class _StubPipeline:
+    """InferencePipeline stand-in recording which cadences reached the inference stage.
+    Raises for any npy_path in fail_paths (simulating a mid-cadence death)."""
+
+    instances: list = []
+
+    def __init__(self, strategy=None):
+        self.strategy = strategy
+        self.inferred_paths: list[str] = []
+        self.fail_paths: set[str] = set(type(self)._fail_paths)
+        type(self).instances.append(self)
+
+    _fail_paths: set = set()
+
+    def run_inference(self, data, npy_path, **provenance):
+        if npy_path in self.fail_paths:
+            raise RuntimeError("simulated mid-cadence death")
+        self.inferred_paths.append(npy_path)
+        n = data.shape[0]
+        proba = np.linspace(0.05, 0.95, n)
+        predictions = (proba > 0.9).astype(int)
+        return {
+            "n_cadence_snippets": n,
+            "n_processed": n,
+            "n_candidates": int(predictions.sum()),
+            "proba_true": proba,
+            "predictions": predictions,
+            "latents": np.zeros((n * 6, 8), dtype=np.float32),
+        }
+
+
+@pytest.fixture
+def stubbed_streaming(tmp_path, initialized_runtime, monkeypatch):
+    """Wire the streaming loop to the stubs; viz disabled (smoke-tested separately in
+    test_inference_viz.py). Returns (db, make_preprocessor)."""
+    db = initialized_runtime
+    config = get_config()
+    config.inference.inference_viz_enabled = False
+    config.checkpoint.save_tag = "test_v1"
+    monkeypatch.setattr(main, "InferencePipeline", _StubPipeline)
+    _StubPipeline.instances = []
+    _StubPipeline._fail_paths = set()
+
+    def make_preprocessor(keys=(("A", "1"), ("B", "2"))):
+        return _StubPreprocessor(tmp_path, list(keys))
+
+    return db, make_preprocessor
+
+
+class TestStreamingResumeStateMachine:
+    def test_fresh_run_infers_all_and_writes_manifest(self, stubbed_streaming):
+        db, make_preprocessor = stubbed_streaming
+        preprocessor = make_preprocessor()
+
+        totals = _run_streaming_csv_inference(preprocessor, strategy=None)
+
+        assert totals["n_cadences"] == 2
+        assert totals["n_skipped"] == 0
+        assert totals["n_cadence_snippets"] == 8
+        assert db.flush(timeout=10) is True
+        rows = db.query_inference_cadences(tag="test_v1", status="inferred")
+        assert len(rows) == 2
+        assert all(r["n_stamps"] == 4 for r in rows)
+        assert all(json.loads(r["confidence_summary"])["n"] == 4 for r in rows)
+
+    def test_inferred_cadence_skipped_on_retry(self, stubbed_streaming):
+        """A live 'inferred' manifest row short-circuits the whole cadence: neither
+        preprocessing nor inference runs for it, and its stored aggregates fold into the
+        totals."""
+        db, make_preprocessor = stubbed_streaming
+        first = make_preprocessor()
+        _run_streaming_csv_inference(first, strategy=None)
+
+        second = make_preprocessor()
+        totals = _run_streaming_csv_inference(second, strategy=None)
+
+        assert totals["n_skipped"] == 2
+        assert totals["n_cadences"] == 2
+        assert totals["n_cadence_snippets"] == 8  # from manifest aggregates
+        assert second.processed_keys == []  # preprocessing never ran
+        # No second pipeline was even constructed (nothing pending -> no model load)
+        assert len(_StubPipeline.instances) == 1
+
+    def test_failed_cadence_recorded_and_retried_alone(self, stubbed_streaming):
+        """Inference-stage containment: cadence B's failure doesn't abort cadence A; the
+        pass raises so the retry loop re-attempts, and the retry re-runs ONLY B."""
+        db, make_preprocessor = stubbed_streaming
+        first = make_preprocessor()
+        fail_path = first.units[1].npy_path
+        _StubPipeline._fail_paths = {fail_path}
+
+        with pytest.raises(RuntimeError, match="failed for 1 cadence"):
+            _run_streaming_csv_inference(first, strategy=None)
+
+        assert db.flush(timeout=10) is True
+        assert [
+            r["npy_path"] for r in db.query_inference_cadences(tag="test_v1", status="inferred")
+        ] == [first.units[0].npy_path]
+        assert [
+            r["npy_path"] for r in db.query_inference_cadences(tag="test_v1", status="failed")
+        ] == [fail_path]
+
+        # Retry pass: A skipped via manifest, B re-attempted and now succeeds
+        _StubPipeline._fail_paths = set()
+        second = make_preprocessor()
+        totals = _run_streaming_csv_inference(second, strategy=None)
+
+        assert totals["n_skipped"] == 1
+        assert totals["n_cadences"] == 2
+        retry_pipeline = _StubPipeline.instances[-1]
+        assert retry_pipeline.inferred_paths == [fail_path]
+        # B's 'failed' row was superseded by the fresh 'inferred' row
+        assert db.flush(timeout=10) is True
+        b_rows = db.query_inference_cadences(tag="test_v1", npy_path=fail_path)
+        assert [r["status"] for r in b_rows] == ["inferred"]
+
+    def test_stale_inference_results_superseded_on_retry(self, stubbed_streaming):
+        """Partial positives written by a dead attempt must be flagged before the re-run's
+        rows land, so candidates can't double up."""
+        db, make_preprocessor = stubbed_streaming
+        preprocessor = make_preprocessor(keys=[("A", "1")])
+        npy_path = preprocessor.units[0].npy_path
+
+        # Simulate a dead attempt's partial write for this cadence under the same tag
+        db.write_inference_result(npy_path, 0, 1, 0.999, tag="test_v1")
+        assert db.flush(timeout=10) is True
+
+        _run_streaming_csv_inference(preprocessor, strategy=None)
+        assert db.flush(timeout=10) is True
+
+        live = db.query_inference_result(tag="test_v1", npy_path=npy_path)
+        assert all(r["superseded"] == 0 for r in live)
+        everything = db.query_inference_result(
+            tag="test_v1", npy_path=npy_path, include_superseded=True
+        )
+        stale = [r for r in everything if r["superseded"] == 1]
+        assert len(stale) == 1
+        assert stale[0]["confidence"] == 0.999
+
+    def test_preprocessing_artifacts_skip_to_inference(self, stubbed_streaming, tmp_path):
+        """A cadence with a stamp .npy but no 'inferred' manifest row (killed between
+        stages) must skip preprocessing and go straight to inference — via the real
+        DataPreprocessor.process_pending_cadence resume path."""
+        db, make_preprocessor = stubbed_streaming
+        stub = make_preprocessor(keys=[("A", "1")])
+        unit = stub.units[0]
+        stub.process_pending_cadence(unit)  # lay down .npy + metadata, no manifest row
+
+        real = DataPreprocessor()
+        result = real.process_pending_cadence(unit)
+        assert result is not None
+        assert result.n_hits == 4  # from the existing .npy, not a re-run
+
+    def test_all_cadences_no_stamps_is_non_retryable(self, stubbed_streaming, monkeypatch):
+        db, make_preprocessor = stubbed_streaming
+        preprocessor = make_preprocessor()
+        monkeypatch.setattr(_StubPreprocessor, "process_pending_cadence", lambda self, unit: None)
+        with pytest.raises(NonRetryableInferenceError, match="No cadence results"):
+            _run_streaming_csv_inference(preprocessor, strategy=None)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -206,6 +206,39 @@ class TestStreamingResumeStateMachine:
         # No second pipeline was even constructed (nothing pending -> no model load)
         assert len(_StubPipeline.instances) == 1
 
+    def test_changed_config_reinfers_instead_of_reusing_stale(self, stubbed_streaming):
+        """A reused save-tag with a CHANGED inference config must NOT skip already-inferred
+        cadences: the manifest's config_fingerprint mismatches, so they are re-inferred rather
+        than silently serving stale results (guards the #122-class sticky-manifest footgun on
+        the inference side)."""
+        db, make_preprocessor = stubbed_streaming
+        config = get_config()
+
+        first = make_preprocessor()
+        _run_streaming_csv_inference(first, strategy=None)
+        assert db.flush(timeout=10) is True
+        fp_before = {
+            r["config_fingerprint"]
+            for r in db.query_inference_cadences(tag="test_v1", status="inferred")
+        }
+
+        # Change a result-affecting inference knob under the SAME save-tag.
+        config.inference.classification_threshold = 0.123
+
+        second = make_preprocessor()
+        totals = _run_streaming_csv_inference(second, strategy=None)
+
+        assert totals["n_skipped"] == 0  # live 'inferred' rows are NOT reused under the new config
+        assert totals["n_cadences"] == 2
+        assert second.processed_keys == [("A", "1"), ("B", "2")]  # both re-preprocessed
+        assert len(_StubPipeline.instances) == 2  # a second pipeline was built (re-inference ran)
+
+        assert db.flush(timeout=10) is True
+        live = db.query_inference_cadences(tag="test_v1", status="inferred")
+        assert len(live) == 2  # stale rows superseded, fresh rows live
+        fp_after = {r["config_fingerprint"] for r in live}
+        assert fp_after.isdisjoint(fp_before)  # fresh rows carry the new config fingerprint
+
     def test_failed_cadence_recorded_and_retried_alone(self, stubbed_streaming):
         """Inference-stage containment: cadence B's failure doesn't abort cadence A; the
         pass raises so the retry loop re-attempts, and the retry re-runs ONLY B."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -107,7 +107,7 @@ class _StubPreprocessor:
         rng = np.random.default_rng(3)
         stamps = rng.random((self.n_stamps, 6, 16, self.width)).astype(np.float32)
         np.save(unit.npy_path, stamps)
-        metadata_path = DataPreprocessor._cadence_metadata_path(unit.npy_path)
+        metadata_path = DataPreprocessor.cadence_metadata_path(unit.npy_path)
         with open(metadata_path, "w") as f:
             json.dump({"h5_paths": unit.group.h5_paths, "key": list(unit.group.key)}, f)
         return CadenceResult(

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -23,6 +23,7 @@ from aetherscan.config import get_config
 from aetherscan.data_generation import log_norm
 from aetherscan.pfb import edge_mid_power_ratio, gen_coarse_channel_response
 from aetherscan.preprocessing import (
+    ED_STAT_HIST_EDGES,
     DataPreprocessor,
     PendingCadence,
     _energy_detect_channel_worker,
@@ -392,12 +393,13 @@ class TestExtractStampsWorkerDownsample:
 
 @pytest.fixture
 def initialized_runtime():
-    """DataPreprocessor needs live db + manager singletons; conftest tears them down."""
+    """DataPreprocessor needs live db + manager singletons; conftest tears them down.
+    Returns the Database so tests can flush/query the run manifest."""
     from aetherscan.db import init_db  # noqa: PLC0415
     from aetherscan.manager import init_manager  # noqa: PLC0415
 
     init_manager()
-    init_db()
+    return init_db()
 
 
 class TestProcessCadenceEndToEnd:
@@ -494,11 +496,35 @@ class TestProcessCadenceEndToEnd:
         assert len(metadata["stamp_frequencies_mhz"]) == result.n_hits
         assert len(metadata["stamp_starts"]) == result.n_hits
 
-        # Resume path: a second call must skip reprocessing and report the same hit count
+        # Viz-suite provenance: per-ON-file all-window statistic histograms on the shared
+        # bins, plus pre-/post-dedup hit frequency lists
+        ed_hist = metadata["ed_stat_hist"]
+        assert ed_hist["bin_edges"] == pytest.approx(list(ED_STAT_HIST_EDGES))
+        assert len(ed_hist["counts_per_on_file"]) == 3  # one histogram per ON file
+        assert all(sum(counts) > 0 for counts in ed_hist["counts_per_on_file"])
+        assert metadata["n_raw_hits"] >= metadata["n_merged_hits"] > 0
+        assert len(metadata["raw_hit_frequencies_mhz"]) == metadata["n_raw_hits"]
+        assert len(metadata["merged_hit_frequencies_mhz"]) == metadata["n_merged_hits"]
+
+        # Preprocessing completion is recorded in the inference_cadences run manifest
+        db = initialized_runtime
+        assert db.flush(timeout=10) is True
+        manifest = db.query_inference_cadences(tag=config.checkpoint.save_tag, npy_path=npy_path)
+        assert [r["status"] for r in manifest] == ["preprocessed"]
+        assert manifest[0]["n_stamps"] == result.n_hits
+        assert manifest[0]["csv_path"] == "unused.csv"
+        assert json.loads(manifest[0]["cadence_key"]) == ["T1", "S1", "L", "7", "2251"]
+        assert manifest[0]["duration_s"] > 0
+
+        # Resume path: a second call must skip reprocessing and report the same hit count,
+        # without duplicating the manifest row
         resumed = preprocessor.process_pending_cadence(PendingCadence(group, npy_path))
         assert resumed is not None
         assert resumed.n_hits == result.n_hits
         assert resumed.npy_path == npy_path
+        assert db.flush(timeout=10) is True
+        manifest = db.query_inference_cadences(tag=config.checkpoint.save_tag, npy_path=npy_path)
+        assert len(manifest) == 1
 
     def test_full_width_stamps_when_disabled(self, tmp_path, initialized_runtime):
         from aetherscan.preprocessing import CadenceGroup  # noqa: PLC0415
@@ -1188,7 +1214,7 @@ class TestEnergyDetectChannelWorker:
         h5_path = make_h5_observation("obs.h5", n_chans=n_chans)
         bandpass_flatten = functools.partial(_spline_flatten_bandpass, spl_order=spl_order)
 
-        hits = _energy_detect_channel_worker(
+        hits, stat_hist = _energy_detect_channel_worker(
             (
                 str(h5_path),
                 channel_index,
@@ -1221,12 +1247,20 @@ class TestEnergyDetectChannelWorker:
             np.testing.assert_allclose(stat_val, expected[idx], rtol=1e-9)
             np.testing.assert_allclose(pval, stats.chi2.sf(stat_val, 2), rtol=1e-9)
 
+        # The summary histogram covers every finite window statistic, not just hits, on the
+        # fixed shared bins — one count per window
+        assert stat_hist.shape == (len(ED_STAT_HIST_EDGES) - 1,)
+        assert stat_hist.sum() == len(statistics)
+        # Hits land in the bins above the threshold
+        hit_bin_counts = stat_hist[np.searchsorted(ED_STAT_HIST_EDGES, stat_threshold) - 1 :]
+        assert hit_bin_counts.sum() >= len(hits)
+
     def test_absolute_indices_offset_by_channel_start(self, make_h5_observation):
         h5_path = make_h5_observation("obs.h5", n_chans=2048)
         coarse_width = 512
         bandpass_flatten = functools.partial(_spline_flatten_bandpass, spl_order=4)
         for channel_index in (0, 3):
-            hits = _energy_detect_channel_worker(
+            hits, _ = _energy_detect_channel_worker(
                 (str(h5_path), channel_index, coarse_width, 16, bandpass_flatten, 64, 32, 0.0)
             )
             starts = [idx for idx, _, _ in hits]
@@ -1235,3 +1269,14 @@ class TestEnergyDetectChannelWorker:
                 channel_index * coarse_width <= s < (channel_index + 1) * coarse_width
                 for s in starts
             )
+
+    def test_no_hits_still_returns_histogram(self, make_h5_observation):
+        """An impossibly high threshold yields no hits but the all-window statistic
+        histogram must still be populated (it feeds the viz suite regardless of hits)."""
+        h5_path = make_h5_observation("obs.h5", n_chans=2048)
+        bandpass_flatten = functools.partial(_spline_flatten_bandpass, spl_order=4)
+        hits, stat_hist = _energy_detect_channel_worker(
+            (str(h5_path), 0, 512, 16, bandpass_flatten, 64, 32, 1e12)
+        )
+        assert hits == []
+        assert stat_hist.sum() > 0


### PR DESCRIPTION
## Summary

Stacked on #120 (`feature/inference-energy-detection-perf`), #122 (`feature/training-retry-overhaul`), and #125 (`feature/pfb-bandpass-equalization`). The PR base `integration/pr08-base` is coordinator scaffolding that merges those three chains; it will be rebased onto `master` as the parents merge — review only the commits unique to this branch.

Implements inference-side stage-aware retries plus the inference visualization suite. Closes #124.

### Retry overhaul

- **`apply_saved_config` save_tag clobber fixed**: the `checkpoint` section of a saved *training* config is now skipped entirely when layering under CLI flags — an inference run can no longer masquerade under the training run's tag (regression test; confirmed live on blpc3: the run logged under its datetime tag despite `--config-path config_test_v17.json`).
- **New `inference_cadences` run manifest** (schema **v2** via the `PRAGMA user_version` mechanism from #122; new tables need no ALTER step — the `CREATE TABLE IF NOT EXISTS` in `_init_database` covers old and new databases, the version stamp records the change): one row per (cadence, stage transition) — `preprocessed` when the stamp `.npy` lands (written by `_process_cadence`, never re-written on resume), a superseding `inferred` row on inference completion carrying the aggregate stats (`n_stamps`, `n_candidates`, JSON confidence-quantile summary from the full P(true) vector, stage `duration_s`), and `failed` when a cadence's inference stage dies. Aggregates in the manifest mean run-level artifacts don't depend on the positives-only `inference_results` table. Writer-queue writes, whitelisted `query_inference_cadences`, `mark_superseded` support (npy_path filter), `(tag, npy_path, status)` index.
- **Stage-aware resume** in the streaming loop: a live `inferred` row for `(tag, npy_path)` skips the cadence entirely (stored aggregates fold into the totals; when nothing is pending the models aren't even loaded); preprocessing artifacts only → straight to inference via the existing `.npy` skip; else preprocess.
- **Supersede-on-retry**: `mark_superseded(inference_results, tag, npy_path=...)` runs before each cadence's fresh rows land, so partial positives from a dead attempt can't mix in; the manifest follows new-row-plus-supersede on completion.
- **Inference-stage failure containment** (mirroring preprocessing's): log → `failed` manifest row → continue; the pass raises at the end so `inference_command`'s retry loop (bounded by `--max-retries`) re-attempts — and the manifest skip means only failed cadences re-run.
- The obsolete cross-attempt `cadence_data` cache on the legacy `--test-files` path is dropped, and `run_inference` computes `predict_proba` once (returning P(true)/predictions/latents as per-cadence transients) instead of a second RF pass.

### Visualization suite (`src/aetherscan/inference_viz.py`)

Nine deliverables, each saved under `plots/inference/{save_tag}/` + Slack upload (train.py's pattern), **all individually exception-guarded** (`_viz_safe`) — a plot bug can never kill a science run. Strictly the OO Figure API, never pyplot (background threads exist; the global registry is not thread-safe).

1. `ed_stat_distributions` — all-window D'Agostino k² histogram (log-log, per-ON-file overlay, threshold line). The vectorized ED workers now also return a fixed log-spaced summary histogram of *every* finite window statistic (a few numpy ops per channel), accumulated per ON file into each cadence's metadata JSON.
2. `ed_hit_spectrum` — hit density vs frequency (MHz), pre- vs post-dedup (raw/merged hit frequency lists added to metadata).
3. `bandpass_flattening` — raw vs flattened integrated spectra with the removed model (scaled PFB response H or spline fit) overlaid; formalizes #125's opt-in debug artifact as a standard per-run figure (reuses the preprocessor's channel-read/flattener helpers so it can't drift from what detection does).
4. `stamp_gallery` — top-K stamps by statistic (`--stamp-gallery-top-k`, default 12) as the 6-obs ON/OFF waterfall grids scientists inspect; overlap-search offset copies collapsed via their shared statistic (median-start representative).
5. `preproc_funnel` — per cadence: raw hits → merged → stamps (+overlap) → snippets inferred, with per-cadence stamp storage annotated.
6. `confidence_distribution` — P(true) histogram over all snippets (log-y, threshold line, per-cadence overlay when ≤ 10 cadences), from fixed-bin histograms folded per cadence (memory stays O(#cadences)).
7. `candidate_gallery` + per-candidate `candidate_{i}_{tag}.png` — implements the long-standing `plot_candidate()` stub: 6-panel cadence waterfall, 48-dim latent bar chart (colored per observation), confidence/frequency/target/session/band/tstart annotations. Sourced from `inference_results` (covers resume-skipped cadences); per-candidate figures capped by `--max-candidate-plots` (default 50).
8. `inference_latent_projection` — this run's cadence-level latent features projected through the **persisted training cadence-level UMAP** (located via the training config JSON's `model_path` + `save_tag` + umap sweep values; skips gracefully with a log when absent), over the UMAP's training embedding as a faint backdrop; candidates starred. Latent pool bounded (20k rows, candidates always kept).
9. `inference_summary` — table card: cadence/snippet/candidate counts, resumed-cadence count, raw/merged hits, stamp storage, per-stage durations + throughput from the manifest, per-target/band candidate counts.

Config: `inference_viz_enabled` (default on) / `stamp_gallery_top_k` / `max_candidate_plots` + `--inference-viz|--no-inference-viz`, `--stamp-gallery-top-k`, `--max-candidate-plots` (validation, `to_dict()`, README CLI Reference regenerated via `PYTHONPATH=src python utils/print_cli_help.py all`).

## Cluster validation — kill/retry + figures (blpc3, subset_test.csv = 2 cadences, dummy test_v17 model, `--max-retries 1`)

**Run 1 (tag `20260711_224251`)**: fresh run; the real cluster DB migrated `version 1 → 2` on open. Cadence 1 (DDO210) preprocessed (790 s, 73,004 stamps) and inferred (102.7 s); cadence 2 (NGC7454) preprocessed (336.6 s, 21,663 stamps). A remote watcher **SIGKILLed the whole process tree 10 s into cadence 2's inference** (trigger: the second "Running inference on" log line).

**Run 2 (identical command, same tag)**:
- `Cadence ('DDO210', ...): already inferred under tag 20260711_224251 (73004 snippets, 0 candidate(s)); skipping` → `Streaming inference over 1 cadence(s) (1 already inferred, resumed from manifest)` — **cadence 1 skipped entirely** (no ED, no load, no encode).
- Cadence 2 skipped ED via its existing `.npy` and went straight to inference (32.0 s), then the full viz suite rendered and the run completed successfully. Retry wall time ~3 m 14 s vs ~21 min for the original pass.

**DB assertions after run 2** (sqlite):
- `inference_cadences` for the tag: exactly **one live `inferred` row per cadence**; both `preprocessed` rows superseded (`preprocessed|1 / inferred|0` × 2).
- **No duplicate live `inference_results` rows**: `GROUP BY npy_path, snippet_index HAVING COUNT(*) > 1` with `superseded = 0` returns nothing.
- Confidence summaries stored on both `inferred` rows, e.g. DDO210: `{"n": 73004, "threshold": 0.99, "n_above_threshold": 0, "mean": 0.0517, "max": 0.915, "quantiles": {"p01": 0.0, ..., "p99": 0.461}}`.

**Figures (run 2)**: 8 of 9 rendered under `plots/inference/20260711_224251/` and uploaded to Slack (`#aetherscan-logs`; zero upload-failure signatures in the log — upload success is silent by design, same as train.py's plots): ed_stat_distributions, ed_hit_spectrum, bandpass_flattening, stamp_gallery, preproc_funnel, confidence_distribution, inference_latent_projection (through the real persisted `umap_cadence_nn5_md0.1_test_v17.joblib`, 20,000 features), inference_summary. The candidate figures correctly logged `Viz: no candidates recorded; skipping candidate plots` — the dummy model's max P(true) is 0.918, below the 0.99 threshold (0 candidates, consistent with #125's runs).

**Run 3 (bonus, fresh tag `20260711_231234`, `--classification-threshold 0.8`, `--preprocess-output-dir` pointing at run 1's directory — the documented reuse escape hatch)**: exercised the candidate path on-cluster. 109 candidates written (26 DDO210 + 83 NGC7454), 109 live `inference_results` rows, and **all nine deliverables rendered** under `plots/inference/20260711_231234/`: the eight run-2 figures plus `candidate_gallery` and exactly 50 per-candidate figures (`Viz: rendered 50 of 109 candidate figures (--max-candidate-plots cap)`), zero Slack upload failures. End-to-end ~6.5 min with ED skipped via the reused directory.

## Local verification

- `PYTHONPATH=src pytest -m "not gpu and not cluster" -q` → **402 passed, 3 skipped (integration), 2 deselected** (arm64 venv, Python 3.12, TF 2.17.1), after rebasing onto the refreshed `integration/pr08-base` (8e42ce5, incl. #125's PFB sidecar-cache memory fix).
- New unit tests: manifest write/query round-trip + status filters + supersede-on-retry flow + npy_path scoping; v0→v2 migration (old DB gains the table; idempotent across reopens); streaming state machine with the GPU pipeline stubbed (fresh-run manifest writes, skip-on-retry without model load, failed-cadence containment + solo re-attempt, stale-positive supersede, artifact-only resume, no-stamps non-retryable); `summarize_confidences` math (quantiles, strict threshold boundary, JSON round-trip); `apply_saved_config` checkpoint-skip regression; ED-worker histogram invariants; viz-flag routing + validation; and smoke tests for every figure (files exist, non-empty) including graceful-skip paths and a suite-entry test that survives fully broken records.
- `ruff check` / `ruff format` / all pre-commit hooks pass; all commits GPG-signed.

## AI disclosure

Implemented end-to-end with Claude Code (model: Claude Fable 5): design-from-spec, implementation, unit tests, cluster kill/retry validation, and this PR description. Human oversight: repo owner reviews/merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
