### PR TITLE
Packaging + release CD: PyPI trusted publishing, GitHub Releases, version-coupled HF weights

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,10 +202,19 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          # The static pre-release version isn't bumped between releases, so a repeated dry run
+          # re-uploads the same filename; skip-existing keeps the "recommended before the first
+          # real release" dry run idempotent instead of hard-failing on TestPyPI's 400.
+          skip-existing: true
 
       - name: Publish to PyPI
         if: needs.guard.outputs.dry_run != 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Idempotent partial-failure recovery: if PyPI publish succeeds but a later gate
+          # (github-release) fails, re-running the whole workflow won't hard-fail here on the
+          # already-published (immutable) version. The guard job still pins tag == version.
+          skip-existing: true
 
   # Decorate the tag into a GitHub Release with generated notes and the built artifacts
   # attached. The generated notes are a starting point — curate the body from the per-PR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 # Release CD — the automation half of the release contract in docs/RELEASE.md.
 #
 # Trigger: pushing a release tag (git tag -s vX.Y.Z && git push origin vX.Y.Z). The gates run
-# in order — version guard -> unit tests -> HF weights verification -> build -> PyPI publish
+# in order — signed-tag + version guard -> unit tests -> HF weights verification -> build -> PyPI publish
 # (trusted publishing) -> GitHub Release — so a half-released state is impossible: nothing
 # publishes unless the tag matches pyproject.toml, the suite is green, and the blessed
 # weights tag already exists on the HF model repo (CD verifies weights, never creates them —
@@ -48,6 +48,34 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+
+      - name: Enforce a signed release tag
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          # Releases carry the same provenance as commits (this repo requires signed commits): the
+          # tag must be an ANNOTATED, GPG-signed tag whose signature GitHub verifies against a key
+          # registered to the tagger's account. Rejects lightweight tags and unsigned/unverified
+          # ones. No key material lives in CI — GitHub does the verification. (Dry-run
+          # workflow_dispatch has no tag, so this step is skipped there.)
+          obj_type=$(gh api "repos/$GH_REPO/git/ref/tags/$REF_NAME" --jq '.object.type')
+          if [ "$obj_type" != "tag" ]; then
+            echo "::error::Release tag '$REF_NAME' is a lightweight tag. Cut it signed:" \
+                 "git tag -s $REF_NAME (docs/RELEASE.md step 5)."
+            exit 1
+          fi
+          tag_sha=$(gh api "repos/$GH_REPO/git/ref/tags/$REF_NAME" --jq '.object.sha')
+          verified=$(gh api "repos/$GH_REPO/git/tags/$tag_sha" --jq '.verification.verified')
+          reason=$(gh api "repos/$GH_REPO/git/tags/$tag_sha" --jq '.verification.reason')
+          if [ "$verified" != "true" ]; then
+            echo "::error::Release tag '$REF_NAME' signature not verified (reason: $reason)." \
+                 "Sign with git tag -s using a GPG key registered on your GitHub account."
+            exit 1
+          fi
+          echo "Signed-tag check passed: '$REF_NAME' ($reason)."
 
       - name: Resolve version and enforce tag match
         id: resolve
@@ -199,7 +227,9 @@ jobs:
 
       - name: Publish to TestPyPI (dry run)
         if: needs.guard.outputs.dry_run == 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # SHA-pinned (not @release/v1) because this is the only job holding the PyPI publish
+        # credential (id-token); claude-dependency-check.yml flags a newer release weekly to bump.
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.1
         with:
           repository-url: https://test.pypi.org/legacy/
           # The static pre-release version isn't bumped between releases, so a repeated dry run
@@ -209,7 +239,9 @@ jobs:
 
       - name: Publish to PyPI
         if: needs.guard.outputs.dry_run != 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # SHA-pinned (not @release/v1) because this is the only job holding the PyPI publish
+        # credential (id-token); claude-dependency-check.yml flags a newer release weekly to bump.
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247  # v1.14.1
         with:
           # Idempotent partial-failure recovery: if PyPI publish succeeds but a later gate
           # (github-release) fails, re-running the whole workflow won't hard-fail here on the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,233 @@
