### PR TITLE
HuggingFace Hub integration: opt-in weight upload after training, default weight download for inference, tag dedup guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ AETHERSCAN_EXTRA_BINDS=/extra/host/paths
 # If none specified, Slack integration is automatically disabled
 SLACK_BOT_TOKEN=your-slack-bot-token
 SLACK_CHANNEL=your-slack-channel
+
+# Only needed for uploading model weights to the HuggingFace Hub (train --hf-upload);
+# downloads (the inference default) hit a public repo and need no token
+HF_TOKEN=your-huggingface-write-token
 ```
 
 > [!TIP]
@@ -137,7 +141,7 @@ export SLACK_CHANNEL="your-slack-channel"
 ./utils/run_container.sh python -m aetherscan.main train ...
 ```
 
-The `AETHERSCAN_*` paths are bind-mounted 1:1 between host and container, so they must already exist on the host before the pipeline starts. The `utils/run_container.sh` wrapper forwards `SLACK_*` and `AETHERSCAN_*` into the container explicitly; if you need additional env vars on the container side, extend the wrapper's `--env` list.
+The `AETHERSCAN_*` paths are bind-mounted 1:1 between host and container, so they must already exist on the host before the pipeline starts. The `utils/run_container.sh` wrapper forwards `SLACK_*`, `AETHERSCAN_*`, and `HF_TOKEN` into the container explicitly; if you need additional env vars on the container side, extend the wrapper's `--env` list.
 
 **5. Run pipeline**
 
@@ -455,8 +459,10 @@ usage: train [-h] [--data-path DATA_PATH] [--model-path MODEL_PATH]
              [--patience-threshold PATIENCE_THRESHOLD]
              [--lr-reduction-factor LR_REDUCTION_FACTOR]
              [--max-retries MAX_RETRIES] [--retry-delay RETRY_DELAY]
+             [--hf-upload | --no-hf-upload] [--hf-repo-id HF_REPO_ID]
              [--load-dir LOAD_DIR] [--load-tag LOAD_TAG]
              [--start-round START_ROUND] [--save-tag SAVE_TAG]
+             [--force-tag | --no-force-tag]
 
 options:
   -h, --help            show this help message and exit
@@ -677,6 +683,15 @@ options:
   --retry-delay RETRY_DELAY
                         Delay in seconds between retry attempts after training
                         failure
+  --hf-upload, --no-hf-upload
+                        Upload the final model artifacts (encoder, decoder,
+                        random forest, config) plus a generated model card to
+                        the HuggingFace Hub after training completes, tagging
+                        the commit with --save-tag (default: disabled = local-
+                        only). Requires HF_TOKEN in the environment (via .env)
+  --hf-repo-id HF_REPO_ID
+                        HuggingFace model repo id (namespace/name) for weight
+                        upload/download (default: zachtheyek/aetherscan)
   --load-dir LOAD_DIR   Subdirectory for checkpoint loading (relative to
                         --model-path)
   --load-tag LOAD_TAG   Model tag for checkpoint loading. Accepted formats:
@@ -689,6 +704,12 @@ options:
   --save-tag SAVE_TAG   Tag for current pipeline run. Accepted formats:
                         final_vX, round_XX, test_vX. Current timestamp used
                         (YYYYMMDD_HHMMSS) if none specified
+  --force-tag, --no-force-tag
+                        Override the fail-early save-tag collision guard:
+                        proceed even when an explicitly-provided --save-tag
+                        matches existing artifacts, DB rows, or (with --hf-
+                        upload) an existing HuggingFace tag (default:
+                        disabled)
 ```
 
 ### Inference Command Help
@@ -726,7 +747,8 @@ usage: inference [-h] [--data-path DATA_PATH] [--model-path MODEL_PATH]
                  [--stamp-gallery-top-k STAMP_GALLERY_TOP_K]
                  [--max-candidate-plots MAX_CANDIDATE_PLOTS]
                  [--max-retries MAX_RETRIES] [--retry-delay RETRY_DELAY]
-                 [--save-tag SAVE_TAG]
+                 [--hf-repo-id HF_REPO_ID] [--hf-revision HF_REVISION]
+                 [--save-tag SAVE_TAG] [--force-tag | --no-force-tag]
 
 options:
   -h, --help            show this help message and exit
@@ -765,11 +787,19 @@ options:
                         provided, triggers the energy detection preprocessing
                         pipeline and takes precedence over --test-files
   --encoder-path ENCODER_PATH
-                        Path to trained VAE encoder model file (.keras)
-  --rf-path RF_PATH     Path to trained Random Forest model file (.joblib)
+                        Path to trained VAE encoder model file (.keras).
+                        Optional: when none of --encoder-path/--rf-
+                        path/--config-path are given, the artifacts are
+                        downloaded from the HuggingFace Hub (see --hf-repo-
+                        id/--hf-revision); provide either all three local
+                        paths or none
+  --rf-path RF_PATH     Path to trained Random Forest model file (.joblib).
+                        Optional: see --encoder-path for the all-three-or-none
+                        rule
   --config-path CONFIG_PATH
                         Path to config file from corresponding training run
-                        (.json)
+                        (.json). Optional: see --encoder-path for the all-
+                        three-or-none rule
   --per-replica-batch-size PER_REPLICA_BATCH_SIZE
                         Batch size per GPU/device replica during inference
   --classification-threshold CLASSIFICATION_THRESHOLD
@@ -868,8 +898,22 @@ options:
                         (including preprocessing) on failure
   --retry-delay RETRY_DELAY
                         Delay in seconds between inference retry attempts
+  --hf-repo-id HF_REPO_ID
+                        HuggingFace model repo id (namespace/name) for weight
+                        upload/download (default: zachtheyek/aetherscan)
+  --hf-revision HF_REVISION
+                        HuggingFace revision (tag, branch, or commit hash) to
+                        pin the model download to when no local artifact paths
+                        are given (default: the repo's latest release tag —
+                        highest semver vX.Y.Z tag, falling back to the highest
+                        final_vX training tag)
   --save-tag SAVE_TAG   Tag for current pipeline run. Current timestamp used
                         (YYYYMMDD_HHMMSS) if none specified
+  --force-tag, --no-force-tag
+                        Override the fail-early save-tag collision guard:
+                        proceed even when an explicitly-provided --save-tag
+                        matches a previous run's saved config or DB rows
+                        (default: disabled)
 ```
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,6 +64,14 @@ If you suspect a token has been compromised, rotate immediately:
 6. Update `SLACK_BOT_TOKEN` in all deployment environments
 7. Verify the new token works: `PYTHONPATH=src python utils/print_cli_help.py train` (should not show Slack errors)
 
+#### HuggingFace Hub Token
+
+1. Go to [HuggingFace access tokens](https://huggingface.co/settings/tokens)
+2. Locate the compromised token and invalidate (refresh) or delete it
+3. Create a replacement token — grant **write** access only if you upload artifacts (`train --hf-upload`); the default inference path downloads from a **public** repo and needs no token at all
+4. Update `HF_TOKEN` in all deployment environments (the gitignored `.env`, or exported in the shell)
+5. Verify the new token works by re-running an upload: `./utils/run_container.sh python -m aetherscan.main train --hf-upload ...` (the upload stage should authenticate without errors)
+
 ---
 
 ## Secrets Management
@@ -72,9 +80,12 @@ If you suspect a token has been compromised, rotate immediately:
 
 Aetherscan uses the following secrets that must be protected:
 
-| Secret          | Environment Variable | Purpose                        |
-| --------------- | -------------------- | ------------------------------ |
-| Slack Bot Token | `SLACK_BOT_TOKEN`    | Slack alerts and notifications |
+| Secret            | Environment Variable | Purpose                                       |
+| ----------------- | -------------------- | --------------------------------------------- |
+| Slack Bot Token   | `SLACK_BOT_TOKEN`    | Slack alerts and notifications                |
+| HuggingFace Token | `HF_TOKEN`           | Upload model artifacts to the HuggingFace Hub |
+
+`HF_TOKEN` is only needed to **upload** trained model artifacts to the HuggingFace Hub (opt-in via `train --hf-upload`); the default inference path downloads from a **public** repo and needs no token, so grant the token **write** scope only when uploading. Like `SLACK_BOT_TOKEN`, it is read from the gitignored `.env` (never committed) and forwarded into the NGC container through `utils/run_container.sh`'s explicit `--env` allowlist — never log it (INFO-level logs may reach Slack).
 
 ### Best Practices
 

--- a/docs/CONFIG_AND_CLI.md
+++ b/docs/CONFIG_AND_CLI.md
@@ -76,7 +76,8 @@ subcommand uses it:
 | `DataConfig`         | Data shape, file lists, chunk sizes                                                                                                |
 | `TrainingConfig`     | Anything specific to the `train` command — sample counts, batch sizes, LR schedule, curriculum, latent-viz, retries                |
 | `InferenceConfig`    | Anything specific to the `inference` command — encoder/RF paths, classification threshold, energy-detection preprocessing, retries |
-| `CheckpointConfig`   | Load/save tags, start round                                                                                                        |
+| `HFConfig`           | HuggingFace Hub integration — target repo id, opt-in post-training upload, inference revision pin                                  |
+| `CheckpointConfig`   | Load/save tags, start round, tag-collision-guard override                                                                          |
 
 Two important consequences:
 
@@ -162,7 +163,9 @@ Current Pattern B flags:
 - `--gpu-memory-limit-mb` → `config.gpu.per_gpu_memory_limit_mb`
 - `--async-allocator` → `config.gpu.use_async_allocator`
 - `--num-replicas` → `config.gpu.num_replicas`
+- `--hf-repo-id` → `config.hf.repo_id`
 - `--save-tag` → `config.checkpoint.save_tag`
+- `--force-tag` → `config.checkpoint.force_tag`
 
 #### Pattern C — shared flag, divergent destination
 
@@ -364,5 +367,5 @@ mode && /^ *"--/{
 
 The second command lists every shared flag (those appearing in both subparsers); each
 should match either a single Pattern B `apply_args` block or a pair of Pattern C blocks
-with a `command` discriminator. As of this writing it yields 10 shared flags —
-7 Pattern B + 3 Pattern C — matching the tables above.
+with a `command` discriminator. As of this writing it yields 12 shared flags —
+9 Pattern B + 3 Pattern C — matching the tables above.

--- a/environment.yml
+++ b/environment.yml
@@ -57,3 +57,6 @@ dependencies:
       - shap>=0.46.0,<0.47
       - slack-sdk>=3.31.0,<4
       - python-dotenv>=1.0,<2
+      # Model weight distribution via the HuggingFace Hub — pin range mirrors
+      # requirements-container.txt (see the rationale there).
+      - huggingface_hub>=1.21,<1.22

--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -20,6 +20,10 @@ umap-learn>=0.5.6,<0.6
 shap>=0.46.0,<0.47
 slack-sdk>=3.31.0,<4
 python-dotenv>=1.0,<2
+# Model weight distribution via the HuggingFace Hub (upload after training, download for
+# inference). 1.21 per SECURITY.md's version policy: two minors below the latest stable
+# (1.23) at pin time, newer than the newest >=6-month-old release.
+huggingface_hub>=1.21,<1.22
 # setuptools provides pkg_resources, which blimpy (transitive via setigen)
 # imports at module load. Recent pip / Python releases dropped setuptools
 # from the bootstrap, so we install it explicitly. Upper-bound at <81 because

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -37,6 +37,9 @@ _CURRICULUM_SCHEDULES = {"linear", "exponential", "step"}
 # Allowed values for bandpass_method (energy-detection bandpass flattening)
 _BANDPASS_METHODS = {"pfb", "spline"}
 
+# HuggingFace Hub repo ids are "namespace/name" (user or org namespace)
+_HF_REPO_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9._-]+$")
+
 
 @dataclass
 class ValidationError:
@@ -608,6 +611,20 @@ def _add_train_flags_to(parser):
         help="Delay in seconds between retry attempts after training failure",
     )
 
+    # HuggingFace Hub configuration
+    parser.add_argument(
+        "--hf-upload",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Upload the final model artifacts (encoder, decoder, random forest, config) plus a generated model card to the HuggingFace Hub after training completes, tagging the commit with --save-tag (default: disabled = local-only). Requires HF_TOKEN in the environment (via .env)",
+    )
+    parser.add_argument(
+        "--hf-repo-id",
+        type=str,
+        default=None,
+        help="HuggingFace model repo id (namespace/name) for weight upload/download (default: zachtheyek/aetherscan)",
+    )
+
     # Checkpoint configuration
     parser.add_argument(
         "--load-dir",
@@ -632,6 +649,12 @@ def _add_train_flags_to(parser):
         type=str,
         default=None,
         help="Tag for current pipeline run. Accepted formats: final_vX, round_XX, test_vX. Current timestamp used (YYYYMMDD_HHMMSS) if none specified",
+    )
+    parser.add_argument(
+        "--force-tag",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Override the fail-early save-tag collision guard: proceed even when an explicitly-provided --save-tag matches existing artifacts, DB rows, or (with --hf-upload) an existing HuggingFace tag (default: disabled)",
     )
 
 
@@ -710,19 +733,19 @@ def _add_inference_flags_to(parser):
         "--encoder-path",
         type=str,
         default=None,
-        help="Path to trained VAE encoder model file (.keras)",
+        help="Path to trained VAE encoder model file (.keras). Optional: when none of --encoder-path/--rf-path/--config-path are given, the artifacts are downloaded from the HuggingFace Hub (see --hf-repo-id/--hf-revision); provide either all three local paths or none",
     )
     parser.add_argument(
         "--rf-path",
         type=str,
         default=None,
-        help="Path to trained Random Forest model file (.joblib)",
+        help="Path to trained Random Forest model file (.joblib). Optional: see --encoder-path for the all-three-or-none rule",
     )
     parser.add_argument(
         "--config-path",
         type=str,
         default=None,
-        help="Path to config file from corresponding training run (.json)",
+        help="Path to config file from corresponding training run (.json). Optional: see --encoder-path for the all-three-or-none rule",
     )
     parser.add_argument(
         "--per-replica-batch-size",
@@ -874,12 +897,32 @@ def _add_inference_flags_to(parser):
         help="Delay in seconds between inference retry attempts",
     )
 
+    # HuggingFace Hub configuration
+    parser.add_argument(
+        "--hf-repo-id",
+        type=str,
+        default=None,
+        help="HuggingFace model repo id (namespace/name) for weight upload/download (default: zachtheyek/aetherscan)",
+    )
+    parser.add_argument(
+        "--hf-revision",
+        type=str,
+        default=None,
+        help="HuggingFace revision (tag, branch, or commit hash) to pin the model download to when no local artifact paths are given (default: the repo's latest release tag — highest semver vX.Y.Z tag, falling back to the highest final_vX training tag)",
+    )
+
     # Checkpoint configuration
     parser.add_argument(
         "--save-tag",
         type=str,
         default=None,
         help="Tag for current pipeline run. Current timestamp used (YYYYMMDD_HHMMSS) if none specified",
+    )
+    parser.add_argument(
+        "--force-tag",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Override the fail-early save-tag collision guard: proceed even when an explicitly-provided --save-tag matches a previous run's saved config or DB rows (default: disabled)",
     )
 
 
@@ -1139,6 +1182,18 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
     ):
         config.training.retry_delay = args.retry_delay
 
+    # HuggingFace Hub configuration
+    # hf_upload uses argparse.BooleanOptionalAction with default=None so that the CLI can
+    # express "leave the config default" (omit), "force on" (--hf-upload), and "force off"
+    # (--no-hf-upload). The `is not None` guard preserves the config default when the user
+    # passes neither
+    if hasattr(args, "hf_upload") and args.hf_upload is not None:
+        config.hf.upload_after_training = args.hf_upload
+    if hasattr(args, "hf_repo_id") and args.hf_repo_id is not None:
+        config.hf.repo_id = args.hf_repo_id
+    if hasattr(args, "hf_revision") and args.hf_revision is not None:
+        config.hf.revision = args.hf_revision
+
     # Checkpoint configuration
     if hasattr(args, "load_dir") and args.load_dir is not None:
         config.checkpoint.load_dir = args.load_dir
@@ -1149,6 +1204,10 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
         config.checkpoint.start_round = args.start_round  # Override start_round if provided
     if hasattr(args, "save_tag") and args.save_tag is not None:
         config.checkpoint.save_tag = args.save_tag
+    # force_tag uses argparse.BooleanOptionalAction with default=None (same tri-state as
+    # hf_upload above)
+    if hasattr(args, "force_tag") and args.force_tag is not None:
+        config.checkpoint.force_tag = args.force_tag
 
     # Inference configuration
     if hasattr(args, "encoder_path") and args.encoder_path is not None:
@@ -1265,6 +1324,21 @@ def collect_validation_errors(
     # config.py. Within each section, fields appear in the same order they are
     # registered on the parser. Cross-parameter checks live in the section of the
     # primary constrained field.
+
+    # ============================================================================
+    # COMMON CHECKS — flags shared by both subcommands
+    # ============================================================================
+    # --hf-repo-id must look like an HF "namespace/name" repo id (shared Pattern B flag).
+    hf_repo_id = _resolve(args, "hf_repo_id", config.hf.repo_id)
+    if hf_repo_id is not None and not _HF_REPO_ID_PATTERN.match(hf_repo_id):
+        errors.append(
+            ValidationError(
+                field="hf.repo_id",
+                current=hf_repo_id,
+                message=f"--hf-repo-id must be a HuggingFace repo id of the form namespace/name, got {hf_repo_id!r}",
+                fix_kind="format",
+            )
+        )
 
     # ============================================================================
     # TRAINING-MODE CHECKS — match _add_train_flags_to layout
@@ -1870,27 +1944,35 @@ def collect_validation_errors(
     # INFERENCE-MODE CHECKS — match _add_inference_flags_to layout
     # ============================================================================
     if cmd == "inference":
-        # ----------------------------------------------------- Required inference artifacts
-        # Encoder, RF, and config paths are mandatory for any inference run. Checked
-        # here (rather than in inference_command at runtime) so failures surface during
-        # validate_args and the structured ValidationErrors flow into the helpful-fix
-        # proposer.
-        for arg_name, cfg_attr, flag in (
+        # ----------------------------------------------------- Inference model artifacts
+        # The encoder/RF/config artifact trio is all-or-none: with all three paths given
+        # they must each exist on disk; with none given, main.py's
+        # resolve_inference_artifacts() has already filled `args` with HuggingFace-
+        # downloaded cache paths before validation runs (utility scripts that skip that
+        # step simply defer to the Hub default). A partial trio is an error — mixing local
+        # and Hub-sourced artifacts would silently pair mismatched models.
+        artifact_specs = (
             ("encoder_path", "encoder_path", "--encoder-path"),
             ("rf_path", "rf_path", "--rf-path"),
             ("config_path", "config_path", "--config-path"),
-        ):
-            path = _resolve(args, arg_name, getattr(config.inference, cfg_attr))
-            if path is None:
+        )
+        artifact_paths = {
+            arg_name: _resolve(args, arg_name, getattr(config.inference, cfg_attr))
+            for arg_name, cfg_attr, _flag in artifact_specs
+        }
+        n_provided = sum(path is not None for path in artifact_paths.values())
+        for arg_name, cfg_attr, flag in artifact_specs:
+            path = artifact_paths[arg_name]
+            if path is None and 0 < n_provided < len(artifact_specs):
                 errors.append(
                     ValidationError(
                         field=f"inference.{cfg_attr}",
                         current=None,
-                        message=f"{flag} is required for inference; pass it on the CLI or set inference.{cfg_attr} in the saved config",
+                        message=f"{flag} is missing: provide all three of --encoder-path/--rf-path/--config-path, or omit all three to download the artifacts from the HuggingFace Hub",
                         fix_kind="file_exists",
                     )
                 )
-            elif not os.path.exists(path):
+            elif path is not None and not os.path.exists(path):
                 errors.append(
                     ValidationError(
                         field=f"inference.{cfg_attr}",

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -371,6 +371,20 @@ class InferenceConfig:
 
 
 @dataclass
+class HFConfig:
+    """HuggingFace Hub integration configuration"""
+
+    # Target model repo for weight upload (train) and download (inference).
+    repo_id: str = "zachtheyek/aetherscan"
+    # Opt-in: publish the final artifacts + a generated model card after training completes
+    # (requires HF_TOKEN in the environment; default off = local-only).
+    upload_after_training: bool = False
+    # Inference pin: HF revision (tag/branch/commit) to download artifacts from. None
+    # resolves to the latest release tag (highest semver vX.Y.Z, else highest final_vX).
+    revision: str | None = None
+
+
+@dataclass
 class CheckpointConfig:
     """Checkpoint configuration"""
 
@@ -378,6 +392,9 @@ class CheckpointConfig:
     load_tag: str | None = None
     start_round: int = 1
     save_tag: str = datetime.now().strftime("%Y%m%d_%H%M%S")
+    # Override the fail-early save-tag dedup guards (local artifact/DB collisions and the
+    # HF-side tag check) for an explicitly-provided save_tag.
+    force_tag: bool = False
 
     def infer_start_round(self):
         """Infer start_round from load_tag"""
@@ -434,6 +451,7 @@ class Config:
         self.data = DataConfig()
         self.training = TrainingConfig()
         self.inference = InferenceConfig()
+        self.hf = HFConfig()
         self.checkpoint = CheckpointConfig()
 
         # Paths
@@ -648,11 +666,17 @@ class Config:
                 "max_retries": self.inference.max_retries,
                 "retry_delay": self.inference.retry_delay,
             },
+            "hf": {
+                "repo_id": self.hf.repo_id,
+                "upload_after_training": self.hf.upload_after_training,
+                "revision": self.hf.revision,
+            },
             "checkpoint": {
                 "load_dir": self.checkpoint.load_dir,
                 "load_tag": self.checkpoint.load_tag,
                 "start_round": self.checkpoint.start_round,
                 "save_tag": self.checkpoint.save_tag,
+                "force_tag": self.checkpoint.force_tag,
             },
         }
 

--- a/src/aetherscan/hf_hub.py
+++ b/src/aetherscan/hf_hub.py
@@ -1,0 +1,396 @@
+"""
+HuggingFace Hub integration for Aetherscan model artifacts.
+
+One public model repo (config.hf.repo_id, default zachtheyek/aetherscan) carries the released
+weights at stable filenames in the repo root — vae_encoder.keras, vae_decoder.keras,
+random_forest.joblib, config.json, plus an auto-generated model card README.md — with HF git
+tags carrying the versioning. Two tag families exist on the Hub: training tags (= a run's
+save_tag, e.g. final_v3, created by upload_run_to_hf after training) and release tags
+(vX.Y.Z, added by the release runbook pointing at the blessed weights commit).
+
+Upload (train, opt-in via --hf-upload) stages the four run artifacts under the stable names,
+commits them with the save_tag as the commit message, and tags the commit. Download
+(inference, the default when no local artifact paths are given) resolves a revision —
+explicit --hf-revision, else the highest semver vX.Y.Z tag, else the highest final_vX tag —
+and pulls the artifact trio revision-pinned via hf_hub_download.
+
+Auth: uploads require HF_TOKEN in the environment (loaded from the gitignored .env);
+huggingface_hub reads it implicitly. The repo is public, so downloads need no token. The
+token value is never logged.
+
+huggingface_hub is imported lazily inside the thin _hf_api()/_hf_hub_download() seams so this
+module stays importable (and unit-testable with those seams monkeypatched) without the
+dependency installed — e.g. in the pre-rebuild NGC container, where only actual Hub calls
+should fail.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import logging
+import os
+import platform
+import re
+import shutil
+import tempfile
+from typing import Any
+
+from aetherscan.config import get_config
+
+logger = logging.getLogger(__name__)
+
+# Stable artifact filenames at the HF repo root (versioning lives in git tags, not names).
+HF_ENCODER_FILENAME = "vae_encoder.keras"
+HF_DECODER_FILENAME = "vae_decoder.keras"
+HF_RF_FILENAME = "random_forest.joblib"
+HF_CONFIG_FILENAME = "config.json"
+HF_CARD_FILENAME = "README.md"
+
+GITHUB_URL = "https://github.com/zachtheyek/Aetherscan"
+
+# Release tags (vX.Y.Z, from the release runbook) outrank training tags (final_vX) when
+# resolving the default download revision.
+_SEMVER_TAG_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
+_FINAL_TAG_PATTERN = re.compile(r"^final_v(\d+)$")
+
+
+def _hf_api():
+    """Construct an HfApi client (lazy import — see module docstring). HF_TOKEN is picked up
+    from the environment implicitly for authenticated calls."""
+    from huggingface_hub import HfApi  # noqa: PLC0415
+
+    return HfApi()
+
+
+def _hf_hub_download(**kwargs) -> str:
+    """Thin seam over huggingface_hub.hf_hub_download (lazy import — see module docstring)."""
+    from huggingface_hub import hf_hub_download  # noqa: PLC0415
+
+    return hf_hub_download(**kwargs)
+
+
+def list_hf_tags(repo_id: str) -> list[str]:
+    """Return the names of every git tag on the HF model repo; [] when the repo doesn't exist
+    yet (first upload creates it). Network/auth errors propagate to the caller."""
+    from huggingface_hub.errors import RepositoryNotFoundError  # noqa: PLC0415
+
+    try:
+        refs = _hf_api().list_repo_refs(repo_id, repo_type="model")
+    except RepositoryNotFoundError:
+        return []
+    return [ref.name for ref in refs.tags]
+
+
+def hf_tag_exists(repo_id: str, tag: str) -> bool:
+    """True when `tag` already exists on the HF repo (used by the fail-early dedup guard)."""
+    return tag in list_hf_tags(repo_id)
+
+
+def select_default_revision(tags: list[str]) -> str | None:
+    """
+    Pick the default download revision from a repo's tag list: the highest semver vX.Y.Z
+    release tag; if none exist, the highest final_vX training tag; else None. Comparison is
+    numeric (v1.10.0 > v1.9.9), and tags in neither family (test_vX, timestamps) never win.
+    """
+    semver = [
+        (tuple(int(g) for g in m.groups()), t) for t in tags if (m := _SEMVER_TAG_PATTERN.match(t))
+    ]
+    if semver:
+        return max(semver)[1]
+    final = [(int(m.group(1)), t) for t in tags if (m := _FINAL_TAG_PATTERN.match(t))]
+    if final:
+        return max(final)[1]
+    return None
+
+
+def resolve_hf_revision(repo_id: str, revision: str | None) -> str:
+    """
+    Resolve the HF revision inference should download from: an explicitly requested revision
+    is returned as-is (existence is checked by the download itself), otherwise the repo's
+    tags are listed and select_default_revision picks the latest release. Raises RuntimeError
+    with guidance when nothing is resolvable.
+    """
+    if revision is not None:
+        return revision
+    tags = list_hf_tags(repo_id)
+    selected = select_default_revision(tags)
+    if selected is None:
+        raise RuntimeError(
+            f"No release tag (vX.Y.Z) or training tag (final_vX) found on HF repo "
+            f"'{repo_id}' to download model artifacts from. Either pin a revision with "
+            f"--hf-revision, point --hf-repo-id at a repo with released weights, or pass "
+            f"all three local artifact paths (--encoder-path/--rf-path/--config-path)."
+        )
+    logger.info(f"Resolved HF revision '{selected}' (latest release tag on {repo_id})")
+    return selected
+
+
+def download_inference_artifacts(repo_id: str, revision: str) -> tuple[str, str, str]:
+    """
+    Download the (encoder, random forest, config) artifact trio from the HF repo at the
+    pinned revision. Returns the local cache paths (under HF_HOME / ~/.cache/huggingface;
+    repeated runs hit the cache). Public repo — no token required.
+    """
+    paths = tuple(
+        _hf_hub_download(repo_id=repo_id, filename=filename, revision=revision)
+        for filename in (HF_ENCODER_FILENAME, HF_RF_FILENAME, HF_CONFIG_FILENAME)
+    )
+    logger.info(f"Downloaded model artifacts from {repo_id}@{revision}")
+    return paths
+
+
+def resolve_inference_artifacts(args: argparse.Namespace) -> None:
+    """
+    Ensure the inference artifact trio (encoder/rf/config paths) is populated on `args`
+    before validation runs, in resolution order: explicit local paths (highest) >
+    --hf-revision > latest release tag on the HF repo.
+
+    When none of the three paths were given, the resolved revision's artifacts are
+    downloaded and their cache paths written onto `args` — exactly as if the user had passed
+    them on the CLI, so the existing validate_args / apply_saved_config / model-load path is
+    reused unchanged. The resolved revision is also written to args.hf_revision so it lands
+    in config.hf.revision (and thus the saved inference config) for provenance.
+
+    A partial set of local paths is left untouched: collect_validation_errors reports the
+    missing ones (mixing local and Hub-sourced artifacts would silently pair mismatched
+    models). Raises RuntimeError (via resolve_hf_revision) or huggingface_hub errors when HF
+    resolution fails — the caller exits with the message as guidance.
+    """
+    provided = [
+        getattr(args, name, None) is not None for name in ("encoder_path", "rf_path", "config_path")
+    ]
+    if all(provided):
+        if getattr(args, "hf_revision", None) is not None:
+            logger.info("Explicit local artifact paths take precedence — ignoring --hf-revision")
+        return
+    if any(provided):
+        # Partial trio: leave args as-is; validation reports the missing paths.
+        return
+
+    config = get_config()
+    repo_id = getattr(args, "hf_repo_id", None) or config.hf.repo_id
+    revision = resolve_hf_revision(repo_id, getattr(args, "hf_revision", None))
+    logger.info(
+        f"No local artifact paths given — downloading model artifacts from HF repo "
+        f"'{repo_id}' at revision '{revision}'"
+    )
+    args.encoder_path, args.rf_path, args.config_path = download_inference_artifacts(
+        repo_id, revision
+    )
+    args.hf_revision = revision
+
+
+def _collect_library_versions() -> dict[str, str]:
+    """Best-effort version stamps for the model card; import failures record 'unknown'."""
+    versions: dict[str, str] = {"python": platform.python_version()}
+    for card_name, module_name in (
+        ("tensorflow", "tensorflow"),
+        ("numpy", "numpy"),
+        ("scikit-learn", "sklearn"),
+        ("huggingface_hub", "huggingface_hub"),
+    ):
+        try:
+            module = __import__(module_name)
+            versions[card_name] = str(module.__version__)
+        except Exception:
+            versions[card_name] = "unknown"
+    return versions
+
+
+def compute_rf_metrics(model_path: str, tag: str) -> dict[str, Any] | None:
+    """
+    Derive validation metrics for the model card from the run's persisted RF eval artifacts
+    (rf_eval_artifacts_{tag}.joblib, written by train_random_forest). Returns None when the
+    artifact is missing or unreadable — the card simply omits its metrics section.
+    """
+    artifact_path = os.path.join(model_path, f"rf_eval_artifacts_{tag}.joblib")
+    if not os.path.exists(artifact_path):
+        logger.info(f"No RF eval artifacts at {artifact_path} — model card omits metrics")
+        return None
+    try:
+        import joblib  # noqa: PLC0415
+        from sklearn.metrics import average_precision_score, roc_auc_score  # noqa: PLC0415
+
+        artifacts = joblib.load(artifact_path)
+        labels = artifacts["val_binary_labels"]
+        probas = artifacts["val_probas"]
+        return {
+            "val_roc_auc": float(roc_auc_score(labels, probas)),
+            "val_average_precision": float(average_precision_score(labels, probas)),
+            "classification_threshold": float(artifacts["classification_threshold"]),
+            "n_val": int(len(labels)),
+        }
+    except Exception as e:
+        logger.warning(f"Failed to compute RF metrics from {artifact_path}: {e}")
+        return None
+
+
+def generate_model_card(
+    *,
+    tag: str,
+    repo_id: str,
+    config_dict: dict[str, Any],
+    metrics: dict[str, Any] | None,
+    versions: dict[str, str],
+) -> str:
+    """
+    Render the repo card (README.md) uploaded alongside the weights: pipeline description,
+    training tag, config summary (rounds / samples / SNR schedule), validation metrics when
+    available, library versions, and the GitHub link + citation pointer.
+    """
+    training = config_dict.get("training", {})
+    beta_vae = config_dict.get("beta_vae", {})
+    rf = config_dict.get("rf", {})
+
+    def row(name: str, section: dict[str, Any], key: str) -> str:
+        return f"| {name} | `{section.get(key, 'n/a')}` |"
+
+    config_rows = "\n".join(
+        [
+            row("Training rounds", training, "num_training_rounds"),
+            row("Epochs per round", training, "epochs_per_round"),
+            row("Beta-VAE samples per round", training, "num_samples_beta_vae"),
+            row("Random Forest samples", training, "num_samples_rf"),
+            row("Curriculum schedule", training, "curriculum_schedule"),
+            row("SNR base", training, "snr_base"),
+            row("Initial SNR range", training, "initial_snr_range"),
+            row("Final SNR range", training, "final_snr_range"),
+            row("Latent dimensions", beta_vae, "latent_dim"),
+            row("Beta (KL weight)", beta_vae, "beta"),
+            row("Alpha (clustering weight)", beta_vae, "alpha"),
+            row("RF estimators", rf, "n_estimators"),
+        ]
+    )
+
+    if metrics is not None:
+        metrics_section = (
+            "## Evaluation (validation split)\n\n"
+            "| Metric | Value |\n|---|---|\n"
+            f"| ROC AUC | {metrics['val_roc_auc']:.4f} |\n"
+            f"| Average precision | {metrics['val_average_precision']:.4f} |\n"
+            f"| Classification threshold | {metrics['classification_threshold']} |\n"
+            f"| Validation samples | {metrics['n_val']} |\n"
+        )
+    else:
+        metrics_section = "## Evaluation\n\nNo evaluation artifacts were available for this run.\n"
+
+    versions_rows = "\n".join(f"| {name} | `{ver}` |" for name, ver in versions.items())
+
+    return f"""---
+license: bsd-3-clause
+library_name: keras
+tags:
+- seti
+- radio-astronomy
+- anomaly-detection
+- beta-vae
+- random-forest
+---
+
+# Aetherscan
+
+[Breakthrough Listen](https://breakthroughinitiatives.org/initiative/1)'s deep-learning SETI
+pipeline: a two-stage architecture where a **Beta-VAE encoder** compresses each observation of
+a 6-observation cadence (3 ON / 3 OFF, ABACAD) into an 8-dimensional latent, and a **Random
+Forest** classifies the cadence's concatenated latents as a technosignature candidate or not.
+
+This repository carries the released model weights at stable filenames, versioned via git
+tags: training tags match the pipeline run's save tag (e.g. `final_v3`), and release tags
+(`vX.Y.Z`) mark blessed weights.
+
+**Training tag**: `{tag}`
+
+## Files
+
+| File | Description |
+|---|---|
+| `{HF_ENCODER_FILENAME}` | Beta-VAE encoder (Keras) — the inference feature extractor |
+| `{HF_DECODER_FILENAME}` | Beta-VAE decoder (Keras) — for reconstruction/traversal analysis |
+| `{HF_RF_FILENAME}` | Random Forest cadence classifier (joblib) |
+| `{HF_CONFIG_FILENAME}` | Full resolved training configuration for this run |
+
+## Training configuration
+
+| Parameter | Value |
+|---|---|
+{config_rows}
+
+The complete configuration is in `{HF_CONFIG_FILENAME}`.
+
+{metrics_section}
+## Library versions
+
+| Library | Version |
+|---|---|
+{versions_rows}
+
+## Usage
+
+Aetherscan inference downloads these weights by default when no local artifact paths are
+given (pin a version with `--hf-revision`):
+
+```bash
+python -m aetherscan.main inference --hf-revision {tag} --inference-files <catalog.csv>
+```
+
+## Links & citation
+
+Source code, documentation, and issue tracker: [{GITHUB_URL}]({GITHUB_URL}).
+If you use Aetherscan in your research, please cite it via the repository's `CITATION.cff`.
+"""
+
+
+def upload_run_to_hf(
+    *, repo_id: str, tag: str, model_path: str, output_path: str, force: bool = False
+) -> None:
+    """
+    Publish one training run's final artifacts to the HF model repo: stage the four artifacts
+    under their stable names plus a generated model card, commit them (commit message = the
+    run's save_tag), and tag the commit with the save_tag. Creates the (public) repo when it
+    doesn't exist yet. With force=True a pre-existing identical tag is moved to the new
+    commit (the startup dedup guard was consciously overridden via --force-tag).
+
+    Raises on any failure — the caller (the hf_upload training stage) records it in the run
+    manifest without failing the run.
+    """
+    sources = {
+        HF_ENCODER_FILENAME: os.path.join(model_path, f"vae_encoder_{tag}.keras"),
+        HF_DECODER_FILENAME: os.path.join(model_path, f"vae_decoder_{tag}.keras"),
+        HF_RF_FILENAME: os.path.join(model_path, f"random_forest_{tag}.joblib"),
+        HF_CONFIG_FILENAME: os.path.join(output_path, f"config_{tag}.json"),
+    }
+    missing = [path for path in sources.values() if not os.path.exists(path)]
+    if missing:
+        raise FileNotFoundError(
+            f"Cannot upload run '{tag}' to HF: missing artifact(s): {', '.join(missing)}"
+        )
+
+    with open(sources[HF_CONFIG_FILENAME]) as f:
+        config_dict = json.load(f)
+    card = generate_model_card(
+        tag=tag,
+        repo_id=repo_id,
+        config_dict=config_dict,
+        metrics=compute_rf_metrics(model_path, tag),
+        versions=_collect_library_versions(),
+    )
+
+    api = _hf_api()
+    with tempfile.TemporaryDirectory(prefix="aetherscan_hf_upload_") as staging:
+        for stable_name, source in sources.items():
+            shutil.copy2(source, os.path.join(staging, stable_name))
+        with open(os.path.join(staging, HF_CARD_FILENAME), "w") as f:
+            f.write(card)
+
+        api.create_repo(repo_id, repo_type="model", private=False, exist_ok=True)
+        api.upload_folder(repo_id=repo_id, folder_path=staging, commit_message=tag)
+
+    if force:
+        # --force-tag semantics: repoint the existing tag at the fresh commit rather than
+        # failing (delete errors are ignored — the tag may simply not exist yet).
+        with contextlib.suppress(Exception):
+            api.delete_tag(repo_id, tag=tag)
+    api.create_tag(repo_id, tag=tag)
+    logger.info(f"Uploaded run '{tag}' to https://huggingface.co/{repo_id} and tagged the commit")

--- a/src/aetherscan/hf_hub.py
+++ b/src/aetherscan/hf_hub.py
@@ -71,6 +71,17 @@ def _hf_hub_download(**kwargs) -> str:
     return hf_hub_download(**kwargs)
 
 
+def _is_tag_conflict(exc: Exception) -> bool:
+    """True when `exc` is the Hub's tag-already-exists HTTP 409 conflict."""
+    try:
+        from huggingface_hub.errors import HfHubHTTPError  # noqa: PLC0415
+    except Exception:
+        return False
+    if not isinstance(exc, HfHubHTTPError):
+        return False
+    return getattr(getattr(exc, "response", None), "status_code", None) == 409
+
+
 def list_hf_tags(repo_id: str) -> list[str]:
     """Return the names of every git tag on the HF model repo; [] when the repo doesn't exist
     yet (first upload creates it). Network/auth errors propagate to the caller."""
@@ -114,7 +125,15 @@ def resolve_hf_revision(repo_id: str, revision: str | None) -> str:
     """
     if revision is not None:
         return revision
-    tags = list_hf_tags(repo_id)
+    try:
+        tags = list_hf_tags(repo_id)
+    except Exception as e:
+        raise RuntimeError(
+            f"Could not list tags on HF repo '{repo_id}' to resolve the latest release: {e}. "
+            f"Check that --hf-repo-id is correct, the repo is public (or HF_TOKEN grants "
+            f"access), and this host can reach huggingface.co — or pin a revision with "
+            f"--hf-revision / pass all three local artifact paths."
+        ) from e
     selected = select_default_revision(tags)
     if selected is None:
         raise RuntimeError(
@@ -133,10 +152,20 @@ def download_inference_artifacts(repo_id: str, revision: str) -> tuple[str, str,
     pinned revision. Returns the local cache paths (under HF_HOME / ~/.cache/huggingface;
     repeated runs hit the cache). Public repo — no token required.
     """
-    paths = tuple(
-        _hf_hub_download(repo_id=repo_id, filename=filename, revision=revision)
-        for filename in (HF_ENCODER_FILENAME, HF_RF_FILENAME, HF_CONFIG_FILENAME)
-    )
+    try:
+        paths = tuple(
+            _hf_hub_download(repo_id=repo_id, filename=filename, revision=revision)
+            for filename in (HF_ENCODER_FILENAME, HF_RF_FILENAME, HF_CONFIG_FILENAME)
+        )
+    except Exception as e:
+        # Wrap raw huggingface_hub errors (404s, network failures, auth) with operator
+        # guidance — this surfaces via main.py's resolution path at startup.
+        raise RuntimeError(
+            f"Failed to download model artifacts from {repo_id}@{revision}: {e}. Check "
+            f"that the revision exists (--hf-revision), the repo id is correct "
+            f"(--hf-repo-id), the repo is public (or HF_TOKEN grants access), and this "
+            f"host can reach huggingface.co."
+        ) from e
     logger.info(f"Downloaded model artifacts from {repo_id}@{revision}")
     return paths
 
@@ -390,7 +419,24 @@ def upload_run_to_hf(
     if force:
         # --force-tag semantics: repoint the existing tag at the fresh commit rather than
         # failing (delete errors are ignored — the tag may simply not exist yet).
+        # NOTE: delete_tag -> create_tag is not atomic (the Hub has no tag-move primitive):
+        # a crash between the two calls leaves the tag missing until the stage is retried —
+        # hf_upload stays un-done in the run manifest, so re-running the identical command
+        # recreates it. Acceptable for a consciously-forced override.
         with contextlib.suppress(Exception):
             api.delete_tag(repo_id, tag=tag)
-    api.create_tag(repo_id, tag=tag)
+    try:
+        api.create_tag(repo_id, tag=tag)
+    except Exception as e:
+        if _is_tag_conflict(e):
+            # TOCTOU: the startup dedup guard checked this tag hours ago (a full-scale run
+            # trains for ~30 h) — a concurrent run may have created it since. The artifacts
+            # are safely uploaded on the main branch; only the tag is missing.
+            raise RuntimeError(
+                f"Tag '{tag}' already exists on {repo_id} (created after this run's "
+                f"startup check, e.g. by a concurrent run). The artifacts were uploaded "
+                f"but left untagged — re-run the identical command with --force-tag to "
+                f"move the tag to this run's upload."
+            ) from e
+        raise
     logger.info(f"Uploaded run '{tag}' to https://huggingface.co/{repo_id} and tagged the commit")

--- a/src/aetherscan/hf_hub.py
+++ b/src/aetherscan/hf_hub.py
@@ -71,6 +71,19 @@ def _hf_hub_download(**kwargs) -> str:
     return hf_hub_download(**kwargs)
 
 
+def _disable_hub_progress_bars() -> None:
+    """Disable huggingface_hub's tqdm progress bars for this process. The pipeline redirects
+    sys.stdout/sys.stderr to loggers (StreamToLogger), so interactive progress rendering is
+    line-spam at best — and tty/capability probing by the progress machinery must never be a
+    failure surface for uploads/downloads (hf_upload once died on a stdout isatty() probe).
+    Tolerant of a missing huggingface_hub: the subsequent Hub call raises its own error."""
+    try:
+        from huggingface_hub.utils import disable_progress_bars  # noqa: PLC0415
+    except Exception:
+        return
+    disable_progress_bars()
+
+
 def _is_tag_conflict(exc: Exception) -> bool:
     """True when `exc` is the Hub's tag-already-exists HTTP 409 conflict."""
     try:
@@ -152,6 +165,7 @@ def download_inference_artifacts(repo_id: str, revision: str) -> tuple[str, str,
     pinned revision. Returns the local cache paths (under HF_HOME / ~/.cache/huggingface;
     repeated runs hit the cache). Public repo — no token required.
     """
+    _disable_hub_progress_bars()
     try:
         paths = tuple(
             _hf_hub_download(repo_id=repo_id, filename=filename, revision=revision)
@@ -406,6 +420,7 @@ def upload_run_to_hf(
         versions=_collect_library_versions(),
     )
 
+    _disable_hub_progress_bars()
     api = _hf_api()
     with tempfile.TemporaryDirectory(prefix="aetherscan_hf_upload_") as staging:
         for stable_name, source in sources.items():

--- a/src/aetherscan/hf_hub.py
+++ b/src/aetherscan/hf_hub.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import copy
 import json
 import logging
 import os
@@ -385,6 +386,33 @@ If you use Aetherscan in your research, please cite it via the repository's `CIT
 """
 
 
+# Environment-specific config fields stripped before config.json is published to the PUBLIC Hub
+# repo (HFSEC-1): whole sections that are pure host layout, and per-field absolute paths / real
+# observation filenames. None are reproducible off-host, and they would otherwise disclose the
+# operator's username, directory layout, and dataset file names on huggingface.co.
+_UPLOAD_REDACT_SECTIONS = ("paths",)
+_UPLOAD_REDACT_FIELDS = {
+    "data": ("train_files", "test_files", "inference_files"),
+    "inference": ("encoder_path", "rf_path", "config_path", "preprocess_output_dir"),
+    "checkpoint": ("load_dir",),
+}
+
+
+def _sanitize_config_for_upload(config_dict: dict) -> dict:
+    """Return a copy of the run config with host-specific fields (absolute paths, real dataset
+    filenames) stripped, so the config.json published to the public Hub repo carries only
+    reproducibility-relevant hyperparameters. See HFSEC-1."""
+    sanitized = copy.deepcopy(config_dict)
+    for section in _UPLOAD_REDACT_SECTIONS:
+        sanitized.pop(section, None)
+    for section, fields in _UPLOAD_REDACT_FIELDS.items():
+        block = sanitized.get(section)
+        if isinstance(block, dict):
+            for field in fields:
+                block.pop(field, None)
+    return sanitized
+
+
 def upload_run_to_hf(
     *, repo_id: str, tag: str, model_path: str, output_path: str, force: bool = False
 ) -> None:
@@ -412,10 +440,15 @@ def upload_run_to_hf(
 
     with open(sources[HF_CONFIG_FILENAME]) as f:
         config_dict = json.load(f)
+    # The repo is PUBLIC, so strip environment-specific fields before publishing config.json:
+    # absolute host paths (username + internal layout) and real observation filenames, none of
+    # which are reproducible off-host (HFSEC-1). The model card renders only hyperparameters, so
+    # it is safe to build from the sanitized config too.
+    public_config = _sanitize_config_for_upload(config_dict)
     card = generate_model_card(
         tag=tag,
         repo_id=repo_id,
-        config_dict=config_dict,
+        config_dict=public_config,
         metrics=compute_rf_metrics(model_path, tag),
         versions=_collect_library_versions(),
     )
@@ -424,7 +457,11 @@ def upload_run_to_hf(
     api = _hf_api()
     with tempfile.TemporaryDirectory(prefix="aetherscan_hf_upload_") as staging:
         for stable_name, source in sources.items():
-            shutil.copy2(source, os.path.join(staging, stable_name))
+            if stable_name == HF_CONFIG_FILENAME:
+                with open(os.path.join(staging, stable_name), "w") as f:
+                    json.dump(public_config, f, indent=2)
+            else:
+                shutil.copy2(source, os.path.join(staging, stable_name))
         with open(os.path.join(staging, HF_CARD_FILENAME), "w") as f:
             f.write(card)
 

--- a/src/aetherscan/inference.py
+++ b/src/aetherscan/inference.py
@@ -226,7 +226,10 @@ class InferencePipeline:
         # instead of accumulating a new concrete function per cadence
         self._encode_step = None
 
-    # TODO: implement model loading from HuggingFace (parametrize args to InferenceConfig)
+    # NOTE: HuggingFace Hub model loading is handled upstream: when no local artifact paths
+    # are given, hf_hub.resolve_inference_artifacts() (called from main()) downloads the
+    # revision-pinned artifacts and routes their cache paths into config.inference, so the
+    # paths received here are always local files
     def init_models(self, encoder_path: str, rf_path: str):
         """Load the VAE encoder (inside strategy.scope) and the Random Forest classifier from disk."""
         if not os.path.exists(encoder_path):

--- a/src/aetherscan/logger/logger.py
+++ b/src/aetherscan/logger/logger.py
@@ -7,6 +7,7 @@ outputs from concurrent writes (e.g. from worker processes)
 
 from __future__ import annotations
 
+import io
 import logging
 import os
 import sys
@@ -59,6 +60,28 @@ class StreamToLogger:
         # Flush all handlers attached to the logger
         for handler in self.logger.handlers:
             handler.flush()
+
+    # File-protocol probes: libraries that write to sys.stdout/sys.stderr (tqdm progress
+    # bars via huggingface_hub, click, rich, ...) probe the stream for interactivity and
+    # capabilities before writing. Without these, any such probe crashes with
+    # AttributeError (e.g. hf_upload failed with "'StreamToLogger' object has no
+    # attribute 'isatty'"), so answer like the non-interactive pipe this stream is.
+
+    def isatty(self) -> bool:
+        """Never a terminal — suppresses interactive control codes/progress rendering."""
+        return False
+
+    def readable(self) -> bool:
+        return False
+
+    def writable(self) -> bool:
+        return True
+
+    def fileno(self):
+        """No OS-level file descriptor backs this stream. io.UnsupportedOperation is the
+        io-module convention (what io.StringIO raises); it subclasses both OSError and
+        ValueError, which is what fileno() probers guard against."""
+        raise io.UnsupportedOperation("fileno")
 
 
 class Logger:

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -26,6 +26,7 @@ from aetherscan.cli import (
 )
 from aetherscan.config import get_config, init_config
 from aetherscan.db import get_db, init_db
+from aetherscan.hf_hub import resolve_inference_artifacts
 from aetherscan.inference import InferencePipeline, run_inference_pipeline, summarize_confidences
 from aetherscan.inference_viz import InferenceVizCollector, render_inference_visualizations
 from aetherscan.logger import init_logger
@@ -33,6 +34,7 @@ from aetherscan.manager import get_manager, init_manager, register_logger
 from aetherscan.monitor import init_monitor
 from aetherscan.preprocessing import DataPreprocessor, derive_cadence_provenance
 from aetherscan.run_state import inference_config_fingerprint
+from aetherscan.tag_guards import enforce_tag_guards
 from aetherscan.train import run_training_pipeline
 
 logger = logging.getLogger(__name__)
@@ -610,9 +612,11 @@ def inference_command():
     if config is None:
         raise ValueError("get_config() returned None")
 
-    # Required artifacts (encoder/rf/config paths) and stamp_width == width_bin
-    # are enforced upstream by collect_validation_errors() in cli.py, so by the
-    # time inference_command() runs those preconditions are guaranteed to hold.
+    # The artifact trio (encoder/rf/config paths) is populated upstream — either explicit
+    # local paths validated by collect_validation_errors() in cli.py, or HuggingFace-
+    # downloaded cache paths from resolve_inference_artifacts() — and stamp_width ==
+    # width_bin is enforced by validation, so by the time inference_command() runs those
+    # preconditions are guaranteed to hold.
     # TODO: add a sanity check that verifies encoder, RF, and config path all have the same tag. throw a warning if false
 
     # NOTE: come back to this later (print more descriptive info)
@@ -794,6 +798,20 @@ def main():
         # so cleanup handlers still run via atexit
         raise
 
+    # Inference mode: resolve the model artifact trio before anything reads it. When the
+    # user provided none of --encoder-path/--rf-path/--config-path, the pinned
+    # (--hf-revision) or latest-release revision is downloaded from the HuggingFace Hub
+    # and the cached paths are written onto `args` — exactly as if they were passed on the
+    # CLI — so validation, apply_saved_config, and the model-load path run unchanged.
+    # Explicit local paths take precedence; a partial trio falls through to validate_args,
+    # which reports the missing paths.
+    if args.command == "inference":
+        try:
+            resolve_inference_artifacts(args)
+        except Exception as e:
+            logger.error(f"Failed to resolve inference model artifacts: {e}")
+            sys.exit(1)
+
     # NOTE: come back to this later
     # Inference mode: if the user pointed --config-path at a saved JSON config,
     # layer its values onto the singleton *before* validate_args runs. That way
@@ -848,6 +866,12 @@ def main():
         sys.exit(1)
 
     try:
+        # Fail-early save-tag dedup guards: hard-stop before any expensive work when an
+        # explicitly-provided --save-tag collides with a previous run's artifacts/DB rows
+        # (resumable-run manifests exempt same-tag retries), and check the HF repo for a
+        # tag collision when --hf-upload is set. --force-tag overrides.
+        enforce_tag_guards(args)
+
         # Execute command
         if args.command == "train":
             train_command()

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -164,9 +164,9 @@ def _report_final_training_status(pipeline) -> None:
     Emit the terminal training status and exit nonzero on any permanently-failed stage.
 
     Extracted from train_command so the exit contract is unit-testable: a fully-successful run
-    exits 0, a run with any recorded non-critical stage failure (vae_plots/rf_plots that never
-    recovered across attempts) exits 1, and a missing pipeline exits 1 rather than reporting a
-    false success.
+    exits 0, a run with any recorded non-critical stage failure (vae_plots/rf_plots/hf_upload that
+    never recovered across attempts) exits 1, and a missing pipeline exits 1 rather than reporting
+    a false success.
     """
     if pipeline is None:
         # Defensive: the retry loop always sets pipeline or sys.exit(1)s first, and

--- a/src/aetherscan/run_state.py
+++ b/src/aetherscan/run_state.py
@@ -9,7 +9,7 @@ where the previous attempt died:
   from it, so every DB query/plot spans the whole run rather than just the current attempt.
 - completed_rounds: beta-VAE rounds whose checkpoint was saved; resume starts at max + 1.
 - stages_done / stages_failed: drive run_training_pipeline's stage machine — done stages are
-  skipped, failed non-critical stages (plots) are retried on the next run and force a nonzero
+  skipped, failed non-critical stages (plots, hf_upload) are retried on the next run and force a nonzero
   exit if they never succeed.
 
 Writes are atomic (tmp -> os.replace, mirroring round_data's .done manifest protocol) so a
@@ -51,10 +51,12 @@ def run_state_path(output_path: str, tag: str) -> str:
 
 
 # Config sections excluded from a run's fingerprint: pure infra/runtime (db, manager, monitor,
-# logger), resume-control (checkpoint), environment paths, and the inference config — none of
-# which change the training result, so a change to any of them must NOT force a fresh run.
+# logger), resume-control (checkpoint), environment paths, the inference config, and the HF
+# upload config — none of which change the training result, so a change to any of them must NOT
+# force a fresh run. In particular, toggling --hf-upload or changing its repo/revision must never
+# be read as training drift (that would discard the manifest and overwrite a completed model).
 _FINGERPRINT_EXCLUDE_SECTIONS = frozenset(
-    {"db", "manager", "monitor", "logger", "inference", "paths", "checkpoint"}
+    {"db", "manager", "monitor", "logger", "inference", "paths", "checkpoint", "hf"}
 )
 # Retry knobs live in the training section but only control the retry loop, not the result.
 _FINGERPRINT_EXCLUDE_TRAINING_KEYS = frozenset({"max_retries", "retry_delay"})

--- a/src/aetherscan/run_state.py
+++ b/src/aetherscan/run_state.py
@@ -34,12 +34,14 @@ STAGE_VAE_PLOTS = "vae_plots"
 STAGE_RF_TRAIN = "rf_train"
 STAGE_RF_PLOTS = "rf_plots"
 STAGE_FINAL_SAVE = "final_save"
+STAGE_HF_UPLOAD = "hf_upload"  # Opt-in (config.hf.upload_after_training); non-critical
 TRAINING_STAGES = (
     STAGE_VAE_ROUNDS,
     STAGE_VAE_PLOTS,
     STAGE_RF_TRAIN,
     STAGE_RF_PLOTS,
     STAGE_FINAL_SAVE,
+    STAGE_HF_UPLOAD,
 )
 
 
@@ -162,6 +164,13 @@ class TrainingRunState:
         """Record a non-critical stage failure; not in stages_done, so relaunches retry it."""
         if stage not in self.stages_failed:
             self.stages_failed.append(stage)
+
+    def clear_stage_failure(self, stage: str) -> None:
+        """Drop a recorded failure without marking the stage done — used when the user opts
+        out of an optional stage (e.g. re-running without --hf-upload) so a stale failure
+        can't force a nonzero exit forever."""
+        if stage in self.stages_failed:
+            self.stages_failed.remove(stage)
 
     def mark_round_completed(self, round_number: int) -> None:
         if round_number not in self.completed_rounds:

--- a/src/aetherscan/tag_guards.py
+++ b/src/aetherscan/tag_guards.py
@@ -31,7 +31,7 @@ import sys
 
 from aetherscan.config import get_config
 from aetherscan.db import get_db
-from aetherscan.run_state import run_state_path
+from aetherscan.run_state import STAGE_FINAL_SAVE, load_run_state, run_state_path
 
 logger = logging.getLogger(__name__)
 
@@ -151,10 +151,19 @@ def enforce_tag_guards(args: argparse.Namespace) -> None:
     if command == "train":
         if explicit:
             manifest_path = run_state_path(config.output_path, tag)
-            if os.path.isfile(manifest_path):
+            # Only an UNFINISHED run's manifest exempts the collision guard. The manifest
+            # persists on success, so a completed run's manifest must NOT keep disabling dedup
+            # for that tag — otherwise a reused --save-tag would silently overwrite a finished
+            # model with no warning (TG-1). "Unfinished" = final_save not yet done, or a
+            # recorded non-critical stage failure still pending retry.
+            state = load_run_state(manifest_path)
+            resumable = state is not None and (
+                not state.is_stage_done(STAGE_FINAL_SAVE) or bool(state.stages_failed)
+            )
+            if resumable:
                 logger.info(
-                    f"Run-state manifest found at {manifest_path} — tag '{tag}' marks a "
-                    f"resumable run, skipping the collision guard"
+                    f"Run-state manifest at {manifest_path} marks an unfinished run — tag "
+                    f"'{tag}' is resumable, skipping the collision guard"
                 )
             else:
                 collisions = find_train_tag_collisions(tag)

--- a/src/aetherscan/tag_guards.py
+++ b/src/aetherscan/tag_guards.py
@@ -1,0 +1,188 @@
+"""
+Fail-early save-tag dedup guards.
+
+Reusing a save_tag silently mixes a new run's artifacts, config JSON, and DB rows with a
+previous run's — the stale-artifact confusion the cluster runbook works around by manually
+incrementing test_vNN tags. These guards hard-stop a run at startup (before any expensive
+work or writes) when an explicitly-provided --save-tag collides with existing state, while
+staying out of the way of the two legitimate same-tag flows:
+
+- Training retries/relaunches: a run-state manifest (run_state_{tag}.json) marks the tag as
+  an in-progress resumable run, so the guard is skipped entirely (PR-04's supersede
+  semantics are what make same-tag retries safe).
+- Inference resume: manifest rows in the inference_cadences DB table mark an in-progress
+  streaming run. Only a completed run — evidenced by its saved config_{tag}.json, written at
+  the very end of a successful pass — or stale legacy-path DB rows count as collisions.
+
+Default (datetime) save tags are immune by construction — a fresh second-resolution
+timestamp can't collide — so the local guards only fire for explicitly-provided tags.
+--force-tag consciously overrides every guard.
+
+enforce_tag_guards() is called from main() immediately before command dispatch
+(post-validation, post-DB-init, pre-any-work).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+from aetherscan.config import get_config
+from aetherscan.db import get_db
+from aetherscan.run_state import run_state_path
+
+logger = logging.getLogger(__name__)
+
+
+def find_train_tag_collisions(tag: str) -> list[str]:
+    """
+    Human-readable descriptions of existing training state that would collide with `tag`:
+    the final encoder artifact under model_path, the saved config JSON under output_path,
+    and non-superseded training_stats DB rows. Empty list = no collisions.
+    """
+    config = get_config()
+    db = get_db()
+    collisions: list[str] = []
+
+    encoder_path = os.path.join(config.model_path, f"vae_encoder_{tag}.keras")
+    if os.path.exists(encoder_path):
+        collisions.append(f"model artifact exists: {encoder_path}")
+
+    config_path = os.path.join(config.output_path, f"config_{tag}.json")
+    if os.path.exists(config_path):
+        collisions.append(f"saved run config exists: {config_path}")
+
+    if db is not None:
+        rows = db.query_training_stat(tag=tag, columns=["tag"])
+        if rows:
+            collisions.append(
+                f"{len(rows)} non-superseded training_stats DB row(s) carry tag '{tag}'"
+            )
+
+    return collisions
+
+
+def find_inference_tag_collisions(tag: str) -> list[str]:
+    """
+    Collisions scoped to what inference writes. A saved config_{tag}.json marks a *completed*
+    run under this tag (it is written at the very end of a successful pass) — reusing its tag
+    is always a collision. DB rows alone are only a collision on the legacy --test-files path
+    (no inference_cadences manifest rows): with manifest rows present, same-tag DB state is
+    exactly what the streaming path's resume flow consumes, so it must not be flagged.
+    """
+    config = get_config()
+    db = get_db()
+    collisions: list[str] = []
+
+    config_path = os.path.join(config.output_path, f"config_{tag}.json")
+    if os.path.exists(config_path):
+        collisions.append(f"saved run config exists (completed run marker): {config_path}")
+
+    if db is not None and not db.query_inference_cadences(tag=tag, columns=["tag"]):
+        rows = db.query_inference_result(tag=tag, columns=["tag"])
+        if rows:
+            collisions.append(
+                f"{len(rows)} non-superseded inference_results DB row(s) carry tag '{tag}' "
+                f"(no resumable run manifest)"
+            )
+
+    return collisions
+
+
+def _exit_on_collisions(tag: str, collisions: list[str], resume_hint: str) -> None:
+    """Log the collision list plus the user's options, then hard-exit."""
+    logger.error("=" * 60)
+    logger.error(f"--save-tag '{tag}' collides with existing state from a previous run:")
+    for collision in collisions:
+        logger.error(f"  - {collision}")
+    logger.error("Options:")
+    logger.error("  - pick a new --save-tag")
+    logger.error(f"  - {resume_hint}")
+    logger.error("  - pass --force-tag to consciously override this guard")
+    logger.error("=" * 60)
+    sys.exit(1)
+
+
+def _guard_hf_tag(tag: str, force: bool) -> None:
+    """
+    HF-side dedup guard, run at startup when --hf-upload is enabled so a tag collision on the
+    Hub surfaces now, not after ~30 h of training. A failed check (network/auth) only warns:
+    the upload stage itself is non-critical, so its guard must not block training either.
+    """
+    config = get_config()
+    repo_id = config.hf.repo_id
+    from aetherscan.hf_hub import hf_tag_exists  # noqa: PLC0415
+
+    try:
+        exists = hf_tag_exists(repo_id, tag)
+    except Exception as e:
+        logger.warning(f"Could not check HF repo '{repo_id}' for tag collisions ({e}) — proceeding")
+        return
+    if not exists:
+        return
+    if force:
+        logger.warning(
+            f"Tag '{tag}' already exists on HF repo '{repo_id}' — --force-tag set, the "
+            f"upload stage will move it to the new commit"
+        )
+        return
+    logger.error("=" * 60)
+    logger.error(f"--hf-upload is enabled but tag '{tag}' already exists on HF repo '{repo_id}'.")
+    logger.error("Options: pick a new --save-tag, or pass --force-tag to move the HF tag.")
+    logger.error("=" * 60)
+    sys.exit(1)
+
+
+def enforce_tag_guards(args: argparse.Namespace) -> None:
+    """
+    Fail-early save-tag dedup guards, dispatched by mode (see module docstring). Reads the
+    post-apply config singleton for the effective tag/force values and `args` only to learn
+    whether --save-tag was explicitly provided (default datetime tags are immune by
+    construction, so the local guards are skipped for them).
+    """
+    config = get_config()
+    tag = config.checkpoint.save_tag
+    force = bool(config.checkpoint.force_tag)
+    explicit = getattr(args, "save_tag", None) is not None
+    command = getattr(args, "command", None)
+
+    if command == "train":
+        if explicit:
+            manifest_path = run_state_path(config.output_path, tag)
+            if os.path.isfile(manifest_path):
+                logger.info(
+                    f"Run-state manifest found at {manifest_path} — tag '{tag}' marks a "
+                    f"resumable run, skipping the collision guard"
+                )
+            else:
+                collisions = find_train_tag_collisions(tag)
+                if collisions and force:
+                    logger.warning(
+                        f"--force-tag set: proceeding despite {len(collisions)} "
+                        f"collision(s) on tag '{tag}'"
+                    )
+                elif collisions:
+                    _exit_on_collisions(
+                        tag,
+                        collisions,
+                        "to resume the previous run, re-run its identical command "
+                        "(resume requires its run-state manifest)",
+                    )
+        if config.hf.upload_after_training:
+            _guard_hf_tag(tag, force)
+
+    elif command == "inference" and explicit:
+        collisions = find_inference_tag_collisions(tag)
+        if collisions and force:
+            logger.warning(
+                f"--force-tag set: proceeding despite {len(collisions)} collision(s) on tag '{tag}'"
+            )
+        elif collisions:
+            _exit_on_collisions(
+                tag,
+                collisions,
+                "an in-progress run (manifest rows, no saved config JSON) resumes by "
+                "re-running its identical command",
+            )

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -47,6 +47,7 @@ from tensorflow.keras.layers import Conv2D, Dense
 from aetherscan.config import get_config
 from aetherscan.data_generation import DataGenerator
 from aetherscan.db import get_db, get_system_metadata
+from aetherscan.hf_hub import upload_run_to_hf
 from aetherscan.logger import get_logger
 from aetherscan.models import (
     RandomForestModel,
@@ -62,6 +63,7 @@ from aetherscan.round_data import (
 )
 from aetherscan.run_state import (
     STAGE_FINAL_SAVE,
+    STAGE_HF_UPLOAD,
     STAGE_RF_PLOTS,
     STAGE_RF_TRAIN,
     STAGE_VAE_PLOTS,
@@ -1087,6 +1089,13 @@ class TrainingPipeline:
         self.run_state.record_stage_failure(stage)
         self._persist_run_state()
         logger.error(f"Stage '{stage}' failed (recorded in run manifest)")
+
+    def _clear_stage_failure(self, stage: str):
+        """Drop a recorded stage failure from the manifest and persist it (used when the
+        user opts out of an optional stage whose previous attempt failed — see
+        TrainingRunState.clear_stage_failure)."""
+        self.run_state.clear_stage_failure(stage)
+        self._persist_run_state()
 
     def _mark_round_completed(self, round_number: int):
         """Record a fully-trained round (checkpoint saved) in the manifest and persist it."""
@@ -6542,6 +6551,18 @@ class TrainingPipeline:
             json.dump(self.config.to_dict(), f, indent=2)
         logger.info(f"Training configuration saved to {config_path}")
 
+    def upload_to_hf(self) -> None:
+        """The hf_upload stage: publish the final artifacts (staged under stable names) plus
+        a generated model card to the configured HuggingFace Hub repo, then tag the commit
+        with this run's save_tag. Requires HF_TOKEN in the environment (via .env)."""
+        upload_run_to_hf(
+            repo_id=self.config.hf.repo_id,
+            tag=self.config.checkpoint.save_tag,
+            model_path=self.config.model_path,
+            output_path=self.config.output_path,
+            force=self.config.checkpoint.force_tag,
+        )
+
 
 def _execute_training_stages(pipeline) -> None:
     """
@@ -6550,9 +6571,10 @@ def _execute_training_stages(pipeline) -> None:
 
     Critical stages (vae_rounds, rf_train, final_save) raise on failure — the retry loop in
     main.py rebuilds the pipeline and the manifest resumes it here. Non-critical stages
-    (vae_plots, rf_plots) are recorded in stages_failed and execution continues: a broken
-    plot mustn't cost a retry cycle including data regeneration, but main.py exits nonzero
-    at the very end if any recorded failure never recovers, so lost artifacts stay loud.
+    (vae_plots, rf_plots, hf_upload) are recorded in stages_failed and execution continues:
+    a broken plot or Hub upload mustn't cost a retry cycle including data regeneration, but
+    main.py exits nonzero at the very end if any recorded failure never recovers, so lost
+    artifacts stay loud.
 
     `pipeline` is duck-typed (a TrainingPipeline in production) so unit tests can drive the
     stage logic with a lightweight stub.
@@ -6623,6 +6645,29 @@ def _execute_training_stages(pipeline) -> None:
         pipeline.final_save()
         pipeline._mark_stage_done(STAGE_FINAL_SAVE)
 
+    # Stage 6: hf_upload (opt-in via config.hf.upload_after_training; non-critical) —
+    # publish the final artifacts + model card to the HuggingFace Hub. Failure is recorded
+    # in the manifest but never fails the run (the weights are already safe locally);
+    # re-running the identical command retries just this stage.
+    if not pipeline.config.hf.upload_after_training:
+        if STAGE_HF_UPLOAD in state.stages_failed:
+            # The user opted out after a failed upload attempt — the upload is no longer
+            # pending, so drop the stale failure (it must not force a nonzero exit forever)
+            logger.info(
+                f"HF upload disabled — clearing the stale '{STAGE_HF_UPLOAD}' failure "
+                f"recorded by a previous attempt"
+            )
+            pipeline._clear_stage_failure(STAGE_HF_UPLOAD)
+    elif state.is_stage_done(STAGE_HF_UPLOAD):
+        logger.info(f"Stage '{STAGE_HF_UPLOAD}' already complete — skipping")
+    else:
+        try:
+            pipeline.upload_to_hf()
+            pipeline._mark_stage_done(STAGE_HF_UPLOAD)
+        except Exception as e:
+            logger.error(f"Stage '{STAGE_HF_UPLOAD}' failed: {e}")
+            pipeline._record_stage_failure(STAGE_HF_UPLOAD)
+
 
 def run_training_pipeline(
     background_data: np.ndarray, strategy: tf.distribute.Strategy = None
@@ -6630,8 +6675,8 @@ def run_training_pipeline(
     """
     End-to-end training entry point: construct a TrainingPipeline from preprocessed background
     data (shape (n, 6, 16, 512)) and an optional tf.distribute strategy, then run the ordered
-    training stages (vae_rounds -> vae_plots -> rf_train -> rf_plots -> final_save), skipping
-    any the persisted run manifest already records as done.
+    training stages (vae_rounds -> vae_plots -> rf_train -> rf_plots -> final_save ->
+    hf_upload), skipping any the persisted run manifest already records as done.
     """
     try:
         # Create pipeline (no cleanup needed on failure)

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -214,14 +214,55 @@ class TestSemanticChecks:
         errors = collect_validation_errors(_parse(["train"]), None)
         assert [e for e in errors if e.fix_kind == "file_exists"] == []
 
-    def test_inference_requires_model_artifacts(self):
+    def test_inference_artifact_trio_omitted_is_valid(self):
+        # No local artifact paths -> resolution is handled upstream (HF download in main.py),
+        # so validation must not demand them.
         errors = collect_validation_errors(_parse(["inference"]), None)
+        artifact_fields = {"inference.encoder_path", "inference.rf_path", "inference.config_path"}
+        assert not artifact_fields & {e.field for e in errors}
+
+    def test_inference_artifact_partial_trio_rejected(self, tmp_path):
+        encoder = tmp_path / "vae_encoder_test_v1.keras"
+        encoder.touch()
+        errors = collect_validation_errors(
+            _parse(["inference", "--encoder-path", str(encoder)]), None
+        )
+        fields = {e.field for e in errors if e.fix_kind == "file_exists"}
+        # The two missing paths are reported; the provided one passes.
+        assert {"inference.rf_path", "inference.config_path"} <= fields
+        assert "inference.encoder_path" not in fields
+
+    def test_inference_artifact_full_trio_must_exist_on_disk(self):
+        errors = collect_validation_errors(
+            _parse(
+                [
+                    "inference",
+                    "--encoder-path",
+                    "/nonexistent/e.keras",
+                    "--rf-path",
+                    "/nonexistent/r.joblib",
+                    "--config-path",
+                    "/nonexistent/c.json",
+                ]
+            ),
+            None,
+        )
         fields = {e.field for e in errors if e.fix_kind == "file_exists"}
         assert {
             "inference.encoder_path",
             "inference.rf_path",
             "inference.config_path",
         } <= fields
+
+    @pytest.mark.parametrize("command", ["train", "inference"])
+    def test_hf_repo_id_format_rejected(self, command):
+        errors = collect_validation_errors(_parse([command, "--hf-repo-id", "not-a-repo-id"]), None)
+        assert any(e.field == "hf.repo_id" for e in errors)
+
+    @pytest.mark.parametrize("repo_id", ["zachtheyek/aetherscan", "org-name/repo.name-1"])
+    def test_hf_repo_id_valid_values_pass(self, repo_id):
+        errors = collect_validation_errors(_parse(["train", "--hf-repo-id", repo_id]), None)
+        assert [e for e in errors if e.field == "hf.repo_id"] == []
 
     def test_inference_stamp_width_must_match_width_bin(self, make_inference_csv):
         csv_path = make_inference_csv("subset.csv")
@@ -499,6 +540,28 @@ class TestApplyArgsToConfig:
         config.inference.bandpass_debug_plot = True
         apply_args_to_config(_parse(["inference"]))
         assert config.inference.bandpass_debug_plot is True
+
+    def test_hf_flags_route_to_hf_section(self):
+        config = get_config()
+        assert config.hf.upload_after_training is False  # default: local-only
+        apply_args_to_config(_parse(["train", "--hf-upload", "--hf-repo-id", "other/repo"]))
+        assert config.hf.upload_after_training is True
+        assert config.hf.repo_id == "other/repo"
+
+        apply_args_to_config(_parse(["train", "--no-hf-upload"]))
+        assert config.hf.upload_after_training is False
+
+        apply_args_to_config(_parse(["inference", "--hf-revision", "v0.1.0"]))
+        assert config.hf.revision == "v0.1.0"
+
+    def test_force_tag_routes_to_checkpoint_section(self):
+        config = get_config()
+        assert config.checkpoint.force_tag is False
+        apply_args_to_config(_parse(["train", "--force-tag"]))
+        assert config.checkpoint.force_tag is True
+        # Omitting the flag leaves the config value untouched (tri-state BooleanOptionalAction)
+        apply_args_to_config(_parse(["inference"]))
+        assert config.checkpoint.force_tag is True
 
 
 class TestLatentTraversalFlags:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -22,6 +22,7 @@ _CONFIG_SECTIONS = (
     "data",
     "training",
     "inference",
+    "hf",
     "checkpoint",
 )
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -10,21 +10,16 @@ import os
 
 from aetherscan.config import Config, get_config, init_config
 
-# Sub-dataclass sections serialized by Config.to_dict(), keyed by attribute name.
-_CONFIG_SECTIONS = (
-    "db",
-    "manager",
-    "monitor",
-    "logger",
-    "beta_vae",
-    "rf",
-    "gpu",
-    "data",
-    "training",
-    "inference",
-    "hf",
-    "checkpoint",
-)
+# Keys to_dict() emits that are not sub-dataclass sections (derived/grouped scalars).
+_NON_SECTION_KEYS = frozenset({"paths"})
+
+
+def _config_sections(config: Config) -> set[str]:
+    """Attribute names on a Config whose values are dataclass instances (its serialized sections).
+
+    Derived at runtime so a newly added section is auto-covered by the coverage test below.
+    """
+    return {name for name, value in vars(config).items() if dataclasses.is_dataclass(value)}
 
 
 class TestSingletonSemantics:
@@ -76,10 +71,21 @@ class TestSingletonSemantics:
 
 class TestToDict:
     def test_sections_cover_every_dataclass_field(self):
-        """to_dict() must be updated by hand for every new config field — catch drift."""
+        """to_dict() must be updated by hand for every new config section/field — catch drift."""
         config = get_config()
         serialized = config.to_dict()
-        for section in _CONFIG_SECTIONS:
+        sections = _config_sections(config)
+
+        # A forgotten (or spurious extra) whole section: the section keys to_dict() emits, minus
+        # the known non-section keys, must equal the dynamically-derived set of Config sections.
+        serialized_sections = set(serialized) - _NON_SECTION_KEYS
+        assert serialized_sections == sections, (
+            "Config.to_dict() sections are out of sync with Config: "
+            f"missing={sections - serialized_sections}, extra={serialized_sections - sections}"
+        )
+
+        # A forgotten field within a section: each section's keys must equal its dataclass fields.
+        for section in sections:
             expected = {f.name for f in dataclasses.fields(type(getattr(config, section)))}
             actual = set(serialized[section].keys())
             assert actual == expected, (
@@ -96,7 +102,7 @@ class TestToDict:
         assert serialized["training"]["num_training_rounds"] == 5
         assert serialized["gpu"]["num_replicas"] == 4
         assert serialized["paths"]["data_path"] == config.data_path
-        for section in _CONFIG_SECTIONS:
+        for section in _config_sections(config):
             for field_name, value in serialized[section].items():
                 stored = getattr(getattr(config, section), field_name)
                 if isinstance(stored, tuple):

--- a/tests/unit/test_hf_hub.py
+++ b/tests/unit/test_hf_hub.py
@@ -135,6 +135,14 @@ class TestResolveHfRevision:
         with pytest.raises(RuntimeError, match="--hf-revision"):
             resolve_hf_revision("ns/repo", None)
 
+    def test_listing_failure_wrapped_with_guidance(self, monkeypatch):
+        def boom(repo_id):
+            raise ConnectionError("no route to host")
+
+        monkeypatch.setattr(hf_hub, "list_hf_tags", boom)
+        with pytest.raises(RuntimeError, match="--hf-revision"):
+            resolve_hf_revision("ns/repo", None)
+
 
 class TestListHfTags:
     def test_names_extracted_from_refs(self, monkeypatch, fake_api):
@@ -250,6 +258,14 @@ class TestResolveInferenceArtifacts:
         # The resolved revision is written back to args so it lands in config.hf.revision
         # (and the saved inference config) via apply_args_to_config.
         assert args.hf_revision == "v0.1.0"
+
+    def test_download_failure_wrapped_with_guidance(self, monkeypatch):
+        def boom(**kwargs):
+            raise ConnectionError("connection reset")
+
+        monkeypatch.setattr(hf_hub, "_hf_hub_download", boom)
+        with pytest.raises(RuntimeError, match="--hf-revision"):
+            hf_hub.download_inference_artifacts("ns/repo", "v0.1.0")
 
     def test_repo_id_flag_overrides_config_default(self, monkeypatch):
         seen = []
@@ -406,3 +422,34 @@ class TestUploadRunToHf:
                 model_path=config.model_path,
                 output_path=config.output_path,
             )
+
+    def test_tag_conflict_after_upload_points_at_force_tag(self, monkeypatch):
+        # TOCTOU: the tag appeared between the startup dedup check and the post-upload
+        # create_tag (e.g. a concurrent run). The wrapped error must point at --force-tag.
+        import httpx  # noqa: PLC0415
+        from huggingface_hub.errors import HfHubHTTPError  # noqa: PLC0415
+
+        config = get_config()
+        _write_run_artifacts(config, "test_v1")
+        api = _FakeHfApi()
+
+        def conflict(repo_id, *, tag):
+            api._record("create_tag", repo_id=repo_id, tag=tag)
+            raise HfHubHTTPError(
+                "conflict",
+                response=httpx.Response(
+                    409, request=httpx.Request("POST", "https://huggingface.co/api")
+                ),
+            )
+
+        api.create_tag = conflict
+        monkeypatch.setattr(hf_hub, "_hf_api", lambda: api)
+        with pytest.raises(RuntimeError, match="--force-tag"):
+            upload_run_to_hf(
+                repo_id="ns/repo",
+                tag="test_v1",
+                model_path=config.model_path,
+                output_path=config.output_path,
+            )
+        # The artifacts were still uploaded before the tag conflict surfaced.
+        assert [name for name, _ in api.calls[:2]] == ["create_repo", "upload_folder"]

--- a/tests/unit/test_hf_hub.py
+++ b/tests/unit/test_hf_hub.py
@@ -1,0 +1,408 @@
+"""Unit tests for aetherscan.hf_hub: revision selection/resolution, inference artifact
+resolution, upload staging/arg shapes, and model card content. huggingface_hub is never
+contacted — the module's _hf_api()/_hf_hub_download() seams are monkeypatched."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+import joblib
+import numpy as np
+import pytest
+
+from aetherscan import hf_hub
+from aetherscan.config import get_config
+from aetherscan.hf_hub import (
+    HF_CARD_FILENAME,
+    HF_CONFIG_FILENAME,
+    HF_DECODER_FILENAME,
+    HF_ENCODER_FILENAME,
+    HF_RF_FILENAME,
+    compute_rf_metrics,
+    generate_model_card,
+    resolve_hf_revision,
+    resolve_inference_artifacts,
+    select_default_revision,
+    upload_run_to_hf,
+)
+
+
+class _FakeHfApi:
+    """Records every HfApi call. upload_folder snapshots the staging directory's contents
+    (the TemporaryDirectory is deleted right after the call, so assertions need a copy)."""
+
+    def __init__(self, fail_on=()):
+        self.calls = []
+        self.uploaded_files: dict[str, str] = {}
+        self._fail_on = set(fail_on)
+
+    def _record(self, name, **kwargs):
+        self.calls.append((name, kwargs))
+        if name in self._fail_on:
+            raise RuntimeError(f"{name} failed")
+
+    def create_repo(self, repo_id, **kwargs):
+        self._record("create_repo", repo_id=repo_id, **kwargs)
+
+    def upload_folder(self, *, repo_id, folder_path, commit_message):
+        for name in sorted(os.listdir(folder_path)):
+            with open(os.path.join(folder_path, name), errors="replace") as f:
+                self.uploaded_files[name] = f.read()
+        self._record(
+            "upload_folder",
+            repo_id=repo_id,
+            folder_path=folder_path,
+            commit_message=commit_message,
+        )
+
+    def create_tag(self, repo_id, *, tag):
+        self._record("create_tag", repo_id=repo_id, tag=tag)
+
+    def delete_tag(self, repo_id, *, tag):
+        self._record("delete_tag", repo_id=repo_id, tag=tag)
+
+    def list_repo_refs(self, repo_id, repo_type=None):
+        self._record("list_repo_refs", repo_id=repo_id, repo_type=repo_type)
+        raise AssertionError("list_repo_refs must be stubbed per-test when needed")
+
+
+@pytest.fixture
+def fake_api(monkeypatch):
+    api = _FakeHfApi()
+    monkeypatch.setattr(hf_hub, "_hf_api", lambda: api)
+    return api
+
+
+def _write_run_artifacts(config, tag, with_eval_artifacts=True):
+    """Create the on-disk artifacts final_save leaves behind for `tag`."""
+    os.makedirs(config.model_path, exist_ok=True)
+    os.makedirs(config.output_path, exist_ok=True)
+    for name in (f"vae_encoder_{tag}.keras", f"vae_decoder_{tag}.keras"):
+        with open(os.path.join(config.model_path, name), "w") as f:
+            f.write("stub-keras")
+    with open(os.path.join(config.model_path, f"random_forest_{tag}.joblib"), "w") as f:
+        f.write("stub-joblib")
+    with open(os.path.join(config.output_path, f"config_{tag}.json"), "w") as f:
+        json.dump(config.to_dict(), f)
+    if with_eval_artifacts:
+        joblib.dump(
+            {
+                "val_binary_labels": np.array([0, 0, 1, 1]),
+                "val_probas": np.array([0.1, 0.4, 0.35, 0.8], dtype=np.float32),
+                "classification_threshold": 0.99,
+            },
+            os.path.join(config.model_path, f"rf_eval_artifacts_{tag}.joblib"),
+        )
+
+
+class TestSelectDefaultRevision:
+    def test_semver_outranks_final(self):
+        assert select_default_revision(["final_v9", "v1.2.3", "v0.1.0"]) == "v1.2.3"
+
+    def test_semver_sorted_numerically_not_lexicographically(self):
+        assert select_default_revision(["v1.9.9", "v1.10.0"]) == "v1.10.0"
+        assert select_default_revision(["v2.0.0", "v10.0.0", "v9.9.9"]) == "v10.0.0"
+
+    def test_final_tags_sorted_numerically(self):
+        assert select_default_revision(["final_v2", "final_v12", "final_v3"]) == "final_v12"
+
+    def test_other_tag_families_never_win(self):
+        assert select_default_revision(["test_v17", "20260712_010203", "round_02"]) is None
+
+    def test_partial_semver_is_not_a_release_tag(self):
+        assert select_default_revision(["v1.2", "v1", "final_v1"]) == "final_v1"
+
+    def test_empty(self):
+        assert select_default_revision([]) is None
+
+
+class TestResolveHfRevision:
+    def test_explicit_revision_returned_without_listing(self, monkeypatch):
+        def boom(repo_id):
+            raise AssertionError("must not list tags for an explicit revision")
+
+        monkeypatch.setattr(hf_hub, "list_hf_tags", boom)
+        assert resolve_hf_revision("ns/repo", "test_v17") == "test_v17"
+
+    def test_latest_release_selected(self, monkeypatch):
+        monkeypatch.setattr(hf_hub, "list_hf_tags", lambda repo_id: ["final_v1", "v0.2.0"])
+        assert resolve_hf_revision("ns/repo", None) == "v0.2.0"
+
+    def test_no_resolvable_tag_raises_with_guidance(self, monkeypatch):
+        monkeypatch.setattr(hf_hub, "list_hf_tags", lambda repo_id: ["test_v1"])
+        with pytest.raises(RuntimeError, match="--hf-revision"):
+            resolve_hf_revision("ns/repo", None)
+
+
+class TestListHfTags:
+    def test_names_extracted_from_refs(self, monkeypatch, fake_api):
+        class Ref:
+            def __init__(self, name):
+                self.name = name
+
+        class Refs:
+            tags = [Ref("v0.1.0"), Ref("final_v2")]
+
+        fake_api.list_repo_refs = lambda repo_id, repo_type=None: Refs()
+        assert hf_hub.list_hf_tags("ns/repo") == ["v0.1.0", "final_v2"]
+
+    def test_missing_repo_yields_empty(self, monkeypatch, fake_api):
+        import httpx  # noqa: PLC0415
+        from huggingface_hub.errors import RepositoryNotFoundError  # noqa: PLC0415
+
+        response = httpx.Response(
+            404, request=httpx.Request("GET", "https://huggingface.co/api/models/ns/repo")
+        )
+
+        def raise_missing(repo_id, repo_type=None):
+            raise RepositoryNotFoundError("nope", response=response)
+
+        fake_api.list_repo_refs = raise_missing
+        assert hf_hub.list_hf_tags("ns/repo") == []
+
+
+class TestResolveInferenceArtifacts:
+    def _args(self, **kwargs):
+        defaults = {
+            "command": "inference",
+            "encoder_path": None,
+            "rf_path": None,
+            "config_path": None,
+            "hf_repo_id": None,
+            "hf_revision": None,
+        }
+        defaults.update(kwargs)
+        return argparse.Namespace(**defaults)
+
+    def test_all_local_paths_are_a_noop(self, monkeypatch):
+        monkeypatch.setattr(
+            hf_hub,
+            "download_inference_artifacts",
+            lambda *a, **k: pytest.fail("must not download"),
+        )
+        args = self._args(encoder_path="e.keras", rf_path="r.joblib", config_path="c.json")
+        resolve_inference_artifacts(args)
+        assert (args.encoder_path, args.rf_path, args.config_path) == (
+            "e.keras",
+            "r.joblib",
+            "c.json",
+        )
+
+    def test_local_paths_outrank_hf_revision(self, monkeypatch):
+        monkeypatch.setattr(
+            hf_hub,
+            "download_inference_artifacts",
+            lambda *a, **k: pytest.fail("must not download"),
+        )
+        args = self._args(
+            encoder_path="e.keras",
+            rf_path="r.joblib",
+            config_path="c.json",
+            hf_revision="v0.1.0",
+        )
+        resolve_inference_artifacts(args)
+        assert args.encoder_path == "e.keras"
+
+    def test_partial_trio_left_untouched_for_validation(self, monkeypatch):
+        monkeypatch.setattr(
+            hf_hub,
+            "download_inference_artifacts",
+            lambda *a, **k: pytest.fail("must not download"),
+        )
+        args = self._args(encoder_path="e.keras")
+        resolve_inference_artifacts(args)
+        assert args.encoder_path == "e.keras"
+        assert args.rf_path is None
+        assert args.config_path is None
+
+    def test_no_paths_downloads_pinned_revision(self, monkeypatch):
+        downloads = []
+
+        def fake_download(repo_id, filename, revision):
+            downloads.append((repo_id, filename, revision))
+            return f"/cache/{filename}"
+
+        monkeypatch.setattr(
+            hf_hub,
+            "_hf_hub_download",
+            lambda **kw: fake_download(kw["repo_id"], kw["filename"], kw["revision"]),
+        )
+        args = self._args(hf_revision="test_v17")
+        resolve_inference_artifacts(args)
+        # Revision-pinned, correct repo (config default), correct filenames.
+        repo_id = get_config().hf.repo_id
+        assert downloads == [
+            (repo_id, HF_ENCODER_FILENAME, "test_v17"),
+            (repo_id, HF_RF_FILENAME, "test_v17"),
+            (repo_id, HF_CONFIG_FILENAME, "test_v17"),
+        ]
+        assert args.encoder_path == f"/cache/{HF_ENCODER_FILENAME}"
+        assert args.rf_path == f"/cache/{HF_RF_FILENAME}"
+        assert args.config_path == f"/cache/{HF_CONFIG_FILENAME}"
+
+    def test_no_paths_no_revision_resolves_latest_and_records_provenance(self, monkeypatch):
+        monkeypatch.setattr(hf_hub, "list_hf_tags", lambda repo_id: ["v0.1.0", "final_v3"])
+        monkeypatch.setattr(hf_hub, "_hf_hub_download", lambda **kw: f"/cache/{kw['filename']}")
+        args = self._args()
+        resolve_inference_artifacts(args)
+        # The resolved revision is written back to args so it lands in config.hf.revision
+        # (and the saved inference config) via apply_args_to_config.
+        assert args.hf_revision == "v0.1.0"
+
+    def test_repo_id_flag_overrides_config_default(self, monkeypatch):
+        seen = []
+        monkeypatch.setattr(
+            hf_hub,
+            "_hf_hub_download",
+            lambda **kw: (seen.append(kw["repo_id"]), f"/cache/{kw['filename']}")[1],
+        )
+        args = self._args(hf_repo_id="other/repo", hf_revision="final_v1")
+        resolve_inference_artifacts(args)
+        assert set(seen) == {"other/repo"}
+
+
+class TestComputeRfMetrics:
+    def test_metrics_from_eval_artifacts(self):
+        config = get_config()
+        _write_run_artifacts(config, "test_v1")
+        metrics = compute_rf_metrics(config.model_path, "test_v1")
+        # val_probas orders one positive below one negative -> AUC 0.75 for these arrays.
+        assert metrics["val_roc_auc"] == pytest.approx(0.75)
+        assert 0.0 <= metrics["val_average_precision"] <= 1.0
+        assert metrics["classification_threshold"] == pytest.approx(0.99)
+        assert metrics["n_val"] == 4
+
+    def test_missing_artifact_returns_none(self):
+        assert compute_rf_metrics(get_config().model_path, "test_v9") is None
+
+    def test_corrupt_artifact_returns_none(self):
+        config = get_config()
+        os.makedirs(config.model_path, exist_ok=True)
+        with open(os.path.join(config.model_path, "rf_eval_artifacts_test_v2.joblib"), "w") as f:
+            f.write("not a joblib")
+        assert compute_rf_metrics(config.model_path, "test_v2") is None
+
+
+class TestGenerateModelCard:
+    def _card(self, metrics=None):
+        return generate_model_card(
+            tag="test_v17",
+            repo_id="zachtheyek/aetherscan",
+            config_dict=get_config().to_dict(),
+            metrics=metrics,
+            versions={"python": "3.10.0", "tensorflow": "2.17.1"},
+        )
+
+    def test_contains_tag_config_and_links(self):
+        card = self._card()
+        assert "**Training tag**: `test_v17`" in card
+        config = get_config()
+        assert f"`{config.training.num_training_rounds}`" in card
+        assert f"`{config.training.curriculum_schedule}`" in card
+        assert hf_hub.GITHUB_URL in card
+        for filename in (
+            HF_ENCODER_FILENAME,
+            HF_DECODER_FILENAME,
+            HF_RF_FILENAME,
+            HF_CONFIG_FILENAME,
+        ):
+            assert filename in card
+        assert "3.10.0" in card and "2.17.1" in card
+        # Frontmatter block for the Hub card metadata.
+        assert card.startswith("---\n")
+
+    def test_metrics_section_present_when_available(self):
+        card = self._card(
+            metrics={
+                "val_roc_auc": 0.9876,
+                "val_average_precision": 0.8765,
+                "classification_threshold": 0.99,
+                "n_val": 128,
+            }
+        )
+        assert "0.9876" in card
+        assert "0.8765" in card
+        assert "| Validation samples | 128 |" in card
+
+    def test_metrics_section_omitted_when_unavailable(self):
+        card = self._card(metrics=None)
+        assert "ROC AUC" not in card
+        assert "No evaluation artifacts" in card
+
+
+class TestUploadRunToHf:
+    def test_stages_stable_names_and_tags_commit(self, fake_api):
+        config = get_config()
+        _write_run_artifacts(config, "test_v1")
+        upload_run_to_hf(
+            repo_id="ns/repo",
+            tag="test_v1",
+            model_path=config.model_path,
+            output_path=config.output_path,
+        )
+
+        assert sorted(fake_api.uploaded_files) == sorted(
+            [
+                HF_ENCODER_FILENAME,
+                HF_DECODER_FILENAME,
+                HF_RF_FILENAME,
+                HF_CONFIG_FILENAME,
+                HF_CARD_FILENAME,
+            ]
+        )
+        assert "test_v1" in fake_api.uploaded_files[HF_CARD_FILENAME]
+
+        names = [name for name, _ in fake_api.calls]
+        assert names == ["create_repo", "upload_folder", "create_tag"]
+        create_repo = dict(fake_api.calls[0][1])
+        assert create_repo == {
+            "repo_id": "ns/repo",
+            "repo_type": "model",
+            "private": False,
+            "exist_ok": True,
+        }
+        upload = dict(fake_api.calls[1][1])
+        assert upload["repo_id"] == "ns/repo"
+        assert upload["commit_message"] == "test_v1"  # commit message = save_tag
+        assert dict(fake_api.calls[2][1]) == {"repo_id": "ns/repo", "tag": "test_v1"}
+
+    def test_force_moves_existing_tag(self, fake_api):
+        config = get_config()
+        _write_run_artifacts(config, "test_v1")
+        upload_run_to_hf(
+            repo_id="ns/repo",
+            tag="test_v1",
+            model_path=config.model_path,
+            output_path=config.output_path,
+            force=True,
+        )
+        names = [name for name, _ in fake_api.calls]
+        assert names == ["create_repo", "upload_folder", "delete_tag", "create_tag"]
+
+    def test_missing_artifact_raises_before_any_api_call(self, fake_api):
+        config = get_config()
+        _write_run_artifacts(config, "test_v1")
+        os.remove(os.path.join(config.model_path, "vae_decoder_test_v1.keras"))
+        with pytest.raises(FileNotFoundError, match="vae_decoder_test_v1.keras"):
+            upload_run_to_hf(
+                repo_id="ns/repo",
+                tag="test_v1",
+                model_path=config.model_path,
+                output_path=config.output_path,
+            )
+        assert fake_api.calls == []
+
+    def test_upload_failure_propagates_to_caller(self, monkeypatch):
+        config = get_config()
+        _write_run_artifacts(config, "test_v1")
+        api = _FakeHfApi(fail_on={"upload_folder"})
+        monkeypatch.setattr(hf_hub, "_hf_api", lambda: api)
+        with pytest.raises(RuntimeError, match="upload_folder failed"):
+            upload_run_to_hf(
+                repo_id="ns/repo",
+                tag="test_v1",
+                model_path=config.model_path,
+                output_path=config.output_path,
+            )

--- a/tests/unit/test_hf_hub.py
+++ b/tests/unit/test_hf_hub.py
@@ -20,6 +20,7 @@ from aetherscan.hf_hub import (
     HF_DECODER_FILENAME,
     HF_ENCODER_FILENAME,
     HF_RF_FILENAME,
+    _sanitize_config_for_upload,
     compute_rf_metrics,
     generate_model_card,
     resolve_hf_revision,
@@ -95,6 +96,44 @@ def _write_run_artifacts(config, tag, with_eval_artifacts=True):
             },
             os.path.join(config.model_path, f"rf_eval_artifacts_{tag}.joblib"),
         )
+
+
+class TestSanitizeConfigForUpload:
+    """The config.json published to the PUBLIC Hub repo must not carry host paths or real
+    dataset filenames, only reproducibility-relevant hyperparameters (HFSEC-1)."""
+
+    _CONFIG = {
+        "paths": {"data_path": "/datax/scratch/zachy/data", "output_path": "/datax/out"},
+        "data": {
+            "train_files": ["real_HIP123.npy"],
+            "test_files": ["x.npy"],
+            "num_backgrounds": 45000,
+        },
+        "inference": {
+            "encoder_path": "/datax/enc",
+            "rf_path": "/datax/rf",
+            "classification_threshold": 0.99,
+        },
+        "checkpoint": {"load_dir": "/datax/ckpt", "save_tag": "final_v1"},
+        "beta_vae": {"beta": 1.5, "latent_dim": 8},
+    }
+
+    def test_strips_host_paths_and_filenames_keeps_hyperparameters(self):
+        s = _sanitize_config_for_upload(self._CONFIG)
+        # Whole host-layout section gone; per-field paths/filenames gone.
+        assert "paths" not in s
+        assert "train_files" not in s["data"] and "test_files" not in s["data"]
+        assert "encoder_path" not in s["inference"] and "rf_path" not in s["inference"]
+        assert "load_dir" not in s["checkpoint"]
+        # Reproducibility-relevant fields survive.
+        assert s["data"]["num_backgrounds"] == 45000
+        assert s["inference"]["classification_threshold"] == 0.99
+        assert s["checkpoint"]["save_tag"] == "final_v1"
+        assert s["beta_vae"] == {"beta": 1.5, "latent_dim": 8}
+
+    def test_does_not_mutate_the_input(self):
+        _sanitize_config_for_upload(self._CONFIG)
+        assert "paths" in self._CONFIG and "train_files" in self._CONFIG["data"]
 
 
 class TestSelectDefaultRevision:

--- a/tests/unit/test_hf_hub.py
+++ b/tests/unit/test_hf_hub.py
@@ -425,6 +425,14 @@ class TestUploadRunToHf:
         )
         assert "test_v1" in fake_api.uploaded_files[HF_CARD_FILENAME]
 
+        # HFSEC-1: the config.json actually pushed to the public repo is redacted of host paths
+        # and real dataset filenames, but keeps hyperparameters.
+        uploaded_config = json.loads(fake_api.uploaded_files[HF_CONFIG_FILENAME])
+        assert "paths" not in uploaded_config
+        assert "train_files" not in uploaded_config["data"]
+        assert "encoder_path" not in uploaded_config["inference"]
+        assert uploaded_config["beta_vae"]["latent_dim"] == get_config().beta_vae.latent_dim
+
         names = [name for name, _ in fake_api.calls]
         assert names == ["create_repo", "upload_folder", "create_tag"]
         create_repo = dict(fake_api.calls[0][1])

--- a/tests/unit/test_hf_hub.py
+++ b/tests/unit/test_hf_hub.py
@@ -267,6 +267,22 @@ class TestResolveInferenceArtifacts:
         with pytest.raises(RuntimeError, match="--hf-revision"):
             hf_hub.download_inference_artifacts("ns/repo", "v0.1.0")
 
+    def test_download_disables_hub_progress_bars(self, monkeypatch):
+        # The pipeline redirects stdout/stderr to StreamToLogger — progress bars must be
+        # off so the Hub client never depends on tty probing of the fake stream.
+        from huggingface_hub.utils import (  # noqa: PLC0415
+            are_progress_bars_disabled,
+            enable_progress_bars,
+        )
+
+        monkeypatch.setattr(hf_hub, "_hf_hub_download", lambda **kw: f"/cache/{kw['filename']}")
+        enable_progress_bars()
+        try:
+            hf_hub.download_inference_artifacts("ns/repo", "v0.1.0")
+            assert are_progress_bars_disabled()
+        finally:
+            enable_progress_bars()
+
     def test_repo_id_flag_overrides_config_default(self, monkeypatch):
         seen = []
         monkeypatch.setattr(
@@ -422,6 +438,29 @@ class TestUploadRunToHf:
                 model_path=config.model_path,
                 output_path=config.output_path,
             )
+
+    def test_upload_disables_hub_progress_bars(self, fake_api):
+        # Regression guard for the live-smoke failure: upload_folder's progress machinery
+        # probed the redirected stdout ("'StreamToLogger' object has no attribute
+        # 'isatty'"). Progress bars are force-disabled before any Hub call.
+        from huggingface_hub.utils import (  # noqa: PLC0415
+            are_progress_bars_disabled,
+            enable_progress_bars,
+        )
+
+        config = get_config()
+        _write_run_artifacts(config, "test_v1")
+        enable_progress_bars()
+        try:
+            upload_run_to_hf(
+                repo_id="ns/repo",
+                tag="test_v1",
+                model_path=config.model_path,
+                output_path=config.output_path,
+            )
+            assert are_progress_bars_disabled()
+        finally:
+            enable_progress_bars()
 
     def test_tag_conflict_after_upload_points_at_force_tag(self, monkeypatch):
         # TOCTOU: the tag appeared between the startup dedup check and the post-upload

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1,0 +1,67 @@
+"""Unit tests for aetherscan.logger.logger.StreamToLogger: the file-protocol probe surface
+that libraries writing to the redirected sys.stdout/sys.stderr rely on (tqdm progress bars
+via huggingface_hub probe isatty(); others probe writable()/fileno())."""
+
+from __future__ import annotations
+
+import io
+import logging
+
+import pytest
+
+from aetherscan.logger.logger import StreamToLogger
+
+
+class _CaptureHandler(logging.Handler):
+    def __init__(self):
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+@pytest.fixture
+def capture_logger():
+    log = logging.getLogger("test_stream_to_logger")
+    log.setLevel(logging.DEBUG)
+    log.propagate = False
+    handler = _CaptureHandler()
+    log.addHandler(handler)
+    yield log, handler
+    log.removeHandler(handler)
+
+
+class TestStreamToLogger:
+    def test_write_routes_lines_to_logger(self, capture_logger):
+        log, handler = capture_logger
+        stream = StreamToLogger(log, logging.INFO)
+        stream.write("line one\nline two\n")
+        assert [r.getMessage() for r in handler.records] == ["line one", "line two"]
+        assert all(r.levelno == logging.INFO for r in handler.records)
+
+    def test_flush_is_safe(self, capture_logger):
+        log, _handler = capture_logger
+        StreamToLogger(log, logging.INFO).flush()  # must not raise
+
+    def test_isatty_is_false(self, capture_logger):
+        # The exact probe that killed the hf_upload stage: huggingface_hub's tqdm progress
+        # machinery calls sys.stdout.isatty() on the redirected stream.
+        log, _handler = capture_logger
+        assert StreamToLogger(log, logging.INFO).isatty() is False
+
+    def test_capability_probes(self, capture_logger):
+        log, _handler = capture_logger
+        stream = StreamToLogger(log, logging.INFO)
+        assert stream.writable() is True
+        assert stream.readable() is False
+
+    def test_fileno_raises_unsupported_operation(self, capture_logger):
+        # io.UnsupportedOperation subclasses both OSError and ValueError — the two types
+        # libraries guard fileno() probes against (matching io.StringIO's behavior).
+        log, _handler = capture_logger
+        stream = StreamToLogger(log, logging.INFO)
+        with pytest.raises(io.UnsupportedOperation):
+            stream.fileno()
+        assert issubclass(io.UnsupportedOperation, OSError)
+        assert issubclass(io.UnsupportedOperation, ValueError)

--- a/tests/unit/test_run_state.py
+++ b/tests/unit/test_run_state.py
@@ -165,6 +165,11 @@ class TestConfigFingerprint:
         "training": {"num_samples_beta_vae": 499200, "max_retries": 3, "retry_delay": 60},
         "gpu": {"num_replicas": None},
         "inference": {"max_retries": 3, "parallel_coarse_chans": None},
+        "hf": {
+            "upload_after_training": False,
+            "repo_id": "zachtheyek/aetherscan",
+            "revision": None,
+        },
         "checkpoint": {"save_tag": "final_v1", "load_tag": None, "start_round": 1},
     }
 
@@ -201,6 +206,10 @@ class TestConfigFingerprint:
             ("manager", "n_processes", 96),
             ("logger", "slack_enabled", False),
             ("inference", "max_retries", 9),
+            # HF upload config never affects the training result — toggling --hf-upload or
+            # changing its repo/revision must NOT discard the manifest (regression: #130).
+            ("hf", "upload_after_training", True),
+            ("hf", "repo_id", "other/repo"),
             ("checkpoint", "load_tag", "round_03"),
             ("checkpoint", "start_round", 4),
             ("training", "max_retries", 10),

--- a/tests/unit/test_run_state.py
+++ b/tests/unit/test_run_state.py
@@ -12,6 +12,7 @@ import pytest
 
 from aetherscan.run_state import (
     STAGE_FINAL_SAVE,
+    STAGE_HF_UPLOAD,
     STAGE_RF_PLOTS,
     STAGE_RF_TRAIN,
     STAGE_VAE_PLOTS,
@@ -104,6 +105,7 @@ class TestBookkeeping:
             STAGE_RF_TRAIN,
             STAGE_RF_PLOTS,
             STAGE_FINAL_SAVE,
+            STAGE_HF_UPLOAD,
         )
 
     def test_mark_stage_done_is_idempotent(self):
@@ -122,6 +124,16 @@ class TestBookkeeping:
         state.mark_stage_done(STAGE_VAE_PLOTS)
         assert state.stages_failed == []
         assert state.is_stage_done(STAGE_VAE_PLOTS)
+
+    def test_clear_stage_failure_drops_without_marking_done(self):
+        state = TrainingRunState(tag="test_v1", run_start_time=1.0)
+        state.record_stage_failure(STAGE_HF_UPLOAD)
+        state.clear_stage_failure(STAGE_HF_UPLOAD)
+        assert state.stages_failed == []
+        assert not state.is_stage_done(STAGE_HF_UPLOAD)
+        # Clearing an unrecorded stage is a no-op
+        state.clear_stage_failure(STAGE_HF_UPLOAD)
+        assert state.stages_failed == []
 
     def test_mark_round_completed_sorted_and_deduped(self):
         state = TrainingRunState(tag="test_v1", run_start_time=1.0)

--- a/tests/unit/test_tag_guards.py
+++ b/tests/unit/test_tag_guards.py
@@ -1,0 +1,216 @@
+"""Unit tests for aetherscan.tag_guards: the fail-early save-tag dedup guard matrix (local
+train/inference collisions, resumable-run exemptions, --force-tag override, HF-side check)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+import pytest
+
+from aetherscan import hf_hub, tag_guards
+from aetherscan.config import get_config
+from aetherscan.run_state import run_state_path
+from aetherscan.tag_guards import (
+    enforce_tag_guards,
+    find_inference_tag_collisions,
+    find_train_tag_collisions,
+)
+
+TAG = "test_v5"
+
+
+class _FakeDb:
+    """Stands in for the Database singleton: query methods return canned row lists."""
+
+    def __init__(self, training_rows=0, inference_rows=0, manifest_rows=0):
+        self._training = [{"tag": TAG}] * training_rows
+        self._inference = [{"tag": TAG}] * inference_rows
+        self._manifest = [{"tag": TAG}] * manifest_rows
+
+    def query_training_stat(self, tag=None, columns=None, **kwargs):
+        return list(self._training)
+
+    def query_inference_result(self, tag=None, columns=None, **kwargs):
+        return list(self._inference)
+
+    def query_inference_cadences(self, tag=None, columns=None, **kwargs):
+        return list(self._manifest)
+
+
+@pytest.fixture
+def fake_db(monkeypatch):
+    db = _FakeDb()
+    monkeypatch.setattr(tag_guards, "get_db", lambda: db)
+    return db
+
+
+def _args(command, save_tag=TAG, **kwargs):
+    return argparse.Namespace(command=command, save_tag=save_tag, **kwargs)
+
+
+def _touch(path):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write("stub")
+
+
+def _set_tag(tag=TAG, force=False):
+    config = get_config()
+    config.checkpoint.save_tag = tag
+    config.checkpoint.force_tag = force
+    return config
+
+
+class TestFindTrainTagCollisions:
+    def test_clean_slate_has_no_collisions(self, fake_db):
+        assert find_train_tag_collisions(TAG) == []
+
+    def test_encoder_artifact_collides(self, fake_db):
+        config = get_config()
+        _touch(os.path.join(config.model_path, f"vae_encoder_{TAG}.keras"))
+        collisions = find_train_tag_collisions(TAG)
+        assert len(collisions) == 1
+        assert "vae_encoder" in collisions[0]
+
+    def test_config_json_collides(self, fake_db):
+        config = get_config()
+        _touch(os.path.join(config.output_path, f"config_{TAG}.json"))
+        assert any("config_" in c for c in find_train_tag_collisions(TAG))
+
+    def test_db_rows_collide(self, fake_db):
+        fake_db._training = [{"tag": TAG}] * 3
+        collisions = find_train_tag_collisions(TAG)
+        assert any("3 non-superseded training_stats" in c for c in collisions)
+
+    def test_all_three_reported_together(self, fake_db):
+        config = get_config()
+        _touch(os.path.join(config.model_path, f"vae_encoder_{TAG}.keras"))
+        _touch(os.path.join(config.output_path, f"config_{TAG}.json"))
+        fake_db._training = [{"tag": TAG}]
+        assert len(find_train_tag_collisions(TAG)) == 3
+
+
+class TestFindInferenceTagCollisions:
+    def test_clean_slate_has_no_collisions(self, fake_db):
+        assert find_inference_tag_collisions(TAG) == []
+
+    def test_completed_run_config_json_collides(self, fake_db):
+        config = get_config()
+        _touch(os.path.join(config.output_path, f"config_{TAG}.json"))
+        assert any("completed run marker" in c for c in find_inference_tag_collisions(TAG))
+
+    def test_legacy_db_rows_without_manifest_collide(self, fake_db):
+        fake_db._inference = [{"tag": TAG}] * 2
+        collisions = find_inference_tag_collisions(TAG)
+        assert any("inference_results" in c for c in collisions)
+
+    def test_manifest_rows_mark_resumable_run_not_collision(self, fake_db):
+        # An in-progress streaming run: manifest rows exist, no completed-run config JSON.
+        # Same-tag DB state is exactly what the resume flow consumes — never a collision.
+        fake_db._manifest = [{"tag": TAG}]
+        fake_db._inference = [{"tag": TAG}] * 10
+        assert find_inference_tag_collisions(TAG) == []
+
+
+class TestEnforceTagGuardsTrain:
+    def test_default_datetime_tag_skips_guard(self, fake_db):
+        # args.save_tag is None -> tag was not explicitly provided -> immune by construction
+        config = _set_tag()
+        _touch(os.path.join(config.model_path, f"vae_encoder_{TAG}.keras"))
+        enforce_tag_guards(_args("train", save_tag=None))  # must not exit
+
+    def test_explicit_tag_with_collision_exits(self, fake_db):
+        config = _set_tag()
+        _touch(os.path.join(config.model_path, f"vae_encoder_{TAG}.keras"))
+        with pytest.raises(SystemExit) as excinfo:
+            enforce_tag_guards(_args("train"))
+        assert excinfo.value.code == 1
+
+    def test_explicit_tag_clean_slate_passes(self, fake_db):
+        _set_tag()
+        enforce_tag_guards(_args("train"))
+
+    def test_resumable_manifest_exempts_same_tag_retry(self, fake_db):
+        config = _set_tag()
+        _touch(os.path.join(config.model_path, f"vae_encoder_{TAG}.keras"))
+        with open(run_state_path(config.output_path, TAG), "w") as f:
+            json.dump({"tag": TAG, "run_start_time": 1.0}, f)
+        enforce_tag_guards(_args("train"))  # must not exit
+
+    def test_force_tag_overrides_collision(self, fake_db):
+        config = _set_tag(force=True)
+        _touch(os.path.join(config.model_path, f"vae_encoder_{TAG}.keras"))
+        enforce_tag_guards(_args("train"))  # must not exit
+
+
+class TestEnforceTagGuardsHf:
+    def test_hf_collision_exits_when_upload_enabled(self, fake_db, monkeypatch):
+        config = _set_tag()
+        config.hf.upload_after_training = True
+        monkeypatch.setattr(hf_hub, "hf_tag_exists", lambda repo_id, tag: True)
+        with pytest.raises(SystemExit):
+            enforce_tag_guards(_args("train"))
+
+    def test_hf_check_runs_even_for_default_tags(self, fake_db, monkeypatch):
+        config = _set_tag()
+        config.hf.upload_after_training = True
+        monkeypatch.setattr(hf_hub, "hf_tag_exists", lambda repo_id, tag: True)
+        with pytest.raises(SystemExit):
+            enforce_tag_guards(_args("train", save_tag=None))
+
+    def test_hf_clean_tag_passes(self, fake_db, monkeypatch):
+        config = _set_tag()
+        config.hf.upload_after_training = True
+        monkeypatch.setattr(hf_hub, "hf_tag_exists", lambda repo_id, tag: False)
+        enforce_tag_guards(_args("train"))
+
+    def test_hf_check_failure_warns_but_does_not_block(self, fake_db, monkeypatch):
+        config = _set_tag()
+        config.hf.upload_after_training = True
+
+        def boom(repo_id, tag):
+            raise ConnectionError("no network")
+
+        monkeypatch.setattr(hf_hub, "hf_tag_exists", boom)
+        enforce_tag_guards(_args("train"))  # must not exit
+
+    def test_hf_collision_with_force_passes(self, fake_db, monkeypatch):
+        config = _set_tag(force=True)
+        config.hf.upload_after_training = True
+        monkeypatch.setattr(hf_hub, "hf_tag_exists", lambda repo_id, tag: True)
+        enforce_tag_guards(_args("train"))
+
+    def test_hf_check_skipped_when_upload_disabled(self, fake_db, monkeypatch):
+        _set_tag()
+
+        def boom(repo_id, tag):
+            raise AssertionError("HF must not be contacted when --hf-upload is off")
+
+        monkeypatch.setattr(hf_hub, "hf_tag_exists", boom)
+        enforce_tag_guards(_args("train"))
+
+
+class TestEnforceTagGuardsInference:
+    def test_completed_run_collision_exits(self, fake_db):
+        config = _set_tag()
+        _touch(os.path.join(config.output_path, f"config_{TAG}.json"))
+        with pytest.raises(SystemExit):
+            enforce_tag_guards(_args("inference"))
+
+    def test_resumable_manifest_rows_pass(self, fake_db):
+        _set_tag()
+        fake_db._manifest = [{"tag": TAG}]
+        fake_db._inference = [{"tag": TAG}] * 4
+        enforce_tag_guards(_args("inference"))
+
+    def test_default_tag_skips_guard(self, fake_db):
+        config = _set_tag()
+        _touch(os.path.join(config.output_path, f"config_{TAG}.json"))
+        enforce_tag_guards(_args("inference", save_tag=None))
+
+    def test_force_tag_overrides(self, fake_db):
+        config = _set_tag(force=True)
+        _touch(os.path.join(config.output_path, f"config_{TAG}.json"))
+        enforce_tag_guards(_args("inference"))

--- a/tests/unit/test_tag_guards.py
+++ b/tests/unit/test_tag_guards.py
@@ -11,7 +11,7 @@ import pytest
 
 from aetherscan import hf_hub, tag_guards
 from aetherscan.config import get_config
-from aetherscan.run_state import run_state_path
+from aetherscan.run_state import STAGE_FINAL_SAVE, STAGE_VAE_PLOTS, run_state_path
 from aetherscan.tag_guards import (
     enforce_tag_guards,
     find_inference_tag_collisions,
@@ -137,6 +137,35 @@ class TestEnforceTagGuardsTrain:
         _touch(os.path.join(config.model_path, f"vae_encoder_{TAG}.keras"))
         with open(run_state_path(config.output_path, TAG), "w") as f:
             json.dump({"tag": TAG, "run_start_time": 1.0}, f)
+        enforce_tag_guards(_args("train"))  # must not exit
+
+    def test_completed_manifest_does_not_exempt_collision(self, fake_db):
+        # A COMPLETED run's manifest (final_save done, no pending failures) persists on success,
+        # but must NOT keep disabling the collision guard — otherwise a reused --save-tag would
+        # silently overwrite a finished model with no warning (TG-1).
+        config = _set_tag()
+        _touch(os.path.join(config.model_path, f"vae_encoder_{TAG}.keras"))
+        with open(run_state_path(config.output_path, TAG), "w") as f:
+            json.dump({"tag": TAG, "run_start_time": 1.0, "stages_done": [STAGE_FINAL_SAVE]}, f)
+        with pytest.raises(SystemExit) as excinfo:
+            enforce_tag_guards(_args("train"))
+        assert excinfo.value.code == 1
+
+    def test_manifest_with_pending_failure_stays_resumable(self, fake_db):
+        # final_save done but a non-critical stage still failed -> resumable (the relaunch
+        # retries the failed stage), so the collision guard stays exempt.
+        config = _set_tag()
+        _touch(os.path.join(config.model_path, f"vae_encoder_{TAG}.keras"))
+        with open(run_state_path(config.output_path, TAG), "w") as f:
+            json.dump(
+                {
+                    "tag": TAG,
+                    "run_start_time": 1.0,
+                    "stages_done": [STAGE_FINAL_SAVE],
+                    "stages_failed": [STAGE_VAE_PLOTS],
+                },
+                f,
+            )
         enforce_tag_guards(_args("train"))  # must not exit
 
     def test_force_tag_overrides_collision(self, fake_db):

--- a/tests/unit/test_train_utils.py
+++ b/tests/unit/test_train_utils.py
@@ -14,6 +14,7 @@ import pytest
 from aetherscan.config import get_config
 from aetherscan.run_state import (
     STAGE_FINAL_SAVE,
+    STAGE_HF_UPLOAD,
     STAGE_RF_PLOTS,
     STAGE_RF_TRAIN,
     STAGE_VAE_PLOTS,
@@ -340,14 +341,18 @@ class TestSelectPositiveClassShap:
 
 class _StageMachineStub:
     """Duck-typed TrainingPipeline for _execute_training_stages: records the call order,
-    raises inside any method named in `fail`, and reports rf-load success per `rf_load_ok`."""
+    raises inside any method named in `fail`, and reports rf-load success per `rf_load_ok`.
+    `hf_upload` toggles the opt-in hf_upload stage via the config singleton (which the real
+    pipeline also reads through self.config)."""
 
-    def __init__(self, state, fail=(), rf_load_ok=True):
+    def __init__(self, state, fail=(), rf_load_ok=True, hf_upload=False):
         self.run_state = state
         self.calls = []
         self.rf_model = "trained-rf"
         self._fail = set(fail)
         self._rf_load_ok = rf_load_ok
+        self.config = get_config()
+        self.config.hf.upload_after_training = hf_upload
 
     def _invoke(self, name):
         self.calls.append(name)
@@ -369,6 +374,9 @@ class _StageMachineStub:
     def final_save(self):
         self._invoke("final_save")
 
+    def upload_to_hf(self):
+        self._invoke("upload_to_hf")
+
     def save_models(self):
         self._invoke("save_models")
 
@@ -389,6 +397,10 @@ class _StageMachineStub:
     def _record_stage_failure(self, stage):
         self.run_state.record_stage_failure(stage)
 
+    def _clear_stage_failure(self, stage):
+        self.calls.append("_clear_stage_failure")
+        self.run_state.clear_stage_failure(stage)
+
 
 class TestExecuteTrainingStages:
     def _state(self, **kwargs):
@@ -406,7 +418,8 @@ class TestExecuteTrainingStages:
             "_clear_rf_caches",
             "final_save",
         ]
-        assert stub.run_state.stages_done == list(TRAINING_STAGES)
+        # hf_upload is opt-in and disabled by default: skipped, not marked done
+        assert stub.run_state.stages_done == [s for s in TRAINING_STAGES if s != STAGE_HF_UPLOAD]
         assert stub.run_state.stages_failed == []
 
     def test_done_stages_are_skipped(self):
@@ -423,7 +436,7 @@ class TestExecuteTrainingStages:
             "_clear_rf_caches",
             "final_save",
         ]
-        assert state.stages_done == list(TRAINING_STAGES)
+        assert state.stages_done == [s for s in TRAINING_STAGES if s != STAGE_HF_UPLOAD]
 
     def test_vae_plot_failure_is_recorded_but_does_not_abort(self):
         stub = _StageMachineStub(self._state(), fail={"plot_vae_diagnostics"})
@@ -478,3 +491,37 @@ class TestExecuteTrainingStages:
         ]
         assert state.stages_failed == []
         assert state.stages_done[-1] == STAGE_VAE_PLOTS  # re-marked after the retry
+
+    def test_hf_upload_enabled_runs_after_final_save(self):
+        stub = _StageMachineStub(self._state(), hf_upload=True)
+        _execute_training_stages(stub)
+        assert stub.calls[-2:] == ["final_save", "upload_to_hf"]
+        assert stub.run_state.stages_done == list(TRAINING_STAGES)
+        assert stub.run_state.stages_failed == []
+
+    def test_hf_upload_failure_recorded_but_never_fails_the_run(self):
+        stub = _StageMachineStub(self._state(), fail={"upload_to_hf"}, hf_upload=True)
+        _execute_training_stages(stub)  # must not raise — weights are already safe locally
+        assert stub.run_state.stages_failed == [STAGE_HF_UPLOAD]
+        assert not stub.run_state.is_stage_done(STAGE_HF_UPLOAD)
+        assert stub.run_state.is_stage_done(STAGE_FINAL_SAVE)
+
+    def test_hf_upload_done_is_skipped_on_relaunch(self):
+        state = self._state(stages_done=list(TRAINING_STAGES))
+        stub = _StageMachineStub(state, hf_upload=True)
+        _execute_training_stages(stub)
+        assert "upload_to_hf" not in stub.calls
+
+    def test_disabling_hf_upload_clears_stale_failure(self):
+        # A previous --hf-upload attempt failed; the user re-runs without it. The stale
+        # failure must be dropped so it can't force a nonzero exit forever.
+        state = self._state(
+            stages_done=[s for s in TRAINING_STAGES if s != STAGE_HF_UPLOAD],
+            stages_failed=[STAGE_HF_UPLOAD],
+        )
+        stub = _StageMachineStub(state, hf_upload=False)
+        _execute_training_stages(stub)
+        assert "upload_to_hf" not in stub.calls
+        assert "_clear_stage_failure" in stub.calls
+        assert state.stages_failed == []
+        assert not state.is_stage_done(STAGE_HF_UPLOAD)

--- a/utils/run_container.sh
+++ b/utils/run_container.sh
@@ -30,6 +30,8 @@
 #                               (default: none)
 #     SLACK_BOT_TOKEN           Slack bot token, forwarded into the container
 #     SLACK_CHANNEL             Slack channel, forwarded into the container
+#     HF_TOKEN                  HuggingFace token (write access) for --hf-upload,
+#                               forwarded into the container; never logged
 #
 # Note, the runtime's native SINGULARITY_BIND / APPTAINER_BIND env vars still pass
 # through untouched and are additive with the binds set up from AETHERSCAN_EXTRA_BINDS.
@@ -123,4 +125,5 @@ exec "$RUNTIME" exec --nv \
     --env AETHERSCAN_OUTPUT_PATH="$OUTPUT_PATH" \
     --env SLACK_BOT_TOKEN="${SLACK_BOT_TOKEN:-}" \
     --env SLACK_CHANNEL="${SLACK_CHANNEL:-}" \
+    --env HF_TOKEN="${HF_TOKEN:-}" \
     "$SIF" "$@"


### PR DESCRIPTION
Closes #128

## Stacking note

This PR's base is **`integration/pr0910-base`** — coordinator scaffolding that merges the finished train chain (stage machine + run manifest, #122/#126) and inference chain (streaming inference + `inference_cadences` manifest + viz suite, #120/#125, and PR-08's #129). Only the commits on `feature/huggingface-integration` are this PR's diff; review it against the integration base.

## What this adds (PLAN PR-10)

**Dependency** — `huggingface_hub>=1.21,<1.22` in `requirements-container.txt` + `environment.yml` (pip section). Version per SECURITY.md's Version Selection Policy: latest stable at pin time is **1.23.0** (2026-07-09); two minors back is **1.21** (1.21.0, 2026-06-25), which is newer than the newest ≥6-month-old release (pre-1.6, before 2026-01-12), so 1.21 is the target; no known advisory affects it. **Clusters need a container image rebuild** (`singularity build aetherscan-ngc25.02.sif aetherscan.def`) before production use. Pre-rebuild workaround (validated on blpc3): `./utils/run_container.sh python -m pip install --user "huggingface_hub==1.21.0"`, then launch with `SINGULARITYENV_PYTHONNOUSERSITE=` — the NGC image sets `PYTHONNOUSERSITE=1`, which disables the user site the `--user` install lands in.

**Auth** — `HF_TOKEN` via the gitignored `.env`, forwarded by `utils/run_container.sh` (new entry in the env allowlist), documented in the README `.env` example. Never logged. Downloads hit a public repo and need no token; only `--hf-upload` needs one.

**Config/CLI** — new `HFConfig` (`repo_id` = `zachtheyek/aetherscan`, `upload_after_training` = off, `revision` = None) + `checkpoint.force_tag`; flags: train `--hf-upload/--no-hf-upload`, both modes `--hf-repo-id`, inference `--hf-revision`, both modes `--force-tag` (tri-state BooleanOptionalAction like the other bool flags; effective default off). `to_dict()` updated; README CLI Reference regenerated verbatim; `docs/CONFIG_AND_CLI.md` tables/audit counts updated.

**Training upload** — new manifest-tracked `hf_upload` stage after `final_save`: stages the four artifacts under stable names (`vae_encoder.keras`, `vae_decoder.keras`, `random_forest.joblib`, `config.json`) plus a generated model card (pipeline description, tag, config summary, val ROC AUC/AP from `rf_eval_artifacts` when available, library versions, GitHub link/citation), commit message = save_tag, then `create_tag(save_tag)`. Creates the public repo on first upload (`create_repo(exist_ok=True)`). Non-critical: failure is logged + recorded in the run manifest, never fails the run; re-running the identical command retries just this stage, and re-running with the upload disabled clears a stale recorded failure. Hub progress bars are force-disabled and `StreamToLogger` answers file-protocol probes (`isatty`/`writable`/`readable`/`fileno`), so transfers never depend on tty probing of the redirected streams.

**Inference download** — `--encoder-path/--rf-path/--config-path` become optional as an all-or-none trio. Resolution order: explicit local paths → `--hf-revision` → latest semver `v*` tag → latest `final_vX` tag → error with guidance. Downloads are revision-pinned via `hf_hub_download`; the cached trio is written onto `args` before validation, so the existing `apply_saved_config` + strategy-scoped model-load path runs unchanged, and the resolved revision lands in `config.hf.revision` for provenance.

**Tag dedup guards (fail-early)** — enforced right before command dispatch (post-validation, post-DB-init):
- Train, explicitly-provided tags only: collisions with `vae_encoder_{tag}.keras`, `config_{tag}.json`, or non-superseded `training_stats` rows hard-exit with the options listed — unless a resumable run-state manifest exists (same-tag retries keep working).
- HF-side: with `--hf-upload`, the save_tag is checked against existing repo tags at startup, not after ~30 h of training; a failed check (network) only warns.
- Inference: a completed prior run (its saved `config_{tag}.json`) or stale legacy-path DB rows collide; in-progress streaming runs (manifest rows, no config JSON) resume as before.
- Default datetime tags are immune by construction; `--force-tag` consciously overrides (and moves the HF tag on upload).

## Verification

**Unit suite** — `PYTHONPATH=src pytest -m "not gpu and not cluster" -q` → **519 passed, 3 skipped** (local arm64 venv, TF 2.17.1; baseline on the integration base was 445 passed). New tests cover upload arg shapes/staged filenames, revision resolution order, semver sorting, the dedup guard matrix, model-card content, hf_upload stage-machine semantics, StreamToLogger's file-protocol probes, and the progress-bar disabling — `huggingface_hub` fully mocked, no network in the suite. `pre-commit run --all-files` green on every commit.

**Live round-trip on blpc3 (completed)** — `huggingface_hub==1.21.0` installed in the container via the pre-rebuild workaround above; `HF_TOKEN` present in `.env` (never printed/logged).

1. *Train smoke with `--hf-upload`* (5-GPU smoke config, fresh tag `test_v26`): training completed; the first upload attempt exposed a real bug — `'StreamToLogger' object has no attribute 'isatty'` from `upload_folder`'s progress machinery probing the redirected stdout. **Failure containment worked exactly as designed**: the run finished, `hf_upload` was recorded failed in the manifest, and the process exited nonzero with re-run guidance. Fixed in 7cd19e1 (both `StreamToLogger` probes and disabled Hub progress bars).
2. *Manifest-driven stage retry* (real-world validation of the PR-04 stage-resume design): relaunching the **identical** command after the fix skipped all five completed stages and re-ran only the upload:
   ```
   INFO | Resuming training run from manifest .../run_state_test_v26.json (attempt 2, completed rounds: [1, 2], stages done: ['vae_rounds', 'vae_plots', 'rf_train', 'rf_plots', 'final_save'], stages failed: ['hf_upload'])
   INFO | Stage 'vae_rounds' already complete — skipping
   INFO | Stage 'vae_plots' already complete — skipping
   INFO | Stage 'rf_train' already complete — loaded persisted RF model
   INFO | Stage 'rf_plots' already complete — skipping
   INFO | Stage 'final_save' already complete — skipping
   INFO | Uploaded run 'test_v26' to https://huggingface.co/zachtheyek/aetherscan and tagged the commit
   INFO | Stage 'hf_upload' complete (recorded in run manifest)
   INFO | Training completed successfully!
   ```
3. *Hub state verified* (public read, no token): repo `zachtheyek/aetherscan` PUBLIC with `vae_encoder.keras`, `vae_decoder.keras`, `random_forest.joblib`, `config.json`, `README.md` (generated model card with correct frontmatter + this run's config summary) on `main`; tag `test_v26` pointing at the main head.
4. *Inference smoke pulling from the Hub with NO local model paths*: `inference --hf-revision test_v26 --inference-files subset_test.csv` resolved and downloaded the revision-pinned trio into the container's `~/.cache/huggingface` (HOME bind-mount caching confirmed working — no `HF_HOME` override needed), fed the downloaded `config.json` through `apply_saved_config`, loaded the encoder inside `strategy.scope()` from the cache path, and completed: **2 cadences, 94,667 snippets processed, 0 candidates, exit 0** (~22 min wall for the 2-cadence subset).
5. *Cleanup*: tag `test_v26` deleted from the Hub via `delete_tag` (repo + main-branch artifacts left in place; tags now `[]`); cluster scratch/`/tmp`/`/dev/shm` cleaned, repo back on `master`.

## AI disclosure

Implemented with Claude Code (Anthropic), end-to-end: design from the v1 plan, implementation, tests, live cluster validation, and this PR. Human-specified requirements and review by @zachtheyek.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