+# Release CD — the automation half of the release contract in docs/RELEASE.md.
+#
+# Trigger: pushing a release tag (git tag -s vX.Y.Z && git push origin vX.Y.Z). The gates run
+# in order — version guard -> unit tests -> HF weights verification -> build -> PyPI publish
+# (trusted publishing) -> GitHub Release — so a half-released state is impossible: nothing
+# publishes unless the tag matches pyproject.toml, the suite is green, and the blessed
+# weights tag already exists on the HF model repo (CD verifies weights, never creates them —
+# weights only come from cluster training runs).
+#
+# One-time maintainer prerequisites (see docs/RELEASE.md):
+#   - PyPI: create the `aetherscan` project with GitHub as a trusted publisher
+#     (repository zachtheyek/Aetherscan, workflow release.yml, environment pypi) and create
+#     the `pypi` environment in this repo's settings. No API token is stored anywhere.
+#   - For the TestPyPI dry run: the same trusted-publisher setup on test.pypi.org with
+#     environment `testpypi`.
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  # Dry-run path (recommended before the first real release): manual dispatch publishes to
+  # test.pypi.org. Real releases only ever happen via tag pushes — a manual run with
+  # test_pypi unchecked fails the guard.
+  workflow_dispatch:
+    inputs:
+      test_pypi:
+        description: "Publish to test.pypi.org (dry run)"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+env:
+  # The HF model repo carrying the release weights. Must match config.hf.repo_id's default
+  # (src/aetherscan/config.py).
+  HF_WEIGHTS_REPO: zachtheyek/aetherscan
+
+jobs:
+  # Gate 1: fail loudly before anything runs if the pushed tag doesn't equal
+  # "v" + pyproject.toml's [project].version (i.e. the release PR's version bump didn't
+  # land on the tagged commit), or if a manual run tries to target the real PyPI.
+  guard:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      dry_run: ${{ steps.resolve.outputs.dry_run }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Resolve version and enforce tag match
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          TEST_PYPI: ${{ inputs.test_pypi }}
+        run: |
+          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ "$TEST_PYPI" != "true" ]; then
+              echo "::error::Manual runs only support the TestPyPI dry run (test_pypi: true)." \
+                   "Real releases must go through a signed tag push (docs/RELEASE.md step 5)."
+              exit 1
+            fi
+            echo "dry_run=true" >> "$GITHUB_OUTPUT"
+            echo "Dry run: will publish aetherscan $VERSION to test.pypi.org"
+            exit 0
+          fi
+          echo "dry_run=false" >> "$GITHUB_OUTPUT"
+          if [ "$REF_TYPE" != "tag" ]; then
+            echo "::error::Release runs must be triggered by a tag push, got ref type '$REF_TYPE'."
+            exit 1
+          fi
+          if [ "$REF_NAME" != "v$VERSION" ]; then
+            echo "::error::Tag '$REF_NAME' does not match pyproject.toml version '$VERSION'" \
+                 "(expected tag 'v$VERSION'). Land the release PR that bumps the version," \
+                 "then tag its merge commit (docs/RELEASE.md steps 4-5)."
+            exit 1
+          fi
+          echo "Version guard passed: $REF_NAME == v$VERSION"
+
+  # Gate 2: a release build must not outrun a red suite. Calls tests.yml as a reusable
+  # workflow — the same suite and selection as regular CI, by construction.
+  tests:
+    needs: guard
+    uses: ./.github/workflows/tests.yml
+
+  # Gate 3: verify the blessed weights tag exists on the HF model repo (public read, no
+  # token). Verify, never create: if this fails, the release runbook's weight-blessing step
+  # was skipped — the fix is utils/hf_tag_release.py, not anything in CI.
+  verify-weights:
+    needs: guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip on dry run
+        if: needs.guard.outputs.dry_run == 'true'
+        run: |
+          echo "Dry run: skipping HF weights verification — pre-release versions" \
+               "(${{ needs.guard.outputs.version }}) never have a blessed weights tag."
+
+      - name: Set up Python
+        if: needs.guard.outputs.dry_run != 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify HF weights tag exists
+        if: needs.guard.outputs.dry_run != 'true'
+        env:
+          RELEASE_TAG: v${{ needs.guard.outputs.version }}
+        run: |
+          # Range mirrors requirements-container.txt
+          pip install "huggingface_hub>=1.21,<1.22"
+          python - <<'EOF'
+          import os
+          import sys
+
+          from huggingface_hub import HfApi
+
+          repo_id = os.environ["HF_WEIGHTS_REPO"]
+          tag = os.environ["RELEASE_TAG"]
+          tags = [ref.name for ref in HfApi().list_repo_refs(repo_id, repo_type="model").tags]
+          if tag in tags:
+              print(f"Weights tag '{tag}' exists on https://huggingface.co/{repo_id} — OK")
+              sys.exit(0)
+          print(
+              f"::error::Weights tag '{tag}' not found on https://huggingface.co/{repo_id} "
+              f"(existing tags: {', '.join(sorted(tags)) or 'none'}). CD verifies release "
+              f"weights but never creates them. Bless the trained weights first — "
+              f"python utils/hf_tag_release.py --save-tag <final_vN> --release {tag} — "
+              f"then re-run this workflow. The git tag is already correct; do not re-push it. "
+              f"See docs/RELEASE.md step 3."
+          )
+          sys.exit(1)
+          EOF
+
+  # Build the sdist + wheel from the tagged source, and smoke the wheel: it must install
+  # and report exactly the guarded version.
+  build:
+    needs: [guard, tests, verify-weights]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Smoke the wheel (installs and reports the guarded version)
+        env:
+          EXPECTED_VERSION: ${{ needs.guard.outputs.version }}
+        run: |
+          # --no-deps: the full dependency tree (TF + CUDA wheels) is exercised by the test
+          # jobs; here we only check packaging metadata and importability.
+          pip install --no-deps dist/*.whl
+          INSTALLED=$(python -c "import aetherscan; print(aetherscan.__version__)")
+          if [ "$INSTALLED" != "$EXPECTED_VERSION" ]; then
+            echo "::error::Installed wheel reports version '$INSTALLED', expected '$EXPECTED_VERSION'."
+            exit 1
+          fi
+          echo "Wheel smoke passed: aetherscan.__version__ == $INSTALLED"
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  # Publish via PyPI trusted publishing (OIDC): the `pypi` / `testpypi` GitHub environment
+  # plus id-token permission is the whole credential — no stored API token.
+  publish:
+    needs: [guard, build]
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ needs.guard.outputs.dry_run == 'true' && 'testpypi' || 'pypi' }}
+      url: ${{ needs.guard.outputs.dry_run == 'true' && 'https://test.pypi.org/p/aetherscan' || 'https://pypi.org/p/aetherscan' }}
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI (dry run)
+        if: needs.guard.outputs.dry_run == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: Publish to PyPI
+        if: needs.guard.outputs.dry_run != 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  # Decorate the tag into a GitHub Release with generated notes and the built artifacts
+  # attached. The generated notes are a starting point — curate the body from the per-PR
+  # claude-release-notes comments afterwards (docs/RELEASE.md step 6).
+  github-release:
+    needs: [guard, publish]
+    if: needs.guard.outputs.dry_run != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: v${{ needs.guard.outputs.version }}
+        run: |
+          gh release create "$RELEASE_TAG" dist/* \
+            --verify-tag \
+            --title "$RELEASE_TAG" \
+            --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,11 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           TEST_PYPI: ${{ inputs.test_pypi }}
         run: |
-          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          VERSION=$(python3 -c "
+          import tomllib
+          with open('pyproject.toml', 'rb') as f:
+              print(tomllib.load(f)['project']['version'])
+          ")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             if [ "$TEST_PYPI" != "true" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,15 +61,17 @@ jobs:
           # registered to the tagger's account. Rejects lightweight tags and unsigned/unverified
           # ones. No key material lives in CI — GitHub does the verification. (Dry-run
           # workflow_dispatch has no tag, so this step is skipped there.)
-          obj_type=$(gh api "repos/$GH_REPO/git/ref/tags/$REF_NAME" --jq '.object.type')
+          ref_json=$(gh api "repos/$GH_REPO/git/ref/tags/$REF_NAME")
+          obj_type=$(jq -r '.object.type' <<<"$ref_json")
+          tag_sha=$(jq -r '.object.sha' <<<"$ref_json")
           if [ "$obj_type" != "tag" ]; then
             echo "::error::Release tag '$REF_NAME' is a lightweight tag. Cut it signed:" \
                  "git tag -s $REF_NAME (docs/RELEASE.md step 5)."
             exit 1
           fi
-          tag_sha=$(gh api "repos/$GH_REPO/git/ref/tags/$REF_NAME" --jq '.object.sha')
-          verified=$(gh api "repos/$GH_REPO/git/tags/$tag_sha" --jq '.verification.verified')
-          reason=$(gh api "repos/$GH_REPO/git/tags/$tag_sha" --jq '.verification.reason')
+          tag_json=$(gh api "repos/$GH_REPO/git/tags/$tag_sha")
+          verified=$(jq -r '.verification.verified' <<<"$tag_json")
+          reason=$(jq -r '.verification.reason' <<<"$tag_json")
           if [ "$verified" != "true" ]; then
             echo "::error::Release tag '$REF_NAME' signature not verified (reason: $reason)." \
                  "Sign with git tag -s using a GPG key registered on your GitHub account."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,13 +2,16 @@
 # Unit test suite (pytest)
 name: Tests
 
-# Run on every PR and on pushes to master
+# Run on every PR and on pushes to master. Also callable as a reusable workflow so the
+# release CD (release.yml) runs the exact same suite as a publish gate — by construction,
+# not by copy-paste.
 on:
   push:
     branches: ["master"]
   pull_request:
     branches: ["**"]
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ benchmarks/results/
 # Container artifacts
 *.sif
 
+# Python packaging artifacts (python -m build)
+dist/
+*.egg-info/
+
 
 ### Global gitignore (https://github.com/zachtheyek/dotfiles/blob/master/git/.gitignore_global)
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
     Breakthrough Listen's first end-to-end production-grade deep learning pipeline for SETI @ scale
     <br />
     <br />
+    <a href="https://github.com/zachtheyek/Aetherscan/actions/workflows/tests.yml"><img src="https://github.com/zachtheyek/Aetherscan/actions/workflows/tests.yml/badge.svg" alt="Tests"></a>
+    <a href="https://pypi.org/project/aetherscan/"><img src="https://img.shields.io/pypi/v/aetherscan.svg" alt="PyPI"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/License-BSD_3--Clause-blue.svg" alt="License"></a>
     <a href="https://www.python.org/"><img src="https://img.shields.io/badge/Python-3.10%E2%80%933.12-blue.svg" alt="Python"></a>
     <a href="https://www.tensorflow.org/"><img src="https://img.shields.io/badge/TensorFlow-2.17-orange.svg" alt="TensorFlow"></a>

--- a/README.md
+++ b/README.md
@@ -478,10 +478,9 @@ options:
                         Path to output directory (overrides
                         AETHERSCAN_OUTPUT_PATH environment variable)
   --dashboard, --no-dashboard
-                        Auto-launch the live monitoring dashboard
-                        (utils/dashboard.py) for this run; SSH-forward the
-                        port to view it (default: on). Use --no-dashboard to
-                        disable
+                        Auto-launch the live monitoring Streamlit dashboard
+                        for this run; SSH-forward the port to view it
+                        (default: on). Use --no-dashboard to disable
   --dashboard-port DASHBOARD_PORT
                         Port for the auto-launched live dashboard (default:
                         8501)
@@ -774,10 +773,9 @@ options:
                         Path to output directory (overrides
                         AETHERSCAN_OUTPUT_PATH environment variable)
   --dashboard, --no-dashboard
-                        Auto-launch the live monitoring dashboard
-                        (utils/dashboard.py) for this run; SSH-forward the
-                        port to view it (default: on). Use --no-dashboard to
-                        disable
+                        Auto-launch the live monitoring Streamlit dashboard
+                        for this run; SSH-forward the port to view it
+                        (default: on). Use --no-dashboard to disable
   --dashboard-port DASHBOARD_PORT
                         Port for the auto-launched live dashboard (default:
                         8501)

--- a/README.md
+++ b/README.md
@@ -924,9 +924,10 @@ options:
   --hf-revision HF_REVISION
                         HuggingFace revision (tag, branch, or commit hash) to
                         pin the model download to when no local artifact paths
-                        are given (default: the repo's latest release tag —
-                        highest semver vX.Y.Z tag, falling back to the highest
-                        final_vX training tag)
+                        are given (default: v{package version} when running as
+                        an installed release, else the repo's latest release
+                        tag — highest semver vX.Y.Z tag, falling back to the
+                        highest final_vX training tag)
   --save-tag SAVE_TAG   Tag for current pipeline run. Current timestamp used
                         (YYYYMMDD_HHMMSS) if none specified
   --force-tag, --no-force-tag

--- a/environment.yml
+++ b/environment.yml
@@ -32,7 +32,7 @@ dependencies:
   - astropy>=6.1,<7
   - matplotlib>=3.9,<3.10
   - joblib>=1.4,<2
-  # pandas backs the dashboard's data layer (utils/dashboard.py). The NGC base image
+  # pandas backs the dashboard's data layer (aetherscan/dashboard.py). The NGC base image
   # ships it, so requirements-container.txt omits it; conda must provide it here.
   - pandas>=2.0,<3
   # setuptools provides pkg_resources, which blimpy (transitive via setigen)
@@ -64,7 +64,7 @@ dependencies:
       # Model weight distribution via the HuggingFace Hub — pin range mirrors
       # requirements-container.txt (see the rationale there).
       - huggingface_hub>=1.21,<1.22
-      # Live monitoring dashboard (utils/dashboard.py). Kept in lockstep with
+      # Live monitoring dashboard (aetherscan/dashboard.py). Kept in lockstep with
       # requirements-container.txt; streamlit 1.39 coexists with TF 2.17 (protobuf 4.x)
       # and numpy<2. plotly is pure-Python.
       - streamlit>=1.39,<1.41

--- a/environment.yml
+++ b/environment.yml
@@ -54,7 +54,8 @@ dependencies:
       # nvidia-nccl-cu12 2.21.x, etc. -- the exact ABI the TF 2.17 wheel was built
       # against. Driver requirement: NVIDIA driver >= 525.60 on the host.
       - tensorflow[and-cuda]==2.17.*
-      - setigen
+      # Range mirrors requirements-container.txt (see the rationale there).
+      - setigen>=2.6,<3
       - imageio>=2.34,<3
       - umap-learn>=0.5.6,<0.6
       - shap>=0.46.0,<0.47

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,12 @@ description = "Breakthrough Listen's first end-to-end production-grade DL pipeli
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
-    # Mirrors requirements-container.txt's ranges — keep the two (and environment.yml /
-    # aetherscan.def) in lockstep per SECURITY.md's Version Selection Policy. Documented
-    # ceilings (numpy<2.0, setuptools<81, the NGC TF 2.17 ABI) apply to the package exactly
-    # as to the container.
+    # Mirrors requirements-container.txt's ranges for the packaged runtime — keep them (and
+    # environment.yml / aetherscan.def) in lockstep per SECURITY.md's Version Selection Policy.
+    # Documented ceilings (numpy<2.0, setuptools<81, the NGC TF 2.17 ABI) apply to the package
+    # exactly as to the container. The dashboard stack (streamlit/plotly/pandas) is deliberately
+    # NOT mirrored here: utils/dashboard.py is not shipped in the wheel (only src/aetherscan is),
+    # so it's repo-checkout/container-only observability, not a pip-install runtime dependency.
     "numpy>=1.26,<2.0",
     "scipy>=1.13,<1.14",
     "scikit-learn>=1.5,<1.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,18 @@
-# TODO: add build backend (uv)
-# TODO: How to release as package on PyPI & display on GitHub? How to tag new releases on GitHub?
-# [build-system]
-# requires = ["hatchling"]
-# build-backend = "hatchling.build"
-#
-# [tool.hatch.build.targets.wheel]
-# packages = ["src/aetherscan"]
+# Packaging + release process: docs/RELEASE.md (version coupling, CD gates, runbook).
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/aetherscan"]
 
 [project]
 name = "aetherscan"
-version = "0.1.0"
+# Single source of truth for the package version (src/aetherscan/__init__.py reads it back
+# via importlib.metadata). Kept a pre-release between releases; the release PR bumps it to
+# the final X.Y.Z, and the CD workflow (.github/workflows/release.yml) enforces that the
+# pushed git tag matches it exactly.
+version = "0.9.0.dev0"
 authors = [
     { name = "Zach Yek", email = "xiaoxiyek1.5@gmail.com" },
 ]
@@ -20,7 +23,34 @@ description = "Breakthrough Listen's first end-to-end production-grade DL pipeli
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
-    # TODO: sync with environment.yml files (include for uv)
+    # Mirrors requirements-container.txt's ranges — keep the two (and environment.yml /
+    # aetherscan.def) in lockstep per SECURITY.md's Version Selection Policy. Documented
+    # ceilings (numpy<2.0, setuptools<81, the NGC TF 2.17 ABI) apply to the package exactly
+    # as to the container.
+    "numpy>=1.26,<2.0",
+    "scipy>=1.13,<1.14",
+    "scikit-learn>=1.5,<1.6",
+    "matplotlib>=3.9,<3.10",
+    "astropy>=6.1,<7",
+    "scikit-image>=0.24,<0.25",
+    "joblib>=1.4,<2",
+    "imageio>=2.34,<3",
+    "umap-learn>=0.5.6,<0.6",
+    "shap>=0.46.0,<0.47",
+    "slack-sdk>=3.31.0,<4",
+    "python-dotenv>=1.0,<2",
+    "huggingface_hub>=1.21,<1.22",
+    # setuptools provides pkg_resources, which blimpy (transitive via setigen) imports at
+    # module load; <81 because setuptools 81 removed the vendored pkg_resources.
+    "setuptools>=70,<81",
+    "setigen",
+    # The NGC base image provides these implicitly (so requirements-container.txt omits
+    # them); a pip install has no base image to lean on and must declare them. Ranges
+    # mirror environment.yml's pins.
+    "tensorflow[and-cuda]==2.17.*",
+    "h5py>=3.11,<3.12",
+    "hdf5plugin",
+    "psutil>=6.0,<6.1",
 ]
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]
@@ -35,12 +65,17 @@ keywords = [
     "Data Methods",
 ]
 classifiers = [
-    "Development Status :: 2 - Pre-Alpha",  # TODO: update development status on v1 release
+    # TODO: v1 release PR — flip to "Development Status :: 4 - Beta" or
+    # "Development Status :: 5 - Production/Stable" (maintainer's call at release time;
+    # revisit in every release PR per docs/RELEASE.md)
+    "Development Status :: 2 - Pre-Alpha",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.12",
     "Operating System :: Unix",
     "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.4",
-    "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.8",
+    # NOTE: the NGC 25.02 container runs CUDA 12.8, but the trove classifier list currently
+    # tops out at "12 :: 12.6" — the bare ":: 12" parent is the closest valid classifier
+    "Environment :: GPU :: NVIDIA CUDA :: 12",
     "License :: OSI Approved :: BSD License",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
@@ -53,7 +88,7 @@ Homepage = "https://github.com/zachtheyek/Aetherscan"
 Issues = "https://github.com/zachtheyek/Aetherscan/issues"
 
 [project.optional-dependencies]
-dev = ["ruff"]  # Python linter
+dev = ["ruff", "pre-commit", "pytest"]
 
 [tool.pytest.ini_options]
 # Make `import aetherscan` work without a PYTHONPATH=src prefix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     # setuptools provides pkg_resources, which blimpy (transitive via setigen) imports at
     # module load; <81 because setuptools 81 removed the vendored pkg_resources.
     "setuptools>=70,<81",
-    "setigen",
+    "setigen>=2.6,<3",
     # The NGC base image provides these implicitly (so requirements-container.txt omits
     # them); a pip install has no base image to lean on and must declare them. Ranges
     # mirror environment.yml's pins.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,9 @@ dependencies = [
     # Mirrors requirements-container.txt's ranges for the packaged runtime — keep them (and
     # environment.yml / aetherscan.def) in lockstep per SECURITY.md's Version Selection Policy.
     # Documented ceilings (numpy<2.0, setuptools<81, the NGC TF 2.17 ABI) apply to the package
-    # exactly as to the container. The dashboard stack (streamlit/plotly/pandas) is deliberately
-    # NOT mirrored here: utils/dashboard.py is not shipped in the wheel (only src/aetherscan is),
-    # so it's repo-checkout/container-only observability, not a pip-install runtime dependency.
+    # exactly as to the container. The dashboard stack (streamlit/plotly/pandas) lives in the
+    # optional `dashboard` extra below — not core deps — so a bare install stays lean while
+    # `pip install aetherscan[dashboard]` still gets the packaged dashboard (aetherscan/dashboard.py).
     "numpy>=1.26,<2.0",
     "scipy>=1.13,<1.14",
     "scikit-learn>=1.5,<1.6",
@@ -91,6 +91,12 @@ Issues = "https://github.com/zachtheyek/Aetherscan/issues"
 
 [project.optional-dependencies]
 dev = ["ruff", "pre-commit", "pytest"]
+# Live monitoring dashboard (aetherscan/dashboard.py, auto-launched by main.py). Opt-in extra so a
+# bare `pip install aetherscan` stays lean; `pip install aetherscan[dashboard]` pulls the stack.
+# Ranges mirror requirements-container.txt / environment.yml (kept in lockstep); streamlit 1.39
+# coexists with TF 2.17's protobuf 4.x and numpy<2, plotly is pure-Python, pandas backs the data
+# layer (the NGC base ships pandas, so requirements-container.txt omits it there).
+dashboard = ["streamlit>=1.39,<1.41", "plotly>=5.24,<6", "pandas>=2.0,<3"]
 
 [tool.pytest.ini_options]
 # Make `import aetherscan` work without a PYTHONPATH=src prefix

--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -30,7 +30,9 @@ huggingface_hub>=1.21,<1.22
 # setuptools 81 removed pkg_resources as a vendored submodule -- revisit
 # once blimpy migrates off pkg_resources (upstream issue).
 setuptools>=70,<81
-setigen
+# Range covers the proven 2.6/2.7 line (2.7.0 in current use) and blocks a future
+# major-version break; keep in lockstep with environment.yml and pyproject.toml.
+setigen>=2.6,<3
 # Live monitoring dashboard (utils/dashboard.py, auto-launched by main.py). streamlit 1.39
 # per SECURITY.md's version policy (proven, >=6-month-old); it accepts protobuf>=3.20,<6 and
 # numpy>=1.23, so it coexists with TF 2.17's protobuf 4.x pin and the numpy<2 ceiling (pyarrow

--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -33,7 +33,7 @@ setuptools>=70,<81
 # Range covers the proven 2.6/2.7 line (2.7.0 in current use) and blocks a future
 # major-version break; keep in lockstep with environment.yml and pyproject.toml.
 setigen>=2.6,<3
-# Live monitoring dashboard (utils/dashboard.py, auto-launched by main.py). streamlit 1.39
+# Live monitoring dashboard (aetherscan/dashboard.py, auto-launched by main.py). streamlit 1.39
 # per SECURITY.md's version policy (proven, >=6-month-old); it accepts protobuf>=3.20,<6 and
 # numpy>=1.23, so it coexists with TF 2.17's protobuf 4.x pin and the numpy<2 ceiling (pyarrow
 # /tornado/altair pulled transitively). plotly is pure-Python (no numpy ABI coupling). pandas

--- a/src/aetherscan/__init__.py
+++ b/src/aetherscan/__init__.py
@@ -9,7 +9,16 @@ exposes only the version string.
 
 from __future__ import annotations
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+# Version is single-sourced from pyproject.toml's [project].version via the installed
+# distribution's metadata. Source-tree runs (PYTHONPATH=src, the NGC container) have no
+# installed distribution — they fall back to a dev sentinel, which also keeps the
+# version-coupled HF weight resolution (hf_hub.version_default_revision) inactive there.
+try:
+    __version__ = version("aetherscan")
+except PackageNotFoundError:
+    __version__ = "0.0.0.dev0"
 __author__ = "Zach Yek"
 
 # TODO: determine which components are necessary to expose for public API

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -932,7 +932,7 @@ def _add_inference_flags_to(parser):
         "--hf-revision",
         type=str,
         default=None,
-        help="HuggingFace revision (tag, branch, or commit hash) to pin the model download to when no local artifact paths are given (default: the repo's latest release tag — highest semver vX.Y.Z tag, falling back to the highest final_vX training tag)",
+        help="HuggingFace revision (tag, branch, or commit hash) to pin the model download to when no local artifact paths are given (default: v{package version} when running as an installed release, else the repo's latest release tag — highest semver vX.Y.Z tag, falling back to the highest final_vX training tag)",
     )
 
     # Checkpoint configuration

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -218,7 +218,7 @@ def _add_train_flags_to(parser):
         "--dashboard",
         action=argparse.BooleanOptionalAction,
         default=None,
-        help="Auto-launch the live monitoring dashboard (utils/dashboard.py) for this run; SSH-forward the port to view it (default: on). Use --no-dashboard to disable",
+        help="Auto-launch the live monitoring Streamlit dashboard for this run; SSH-forward the port to view it (default: on). Use --no-dashboard to disable",
     )
     parser.add_argument(
         "--dashboard-port",
@@ -707,7 +707,7 @@ def _add_inference_flags_to(parser):
         "--dashboard",
         action=argparse.BooleanOptionalAction,
         default=None,
-        help="Auto-launch the live monitoring dashboard (utils/dashboard.py) for this run; SSH-forward the port to view it (default: on). Use --no-dashboard to disable",
+        help="Auto-launch the live monitoring Streamlit dashboard for this run; SSH-forward the port to view it (default: on). Use --no-dashboard to disable",
     )
     parser.add_argument(
         "--dashboard-port",

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -49,7 +49,7 @@ class MonitorConfig:
     # as labeled translucent bands on the resource plot's CPU panel, so utilization
     # plateaus are attributable to pipeline stages at a glance
     annotate_stages: bool = True
-    # Live monitoring dashboard (utils/dashboard.py) auto-launched by main.py at run start;
+    # Live monitoring dashboard (aetherscan/dashboard.py) auto-launched by main.py at run start;
     # --no-dashboard opts out. Served headless on dashboard_port (SSH-forward to reach it).
     dashboard_enabled: bool = True
     dashboard_port: int = 8501

--- a/src/aetherscan/dashboard.py
+++ b/src/aetherscan/dashboard.py
@@ -8,12 +8,16 @@ stats suite, a live latent-space scatter, the stage timeline (PR #134), and infe
 stats — plus a gallery of every saved plot PNG (RF diagnostics, latent traversals, inference
 figures) as it appears on disk.
 
-Like utils/benchmark_report.py it is STANDALONE — no `aetherscan` imports, only stdlib sqlite3 +
-numpy + pandas + plotly + streamlit — so it runs against a live run's DB or one fetched from a
-cluster with utils/fetch_run_outputs.sh. main.py auto-launches it (--no-dashboard to opt out); it
-can also be run by hand:
+It is STANDALONE — no `aetherscan` imports (like utils/benchmark_report.py), only stdlib sqlite3 +
+numpy + pandas + plotly + streamlit — so streamlit can execute it directly and it runs against a
+live run's DB or one fetched from a cluster with utils/fetch_run_outputs.sh. It ships inside the
+package (src/aetherscan/dashboard.py) so every install method (pip `aetherscan[dashboard]`, the
+container, or a source checkout) can auto-launch it. main.py auto-launches it (--no-dashboard to
+opt out); to run it by hand against a saved DB, point streamlit at the installed module file:
 
-    streamlit run utils/dashboard.py -- --db-path /path/to/aetherscan.db --tag final_v1
+    streamlit run "$(python -c 'import aetherscan, os; \
+        print(os.path.join(os.path.dirname(aetherscan.__file__), "dashboard.py"))')" \
+        -- --db-path /path/to/aetherscan.db --tag final_v1
 
 To watch a run on a cluster, SSH-forward the port:  ssh -L 8501:localhost:8501 blpc3
 

--- a/src/aetherscan/dashboard_launcher.py
+++ b/src/aetherscan/dashboard_launcher.py
@@ -1,5 +1,5 @@
 """
-Auto-launch the live monitoring dashboard (utils/dashboard.py) alongside a train/inference run.
+Auto-launch the live monitoring dashboard (aetherscan/dashboard.py) alongside a train/inference run.
 
 main.py calls launch_dashboard() once at startup (after the DB is initialized). It spawns a
 headless Streamlit server as a detached subprocess pointed at this run's DB + tag, logs the
@@ -28,8 +28,9 @@ from aetherscan.db import get_db
 
 logger = logging.getLogger(__name__)
 
-# utils/dashboard.py sits at the repo root; this module is src/aetherscan/dashboard_launcher.py
-_DASHBOARD_SCRIPT = Path(__file__).resolve().parents[2] / "utils" / "dashboard.py"
+# dashboard.py ships alongside this module inside the package, so it resolves identically for a
+# source checkout, the container, and a pip install (streamlit runs it by file path).
+_DASHBOARD_SCRIPT = Path(__file__).resolve().parent / "dashboard.py"
 
 
 def build_dashboard_command(
@@ -135,8 +136,9 @@ def launch_dashboard() -> subprocess.Popen | None:
 
     if importlib.util.find_spec("streamlit") is None:
         logger.warning(
-            "Dashboard skipped: streamlit not installed. Rebuild the NGC container (.sif) or the "
-            "conda env after the streamlit/plotly deps landed, or run with --no-dashboard."
+            "Dashboard skipped: streamlit not installed. Install the extra "
+            "(pip install 'aetherscan[dashboard]'), rebuild the NGC container (.sif) / conda env "
+            "after the streamlit/plotly deps landed, or run with --no-dashboard."
         )
         return None
 

--- a/src/aetherscan/hf_hub.py
+++ b/src/aetherscan/hf_hub.py
@@ -11,8 +11,10 @@ save_tag, e.g. final_v3, created by upload_run_to_hf after training) and release
 Upload (train, opt-in via --hf-upload) stages the four run artifacts under the stable names,
 commits them with the save_tag as the commit message, and tags the commit. Download
 (inference, the default when no local artifact paths are given) resolves a revision —
-explicit --hf-revision, else the highest semver vX.Y.Z tag, else the highest final_vX tag —
-and pulls the artifact trio revision-pinned via hf_hub_download.
+explicit --hf-revision, else v{__version__} when running as an installed release (see
+version_default_revision — this is what makes `pip install aetherscan==1.0.0` + bare
+inference pull exactly the v1.0.0 weights), else the highest semver vX.Y.Z tag, else the
+highest final_vX tag — and pulls the artifact trio revision-pinned via hf_hub_download.
 
 Auth: uploads require HF_TOKEN in the environment (loaded from the gitignored .env);
 huggingface_hub reads it implicitly. The repo is public, so downloads need no token. The
@@ -130,15 +132,48 @@ def select_default_revision(tags: list[str]) -> str | None:
     return None
 
 
+def version_default_revision() -> str | None:
+    """
+    The version-coupled default HF revision — f"v{__version__}" — or None when this run's
+    version can't name a release tag. This is the runtime half of the release contract
+    (docs/RELEASE.md): `pip install aetherscan==1.0.0` + inference with no model-path flags
+    downloads exactly the v1.0.0-blessed weights, because the installed package version is
+    the default revision.
+
+    Guard: the default only activates when v{__version__} lands in the release-tag family
+    (_SEMVER_TAG_PATTERN, strict vX.Y.Z). The importlib.metadata fallback ("0.0.0.dev0" —
+    source-tree/container runs), .dev pre-releases (e.g. "0.9.0.dev0" — a pip install of a
+    between-releases tree), and rc/post/local versions all fail the match and fall through
+    to latest-release resolution instead. Deliberately NOT existence-checked: an installed
+    release whose weights tag is missing must fail the download loudly (the release
+    runbook's blessing step was skipped) rather than silently pull some other version's
+    weights.
+    """
+    import aetherscan  # noqa: PLC0415  (late import so tests can monkeypatch __version__)
+
+    candidate = f"v{aetherscan.__version__}"
+    if not _SEMVER_TAG_PATTERN.match(candidate):
+        return None
+    return candidate
+
+
 def resolve_hf_revision(repo_id: str, revision: str | None) -> str:
     """
     Resolve the HF revision inference should download from: an explicitly requested revision
-    is returned as-is (existence is checked by the download itself), otherwise the repo's
-    tags are listed and select_default_revision picks the latest release. Raises RuntimeError
-    with guidance when nothing is resolvable.
+    is returned as-is (existence is checked by the download itself); otherwise an installed
+    release pins its own version's tag (version_default_revision — also download-checked);
+    otherwise the repo's tags are listed and select_default_revision picks the latest
+    release. Raises RuntimeError with guidance when nothing is resolvable.
     """
     if revision is not None:
         return revision
+    version_pinned = version_default_revision()
+    if version_pinned is not None:
+        logger.info(
+            f"Resolved HF revision '{version_pinned}' (pinned to the installed aetherscan "
+            f"release; override with --hf-revision)"
+        )
+        return version_pinned
     try:
         tags = list_hf_tags(repo_id)
     except Exception as e:
@@ -189,7 +224,8 @@ def resolve_inference_artifacts(args: argparse.Namespace) -> None:
     """
     Ensure the inference artifact trio (encoder/rf/config paths) is populated on `args`
     before validation runs, in resolution order: explicit local paths (highest) >
-    --hf-revision > latest release tag on the HF repo.
+    --hf-revision > v{__version__} when running as an installed release (see
+    version_default_revision) > latest release tag on the HF repo.
 
     When none of the three paths were given, the resolved revision's artifacts are
     downloaded and their cache paths written onto `args` — exactly as if the user had passed

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -1,6 +1,6 @@
-"""Unit tests for utils/dashboard.py's pure data layer (the SQL/shaping/PCA/artifact helpers that
-back the live Streamlit dashboard). The Streamlit/plotly render layer is not imported here — it is
-loaded lazily inside dashboard.render(), so this test needs only numpy + pandas + sqlite3."""
+"""Unit tests for aetherscan/dashboard.py's pure data layer (the SQL/shaping/PCA/artifact helpers
+that back the live Streamlit dashboard). The Streamlit/plotly render layer is not imported here — it
+is loaded lazily inside dashboard.render(), so this test needs only numpy + pandas + sqlite3."""
 
 from __future__ import annotations
 
@@ -13,9 +13,9 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-# utils/ is not a package — load the dashboard tool straight from its file (same pattern as
-# test_benchmark.py loads benchmark_report).
-_DASHBOARD_PATH = Path(__file__).resolve().parents[2] / "utils" / "dashboard.py"
+# Load the dashboard module straight from its file — standalone (no aetherscan/TF import), so the
+# data layer is testable with just numpy + pandas + sqlite3 even though it now ships in the package.
+_DASHBOARD_PATH = Path(__file__).resolve().parents[2] / "src" / "aetherscan" / "dashboard.py"
 _spec = importlib.util.spec_from_file_location("dashboard", _DASHBOARD_PATH)
 dashboard = importlib.util.module_from_spec(_spec)
 sys.modules["dashboard"] = dashboard

--- a/tests/unit/test_dashboard_launcher.py
+++ b/tests/unit/test_dashboard_launcher.py
@@ -28,14 +28,14 @@ def _fake_config(enabled=True, port=8501, output_path="/out", save_tag="t1"):
 def test_build_dashboard_command_structure():
     cmd = build_dashboard_command(
         "/usr/bin/python",
-        "/repo/utils/dashboard.py",
+        "/pkg/aetherscan/dashboard.py",
         "/out/db/aetherscan.db",
         "final_v1",
         "/out/plots",
         8501,
     )
     # `python -m streamlit run <script>` up front
-    assert cmd[:5] == ["/usr/bin/python", "-m", "streamlit", "run", "/repo/utils/dashboard.py"]
+    assert cmd[:5] == ["/usr/bin/python", "-m", "streamlit", "run", "/pkg/aetherscan/dashboard.py"]
 
     # streamlit's own flags precede `--`; dashboard.py's argparse args follow it
     sep = cmd.index("--")
@@ -132,7 +132,7 @@ def test_launch_spawns_and_registers_teardown():
         mock.patch(f"{_MOD}._install_signal_teardown") as sig_teardown,
     ):
         script.is_file.return_value = True
-        script.__str__ = lambda self: "/repo/utils/dashboard.py"
+        script.__str__ = lambda self: "/pkg/aetherscan/dashboard.py"
         result = launch_dashboard()
         assert result is proc
         # detached so a filling pipe / group signal can't hang or kill the pipeline

--- a/tests/unit/test_hf_hub.py
+++ b/tests/unit/test_hf_hub.py
@@ -12,6 +12,7 @@ import joblib
 import numpy as np
 import pytest
 
+import aetherscan
 from aetherscan import hf_hub
 from aetherscan.config import get_config
 from aetherscan.hf_hub import (
@@ -27,7 +28,15 @@ from aetherscan.hf_hub import (
     resolve_inference_artifacts,
     select_default_revision,
     upload_run_to_hf,
+    version_default_revision,
 )
+
+
+def _set_version(monkeypatch, value):
+    """Pin aetherscan.__version__ (read lazily by version_default_revision) for one test, so
+    resolution behavior never depends on whether the package happens to be pip-installed in
+    the environment running the suite."""
+    monkeypatch.setattr(aetherscan, "__version__", value)
 
 
 class _FakeHfApi:
@@ -157,6 +166,31 @@ class TestSelectDefaultRevision:
         assert select_default_revision([]) is None
 
 
+class TestVersionDefaultRevision:
+    """The version-coupled default only activates for real installed releases (strict X.Y.Z);
+    every other version shape — crucially the source-tree fallback and .dev pre-releases —
+    must return None so resolution falls through to the repo's latest release tag."""
+
+    def test_installed_release_yields_version_tag(self, monkeypatch):
+        _set_version(monkeypatch, "1.2.3")
+        assert version_default_revision() == "v1.2.3"
+
+    @pytest.mark.parametrize(
+        "version",
+        [
+            "0.0.0.dev0",  # the importlib.metadata PackageNotFoundError fallback
+            "0.9.0.dev0",  # a pip install of a between-releases source tree
+            "1.0.0rc1",  # release candidate
+            "1.0.0.post1",  # post-release
+            "1.0.0+local",  # local version
+            "1.0",  # not a full X.Y.Z
+        ],
+    )
+    def test_non_release_versions_are_guarded(self, monkeypatch, version):
+        _set_version(monkeypatch, version)
+        assert version_default_revision() is None
+
+
 class TestResolveHfRevision:
     def test_explicit_revision_returned_without_listing(self, monkeypatch):
         def boom(repo_id):
@@ -165,11 +199,33 @@ class TestResolveHfRevision:
         monkeypatch.setattr(hf_hub, "list_hf_tags", boom)
         assert resolve_hf_revision("ns/repo", "test_v17") == "test_v17"
 
+    def test_explicit_revision_outranks_installed_release(self, monkeypatch):
+        _set_version(monkeypatch, "1.2.3")
+        assert resolve_hf_revision("ns/repo", "final_v9") == "final_v9"
+
+    def test_installed_release_pins_own_version_without_listing(self, monkeypatch):
+        # An installed release resolves v{__version__} directly — no tag listing, and no
+        # silent fallback to other weights (a missing tag must fail the download instead).
+        _set_version(monkeypatch, "1.2.3")
+
+        def boom(repo_id):
+            raise AssertionError("must not list tags for a version-pinned revision")
+
+        monkeypatch.setattr(hf_hub, "list_hf_tags", boom)
+        assert resolve_hf_revision("ns/repo", None) == "v1.2.3"
+
+    def test_dev_version_falls_through_to_latest_release(self, monkeypatch):
+        _set_version(monkeypatch, "0.9.0.dev0")
+        monkeypatch.setattr(hf_hub, "list_hf_tags", lambda repo_id: ["final_v1", "v0.2.0"])
+        assert resolve_hf_revision("ns/repo", None) == "v0.2.0"
+
     def test_latest_release_selected(self, monkeypatch):
+        _set_version(monkeypatch, "0.0.0.dev0")
         monkeypatch.setattr(hf_hub, "list_hf_tags", lambda repo_id: ["final_v1", "v0.2.0"])
         assert resolve_hf_revision("ns/repo", None) == "v0.2.0"
 
     def test_no_resolvable_tag_raises_with_guidance(self, monkeypatch):
+        _set_version(monkeypatch, "0.0.0.dev0")
         monkeypatch.setattr(hf_hub, "list_hf_tags", lambda repo_id: ["test_v1"])
         with pytest.raises(RuntimeError, match="--hf-revision"):
             resolve_hf_revision("ns/repo", None)
@@ -178,6 +234,7 @@ class TestResolveHfRevision:
         def boom(repo_id):
             raise ConnectionError("no route to host")
 
+        _set_version(monkeypatch, "0.0.0.dev0")
         monkeypatch.setattr(hf_hub, "list_hf_tags", boom)
         with pytest.raises(RuntimeError, match="--hf-revision"):
             resolve_hf_revision("ns/repo", None)
@@ -290,6 +347,7 @@ class TestResolveInferenceArtifacts:
         assert args.config_path == f"/cache/{HF_CONFIG_FILENAME}"
 
     def test_no_paths_no_revision_resolves_latest_and_records_provenance(self, monkeypatch):
+        _set_version(monkeypatch, "0.0.0.dev0")
         monkeypatch.setattr(hf_hub, "list_hf_tags", lambda repo_id: ["v0.1.0", "final_v3"])
         monkeypatch.setattr(hf_hub, "_hf_hub_download", lambda **kw: f"/cache/{kw['filename']}")
         args = self._args()
@@ -297,6 +355,25 @@ class TestResolveInferenceArtifacts:
         # The resolved revision is written back to args so it lands in config.hf.revision
         # (and the saved inference config) via apply_args_to_config.
         assert args.hf_revision == "v0.1.0"
+
+    def test_installed_release_downloads_own_version_tag(self, monkeypatch):
+        # The release contract: pip install aetherscan==1.2.3 + bare inference downloads
+        # exactly the v1.2.3 weights, without ever listing the repo's tags.
+        _set_version(monkeypatch, "1.2.3")
+        monkeypatch.setattr(
+            hf_hub, "list_hf_tags", lambda repo_id: pytest.fail("must not list tags")
+        )
+        downloads = []
+
+        def fake_download(**kw):
+            downloads.append(kw["revision"])
+            return f"/cache/{kw['filename']}"
+
+        monkeypatch.setattr(hf_hub, "_hf_hub_download", fake_download)
+        args = self._args()
+        resolve_inference_artifacts(args)
+        assert set(downloads) == {"v1.2.3"}
+        assert args.hf_revision == "v1.2.3"
 
     def test_download_failure_wrapped_with_guidance(self, monkeypatch):
         def boom(**kwargs):

--- a/utils/hf_tag_release.py
+++ b/utils/hf_tag_release.py
@@ -62,6 +62,12 @@ def main() -> int:
     if not _RELEASE_TAG_PATTERN.match(args.release):
         print(f"ERROR: --release must look like vX.Y.Z (e.g. v1.0.0), got {args.release!r}")
         return 1
+    # Fail a mangled save-tag here with a clear message rather than as a Hub 404 later.
+    if not args.save_tag or any(c.isspace() for c in args.save_tag):
+        print(
+            f"ERROR: --save-tag must be a non-empty tag without whitespace, got {args.save_tag!r}"
+        )
+        return 1
 
     if load_dotenv is not None:
         load_dotenv()

--- a/utils/hf_tag_release.py
+++ b/utils/hf_tag_release.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+Bless trained weights as a release: create the HF release tag (vX.Y.Z) pointing at a
+training upload's commit (docs/RELEASE.md step 3).
+
+    python utils/hf_tag_release.py --save-tag final_v1 --release v1.0.0
+
+This is the human "these weights are the release" decision — the release CD workflow
+(.github/workflows/release.yml) verifies the tag exists but deliberately cannot create it.
+A thin wrapper over HfApi.create_tag: the new release tag points at the same commit as the
+training run's save-tag (created by `train --hf-upload`).
+
+Auth: needs a write-scoped HF_TOKEN in the environment; a gitignored .env in the working
+directory is loaded when python-dotenv is available. Standalone on purpose — no PYTHONPATH
+or aetherscan install required.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+from huggingface_hub import HfApi
+from huggingface_hub.errors import HfHubHTTPError, RevisionNotFoundError
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # python-dotenv is optional here — HF_TOKEN may already be exported
+    load_dotenv = None
+
+# Must match config.hf.repo_id's default (src/aetherscan/config.py).
+DEFAULT_REPO_ID = "zachtheyek/aetherscan"
+
+_RELEASE_TAG_PATTERN = re.compile(r"^v\d+\.\d+\.\d+$")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Bless trained weights as a release: create the HF release tag (vX.Y.Z) "
+        "pointing at a training upload's commit (docs/RELEASE.md step 3)."
+    )
+    parser.add_argument(
+        "--save-tag",
+        required=True,
+        help="Training run tag whose uploaded weights are being blessed (e.g. final_v1); "
+        "must already exist on the HF repo (created by `train --hf-upload`)",
+    )
+    parser.add_argument(
+        "--release",
+        required=True,
+        help="Release tag to create, vX.Y.Z (must match the version the release PR ships)",
+    )
+    parser.add_argument(
+        "--repo-id",
+        default=DEFAULT_REPO_ID,
+        help=f"HF model repo id (default: {DEFAULT_REPO_ID})",
+    )
+    args = parser.parse_args()
+
+    if not _RELEASE_TAG_PATTERN.match(args.release):
+        print(f"ERROR: --release must look like vX.Y.Z (e.g. v1.0.0), got {args.release!r}")
+        return 1
+
+    if load_dotenv is not None:
+        load_dotenv()
+    if not os.environ.get("HF_TOKEN"):
+        print(
+            "ERROR: no HF_TOKEN in the environment. Creating tags needs a write-scoped "
+            "token — put it in the gitignored .env (never commit it)."
+        )
+        return 1
+
+    api = HfApi()
+    try:
+        api.create_tag(args.repo_id, tag=args.release, revision=args.save_tag)
+    except RevisionNotFoundError:
+        print(
+            f"ERROR: save-tag {args.save_tag!r} not found on {args.repo_id}. Was the run "
+            f"trained with --hf-upload (and did the hf_upload stage succeed)?"
+        )
+        return 1
+    except HfHubHTTPError as e:
+        if getattr(getattr(e, "response", None), "status_code", None) == 409:
+            print(
+                f"ERROR: release tag {args.release!r} already exists on {args.repo_id}. "
+                f"Released weights are immutable by convention — bless a new version "
+                f"instead, or delete the tag on the Hub first if it was created in error."
+            )
+            return 1
+        raise
+    print(
+        f"Blessed: {args.release} -> weights of training run {args.save_tag!r} "
+        f"(https://huggingface.co/{args.repo_id}/tree/{args.release})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #132

> **Stacked PR**: based on `feature/huggingface-integration` (#130) — it extends the revision-resolution chain that PR introduces. Only the commits past #130's tip belong to this PR; merge #130 first, then rebase this onto `master`.

Implements packaging + release CD per the release contract in `docs/RELEASE.md` (on #131's branch): one version string couples the git tag, the GitHub Release, the PyPI release, and the HF weights tag — with CD enforcing the coupling by verification, never by creating weights.

## What's here

**1. Build system (`pyproject.toml`)**
- Hatchling finalized (`[build-system]` uncommented, wheel target `src/aetherscan`); both stale TODO headers resolved.
- `[project].dependencies` filled from `requirements-container.txt`'s ranges plus the packages the NGC base image provides implicitly (`tensorflow[and-cuda]==2.17.*`, `h5py>=3.11,<3.12`, `hdf5plugin`, `psutil>=6.0,<6.1` — ranges mirror `environment.yml`). `requires-python = ">=3.10,<3.13"` kept.
- `dev` extra = `ruff`, `pre-commit`, `pytest`.
- Development Status classifier: left at `2 - Pre-Alpha` with a clearly-marked TODO knob for the v1 Beta-vs-Production decision (maintainer's call in the release PR).

**2. Version single-sourcing**
- `version = "0.9.0.dev0"` in pyproject is now the only place the version is written (pre-release on purpose; the release PR bumps it to `1.0.0` per the runbook).
- `src/aetherscan/__init__.py` reads it back via `importlib.metadata.version("aetherscan")`, falling back to `"0.0.0.dev0"` on `PackageNotFoundError` so source-tree/container runs work uninstalled.

**3. Version-coupled weight resolution (`hf_hub.py`)**
Resolution chain is now: explicit local paths → `--hf-revision` → **`v{__version__}` when running as an installed release** → latest semver `v*` tag → latest `final_vX` tag → error with guidance. The new step (`version_default_revision`) is what makes `pip install aetherscan==1.0.0` + bare inference pull exactly the `v1.0.0` weights. Two deliberate design points, documented in the docstring:
- **Guard**: the default only activates when `v{__version__}` lands in the release-tag family (strict `vX.Y.Z`). The dev fallback (`0.0.0.dev0`), `.dev` pre-releases, and rc/post/local versions all fall through to latest-release resolution.
- **No existence check / no silent fallback**: an installed release whose weights tag is missing fails the download loudly (the blessing step was skipped) rather than silently pulling some other version's weights.

`--hf-revision` help text updated accordingly → README inference CLI block regenerated with `utils/print_cli_help.py` (top/train blocks verified unchanged).

**4. CD workflow (`.github/workflows/release.yml`)** — `on: push: tags: ["v*"]`, gates in order:
1. **Version guard**: pushed tag must equal `v` + pyproject version, else fail loudly with pointer to the runbook.
2. **Unit tests**: calls `tests.yml` as a reusable workflow (it gained a `workflow_call` trigger), so the release gate runs the exact CI suite by construction instead of by copy-paste.
3. **HF weights verification**: checks the matching tag exists on `zachtheyek/aetherscan` (public read, no token). Verify-never-create; the failure message names the fix (`utils/hf_tag_release.py`) and says not to touch the git tag.
4. **Build**: `python -m build` (sdist + wheel), plus a wheel smoke — `pip install --no-deps` + `__version__` must equal the guarded version.
5. **Publish**: `pypa/gh-action-pypi-publish@release/v1` with `permissions: id-token: write` and environment `pypi` (trusted publishing; no stored token).
6. **GitHub Release**: `gh release create --verify-tag --generate-notes` with the dist files attached (curate the body from the `claude-release-notes` comments afterwards, per the runbook).

Dry run: `workflow_dispatch` with `test_pypi: true` publishes to test.pypi.org under environment `testpypi` (recommended before the first real release). A manual run with the box unchecked fails the guard — real releases only ever go through tag pushes.

**5. `utils/hf_tag_release.py`** — the runbook's weight-blessing step: `python utils/hf_tag_release.py --save-tag final_v1 --release v1.0.0` creates the HF release tag pointing at the training upload's commit. Standalone (no PYTHONPATH/install needed), validates the tag shape, and gives targeted errors for missing token / missing save-tag / already-blessed release.

## Maintainer prerequisites (one-time, before the first release)

- [ ] Create the PyPI project `aetherscan` and add GitHub as a **trusted publisher**: repository `zachtheyek/Aetherscan`, workflow `release.yml`, environment `pypi`.
- [ ] Create the `pypi` environment in this repo's Settings → Environments.
- [ ] (For the dry run) same trusted-publisher setup on **test.pypi.org** + a `testpypi` environment.
- [ ] Confirm the HF model repo `zachtheyek/aetherscan` exists (created by #130's first `--hf-upload`).

## Deliberate divergences / notes vs `docs/RELEASE.md`

- **Wheel smoke step** in the build job is an extra gate the contract doesn't mention (cheap, catches packaging mistakes before publish).
- **Dry runs skip the HF weights gate** — pre-release versions never have a blessed weights tag, so the gate would make the dry-run path permanently red; the skip is logged. The contract doesn't specify dry-run semantics.
- **TestPyPI prerequisites** (`testpypi` environment + trusted publisher on test.pypi.org) aren't in RELEASE.md's one-time setup list — they're documented in the workflow header; RELEASE.md could gain a line when #131 lands.
- **CUDA classifier**: the pre-existing `Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.8` is not a valid trove classifier (the list tops out at `12 :: 12.6`) and broke `python -m build` the moment validation turned on — replaced with the `:: 12` parent (the `12.4` entry is valid and kept).
- **`pip install aetherscan` with deps is Linux-only**: TF 2.17's `and-cuda` extra pins `nvidia-*` wheels unconditionally (no platform markers upstream), and those wheels only exist for Linux. This matches the pipeline's supported runtimes (the clusters); it's why local verification below uses `--no-deps`.
- `CITATION.cff` still says `version: 0.1.0` — it's a version-stamped artifact for the release PR to regenerate (runbook step 4, "regen anything version-stamped").

## Verification

- **Build + install** (macOS arm64, Python 3.12): `python -m build` succeeds (sdist + wheel); wheel installed into a **fresh scratch venv** with `pip install --no-deps` (see Linux-only note above), then:
  ```
  $ python -c "import aetherscan; print(aetherscan.__version__)"
  0.9.0.dev0
  ```
  Source-tree fallback verified too: `PYTHONPATH=src python -c ...` → `0.0.0.dev0` (uninstalled).
- **Unit suite**: `PYTHONPATH=src pytest -m "not gpu and not cluster" -q` → **530 passed, 3 skipped, 2 deselected** (arm64 venv, TF 2.17.1; run after rebasing onto #130's current tip `7cd19e1`) — includes 11 new tests covering the full resolution chain: the dev-version guard (parametrized over dev/rc/post/local/partial versions), explicit-revision precedence, version-pin-without-listing, dev-fallthrough-to-latest, and the end-to-end installed-release download path.
- **Workflows**: `yaml.safe_load` clean on `release.yml` + `tests.yml`; `actionlint` not available locally, so the workflow got a line-by-line manual review (documented gates, permissions per job, artifact handoff, environment-scoped OIDC).
- `pre-commit run --all-files` green; ruff lint + format clean.

## AI disclosure

Implemented end-to-end with Claude Code (model: Claude Fable 5): packaging, resolution-chain extension, CD workflow, helper script, tests, and this PR body. Human review requested per AI_POLICY.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
