### PR TITLE
Benchmarking suite: always-on stage timing, annotated resource plots, report tooling, micro-benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ rzad056.pdf
 # Outputs directory
 outputs/
 
+# Micro-benchmark result JSONs (per-machine; baselines are documented in benchmarks/README.md)
+benchmarks/results/
+
 # Container artifacts
 *.sif
 

--- a/README.md
+++ b/README.md
@@ -731,7 +731,7 @@ usage: inference [-h] [--data-path DATA_PATH] [--model-path MODEL_PATH]
                  [--cadence-h5-path-col CADENCE_H5_PATH_COL]
                  [--cadence-expected-obs CADENCE_EXPECTED_OBS]
                  [--coarse-channel-width COARSE_CHANNEL_WIDTH]
-                 [--parallel-coarse-chans PARALLEL_COARSE_CHANS]
+                 [--coarse-channel-log-interval COARSE_CHANNEL_LOG_INTERVAL]
                  [--bandpass-method BANDPASS_METHOD]
                  [--pfb-taps-per-channel PFB_TAPS_PER_CHANNEL]
                  [--bandpass-debug-plot | --no-bandpass-debug-plot]
@@ -817,7 +817,7 @@ options:
   --coarse-channel-width COARSE_CHANNEL_WIDTH
                         Number of fine channels per coarse channel (default:
                         1048576)
-  --parallel-coarse-chans PARALLEL_COARSE_CHANS
+  --coarse-channel-log-interval COARSE_CHANNEL_LOG_INTERVAL
                         Progress-logging chunk size for energy detection, in
                         coarse channels per log line (default: the number of
                         worker processes). Parallelism itself comes from the

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,59 @@
+# Micro-benchmarks
+
+Small standalone scripts that time the pipeline's hot CPU kernels in isolation, so a change
+to any of them can be measured in seconds instead of via a full training/inference run. No
+framework — each script prints ops/s and writes a JSON result to `benchmarks/results/`
+(gitignored; per-machine baselines live in the table below).
+
+These are **not** collected by pytest (`testpaths = ["tests"]` in `pyproject.toml`) and are
+run on demand:
+
+```bash
+# From the repo root (each script inserts src/ into sys.path itself)
+python benchmarks/bench_normality.py            # sliding-window normality test (energy detection)
+python benchmarks/bench_injection.py            # setigen signal injection (training data gen)
+python benchmarks/bench_lognorm_downsample.py   # per-cadence downsample + log-norm (load path)
+python benchmarks/bench_pfb_vs_spline.py        # PFB static equalization vs per-channel spline fit
+# On the clusters, run through the container:
+./utils/run_container.sh python benchmarks/bench_normality.py
+```
+
+Common flags: `--repeats N` (default 3; ops/s is reported from the best repeat) and
+`--output PATH` for the JSON result. Each script also exposes size knobs (`--width`,
+`--injections`, `--cadences`) — the defaults match production shapes, so stick to them when
+comparing against the baselines.
+
+## What each script measures
+
+| Script | Kernel | Pipeline stage it models |
+|---|---|---|
+| `bench_normality.py` | `preprocessing._sliding_normality_k2` vs the historical per-window `scipy.stats.normaltest` loop | Energy detection thresholding (`inference.*.read_ed_on*`) |
+| `bench_injection.py` | `data_generation.new_cadence` (setigen narrowband injection into a stacked 96x4096 cadence) | Training data generation (`train.round_XX.data_generation`) |
+| `bench_lognorm_downsample.py` | per-observation `downscale_local_mean` (x8) and per-cadence `log_norm` | Stamp extraction downsample + inference load (`inference.*.load_lognorm`) |
+| `bench_pfb_vs_spline.py` | `pfb.equalize_passband` (static response divide) vs `preprocessing._spline_flatten_bandpass` (order-16 fit) on one 1M-bin coarse channel | Bandpass flattening inside energy detection |
+
+## Baseline numbers
+
+Higher is better everywhere. Numbers are the best-of-3 repeats at default parameters;
+expect ~10% run-to-run noise. Regenerate after touching any of the measured kernels and
+update this table in the same PR.
+
+### MacBook Air M3 (arm64, macOS, Python 3.12, July 2026)
+
+| Benchmark | Result |
+|---|---|
+| `bench_normality` — vectorized | 44,442 windows/s (0.18 s per 1M-bin channel) |
+| `bench_normality` — scipy loop | 689 windows/s (11.9 s per channel) → **64x speedup** |
+| `bench_injection` | 6.6 injections/s |
+| `bench_lognorm_downsample` — downsample | 1,900 cadences/s |
+| `bench_lognorm_downsample` — lognorm | 4,861 cadences/s |
+| `bench_pfb_vs_spline` — pfb | 46.3 channels/s (plus a 7.7 s one-time response FFT) |
+| `bench_pfb_vs_spline` — spline | 6.0 channels/s → **7.7x speedup** |
+
+Notes:
+
+- All numbers are single-process: the pipeline parallelizes these kernels across
+  `manager.n_processes` workers, so whole-stage throughput scales roughly with core count
+  (e.g. energy detection runs one fused task per coarse channel on the persistent pool).
+- `bench_injection` is dominated by setigen frame construction, which is why data
+  generation gets a dedicated producer process and worker pool in training.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -50,6 +50,18 @@ update this table in the same PR.
 | `bench_pfb_vs_spline` — pfb | 46.3 channels/s (plus a 7.7 s one-time response FFT) |
 | `bench_pfb_vs_spline` — spline | 6.0 channels/s → **7.7x speedup** |
 
+### blpc3 (EPYC 7313, 32 cores, NGC 25.02 container, July 2026)
+
+| Benchmark | Result |
+|---|---|
+| `bench_normality` — vectorized | 83,667 windows/s (0.10 s per 1M-bin channel) |
+| `bench_normality` — scipy loop | 679 windows/s (12.1 s per channel) → **123x speedup** |
+| `bench_injection` | 5.8 injections/s |
+| `bench_lognorm_downsample` — downsample | 798 cadences/s |
+| `bench_lognorm_downsample` — lognorm | 8,844 cadences/s |
+| `bench_pfb_vs_spline` — pfb | 59.6 channels/s (plus an 11.7 s one-time response FFT) |
+| `bench_pfb_vs_spline` — spline | 5.0 channels/s → **11.9x speedup** |
+
 Notes:
 
 - All numbers are single-process: the pipeline parallelizes these kernels across

--- a/benchmarks/_common.py
+++ b/benchmarks/_common.py
@@ -1,0 +1,73 @@
+"""
+Shared plumbing for the micro-benchmark scripts: src/ importability, machine metadata,
+wall-clock timing of repeated callables, and JSON result output. Deliberately framework-free
+(see benchmarks/README.md) — each bench_*.py is a plain script that prints ops/s and writes
+one JSON file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import sys
+import time
+from datetime import datetime, timezone
+
+# Make src/ importable when running directly: benchmarks/bench_*.py
+_BENCH_DIR = os.path.dirname(os.path.abspath(__file__))
+_SRC_DIR = os.path.join(os.path.dirname(_BENCH_DIR), "src")
+if _SRC_DIR not in sys.path:
+    sys.path.insert(0, _SRC_DIR)
+
+RESULTS_DIR = os.path.join(_BENCH_DIR, "results")
+
+
+def machine_info() -> dict:
+    """Hostname / platform / CPU info stamped into every result JSON."""
+    return {
+        "hostname": platform.node(),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "python": platform.python_version(),
+        "cpu_count": os.cpu_count(),
+    }
+
+
+def time_repeats(func, repeats: int) -> list[float]:
+    """Call func() `repeats` times, returning each call's wall-clock seconds."""
+    durations = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        func()
+        durations.append(time.perf_counter() - start)
+    return durations
+
+
+def summarize(durations: list[float], ops_per_call: float) -> dict:
+    """Best/mean seconds plus ops/s (best-run basis, the conventional benchmark number)."""
+    best = min(durations)
+    return {
+        "repeats": len(durations),
+        "best_s": best,
+        "mean_s": sum(durations) / len(durations),
+        "ops_per_call": ops_per_call,
+        "ops_per_s": ops_per_call / best if best > 0 else float("inf"),
+    }
+
+
+def write_result(name: str, params: dict, results: dict, output: str | None = None) -> str:
+    """Write the benchmark result JSON (default benchmarks/results/{name}_{host}.json)."""
+    payload = {
+        "benchmark": name,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "machine": machine_info(),
+        "params": params,
+        "results": results,
+    }
+    if output is None:
+        os.makedirs(RESULTS_DIR, exist_ok=True)
+        output = os.path.join(RESULTS_DIR, f"{name}_{platform.node()}.json")
+    with open(output, "w") as f:
+        json.dump(payload, f, indent=2)
+    return output

--- a/benchmarks/_common.py
+++ b/benchmarks/_common.py
@@ -14,7 +14,10 @@ import sys
 import time
 from datetime import datetime, timezone
 
-# Make src/ importable when running directly: benchmarks/bench_*.py
+# Make src/ importable when running directly: benchmarks/bench_*.py. This import-time
+# sys.path injection is intentional for standalone script mode (the benchmarks are run as
+# `python benchmarks/bench_*.py`, never imported as a package), so mutating sys.path here
+# is safe and expected rather than a library side effect.
 _BENCH_DIR = os.path.dirname(os.path.abspath(__file__))
 _SRC_DIR = os.path.join(os.path.dirname(_BENCH_DIR), "src")
 if _SRC_DIR not in sys.path:

--- a/benchmarks/bench_injection.py
+++ b/benchmarks/bench_injection.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""
+Micro-benchmark: setigen narrowband signal injection (data_generation.new_cadence) into a
+stacked synthetic cadence — the per-sample kernel of training data generation.
+
+    python benchmarks/bench_injection.py [--injections 200] [--repeats 3]
+
+Prints injections/s and writes a JSON result to benchmarks/results/ (or --output).
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+from _common import summarize, time_repeats, write_result
+
+from aetherscan.data_generation import new_cadence
+
+# Defaults mirror DataConfig: 6 obs x 16 time bins stacked, 4096 fine bins,
+# GBT-resolution axis scales
+NUM_OBSERVATIONS = 6
+TIME_BINS = 16
+WIDTH_BIN = 4096
+FREQ_RESOLUTION = 2.7939677238464355  # Hz
+TIME_RESOLUTION = 18.25361108  # seconds
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--injections", type=int, default=200, help="Injections per repeat")
+    parser.add_argument("--snr", type=float, default=20.0)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--output", default=None, help="Result JSON path")
+    args = parser.parse_args()
+
+    rng = np.random.default_rng(11)
+    stacked = rng.chisquare(df=4, size=(NUM_OBSERVATIONS * TIME_BINS, WIDTH_BIN)).astype(np.float64)
+    print(
+        f"Injecting {args.injections} signals/repeat into a stacked "
+        f"({stacked.shape[0]}, {stacked.shape[1]}) cadence at SNR {args.snr}"
+    )
+
+    def run() -> None:
+        for _ in range(args.injections):
+            # Copy per injection, as batch generation does (each sample gets a fresh plate)
+            new_cadence(stacked.copy(), args.snr, WIDTH_BIN, FREQ_RESOLUTION, TIME_RESOLUTION)
+
+    durations = time_repeats(run, args.repeats)
+    results = {"injection": summarize(durations, args.injections)}
+    print(
+        f"injection:   {results['injection']['ops_per_s']:>10.1f} injections/s "
+        f"(best {results['injection']['best_s']:.3f}s for {args.injections})"
+    )
+
+    path = write_result(
+        "bench_injection",
+        {
+            "injections": args.injections,
+            "snr": args.snr,
+            "width_bin": WIDTH_BIN,
+            "stacked_shape": list(stacked.shape),
+        },
+        results,
+        args.output,
+    )
+    print(f"Result written to {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_lognorm_downsample.py
+++ b/benchmarks/bench_lognorm_downsample.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Micro-benchmark: the two per-cadence CPU transforms of the load path — frequency
+downsampling (skimage downscale_local_mean, as in _downsample_worker / stamp extraction)
+and log-normalization (data_generation.log_norm, as in load_inference_data).
+
+    python benchmarks/bench_lognorm_downsample.py [--cadences 64] [--repeats 3]
+
+Prints cadences/s for each transform and writes a JSON result to benchmarks/results/
+(or --output).
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+from _common import summarize, time_repeats, write_result
+from skimage.transform import downscale_local_mean
+
+from aetherscan.data_generation import log_norm
+
+NUM_OBSERVATIONS = 6
+TIME_BINS = 16
+WIDTH_BIN = 4096
+DOWNSAMPLE_FACTOR = 8
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cadences", type=int, default=64, help="Cadences per repeat")
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--output", default=None, help="Result JSON path")
+    args = parser.parse_args()
+
+    rng = np.random.default_rng(11)
+    full = rng.chisquare(df=4, size=(args.cadences, NUM_OBSERVATIONS, TIME_BINS, WIDTH_BIN)).astype(
+        np.float32
+    )
+    final_width = WIDTH_BIN // DOWNSAMPLE_FACTOR
+    print(
+        f"{args.cadences} cadences of shape ({NUM_OBSERVATIONS}, {TIME_BINS}, {WIDTH_BIN}), "
+        f"downsample x{DOWNSAMPLE_FACTOR} -> {final_width} bins"
+    )
+
+    def run_downsample() -> np.ndarray:
+        # Mirrors _downsample_worker: per-observation downscale_local_mean over frequency
+        out = np.zeros((args.cadences, NUM_OBSERVATIONS, TIME_BINS, final_width), dtype=np.float32)
+        for cadence_idx in range(args.cadences):
+            for obs_idx in range(NUM_OBSERVATIONS):
+                out[cadence_idx, obs_idx] = downscale_local_mean(
+                    full[cadence_idx, obs_idx], (1, DOWNSAMPLE_FACTOR)
+                ).astype(np.float32)
+        return out
+
+    downsampled = run_downsample()
+
+    results = {}
+    durations = time_repeats(run_downsample, args.repeats)
+    results["downsample"] = summarize(durations, args.cadences)
+    print(
+        f"downsample:  {results['downsample']['ops_per_s']:>10.1f} cadences/s "
+        f"(best {results['downsample']['best_s']:.3f}s)"
+    )
+
+    def run_lognorm() -> None:
+        # Mirrors load_inference_data: per-cadence log_norm over the downsampled stamps
+        for cadence_idx in range(args.cadences):
+            log_norm(downsampled[cadence_idx])
+
+    durations = time_repeats(run_lognorm, args.repeats)
+    results["lognorm"] = summarize(durations, args.cadences)
+    print(
+        f"lognorm:     {results['lognorm']['ops_per_s']:>10.1f} cadences/s "
+        f"(best {results['lognorm']['best_s']:.3f}s)"
+    )
+
+    path = write_result(
+        "bench_lognorm_downsample",
+        {
+            "cadences": args.cadences,
+            "width_bin": WIDTH_BIN,
+            "downsample_factor": DOWNSAMPLE_FACTOR,
+        },
+        results,
+        args.output,
+    )
+    print(f"Result written to {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_normality.py
+++ b/benchmarks/bench_normality.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+Micro-benchmark: vectorized sliding-window normality test (_sliding_normality_k2) vs the
+historical per-window scipy.stats.normaltest Python loop — the #1 cost of inference
+preprocessing before PR-06 vectorized it.
+
+    python benchmarks/bench_normality.py [--width 1048576] [--repeats 3] [--skip-baseline]
+
+Prints windows/s for both implementations plus the speedup, and writes a JSON result to
+benchmarks/results/ (or --output).
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+from _common import summarize, time_repeats, write_result
+from scipy import stats
+
+from aetherscan.preprocessing import _sliding_normality_k2
+
+
+def scipy_loop(channel: np.ndarray, window_size: int, step_size: int) -> np.ndarray:
+    """The historical implementation: one scipy.stats.normaltest call per window."""
+    width = channel.shape[1]
+    out = []
+    for start in range(0, width - window_size, step_size):
+        window = channel[:, start : start + window_size].flatten()
+        out.append(stats.normaltest(window).statistic)
+    return np.asarray(out)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--width", type=int, default=1_048_576, help="Channel width (fine bins)")
+    parser.add_argument("--time-bins", type=int, default=16)
+    parser.add_argument("--window", type=int, default=256)
+    parser.add_argument("--step", type=int, default=128)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument(
+        "--skip-baseline", action="store_true", help="Skip the (slow) scipy per-window loop"
+    )
+    parser.add_argument("--output", default=None, help="Result JSON path")
+    args = parser.parse_args()
+
+    rng = np.random.default_rng(11)
+    channel = rng.chisquare(df=4, size=(args.time_bins, args.width)).astype(np.float64)
+    n_windows = len(range(0, args.width - args.window, args.step))
+    print(
+        f"Channel ({args.time_bins}, {args.width}), window={args.window}, step={args.step} "
+        f"-> {n_windows} windows"
+    )
+
+    results = {}
+
+    durations = time_repeats(
+        lambda: _sliding_normality_k2(channel, args.window, args.step), args.repeats
+    )
+    results["vectorized"] = summarize(durations, n_windows)
+    print(
+        f"vectorized:  {results['vectorized']['ops_per_s']:>12.0f} windows/s "
+        f"(best {results['vectorized']['best_s']:.3f}s)"
+    )
+
+    if not args.skip_baseline:
+        durations = time_repeats(lambda: scipy_loop(channel, args.window, args.step), args.repeats)
+        results["scipy_loop"] = summarize(durations, n_windows)
+        print(
+            f"scipy loop:  {results['scipy_loop']['ops_per_s']:>12.0f} windows/s "
+            f"(best {results['scipy_loop']['best_s']:.3f}s)"
+        )
+        speedup = results["vectorized"]["ops_per_s"] / results["scipy_loop"]["ops_per_s"]
+        results["speedup"] = speedup
+        print(f"speedup:     {speedup:.1f}x")
+
+    path = write_result(
+        "bench_normality",
+        {
+            "width": args.width,
+            "time_bins": args.time_bins,
+            "window": args.window,
+            "step": args.step,
+            "n_windows": n_windows,
+        },
+        results,
+        args.output,
+    )
+    print(f"Result written to {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_pfb_vs_spline.py
+++ b/benchmarks/bench_pfb_vs_spline.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Micro-benchmark: the two bandpass flatteners applied per coarse channel during energy
+detection — the static PFB response divide (pfb.equalize_passband, the default) vs the
+historical per-channel spline fit (preprocessing._spline_flatten_bandpass).
+
+    python benchmarks/bench_pfb_vs_spline.py [--width 1048576] [--repeats 3]
+
+Prints channels/s for both methods plus the speedup, and writes a JSON result to
+benchmarks/results/ (or --output). The one-time PFB response FFT is reported separately
+(it is paid once per run, not per channel).
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import numpy as np
+from _common import summarize, time_repeats, write_result
+
+from aetherscan.pfb import equalize_passband, gen_coarse_channel_response
+from aetherscan.preprocessing import _spline_flatten_bandpass
+
+TIME_BINS = 16
+NUM_COARSE = 64  # response fold width param (matches a typical GBT file's coarse count)
+TAPS_PER_CHANNEL = 12  # GBT / Breakthrough Listen backend default
+SPLINE_ORDER = 16  # InferenceConfig.spline_order default
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--width", type=int, default=1_048_576, help="Coarse channel width (fine bins)"
+    )
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--output", default=None, help="Result JSON path")
+    args = parser.parse_args()
+
+    # One-time response generation (lru_cached in production, one FFT per run)
+    response_start = time.perf_counter()
+    response = gen_coarse_channel_response(args.width, NUM_COARSE, TAPS_PER_CHANNEL)
+    response_s = time.perf_counter() - response_start
+
+    # Synthetic coarse channel: chi-2 noise shaped by the PFB response, so both methods
+    # flatten a realistic scalloped passband
+    rng = np.random.default_rng(11)
+    channel = (rng.chisquare(df=4, size=(TIME_BINS, args.width)) * response[np.newaxis, :]).astype(
+        np.float64
+    )
+    print(
+        f"Coarse channel ({TIME_BINS}, {args.width}), taps={TAPS_PER_CHANNEL}, "
+        f"spline order={SPLINE_ORDER} (response FFT: {response_s:.2f}s one-time)"
+    )
+
+    results = {"response_generation_s": response_s}
+
+    durations = time_repeats(lambda: equalize_passband(channel, response), args.repeats)
+    results["pfb"] = summarize(durations, 1)
+    print(
+        f"pfb:         {results['pfb']['ops_per_s']:>8.2f} channels/s "
+        f"(best {results['pfb']['best_s']:.3f}s/channel)"
+    )
+
+    durations = time_repeats(lambda: _spline_flatten_bandpass(channel, SPLINE_ORDER), args.repeats)
+    results["spline"] = summarize(durations, 1)
+    print(
+        f"spline:      {results['spline']['ops_per_s']:>8.2f} channels/s "
+        f"(best {results['spline']['best_s']:.3f}s/channel)"
+    )
+
+    speedup = results["pfb"]["ops_per_s"] / results["spline"]["ops_per_s"]
+    results["speedup"] = speedup
+    print(f"speedup:     {speedup:.1f}x")
+
+    path = write_result(
+        "bench_pfb_vs_spline",
+        {
+            "width": args.width,
+            "time_bins": TIME_BINS,
+            "num_coarse": NUM_COARSE,
+            "taps_per_channel": TAPS_PER_CHANNEL,
+            "spline_order": SPLINE_ORDER,
+        },
+        results,
+        args.output,
+    )
+    print(f"Result written to {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/CONFIG_AND_CLI.md
+++ b/docs/CONFIG_AND_CLI.md
@@ -68,7 +68,7 @@ subcommand uses it:
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | `DBConfig`           | SQLite writer timeouts, buffer sizes                                                                                               |
 | `ManagerConfig`      | Multiprocessing pool sizing                                                                                                        |
-| `MonitorConfig`      | Resource-monitor cadence and timeouts                                                                                              |
+| `MonitorConfig`      | Resource-monitor cadence and timeouts, stage-band plot annotation toggle                                                           |
 | `LoggerConfig`       | Console / file / Slack log routing                                                                                                 |
 | `BetaVAEConfig`      | Beta-VAE model hyperparameters                                                                                                     |
 | `RandomForestConfig` | RF classifier hyperparameters                                                                                                      |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ unfixable = []
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]  # Allow unused imports in __init__.py
 "utils/*" = ["T20"]  # Allow utility scripts to use print()
+"benchmarks/*" = ["T20"]  # Allow micro-benchmark scripts to use print()
 "src/aetherscan/logger/slack_handler.py" = ["T201"]  # Allow logging handler to use print() (for stderr; handler can't log through itself without recursion)
 
 [tool.ruff.lint.isort]

--- a/src/aetherscan/benchmark.py
+++ b/src/aetherscan/benchmark.py
@@ -52,6 +52,18 @@ def current_stage() -> str | None:
     return stack[-1] if stack else None
 
 
+def round_stage_name(round_number: int) -> str:
+    """Canonical umbrella stage name for a 1-based training round ("train.round_02").
+
+    Shared by the trainer (which opens the umbrella span) and the round-data producer
+    (which, running in another process, records the data_generation child by absolute name
+    and so can't rely on thread-local nesting). Routing both sites through this helper keeps
+    the two name constructions from drifting — a mismatch would orphan the producer's
+    data_generation span outside the round subtree in the report tree.
+    """
+    return f"train.round_{round_number:02d}"
+
+
 def record_stage(
     stage: str,
     start_time: float,

--- a/src/aetherscan/benchmark.py
+++ b/src/aetherscan/benchmark.py
@@ -1,0 +1,161 @@
+"""
+Always-on stage timing for the Aetherscan pipeline.
+
+stage_timer() wraps a pipeline stage (context manager or decorator) and records one
+(stage, start_time, end_time, duration_s, tag, metadata) row into the pipeline_stages DB
+table through the database's writer queue — two time.time() calls plus one queue put, so
+the overhead is negligible and the timers stay on in production runs.
+
+Stage names are hierarchical dot-names ("train.round_02.data_generation"). Nesting is
+automatic within a thread: a stage_timer entered while another is active on the same
+thread records its name relative to the active one, so instrumented library code (e.g.
+the encode/rf sub-stages inside InferencePipeline.run_inference) inherits whatever
+umbrella span the caller opened without name plumbing. Timers on different threads don't
+interact (the active-stage stack is thread-local), which matters because training,
+prefetch preprocessing, and the producer drainer all time stages concurrently.
+
+record_stage() writes a span measured elsewhere (explicit start/end timestamps) — used by
+the round-data producer, whose generation happens in another process: the producer can't
+touch the DB writer queue (a thread queue.Queue), so it reports (start, end) over its
+result-message channel and the main-process drainer records it here.
+
+Rows are read back by utils/benchmark_report.py (stage tree + timeline plot) and by
+monitor._save_plot()'s stage-band overlay.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from contextlib import ContextDecorator
+
+logger = logging.getLogger(__name__)
+
+# Thread-local stack of active stage names (full dotted names), driving relative naming
+_ACTIVE_STAGES = threading.local()
+
+
+def _stage_stack() -> list[str]:
+    """The current thread's stack of active (full) stage names."""
+    stack = getattr(_ACTIVE_STAGES, "stack", None)
+    if stack is None:
+        stack = []
+        _ACTIVE_STAGES.stack = stack
+    return stack
+
+
+def current_stage() -> str | None:
+    """Full dotted name of the innermost stage_timer active on this thread, or None."""
+    stack = _stage_stack()
+    return stack[-1] if stack else None
+
+
+def record_stage(
+    stage: str,
+    start_time: float,
+    end_time: float,
+    tag: str | None = None,
+    metadata: dict | None = None,
+) -> None:
+    """
+    Record one pipeline stage span with explicit timestamps (no nesting resolution — the
+    name is used as-is). tag defaults to the run's save tag. Never raises: benchmarking
+    must not be able to fail the pipeline, so a missing DB (unit tests, dev scripts) or a
+    serialization hiccup downgrades to a debug/warning log.
+    """
+    try:
+        # Late imports keep this module import-light and avoid any import-cycle risk
+        # (db imports config + manager; nothing imports benchmark back).
+        from aetherscan.config import get_config  # noqa: PLC0415
+        from aetherscan.db import get_db  # noqa: PLC0415
+
+        db = get_db()
+        if db is None:
+            logger.debug(f"No database instance — dropping stage timing for {stage!r}")
+            return
+
+        if tag is None:
+            config = get_config()
+            tag = config.checkpoint.save_tag if config is not None else None
+
+        db.write_pipeline_stage(
+            stage=stage,
+            start_time=start_time,
+            end_time=end_time,
+            tag=tag,
+            metadata=json.dumps(metadata) if metadata else None,
+        )
+    except Exception as e:
+        logger.warning(f"Failed to record stage timing for {stage!r}: {e}")
+
+
+class _StageTimer(ContextDecorator):
+    """Context manager / decorator that times a block and records it via record_stage().
+
+    One instance holds per-entry state (full_name/start_time), so a decorated function is
+    fine to call repeatedly from one thread but not concurrently from several — for
+    concurrent callers, create the timer inside the function (`with stage_timer(...)`)."""
+
+    def __init__(self, stage: str, tag: str | None = None, metadata: dict | None = None):
+        self.stage = stage
+        self.tag = tag
+        self.metadata = metadata
+        self.full_name: str | None = None
+        self.start_time: float | None = None
+
+    def __enter__(self):
+        parent = current_stage()
+        self.full_name = f"{parent}.{self.stage}" if parent else self.stage
+        _stage_stack().append(self.full_name)
+        self.start_time = time.time()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        end_time = time.time()
+        stack = _stage_stack()
+        # Pop our own frame (guarded: a corrupted stack must not mask the block's result)
+        if stack and stack[-1] == self.full_name:
+            stack.pop()
+        else:
+            logger.warning(
+                f"stage_timer stack mismatch on exit of {self.full_name!r} "
+                f"(top: {stack[-1] if stack else None!r})"
+            )
+
+        metadata = self.metadata
+        if exc_type is not None:
+            # Record the failure but never suppress it (return None -> exception propagates)
+            metadata = dict(metadata or {})
+            metadata["status"] = "failed"
+            metadata["error"] = f"{exc_type.__name__}: {exc_value}"
+
+        # Implicit None return -> exceptions propagate (never suppressed)
+        record_stage(
+            self.full_name,
+            self.start_time,
+            end_time,
+            tag=self.tag,
+            metadata=metadata,
+        )
+
+
+def stage_timer(stage: str, tag: str | None = None, metadata: dict | None = None) -> _StageTimer:
+    """
+    Time a pipeline stage and queue a pipeline_stages DB row on exit.
+
+        with stage_timer("train.round_02.data_generation"):
+            ...
+
+        @stage_timer("inference.viz")
+        def render(): ...
+
+    `stage` is a dotted hierarchical name. If another stage_timer is active on the same
+    thread, `stage` is recorded relative to it (entering stage_timer("encode") while
+    "inference.infer_cadence_001" is active records "inference.infer_cadence_001.encode");
+    with no active parent it is recorded as-is. On exception the span is still recorded
+    (metadata carries status=failed plus the error) and the exception propagates.
+    `metadata`, when given, is a small JSON-serializable dict stored on the row.
+    """
+    return _StageTimer(stage, tag=tag, metadata=metadata)

--- a/src/aetherscan/benchmark.py
+++ b/src/aetherscan/benchmark.py
@@ -78,6 +78,9 @@ def record_stage(
 
         if tag is None:
             config = get_config()
+            # NOTE: tag stays None if a timer fires before checkpoint.save_tag is wired
+            # (early init, pre-CLI-parse). Such rows won't match a tag="..." query filter.
+            # In practice timers don't fire that early, so this is a documented edge, not a bug.
             tag = config.checkpoint.save_tag if config is not None else None
 
         db.write_pipeline_stage(
@@ -121,7 +124,7 @@ class _StageTimer(ContextDecorator):
         else:
             logger.warning(
                 f"stage_timer stack mismatch on exit of {self.full_name!r} "
-                f"(top: {stack[-1] if stack else None!r})"
+                f"(top: {(stack[-1] if stack else None)!r})"
             )
 
         metadata = self.metadata

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -787,7 +787,7 @@ def _add_inference_flags_to(parser):
         help="Number of fine channels per coarse channel (default: 1048576)",
     )
     parser.add_argument(
-        "--parallel-coarse-chans",
+        "--coarse-channel-log-interval",
         type=int,
         default=None,
         help="Progress-logging chunk size for energy detection, in coarse channels per log line (default: the number of worker processes). Parallelism itself comes from the persistent worker pool, not this knob.",
@@ -1234,8 +1234,11 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
         config.inference.cadence_expected_obs = args.cadence_expected_obs
     if hasattr(args, "coarse_channel_width") and args.coarse_channel_width is not None:
         config.inference.coarse_channel_width = args.coarse_channel_width
-    if hasattr(args, "parallel_coarse_chans") and args.parallel_coarse_chans is not None:
-        config.inference.parallel_coarse_chans = args.parallel_coarse_chans
+    if (
+        hasattr(args, "coarse_channel_log_interval")
+        and args.coarse_channel_log_interval is not None
+    ):
+        config.inference.coarse_channel_log_interval = args.coarse_channel_log_interval
     if hasattr(args, "bandpass_method") and args.bandpass_method is not None:
         config.inference.bandpass_method = args.bandpass_method
     if hasattr(args, "pfb_taps_per_channel") and args.pfb_taps_per_channel is not None:
@@ -2087,8 +2090,8 @@ def collect_validation_errors(
         coarse_channel_width = _resolve(
             args, "coarse_channel_width", config.inference.coarse_channel_width
         )
-        parallel_coarse_chans = _resolve(
-            args, "parallel_coarse_chans", config.inference.parallel_coarse_chans
+        coarse_channel_log_interval = _resolve(
+            args, "coarse_channel_log_interval", config.inference.coarse_channel_log_interval
         )
         spline_order = _resolve(args, "spline_order", config.inference.spline_order)
         detection_window_size = _resolve(
@@ -2104,7 +2107,7 @@ def collect_validation_errors(
         # Positivity checks for the bare-int / bare-float fields, in parser order.
         for name, val in (
             ("coarse_channel_width", coarse_channel_width),
-            ("parallel_coarse_chans", parallel_coarse_chans),
+            ("coarse_channel_log_interval", coarse_channel_log_interval),
             ("stat_threshold", stat_threshold),
             ("stamp_width", stamp_width),
         ):

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -321,7 +321,7 @@ class InferenceConfig:
     # Progress-logging chunk size for energy detection (coarse channels per log line).
     # None -> use manager.n_processes. Parallelism itself comes from the persistent worker
     # pool (one fused task per coarse channel), not from this knob.
-    parallel_coarse_chans: int | None = None
+    coarse_channel_log_interval: int | None = None
     # Bandpass flattening method for energy detection: "pfb" divides each coarse channel by
     # the instrument's static polyphase-filterbank response (computed once per run); "spline"
     # fits and subtracts a spline per coarse channel per file (the historical, data-driven
@@ -650,7 +650,7 @@ class Config:
                 "cadence_h5_path_col": self.inference.cadence_h5_path_col,
                 "cadence_expected_obs": self.inference.cadence_expected_obs,
                 "coarse_channel_width": self.inference.coarse_channel_width,
-                "parallel_coarse_chans": self.inference.parallel_coarse_chans,
+                "coarse_channel_log_interval": self.inference.coarse_channel_log_interval,
                 "bandpass_method": self.inference.bandpass_method,
                 "pfb_taps_per_channel": self.inference.pfb_taps_per_channel,
                 "bandpass_debug_plot": self.inference.bandpass_debug_plot,

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -187,8 +187,11 @@ class TrainingConfig:
     signal_injection_chunk_size: int = (
         50000  # Maximum cadences to process at once during data generation
     )
-    # NOTE: is this the optimal size?
-    data_gen_task_size: int = 256  # Cadences per batched worker task (workers write results straight into the round memmap)
+    # Tuned to 64 via smoke-scale (n=8192) task-size sweeps on bla0 (96c) + blpc3 (32c):
+    # finer tasks load-balance the create_true_double straggler with negligible per-task
+    # overhead; 64 was near-optimal on both (256 ran ~2x slower on bla0).
+    # TODO: re-confirm at production sample sizes (~500k) before treating as final.
+    data_gen_task_size: int = 64  # Cadences per batched worker task (workers write results straight into the round memmap)
 
     # Round data pipeline params (disk-backed per-round datasets, see round_data.py)
     round_data_dir: str | None = None  # Defaults to get_training_file_path("round_data") at runtime

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -45,6 +45,10 @@ class MonitorConfig:
     stop_monitor_timeout: float = 10.0  # seconds
     monitor_interval: float = 1.0  # seconds
     monitor_retry_delay: float = 1.0  # seconds
+    # Overlay top-level pipeline_stages spans (depth <= 2 dot-names, e.g. "train.round_03")
+    # as labeled translucent bands on the resource plot's CPU panel, so utilization
+    # plateaus are attributable to pipeline stages at a glance
+    annotate_stages: bool = True
 
 
 @dataclass
@@ -540,6 +544,7 @@ class Config:
                 "stop_monitor_timeout": self.monitor.stop_monitor_timeout,
                 "monitor_interval": self.monitor.monitor_interval,
                 "monitor_retry_delay": self.monitor.monitor_retry_delay,
+                "annotate_stages": self.monitor.annotate_stages,
             },
             "logger": {
                 "console_level": self.logger.console_level,

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -50,7 +50,10 @@ _MARK_SUPERSEDED_SENTINEL = object()
 #     cadence whose stored 'inferred' row was written under the same inference config — guards
 #     the reused-tag-with-changed-config stale-reuse footgun (the inference counterpart of the
 #     training-side config_fingerprint guard).
-_SCHEMA_VERSION = 3
+# v4: added the `pipeline_stages` table (always-on stage timing spans from
+#     aetherscan.benchmark, consumed by utils/benchmark_report.py and the monitor's
+#     stage-band overlay). New table -> no ALTER step, same as v2.
+_SCHEMA_VERSION = 4
 
 
 def get_system_metadata() -> str:
@@ -364,6 +367,30 @@ class Database:
                 ON inference_cadences(tag, npy_path, status)
             """)
 
+            # Pipeline stage timing table (schema v3): one row per timed pipeline stage
+            # span, written by aetherscan.benchmark (stage_timer / record_stage). stage is
+            # a hierarchical dot-name ("train.round_02.data_generation"); metadata is an
+            # optional JSON TEXT blob (e.g. {"status": "failed", ...} for spans that ended
+            # in an exception). Retried stages simply append new rows — consumers see every
+            # attempt, each with its own span.
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS pipeline_stages (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    stage TEXT NOT NULL,
+                    start_time REAL NOT NULL,
+                    end_time REAL NOT NULL,
+                    duration_s REAL NOT NULL,
+                    tag TEXT,
+                    metadata TEXT
+                )
+            """)
+
+            # Composite index for the common filter pattern (tag + start_time)
+            cursor.execute("""
+                CREATE INDEX IF NOT EXISTS idx_pipeline_stages_filter
+                ON pipeline_stages(tag, start_time)
+            """)
+
             conn.commit()
 
             # Bring pre-existing databases (older schema) up to the current version
@@ -406,10 +433,9 @@ class Database:
                     cursor.execute(f"ALTER TABLE {table} ADD COLUMN superseded INTEGER DEFAULT 0")
                     logger.info(f"Schema migration: added {table}.superseded")
 
-        # v2 (inference_cadences table) needs no migration step here: the table is created
-        # for old and new databases alike by the CREATE TABLE IF NOT EXISTS statement in
-        # _init_database(), which always runs before this method. Only the version stamp
-        # below advances.
+        # v2 (inference_cadences table) needs no migration step here: the table is created for
+        # old and new databases alike by the CREATE TABLE IF NOT EXISTS statements in
+        # _init_database(), which always runs before this method.
 
         if version < 3:
             # v3: config_fingerprint on inference_cadences. A fresh db already has the column
@@ -419,6 +445,10 @@ class Database:
             if "config_fingerprint" not in columns:
                 cursor.execute("ALTER TABLE inference_cadences ADD COLUMN config_fingerprint TEXT")
                 logger.info("Schema migration: added inference_cadences.config_fingerprint")
+
+        # v4 (pipeline_stages table) needs no migration step here either: like v2, the table is
+        # created for old and new databases alike by the CREATE TABLE IF NOT EXISTS statement in
+        # _init_database(). Only the version stamp below advances.
 
         # PRAGMA doesn't support parameter binding; _SCHEMA_VERSION is a module-level int constant
         cursor.execute(f"PRAGMA user_version = {_SCHEMA_VERSION:d}")
@@ -741,6 +771,7 @@ class Database:
                 latent_snapshots_records: list[tuple] = []
                 inference_results_records: list[tuple] = []
                 inference_cadences_records: list[tuple] = []
+                pipeline_stages_records: list[tuple] = []
 
                 for table, values in self.buffer:
                     if table == "system_resources":
@@ -755,6 +786,8 @@ class Database:
                         inference_results_records.append(values)
                     elif table == "inference_cadences":
                         inference_cadences_records.append(values)
+                    elif table == "pipeline_stages":
+                        pipeline_stages_records.append(values)
 
                 # Bulk insert each table type
                 if system_resources_records:
@@ -823,6 +856,16 @@ class Database:
                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         inference_cadences_records,
+                    )
+
+                if pipeline_stages_records:
+                    cursor.executemany(
+                        """
+                        INSERT INTO pipeline_stages
+                        (stage, start_time, end_time, duration_s, tag, metadata)
+                        VALUES (?, ?, ?, ?, ?, ?)
+                        """,
+                        pipeline_stages_records,
                     )
 
                 conn.commit()
@@ -1123,6 +1166,38 @@ class Database:
             )
         )
 
+    # TODO: write checks to sanitize values before writing to db. raise error if problematic value passed
+    def write_pipeline_stage(
+        self,
+        stage: str,
+        start_time: float,
+        end_time: float,
+        tag: str | None = None,
+        metadata: str | None = None,
+    ):
+        """
+        Queue a non-blocking write to pipeline_stages.
+
+        stage is a hierarchical dot-name ("train.round_02.data_generation"); start_time /
+        end_time are unix timestamps bounding the span (duration_s is derived here so the
+        table stays internally consistent). metadata, when given, is an already-serialized
+        JSON string (aetherscan.benchmark owns the serialization). Prefer the stage_timer /
+        record_stage helpers in aetherscan.benchmark over calling this directly.
+        """
+        self.write_queue.put(
+            (
+                "pipeline_stages",
+                (
+                    stage,
+                    start_time,
+                    end_time,
+                    end_time - start_time,
+                    tag,
+                    metadata,
+                ),
+            )
+        )
+
     # Column whitelists per table (for SQL injection prevention when using column projection)
     _SYSTEM_RESOURCES_COLUMNS = {
         "id",
@@ -1213,6 +1288,15 @@ class Database:
         "duration_s",
         "config_fingerprint",
         "superseded",
+    }
+    _PIPELINE_STAGES_COLUMNS = {
+        "id",
+        "stage",
+        "start_time",
+        "end_time",
+        "duration_s",
+        "tag",
+        "metadata",
     }
 
     @staticmethod
@@ -1914,6 +1998,61 @@ class Database:
             # Pair column names with values and return to user as a dict
             return [dict(zip(result_columns, row, strict=False)) for row in cursor.fetchall()]
 
+    def query_pipeline_stages(
+        self,
+        stage: str | list[str] | None = None,
+        tag: str | list[str] | None = None,
+        start_time: float | None = None,
+        end_time: float | None = None,
+        columns: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Query rows from pipeline_stages as a list of dicts, ordered by start_time.
+
+        stage and tag accept either a single value (= filter) or a list (IN filter).
+        start_time/end_time bound the row's start_time column (unix time, inclusive on both
+        ends) — a span that started inside the window but ended after end_time is still
+        returned. The returned metadata field is a JSON string or None — callers parse it
+        with json.loads. columns is validated against _PIPELINE_STAGES_COLUMNS.
+        """
+        with self._get_connection() as conn:
+            cursor = conn.cursor()
+
+            select = self._build_select("pipeline_stages", columns, self._PIPELINE_STAGES_COLUMNS)
+            # WHERE 1=1 is a way of building parametrized queries
+            # Since 1=1 is always true, it does nothing functionally
+            # But it allows us to safely add more conditions by appending AND clauses
+            # While not breaking the query if none are added
+            query = f"{select} WHERE 1=1"
+            params: list = []
+
+            # Build the query dynamically based on user-specified conditions
+            if stage:
+                query = self._add_str_filter(query, params, "stage", stage)
+
+            if tag:
+                query = self._add_str_filter(query, params, "tag", tag)
+
+            if start_time is not None:
+                query += " AND start_time >= ?"
+                params.append(start_time)
+
+            if end_time is not None:
+                query += " AND start_time <= ?"
+                params.append(end_time)
+
+            # Chronological order is what every consumer (report tree, timeline plot,
+            # monitor overlay) wants; the table stays small (one row per stage span), so
+            # the filesort on top of idx_pipeline_stages_filter is cheap
+            query += " ORDER BY start_time"
+
+            cursor.execute(query, params)
+
+            # Create a list of column names using query result's metadata
+            result_columns = [desc[0] for desc in cursor.description]
+            # Pair column names with values and return to user as a dict
+            return [dict(zip(result_columns, row, strict=False)) for row in cursor.fetchall()]
+
     # NOTE: this call gets expensive as db grows. create a separate schema to track num_rows_added per pipeline run. then count & update as part of db cleanup routine? or use SQLite's dbstat virtual table or periodic ANALYZE?
     def get_db_stats(self) -> dict[str, Any]:
         """Get summary statistics for the database"""
@@ -1940,6 +2079,9 @@ class Database:
 
             cursor.execute("SELECT COUNT(*) FROM inference_cadences")
             stats["inference_cadences_row_count"] = cursor.fetchone()[0]
+
+            cursor.execute("SELECT COUNT(*) FROM pipeline_stages")
+            stats["pipeline_stages_row_count"] = cursor.fetchone()[0]
 
             # Time range
             # Use system_resources as proxy

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -367,7 +367,7 @@ class Database:
                 ON inference_cadences(tag, npy_path, status)
             """)
 
-            # Pipeline stage timing table (schema v3): one row per timed pipeline stage
+            # Pipeline stage timing table (schema v4): one row per timed pipeline stage
             # span, written by aetherscan.benchmark (stage_timer / record_stage). stage is
             # a hierarchical dot-name ("train.round_02.data_generation"); metadata is an
             # optional JSON TEXT blob (e.g. {"status": "failed", ...} for spans that ended

--- a/src/aetherscan/inference.py
+++ b/src/aetherscan/inference.py
@@ -16,6 +16,7 @@ import time
 import numpy as np
 import tensorflow as tf
 
+from aetherscan.benchmark import stage_timer
 from aetherscan.config import get_config
 from aetherscan.db import get_db
 from aetherscan.models import RandomForestModel
@@ -336,7 +337,8 @@ class InferencePipeline:
                 f"({n_padded} padded) using distributed inference"
             )
 
-            latents = self._distributed_encode(inf_dataset, n_padded, inf_steps)
+            with stage_timer("encode"):
+                latents = self._distributed_encode(inf_dataset, n_padded, inf_steps)
 
             # Drop the encoded padding rows: the first n_samples * num_observations latent
             # rows correspond exactly to the real snippets (row order is snippet-major)
@@ -348,26 +350,28 @@ class InferencePipeline:
             # predict_verbose would have derived from it (probability of the predicted
             # class, so high for confident negatives too).
             logger.info("Running Random Forest classification")
-            probas = self.rf_model.predict_proba(latents)
-            proba_true = probas[:, 1]
-            predictions = (proba_true > self.threshold).astype(int)
-            confidence_scores = np.where(predictions, proba_true, probas[:, 0])
+            with stage_timer("rf"):
+                probas = self.rf_model.predict_proba(latents)
+                proba_true = probas[:, 1]
+                predictions = (proba_true > self.threshold).astype(int)
+                confidence_scores = np.where(predictions, proba_true, probas[:, 0])
 
             # Write results to database
-            n_candidates = self._write_inference_results(
-                npy_path=npy_path,
-                predictions=predictions,
-                confidence_scores=confidence_scores,
-                latents=latents,
-                target=target,
-                session=session,
-                cadence_id=cadence_id,
-                band=band,
-                frequency_mhz=frequency_mhz,
-                stamp_frequencies_mhz=stamp_frequencies_mhz,
-                timestamp_observed=timestamp_observed,
-                h5_path=h5_path,
-            )
+            with stage_timer("db_write"):
+                n_candidates = self._write_inference_results(
+                    npy_path=npy_path,
+                    predictions=predictions,
+                    confidence_scores=confidence_scores,
+                    latents=latents,
+                    target=target,
+                    session=session,
+                    cadence_id=cadence_id,
+                    band=band,
+                    frequency_mhz=frequency_mhz,
+                    stamp_frequencies_mhz=stamp_frequencies_mhz,
+                    timestamp_observed=timestamp_observed,
+                    h5_path=h5_path,
+                )
 
         except Exception as e:
             logger.error(f"Error in run_inference(): {e}")
@@ -576,19 +580,22 @@ def run_inference_pipeline(
     pipeline = InferencePipeline(strategy=strategy)
 
     try:
-        # Run inference
-        results = pipeline.run_inference(
-            data=cadence_data,
-            npy_path=npy_path,
-            target=target,
-            session=session,
-            cadence_id=cadence_id,
-            band=band,
-            frequency_mhz=frequency_mhz,
-            stamp_frequencies_mhz=stamp_frequencies_mhz,
-            timestamp_observed=timestamp_observed,
-            h5_path=h5_path,
-        )
+        # Run inference. The umbrella span makes run_inference's encode/rf/db_write
+        # sub-stages record as "inference.infer.*" on this legacy path (the streaming
+        # path opens a per-cadence "inference.infer_cadence_NNN" umbrella instead)
+        with stage_timer("inference.infer"):
+            results = pipeline.run_inference(
+                data=cadence_data,
+                npy_path=npy_path,
+                target=target,
+                session=session,
+                cadence_id=cadence_id,
+                band=band,
+                frequency_mhz=frequency_mhz,
+                stamp_frequencies_mhz=stamp_frequencies_mhz,
+                timestamp_observed=timestamp_observed,
+                h5_path=h5_path,
+            )
     finally:
         # Force TensorFlow to release internal references to datasets/iterators. Runs once
         # per pipeline lifetime (after the loaded models are no longer needed) rather than

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -18,6 +18,7 @@ import numpy as np
 import tensorflow as tf
 from dotenv import find_dotenv, load_dotenv
 
+from aetherscan.benchmark import stage_timer
 from aetherscan.cli import (
     apply_args_to_config,
     apply_saved_config,
@@ -235,7 +236,8 @@ def train_command():
     # then we should consider moving this into TrainingPipeline proper
     try:
         preprocessor = DataPreprocessor()
-        background_data = preprocessor.load_train_data().astype(np.float32)
+        with stage_timer("train.load_backgrounds"):
+            background_data = preprocessor.load_train_data().astype(np.float32)
         # NOTE: do we need to close preprocessing pools and/or shared memory?
     except Exception as e:
         logger.error(f"Failed to load train backgrounds: {e}")
@@ -344,41 +346,45 @@ def _infer_cadence(
 
     stage_start = time.time()
 
-    # copy=False: the loader already returns float32; don't duplicate GBs of stamps
-    cadence_data = preprocessor.load_inference_data(
-        override_filepaths=[cadence_result.npy_path]
-    ).astype(np.float32, copy=False)
+    # Umbrella stage span for this cadence's inference phase — the load_lognorm /
+    # encode / rf / db_write sub-stages inside nest under it via thread-local naming
+    with stage_timer(f"inference.infer_cadence_{unit.index:03d}"):
+        # copy=False: the loader already returns float32; don't duplicate GBs of stamps
+        with stage_timer("load_lognorm"):
+            cadence_data = preprocessor.load_inference_data(
+                override_filepaths=[cadence_result.npy_path]
+            ).astype(np.float32, copy=False)
 
-    # Step 1: retire any partial rows from a dead attempt before fresh ones land
-    db.mark_superseded("inference_results", tag, npy_path=cadence_result.npy_path)
+        # Step 1: retire any partial rows from a dead attempt before fresh ones land
+        db.mark_superseded("inference_results", tag, npy_path=cadence_result.npy_path)
 
-    results = pipeline.run_inference(
-        data=cadence_data,
-        npy_path=cadence_result.npy_path,
-        **provenance,
-    )
-    del cadence_data
-    gc.collect()
+        results = pipeline.run_inference(
+            data=cadence_data,
+            npy_path=cadence_result.npy_path,
+            **provenance,
+        )
+        del cadence_data
+        gc.collect()
 
-    duration_s = time.time() - stage_start
+        duration_s = time.time() - stage_start
 
-    # Steps 3 + 4: new-row-plus-supersede on the run manifest
-    confidence_summary = summarize_confidences(
-        results["proba_true"], config.inference.classification_threshold
-    )
-    db.mark_superseded("inference_cadences", tag, npy_path=cadence_result.npy_path)
-    db.write_inference_cadence(
-        npy_path=cadence_result.npy_path,
-        status="inferred",
-        tag=tag,
-        csv_path=unit.group.csv_path,
-        cadence_key=cadence_result.key,
-        n_stamps=results["n_cadence_snippets"],
-        n_candidates=results["n_candidates"],
-        confidence_summary=confidence_summary,
-        duration_s=duration_s,
-        config_fingerprint=config_fingerprint,
-    )
+        # Steps 3 + 4: new-row-plus-supersede on the run manifest
+        confidence_summary = summarize_confidences(
+            results["proba_true"], config.inference.classification_threshold
+        )
+        db.mark_superseded("inference_cadences", tag, npy_path=cadence_result.npy_path)
+        db.write_inference_cadence(
+            npy_path=cadence_result.npy_path,
+            status="inferred",
+            tag=tag,
+            csv_path=unit.group.csv_path,
+            cadence_key=cadence_result.key,
+            n_stamps=results["n_cadence_snippets"],
+            n_candidates=results["n_candidates"],
+            confidence_summary=confidence_summary,
+            duration_s=duration_s,
+            config_fingerprint=config_fingerprint,
+        )
 
     results["provenance"] = provenance
     results["duration_s"] = duration_s
@@ -596,7 +602,8 @@ def _run_streaming_csv_inference(
 
     if collector is not None:
         # Every figure is individually exception-guarded — a plot bug can't fail the pass
-        render_inference_visualizations(collector, preprocessor, totals)
+        with stage_timer("inference.viz"):
+            render_inference_visualizations(collector, preprocessor, totals)
 
     return totals
 
@@ -676,7 +683,8 @@ def inference_command():
                 # retry (the old cross-attempt cadence_data cache is gone — the manifest
                 # made it obsolete on the streaming path, and holding a catalog-sized
                 # array across attempts was its only remaining use).
-                cadence_data = preprocessor.load_inference_data().astype(np.float32)
+                with stage_timer("inference.load_lognorm"):
+                    cadence_data = preprocessor.load_inference_data().astype(np.float32)
                 results = run_inference_pipeline(
                     cadence_data=cadence_data,
                     npy_path=config.data.test_files[0],  # TODO: handle multiple test_files properly

--- a/src/aetherscan/monitor/monitor.py
+++ b/src/aetherscan/monitor/monitor.py
@@ -32,6 +32,27 @@ from aetherscan.logger import get_logger
 
 logger = logging.getLogger(__name__)
 
+# Only pipeline_stages spans this shallow (dot-separated components) are overlaid on the
+# resource plot — deep spans (per-ON-file energy detection, encode/rf sub-stages, ...) stay
+# report-tool-only so the CPU panel doesn't drown in bands
+_ANNOTATION_MAX_DEPTH = 2
+
+# Alternating band face colors (matplotlib named colors), cycled across adjacent spans so
+# consecutive stages stay visually separable at low alpha
+_ANNOTATION_COLORS = ("tab:purple", "tab:olive", "tab:cyan")
+
+
+def select_annotation_spans(rows: list[dict], max_depth: int = _ANNOTATION_MAX_DEPTH) -> list[dict]:
+    """
+    Filter pipeline_stages rows down to the ones the resource plot overlays: spans whose
+    dot-name has at most max_depth components (e.g. "train.round_03" but not
+    "train.round_03.epochs"), sorted by start_time. Pure helper, unit-testable without a
+    monitor instance.
+    """
+    spans = [row for row in rows if len(str(row["stage"]).split(".")) <= max_depth]
+    spans.sort(key=lambda row: row["start_time"])
+    return spans
+
 
 # BUG:
 # system total CPU usage appears "unnormalized" compared to aetherscan CPU usage (aetherscan CPU & RAM sometimes exceeds system total)
@@ -382,6 +403,50 @@ class ResourceMonitor:
         # Save plot on shutdown
         self._save_plot()
 
+    def _annotate_stage_spans(self, ax, current_time: float) -> None:
+        """
+        Overlay this run's top-level pipeline_stages spans (depth <= 2 dot-names) as
+        labeled translucent vertical bands on `ax` (the CPU panel). X units match the
+        panel: minutes since monitor start. Flushes the DB first so spans recorded moments
+        before shutdown (final_save, viz) make it onto the plot.
+        """
+        # The writer thread outlives the monitor (manager cleanup order: monitor before
+        # db), so a flush here is safe; a timeout just means the newest spans are missing
+        self.db.flush()
+
+        rows = self.db.query_pipeline_stages(
+            tag=self.tag,
+            start_time=self.start_time,
+            end_time=current_time,
+        )
+        spans = select_annotation_spans(rows)
+        if not spans:
+            logger.info("No top-level pipeline stage spans to annotate")
+            return
+
+        for idx, span in enumerate(spans):
+            start_min = (span["start_time"] - self.start_time) / 60
+            end_min = (min(span["end_time"], current_time) - self.start_time) / 60
+            color = _ANNOTATION_COLORS[idx % len(_ANNOTATION_COLORS)]
+            ax.axvspan(start_min, end_min, alpha=0.12, color=color, zorder=0)
+            # Label with the leaf name component ("round_03", not "train.round_03"),
+            # anchored near the top of the band, clipped to the axes
+            label = str(span["stage"]).split(".")[-1]
+            ax.text(
+                (start_min + end_min) / 2,
+                97,
+                label,
+                rotation=90,
+                ha="center",
+                va="top",
+                fontsize=7,
+                color="dimgray",
+                clip_on=True,
+                zorder=1,
+            )
+
+        logger.info(f"Annotated {len(spans)} pipeline stage span(s) on the CPU panel")
+
     def _save_plot(self):
         """Generate and save resource utilization plot from database"""
         current_time = time.time()
@@ -496,6 +561,15 @@ class ResourceMonitor:
         # TODO: place legend outside of plot (see plot_beta_vae_training_progress()) (only for gpu plot?)
         ax_cpu.legend(loc="upper right", fontsize=10)
         ax_cpu.set_title(f"CPU Pressure (n={psutil.cpu_count()} cores)", fontsize=12)
+
+        # Overlay top-level pipeline stage spans as labeled translucent bands so CPU
+        # plateaus are attributable at a glance ("this plateau = round 3 data gen").
+        # Fully exception-guarded: a broken overlay must never cost the resource plot
+        if self.config.monitor.annotate_stages:
+            try:
+                self._annotate_stage_spans(ax_cpu, current_time)
+            except Exception as e:
+                logger.error(f"Failed to annotate pipeline stages on resource plot: {e}")
 
         # RAM plot
         ax_ram = axes[1]

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -1433,9 +1433,9 @@ class DataPreprocessor:
         boundary, so no blocks, block-sized shared memory, or per-stage pools exist anymore.
         """
         coarse_channel_width = self.config.inference.coarse_channel_width
-        # parallel_coarse_chans is a progress-logging chunk size only (None -> n_processes);
+        # coarse_channel_log_interval is a progress-logging chunk size only (None -> n_processes);
         # actual parallelism is the persistent pool's worker count.
-        parallel_chans = self.config.inference.parallel_coarse_chans
+        log_interval = self.config.inference.coarse_channel_log_interval
         window_size = self.config.inference.detection_window_size
         step_size = self.config.inference.detection_step_size
         stat_threshold = self.config.inference.stat_threshold
@@ -1446,7 +1446,7 @@ class DataPreprocessor:
         downsample_factor = self.config.data.downsample_factor if store_downsampled else 1
         time_bins = self.config.data.time_bins
         n_processes = self.config.manager.n_processes
-        progress_chunk = max(1, parallel_chans if parallel_chans is not None else n_processes)
+        progress_chunk = max(1, log_interval if log_interval is not None else n_processes)
 
         # Read header / metadata from the first ON-source file
         on_source_paths = [group.h5_paths[i] for i in (0, 2, 4)]
@@ -1483,9 +1483,9 @@ class DataPreprocessor:
             return None
 
         # NOTE: every complete coarse channel is processed. The historical block-based path
-        # floored to a multiple of parallel_coarse_chans, silently dropping up to
-        # parallel_coarse_chans - 1 trailing coarse channels when n_chans wasn't an exact
-        # multiple of a block.
+        # floored to a multiple of the old parallel_coarse_chans knob, silently dropping up to
+        # that many - 1 trailing coarse channels when n_chans wasn't an exact multiple of a
+        # block. (That knob is now coarse_channel_log_interval and only affects log cadence.)
         n_coarse_total = n_chans // coarse_channel_width
         if n_coarse_total == 0:
             logger.warning(

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -34,6 +34,7 @@ import numpy as np
 from scipy import interpolate, stats
 from skimage.transform import downscale_local_mean
 
+from aetherscan.benchmark import stage_timer
 from aetherscan.config import get_config
 from aetherscan.data_generation import log_norm
 from aetherscan.db import get_db
@@ -589,6 +590,9 @@ class PendingCadence:
 
     group: CadenceGroup
     npy_path: str
+    # 1-based position in plan_cadences() output (CSV order, so stable across resumed
+    # attempts) — the short label used in this cadence's pipeline_stages span names
+    index: int = 0
 
 
 def derive_cadence_provenance(key: tuple, group_by_cols: list[str], metadata: dict) -> dict:
@@ -1281,7 +1285,11 @@ class DataPreprocessor:
             for group in valid_groups:
                 npy_filename = self._cadence_npy_filename(csv_stem, group.key)
                 units.append(
-                    PendingCadence(group=group, npy_path=os.path.join(output_dir, npy_filename))
+                    PendingCadence(
+                        group=group,
+                        npy_path=os.path.join(output_dir, npy_filename),
+                        index=len(units) + 1,
+                    )
                 )
 
         logger.info(
@@ -1326,7 +1334,11 @@ class DataPreprocessor:
                 )
 
         try:
-            return self._process_cadence(group, npy_path)
+            # Umbrella stage span for this cadence's preprocessing phase — the per-ON-file
+            # read_ed / dedup / extract sub-stages inside _process_cadence nest under it
+            # via thread-local naming. The resume path above records nothing (no work done)
+            with stage_timer(f"inference.preprocess_cadence_{unit.index:03d}"):
+                return self._process_cadence(group, npy_path)
         except Exception as e:
             logger.error(f"Failed to process cadence {group.key}: {e}")
             return None
@@ -1511,50 +1523,53 @@ class DataPreprocessor:
                 f"{on_source_idx + 1}/{len(on_source_paths)}: {on_h5}"
             )
 
-            if pfb_active:
-                # Cheap static-response sanity check (once per file, not per channel)
-                self._warn_on_pfb_response_mismatch(on_h5, n_coarse_total)
+            # One stage span per ON file (read + DC spike + bandpass flatten + threshold)
+            with stage_timer(f"read_ed_on{on_source_idx + 1}"):
+                if pfb_active:
+                    # Cheap static-response sanity check (once per file, not per channel)
+                    self._warn_on_pfb_response_mismatch(on_h5, n_coarse_total)
 
-            tasks = [
-                (
-                    on_h5,
-                    ch,
-                    coarse_channel_width,
-                    time_bins,
-                    bandpass_flatten,
-                    window_size,
-                    step_size,
-                    stat_threshold,
-                )
-                for ch in range(n_coarse_total)
-            ]
-
-            if self._ed_pool is not None:
-                # imap (ordered, chunksize 1) keeps every worker busy across the whole file
-                # while results stream back for progress logging
-                channel_hits_iter = self._ed_pool.imap(_energy_detect_channel_worker, tasks)
-            else:
-                if n_processes > 1:
-                    logger.info(
-                        "Energy detection running sequentially: no persistent pool started "
-                        "(call start_energy_detection_pool() to parallelize)"
+                tasks = [
+                    (
+                        on_h5,
+                        ch,
+                        coarse_channel_width,
+                        time_bins,
+                        bandpass_flatten,
+                        window_size,
+                        step_size,
+                        stat_threshold,
                     )
-                channel_hits_iter = map(_energy_detect_channel_worker, tasks)
+                    for ch in range(n_coarse_total)
+                ]
 
-            for done, (channel_hits, channel_hist) in enumerate(channel_hits_iter, start=1):
-                all_hits.extend(channel_hits)
-                stat_hists[on_source_idx] += channel_hist
-                if done % progress_chunk == 0 or done == n_coarse_total:
-                    logger.info(
-                        f"  Coarse channel {done}/{n_coarse_total} of ON-source "
-                        f"{on_source_idx + 1}/{len(on_source_paths)}"
-                    )
+                if self._ed_pool is not None:
+                    # imap (ordered, chunksize 1) keeps every worker busy across the whole
+                    # file while results stream back for progress logging
+                    channel_hits_iter = self._ed_pool.imap(_energy_detect_channel_worker, tasks)
+                else:
+                    if n_processes > 1:
+                        logger.info(
+                            "Energy detection running sequentially: no persistent pool "
+                            "started (call start_energy_detection_pool() to parallelize)"
+                        )
+                    channel_hits_iter = map(_energy_detect_channel_worker, tasks)
+
+                for done, (channel_hits, channel_hist) in enumerate(channel_hits_iter, start=1):
+                    all_hits.extend(channel_hits)
+                    stat_hists[on_source_idx] += channel_hist
+                    if done % progress_chunk == 0 or done == n_coarse_total:
+                        logger.info(
+                            f"  Coarse channel {done}/{n_coarse_total} of ON-source "
+                            f"{on_source_idx + 1}/{len(on_source_paths)}"
+                        )
 
         logger.info(f"Cadence {group.key}: {len(all_hits)} raw hits across ON-source files")
 
         # NOTE: come back to this later (what's the trade-off for doing dedup vs not? e.g. lower storage & compute, but higher FNR or lower DR sensitivity?)
         # Deduplicate: greedy merge of any pair within stamp_width // 2
-        merged_hits = self._deduplicate_hits(all_hits, stamp_width)
+        with stage_timer("dedup"):
+            merged_hits = self._deduplicate_hits(all_hits, stamp_width)
         logger.info(
             f"Cadence {group.key}: {len(merged_hits)} hits after deduplication "
             f"(stamp_width={stamp_width})"
@@ -1651,15 +1666,16 @@ class DataPreprocessor:
             for base in range(0, n_stamps, chunk_size)
         ]
 
-        if self._ed_pool is not None and len(tasks) > 1:
-            # Reuse the persistent energy-detection pool — extraction workers are plain
-            # (no shared memory), so the same pool serves both stages without churn
-            self._ed_pool.map(_extract_stamps_worker, tasks)
-        else:
-            for task in tasks:
-                _extract_stamps_worker(task)
+        with stage_timer("extract"):
+            if self._ed_pool is not None and len(tasks) > 1:
+                # Reuse the persistent energy-detection pool — extraction workers are plain
+                # (no shared memory), so the same pool serves both stages without churn
+                self._ed_pool.map(_extract_stamps_worker, tasks)
+            else:
+                for task in tasks:
+                    _extract_stamps_worker(task)
 
-        os.replace(tmp_npy_path, npy_path)
+            os.replace(tmp_npy_path, npy_path)
 
         metadata_path = self.cadence_metadata_path(npy_path)
         # Per-stamp frequency = center bin's frequency, computed from header's fch1/foff

--- a/src/aetherscan/round_data.py
+++ b/src/aetherscan/round_data.py
@@ -37,7 +37,7 @@ from logging.handlers import QueueListener
 
 import numpy as np
 
-from aetherscan.benchmark import record_stage
+from aetherscan.benchmark import record_stage, round_stage_name
 from aetherscan.logger import init_worker_logging
 from aetherscan.manager import get_manager
 
@@ -651,7 +651,7 @@ class RoundDataProducer:
             # because the DB writer queue is thread-only
             _, round_idx, start_ts, end_ts = message
             record_stage(
-                f"train.round_{round_idx:02d}.data_generation",
+                f"{round_stage_name(round_idx)}.data_generation",
                 start_ts,
                 end_ts,
                 tag=self._tag,

--- a/src/aetherscan/round_data.py
+++ b/src/aetherscan/round_data.py
@@ -37,6 +37,7 @@ from logging.handlers import QueueListener
 
 import numpy as np
 
+from aetherscan.benchmark import record_stage
 from aetherscan.logger import init_worker_logging
 from aetherscan.manager import get_manager
 
@@ -347,6 +348,13 @@ def _producer_main(
     - in:  ("generate", round_idx, snr_base, snr_range) | ("shutdown",)
     - out: ("stats", round_idx, segment_dict)            per class-segment per chunk
            ("progress", round_idx, chunk, n_chunks)      per chunk
+           ("timing", round_idx, start_ts, end_ts)       generation wall-clock span, sent
+                                                         before "done" (skipped on reuse —
+                                                         no generation happened); the
+                                                         main-process drainer records it as
+                                                         a pipeline_stages row (this
+                                                         process can't reach the DB writer
+                                                         queue, a thread queue.Queue)
            ("done", round_idx, manifest)                 on success (or valid reuse)
            ("error", round_idx, traceback_str)           on failure (producer keeps serving)
            ("shutdown_ack",)                             right before a graceful exit
@@ -429,6 +437,7 @@ def _producer_main(
                     f"RoundDataProducer: generating round {round_idx} data "
                     f"(SNR {snr_base}-{snr_base + snr_range})"
                 )
+                generation_start = time.time()
                 manifest = generate_fn(
                     paths,
                     round_idx,
@@ -442,6 +451,9 @@ def _producer_main(
                     ),
                 )
                 logger.info(f"RoundDataProducer: round {round_idx} data complete")
+                # Timing before done: queue FIFO means the drainer records the stage span
+                # before await_round() unblocks on the done message
+                result_queue.put(("timing", round_idx, generation_start, time.time()))
                 result_queue.put(("done", round_idx, manifest))
             except Exception:
                 result_queue.put(("error", round_idx, traceback.format_exc()))
@@ -634,6 +646,17 @@ class RoundDataProducer:
         elif kind == "progress":
             _, round_idx, chunk, n_chunks = message
             logger.info(f"Round {round_idx} data generation: chunk {chunk}/{n_chunks} complete")
+        elif kind == "timing":
+            # The producer's generation wall-clock span, recorded from this (main) process
+            # because the DB writer queue is thread-only
+            _, round_idx, start_ts, end_ts = message
+            record_stage(
+                f"train.round_{round_idx:02d}.data_generation",
+                start_ts,
+                end_ts,
+                tag=self._tag,
+                metadata={"source": "producer"},
+            )
         elif kind in ("done", "error"):
             _, round_idx, payload = message
             with self._condition:

--- a/src/aetherscan/run_state.py
+++ b/src/aetherscan/run_state.py
@@ -103,7 +103,7 @@ _INFERENCE_FINGERPRINT_EXCLUDE_INFERENCE_KEYS = frozenset(
     {
         "config_path",  # source-config file path, not a result input
         "per_replica_batch_size",  # batching only; #120's pad+truncate makes results batch-invariant
-        "parallel_coarse_chans",  # progress-logging chunk size only (inert)
+        "coarse_channel_log_interval",  # progress-logging chunk size only (inert)
         "bandpass_debug_plot",  # opt-in debug artifact
         "preprocess_output_dir",  # where stamps are written (folded into npy_path, not values)
         "inference_viz_enabled",  # viz toggle

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -44,7 +44,7 @@ from sklearn.metrics import (
 from tensorflow.keras.initializers import GlorotNormal, HeNormal
 from tensorflow.keras.layers import Conv2D, Dense
 
-from aetherscan.benchmark import record_stage, stage_timer
+from aetherscan.benchmark import stage_timer
 from aetherscan.config import get_config
 from aetherscan.data_generation import DataGenerator
 from aetherscan.db import get_db, get_system_metadata
@@ -1394,190 +1394,190 @@ class TrainingPipeline:
         logger.info(f"Gradients accumulated every {accumulation_steps} sub-steps")
 
         try:
-            # Round-level epoch span (per-epoch durations already live in training_stats;
-            # record_stage instead of a `with` block spares the loop body a re-indent)
-            epochs_span_start = time.time()
-            for epoch in range(epochs):
-                # Training
-                epoch_losses, epoch_gradient_norms, train_duration = self._train_epoch(
-                    round_idx,
-                    epoch,
-                    snr_base,
-                    snr_range,
-                    train_dataset,
-                    steps_per_epoch,
-                    accumulation_steps,
-                    time.time(),
-                )
-
-                # Validation
-                val_losses, val_duration = self._validate_epoch(val_dataset, val_steps, time.time())
-
-                # Queue db writes (non-blocking) & log results
-                current_time = time.time()
-
-                if self.db is None:
-                    raise RuntimeError(
-                        "No database instance detected - cannot generate loss curves plot"
+            # Round-level epoch span (per-epoch durations already live in training_stats).
+            # stage_timer records the span even on a mid-loop exception (status=failed).
+            with stage_timer("epochs"):
+                for epoch in range(epochs):
+                    # Training
+                    epoch_losses, epoch_gradient_norms, train_duration = self._train_epoch(
+                        round_idx,
+                        epoch,
+                        snr_base,
+                        snr_range,
+                        train_dataset,
+                        steps_per_epoch,
+                        accumulation_steps,
+                        time.time(),
                     )
 
-                # Training losses
-                for stat_name, key in [
-                    ("total_loss", "total"),
-                    ("reconstruction_loss", "reconstruction"),
-                    ("kl_loss", "kl"),
-                    ("true_loss", "true"),
-                    ("false_loss", "false"),
-                ]:
+                    # Validation
+                    val_losses, val_duration = self._validate_epoch(
+                        val_dataset, val_steps, time.time()
+                    )
+
+                    # Queue db writes (non-blocking) & log results
+                    current_time = time.time()
+
+                    if self.db is None:
+                        raise RuntimeError(
+                            "No database instance detected - cannot generate loss curves plot"
+                        )
+
+                    # Training losses
+                    for stat_name, key in [
+                        ("total_loss", "total"),
+                        ("reconstruction_loss", "reconstruction"),
+                        ("kl_loss", "kl"),
+                        ("true_loss", "true"),
+                        ("false_loss", "false"),
+                    ]:
+                        self.db.write_training_stat(
+                            model_name="beta_vae",
+                            stat_name=stat_name,
+                            value=float(epoch_losses[key]),
+                            round_number=round_idx + 1,
+                            epoch_number=epoch + 1,
+                            tag=self.config.checkpoint.save_tag,
+                            timestamp=current_time,
+                        )
+
+                    # Validation losses
+                    for stat_name, key in [
+                        ("val_total_loss", "total"),
+                        ("val_reconstruction_loss", "reconstruction"),
+                        ("val_kl_loss", "kl"),
+                        ("val_true_loss", "true"),
+                        ("val_false_loss", "false"),
+                    ]:
+                        self.db.write_training_stat(
+                            model_name="beta_vae",
+                            stat_name=stat_name,
+                            value=float(val_losses[key]),
+                            round_number=round_idx + 1,
+                            epoch_number=epoch + 1,
+                            tag=self.config.checkpoint.save_tag,
+                            timestamp=current_time,
+                        )
+
+                    # Gradient norm/clipping statistics
+                    gradient_norm_mean = np.mean(epoch_gradient_norms)
+                    gradient_norm_max = np.max(epoch_gradient_norms)
+                    gradient_norm_std = np.std(epoch_gradient_norms)
+                    clipping_rate = np.sum(np.array(epoch_gradient_norms) > 1.0) / steps_per_epoch
+
+                    for stat_name, stat_value in [
+                        ("gradient_norm_mean", gradient_norm_mean),
+                        ("gradient_norm_max", gradient_norm_max),
+                        ("gradient_norm_std", gradient_norm_std),
+                        ("clipping_rate", clipping_rate),
+                    ]:
+                        self.db.write_training_stat(
+                            model_name="beta_vae",
+                            stat_name=stat_name,
+                            value=float(stat_value),
+                            round_number=round_idx + 1,
+                            epoch_number=epoch + 1,
+                            tag=self.config.checkpoint.save_tag,
+                            timestamp=current_time,
+                        )
+
+                    # Learning rate
+                    current_lr = float(self.vae.optimizer.learning_rate.numpy())
                     self.db.write_training_stat(
                         model_name="beta_vae",
-                        stat_name=stat_name,
-                        value=float(epoch_losses[key]),
+                        stat_name="learning_rate",
+                        value=current_lr,
                         round_number=round_idx + 1,
                         epoch_number=epoch + 1,
                         tag=self.config.checkpoint.save_tag,
                         timestamp=current_time,
                     )
 
-                # Validation losses
-                for stat_name, key in [
-                    ("val_total_loss", "total"),
-                    ("val_reconstruction_loss", "reconstruction"),
-                    ("val_kl_loss", "kl"),
-                    ("val_true_loss", "true"),
-                    ("val_false_loss", "false"),
-                ]:
-                    self.db.write_training_stat(
-                        model_name="beta_vae",
-                        stat_name=stat_name,
-                        value=float(val_losses[key]),
-                        round_number=round_idx + 1,
-                        epoch_number=epoch + 1,
-                        tag=self.config.checkpoint.save_tag,
-                        timestamp=current_time,
+                    # Misc stats
+                    for stat_name, stat_value in [
+                        ("train_duration", train_duration),
+                        ("val_duration", val_duration),
+                        ("snr_range_floor", snr_base),
+                        ("snr_range_ceil", snr_base + snr_range),
+                        ("num_steps", steps_per_epoch),
+                        ("num_sub_steps", accumulation_steps),
+                    ]:
+                        self.db.write_training_stat(
+                            model_name="beta_vae",
+                            stat_name=stat_name,
+                            value=stat_value,
+                            round_number=round_idx + 1,
+                            epoch_number=epoch + 1,
+                            tag=self.config.checkpoint.save_tag,
+                            timestamp=current_time,
+                        )
+
+                    # COMMENTED OUT: Removing TensorBoard support
+                    # TensorBoard logging
+                    # with self.train_writer.as_default():
+                    #     tf.summary.scalar("total_loss", epoch_losses["total"], step=self.global_step)
+                    #     tf.summary.scalar(
+                    #         "reconstruction_loss", epoch_losses["reconstruction"], step=self.global_step
+                    #     )
+                    #     tf.summary.scalar("kl_loss", epoch_losses["kl"], step=self.global_step)
+                    #     tf.summary.scalar("true_loss", epoch_losses["true"], step=self.global_step)
+                    #     tf.summary.scalar("false_loss", epoch_losses["false"], step=self.global_step)
+                    #     tf.summary.scalar(
+                    #         "learning_rate",
+                    #         self.vae.optimizer.learning_rate.numpy(),
+                    #         step=self.global_step,
+                    #     )
+                    #
+                    # with self.val_writer.as_default():
+                    #     tf.summary.scalar(
+                    #         "validation_total_loss", val_losses["total"], step=self.global_step
+                    #     )
+                    #     tf.summary.scalar(
+                    #         "validation_reconstruction_loss",
+                    #         val_losses["reconstruction"],
+                    #         step=self.global_step,
+                    #     )
+                    #     tf.summary.scalar("validation_kl_loss", val_losses["kl"], step=self.global_step)
+                    #     tf.summary.scalar(
+                    #         "validation_true_loss", val_losses["true"], step=self.global_step
+                    #     )
+                    #     tf.summary.scalar(
+                    #         "validation_false_loss", val_losses["false"], step=self.global_step
+                    #     )
+                    #
+                    # # Flush writers to ensure data is written
+                    # self.train_writer.flush()
+                    # self.val_writer.flush()
+                    #
+                    # # Increment global step
+                    # self.global_step += 1
+
+                    logger.info(f"Epoch {epoch + 1}")
+                    logger.info(
+                        f"Train -- Total: {epoch_losses['total']:.4f}, "
+                        f"Recon: {epoch_losses['reconstruction']:.4f}, "
+                        f"KL: {epoch_losses['kl']:.4f}, "
+                        f"True: {epoch_losses['true']:.4f}, "
+                        f"False: {epoch_losses['false']:.4f}, "
+                        f"Duration: {train_duration:.2f} "
+                    )
+                    logger.info(
+                        f"Gradient norm -- Mean: {gradient_norm_mean:.4f}, "
+                        f"Std: {gradient_norm_std:.4f}, "
+                        f"Max: {gradient_norm_max:.4f}, "
+                        f"Clipping rate: {clipping_rate:.4f} "
+                    )
+                    logger.info(
+                        f"Val -- Total: {val_losses['total']:.4f}, "
+                        f"Recon: {val_losses['reconstruction']:.4f}, "
+                        f"KL: {val_losses['kl']:.4f}, "
+                        f"True: {val_losses['true']:.4f}, "
+                        f"False: {val_losses['false']:.4f}, "
+                        f"Duration: {val_duration:.2f} "
                     )
 
-                # Gradient norm/clipping statistics
-                gradient_norm_mean = np.mean(epoch_gradient_norms)
-                gradient_norm_max = np.max(epoch_gradient_norms)
-                gradient_norm_std = np.std(epoch_gradient_norms)
-                clipping_rate = np.sum(np.array(epoch_gradient_norms) > 1.0) / steps_per_epoch
-
-                for stat_name, stat_value in [
-                    ("gradient_norm_mean", gradient_norm_mean),
-                    ("gradient_norm_max", gradient_norm_max),
-                    ("gradient_norm_std", gradient_norm_std),
-                    ("clipping_rate", clipping_rate),
-                ]:
-                    self.db.write_training_stat(
-                        model_name="beta_vae",
-                        stat_name=stat_name,
-                        value=float(stat_value),
-                        round_number=round_idx + 1,
-                        epoch_number=epoch + 1,
-                        tag=self.config.checkpoint.save_tag,
-                        timestamp=current_time,
-                    )
-
-                # Learning rate
-                current_lr = float(self.vae.optimizer.learning_rate.numpy())
-                self.db.write_training_stat(
-                    model_name="beta_vae",
-                    stat_name="learning_rate",
-                    value=current_lr,
-                    round_number=round_idx + 1,
-                    epoch_number=epoch + 1,
-                    tag=self.config.checkpoint.save_tag,
-                    timestamp=current_time,
-                )
-
-                # Misc stats
-                for stat_name, stat_value in [
-                    ("train_duration", train_duration),
-                    ("val_duration", val_duration),
-                    ("snr_range_floor", snr_base),
-                    ("snr_range_ceil", snr_base + snr_range),
-                    ("num_steps", steps_per_epoch),
-                    ("num_sub_steps", accumulation_steps),
-                ]:
-                    self.db.write_training_stat(
-                        model_name="beta_vae",
-                        stat_name=stat_name,
-                        value=stat_value,
-                        round_number=round_idx + 1,
-                        epoch_number=epoch + 1,
-                        tag=self.config.checkpoint.save_tag,
-                        timestamp=current_time,
-                    )
-
-                # COMMENTED OUT: Removing TensorBoard support
-                # TensorBoard logging
-                # with self.train_writer.as_default():
-                #     tf.summary.scalar("total_loss", epoch_losses["total"], step=self.global_step)
-                #     tf.summary.scalar(
-                #         "reconstruction_loss", epoch_losses["reconstruction"], step=self.global_step
-                #     )
-                #     tf.summary.scalar("kl_loss", epoch_losses["kl"], step=self.global_step)
-                #     tf.summary.scalar("true_loss", epoch_losses["true"], step=self.global_step)
-                #     tf.summary.scalar("false_loss", epoch_losses["false"], step=self.global_step)
-                #     tf.summary.scalar(
-                #         "learning_rate",
-                #         self.vae.optimizer.learning_rate.numpy(),
-                #         step=self.global_step,
-                #     )
-                #
-                # with self.val_writer.as_default():
-                #     tf.summary.scalar(
-                #         "validation_total_loss", val_losses["total"], step=self.global_step
-                #     )
-                #     tf.summary.scalar(
-                #         "validation_reconstruction_loss",
-                #         val_losses["reconstruction"],
-                #         step=self.global_step,
-                #     )
-                #     tf.summary.scalar("validation_kl_loss", val_losses["kl"], step=self.global_step)
-                #     tf.summary.scalar(
-                #         "validation_true_loss", val_losses["true"], step=self.global_step
-                #     )
-                #     tf.summary.scalar(
-                #         "validation_false_loss", val_losses["false"], step=self.global_step
-                #     )
-                #
-                # # Flush writers to ensure data is written
-                # self.train_writer.flush()
-                # self.val_writer.flush()
-                #
-                # # Increment global step
-                # self.global_step += 1
-
-                logger.info(f"Epoch {epoch + 1}")
-                logger.info(
-                    f"Train -- Total: {epoch_losses['total']:.4f}, "
-                    f"Recon: {epoch_losses['reconstruction']:.4f}, "
-                    f"KL: {epoch_losses['kl']:.4f}, "
-                    f"True: {epoch_losses['true']:.4f}, "
-                    f"False: {epoch_losses['false']:.4f}, "
-                    f"Duration: {train_duration:.2f} "
-                )
-                logger.info(
-                    f"Gradient norm -- Mean: {gradient_norm_mean:.4f}, "
-                    f"Std: {gradient_norm_std:.4f}, "
-                    f"Max: {gradient_norm_max:.4f}, "
-                    f"Clipping rate: {clipping_rate:.4f} "
-                )
-                logger.info(
-                    f"Val -- Total: {val_losses['total']:.4f}, "
-                    f"Recon: {val_losses['reconstruction']:.4f}, "
-                    f"KL: {val_losses['kl']:.4f}, "
-                    f"True: {val_losses['true']:.4f}, "
-                    f"False: {val_losses['false']:.4f}, "
-                    f"Duration: {val_duration:.2f} "
-                )
-
-                # Adaptive learning rate
-                self._update_learning_rate(val_losses)
-
-            record_stage(f"train.round_{round_number:02d}.epochs", epochs_span_start, time.time())
+                    # Adaptive learning rate
+                    self._update_learning_rate(val_losses)
 
             # NOTE: combine plot_beta_vae_loss_curves(), plot_beta_vae_training_stability(), and plot_latent_space_gif() into plot_training_progress()?
             with stage_timer("plots"):

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -44,7 +44,7 @@ from sklearn.metrics import (
 from tensorflow.keras.initializers import GlorotNormal, HeNormal
 from tensorflow.keras.layers import Conv2D, Dense
 
-from aetherscan.benchmark import stage_timer
+from aetherscan.benchmark import round_stage_name, stage_timer
 from aetherscan.config import get_config
 from aetherscan.data_generation import DataGenerator
 from aetherscan.db import get_db, get_system_metadata
@@ -1269,7 +1269,7 @@ class TrainingPipeline:
 
                 # Umbrella stage span for the whole round (data wait + epochs + plots +
                 # checkpoint save) — the sub-stages inside train_round nest under it
-                with stage_timer(f"train.round_{round_idx + 1:02d}"):
+                with stage_timer(round_stage_name(round_idx + 1)):
                     self.train_round(
                         round_idx=round_idx, epochs=epochs, snr_base=snr_base, snr_range=snr_range
                     )

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -2258,7 +2258,9 @@ class TrainingPipeline:
         if validate_done_manifest(rf_paths, expected_n_samples=n_samples) is not None:
             logger.info(f"Reusing validated RF dataset at {rf_paths.round_dir}")
         else:
-            with stage_timer("data_generation"):
+            # RF data is always generated in-process (no background producer for the RF phase);
+            # tag source to match the per-round data_generation spans (producer / in-process)
+            with stage_timer("data_generation", metadata={"source": "in-process"}):
                 self.data_generator.generate_round(rf_paths, n_samples, snr_base, snr_range)
         rf_data = load_round_arrays(rf_paths)
 

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -44,6 +44,7 @@ from sklearn.metrics import (
 from tensorflow.keras.initializers import GlorotNormal, HeNormal
 from tensorflow.keras.layers import Conv2D, Dense
 
+from aetherscan.benchmark import record_stage, stage_timer
 from aetherscan.config import get_config
 from aetherscan.data_generation import DataGenerator
 from aetherscan.db import get_db, get_system_metadata
@@ -1266,9 +1267,12 @@ class TrainingPipeline:
 
                 logger.info(f"Curriculum LR reset: {current_lr:.2e} → {original_lr:.2e}")
 
-                self.train_round(
-                    round_idx=round_idx, epochs=epochs, snr_base=snr_base, snr_range=snr_range
-                )
+                # Umbrella stage span for the whole round (data wait + epochs + plots +
+                # checkpoint save) — the sub-stages inside train_round nest under it
+                with stage_timer(f"train.round_{round_idx + 1:02d}"):
+                    self.train_round(
+                        round_idx=round_idx, epochs=epochs, snr_base=snr_base, snr_range=snr_range
+                    )
         finally:
             # Wind down the producer (graceful shutdown message, escalating to
             # terminate -> kill through the ResourceManager if it's mid-generation)
@@ -1305,7 +1309,13 @@ class TrainingPipeline:
             self._round_producer.await_round(round_number)
             logger.info(f"Round {round_number} data ready (waited {time.time() - wait_start:.1f}s)")
         else:
-            self.data_generator.generate_round(paths, n_samples, snr_base, snr_range, round_number)
+            # In-process generation (overlap disabled). The producer path records the same
+            # stage from its own timing message (see round_data._producer_main / the
+            # drainer's "timing" handler) — the two paths never both run for one round
+            with stage_timer("data_generation", metadata={"source": "in-process"}):
+                self.data_generator.generate_round(
+                    paths, n_samples, snr_base, snr_range, round_number
+                )
 
         # Immediately queue generation of the next round's data so it runs in the producer
         # process while this round's epochs train (curriculum SNR for round k+1 is
@@ -1384,6 +1394,9 @@ class TrainingPipeline:
         logger.info(f"Gradients accumulated every {accumulation_steps} sub-steps")
 
         try:
+            # Round-level epoch span (per-epoch durations already live in training_stats;
+            # record_stage instead of a `with` block spares the loop body a re-indent)
+            epochs_span_start = time.time()
             for epoch in range(epochs):
                 # Training
                 epoch_losses, epoch_gradient_norms, train_duration = self._train_epoch(
@@ -1564,39 +1577,45 @@ class TrainingPipeline:
                 # Adaptive learning rate
                 self._update_learning_rate(val_losses)
 
+            record_stage(f"train.round_{round_number:02d}.epochs", epochs_span_start, time.time())
+
             # NOTE: combine plot_beta_vae_loss_curves(), plot_beta_vae_training_stability(), and plot_latent_space_gif() into plot_training_progress()?
-            # Plot loss curves
-            self.plot_beta_vae_loss_curves(tag=f"round_{round_idx + 1:02d}", dir="checkpoints")
+            with stage_timer("plots"):
+                # Plot loss curves
+                self.plot_beta_vae_loss_curves(tag=f"round_{round_idx + 1:02d}", dir="checkpoints")
 
-            # Plot clipping rate
-            self.plot_beta_vae_training_stability(
-                tag=f"round_{round_idx + 1:02d}", dir="checkpoints"
-            )
+                # Plot clipping rate
+                self.plot_beta_vae_training_stability(
+                    tag=f"round_{round_idx + 1:02d}", dir="checkpoints"
+                )
 
-            # Plot injection stats
-            self.plot_injection_stats(
-                tag=f"round_{round_idx + 1:02d}",
-                dir="checkpoints",
-            )
+                # Plot injection stats
+                self.plot_injection_stats(
+                    tag=f"round_{round_idx + 1:02d}",
+                    dir="checkpoints",
+                )
 
-            # Optional per-round latent traversal (config-gated; the canonical set renders
-            # once at end of training in the vae_plots stage). Failures are logged and
-            # swallowed — an optional plot mustn't fail the round and cost a retry cycle
-            # including data regeneration
-            if self.config.training.latent_traversal_every_round:
-                try:
-                    self.plot_latent_traversal(tag=f"round_{round_idx + 1:02d}", dir="checkpoints")
-                except Exception as e:
-                    logger.error(
-                        f"Failed to execute plot_latent_traversal for round {round_idx + 1}: {e}"
-                    )
+                # Optional per-round latent traversal (config-gated; the canonical set
+                # renders once at end of training in the vae_plots stage). Failures are
+                # logged and swallowed — an optional plot mustn't fail the round and cost
+                # a retry cycle including data regeneration
+                if self.config.training.latent_traversal_every_round:
+                    try:
+                        self.plot_latent_traversal(
+                            tag=f"round_{round_idx + 1:02d}", dir="checkpoints"
+                        )
+                    except Exception as e:
+                        logger.error(
+                            f"Failed to execute plot_latent_traversal for round {round_idx + 1}: {e}"
+                        )
 
-            # NOTE: commented out to save compute. a final latent space gif at the end of training should suffice
-            # Generate latent space GIF
-            # self.plot_latent_space_gif(tag=f"round_{round_idx + 1:02d}", dir="checkpoints")
+                # NOTE: commented out to save compute. a final latent space gif at the end of training should suffice
+                # Generate latent space GIF
+                # self.plot_latent_space_gif(tag=f"round_{round_idx + 1:02d}", dir="checkpoints")
 
             # Save checkpoint
-            self.save_models(tag=f"round_{round_idx + 1:02d}", dir="checkpoints")
+            with stage_timer("checkpoint_save"):
+                self.save_models(tag=f"round_{round_idx + 1:02d}", dir="checkpoints")
 
             # Checkpoint is on disk — record the round in the run manifest so a retry (or a
             # relaunch of the identical command) resumes at the next round
@@ -2239,7 +2258,8 @@ class TrainingPipeline:
         if validate_done_manifest(rf_paths, expected_n_samples=n_samples) is not None:
             logger.info(f"Reusing validated RF dataset at {rf_paths.round_dir}")
         else:
-            self.data_generator.generate_round(rf_paths, n_samples, snr_base, snr_range)
+            with stage_timer("data_generation"):
+                self.data_generator.generate_round(rf_paths, n_samples, snr_base, snr_range)
         rf_data = load_round_arrays(rf_paths)
 
         # Prepare distributed train+val datasets (stratified split). shuffle=False so the
@@ -2325,23 +2345,24 @@ class TrainingPipeline:
             # each generator only yields rows from its own index subset.
             train_encode_steps = train_steps * accumulation_steps
 
-            [train_latents] = self._distributed_encode(
-                dataset=train_dataset,
-                n_steps=train_encode_steps,
-                encode_fn=rf_encode_fn,
-                n_samples=n_train_trimmed * num_observations,
-                latent_dim=latent_dim,
-                logging=True,
-            )
+            with stage_timer("encode"):
+                [train_latents] = self._distributed_encode(
+                    dataset=train_dataset,
+                    n_steps=train_encode_steps,
+                    encode_fn=rf_encode_fn,
+                    n_samples=n_train_trimmed * num_observations,
+                    latent_dim=latent_dim,
+                    logging=True,
+                )
 
-            [val_latents] = self._distributed_encode(
-                dataset=val_dataset,
-                n_steps=val_steps,
-                encode_fn=rf_encode_fn,
-                n_samples=n_val_trimmed * num_observations,
-                latent_dim=latent_dim,
-                logging=True,
-            )
+                [val_latents] = self._distributed_encode(
+                    dataset=val_dataset,
+                    n_steps=val_steps,
+                    encode_fn=rf_encode_fn,
+                    n_samples=n_val_trimmed * num_observations,
+                    latent_dim=latent_dim,
+                    logging=True,
+                )
 
             # Derive aligned binary & sub-type labels for train/val splits. With shuffle=False,
             # the i-th cadence in the encoded train/val array corresponds to train_indices[i] /
@@ -2356,7 +2377,8 @@ class TrainingPipeline:
             )
 
             # Train Random Forest classifier (passes latent_vectors; model flattens internally)
-            self.rf_model.train(train_latents, train_binary_labels)
+            with stage_timer("fit"):
+                self.rf_model.train(train_latents, train_binary_labels)
             logger.info("Random Forest training complete")
 
             # NOTE: come back to this later (is it correct to call prepare_latent_features directly? this impacts the __init__.py in models/. what do we need features & probas for? why are we calling model.predict_proba directly? is it better to have a wrapper here? could we modify the return signature of predict_proba to return both features & probabilities?)
@@ -6594,7 +6616,8 @@ def _execute_training_stages(pipeline) -> None:
         logger.info(f"Stage '{STAGE_VAE_PLOTS}' already complete — skipping")
     else:
         try:
-            pipeline.plot_vae_diagnostics()
+            with stage_timer("train.vae_plots"):
+                pipeline.plot_vae_diagnostics()
             pipeline._mark_stage_done(STAGE_VAE_PLOTS)
         except Exception as e:
             logger.error(f"Stage '{STAGE_VAE_PLOTS}' failed: {e}")
@@ -6611,7 +6634,10 @@ def _execute_training_stages(pipeline) -> None:
         logger.info(f"Stage '{STAGE_RF_TRAIN}' already complete — loaded persisted RF model")
     else:
         try:
-            pipeline.train_random_forest()
+            # Umbrella span for the RF stage — the data_generation / encode / fit
+            # sub-stages inside train_random_forest nest under it
+            with stage_timer("train.rf"):
+                pipeline.train_random_forest()
         except Exception as e:
             logger.error(f"Error in train_random_forest(): {e}")
             # Attempt to save models on RF training failure
@@ -6625,7 +6651,8 @@ def _execute_training_stages(pipeline) -> None:
         logger.info(f"Stage '{STAGE_RF_PLOTS}' already complete — skipping")
     else:
         try:
-            pipeline.plot_rf_diagnostics()
+            with stage_timer("train.rf_plots"):
+                pipeline.plot_rf_diagnostics()
             pipeline._mark_stage_done(STAGE_RF_PLOTS)
         except Exception as e:
             logger.error(f"Stage '{STAGE_RF_PLOTS}' failed: {e}")
@@ -6642,7 +6669,8 @@ def _execute_training_stages(pipeline) -> None:
     if state.is_stage_done(STAGE_FINAL_SAVE):
         logger.info(f"Stage '{STAGE_FINAL_SAVE}' already complete — skipping")
     else:
-        pipeline.final_save()
+        with stage_timer("train.final_save"):
+            pipeline.final_save()
         pipeline._mark_stage_done(STAGE_FINAL_SAVE)
 
     # Stage 6: hf_upload (opt-in via config.hf.upload_after_training; non-critical) —

--- a/tests/unit/test_benchmark.py
+++ b/tests/unit/test_benchmark.py
@@ -1,0 +1,425 @@
+"""Unit tests for aetherscan.benchmark (stage_timer nesting / DB rows / failure recording),
+the monitor's stage-band span selection, and utils/benchmark_report.py's tree math and
+suggestion rules — all against tmp-path SQLite files."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sqlite3
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+from aetherscan.benchmark import current_stage, record_stage, stage_timer
+from aetherscan.config import get_config
+from aetherscan.db.db import Database
+from aetherscan.monitor.monitor import select_annotation_spans
+
+# utils/ is not a package — load the report tool straight from its file. The sys.modules
+# registration must precede exec_module: the module's @dataclass resolves its own module
+# by name at class-creation time (PEP 563 string annotations).
+_REPORT_PATH = Path(__file__).resolve().parents[2] / "utils" / "benchmark_report.py"
+_spec = importlib.util.spec_from_file_location("benchmark_report", _REPORT_PATH)
+benchmark_report = importlib.util.module_from_spec(_spec)
+sys.modules["benchmark_report"] = benchmark_report
+_spec.loader.exec_module(benchmark_report)
+
+
+@pytest.fixture
+def db(tmp_path):
+    """A started Database against the tmp output path with periodic flushing effectively
+    disabled, so flush() is the only thing that drains writes (same setup as test_db)."""
+    config = get_config()
+    config.db.write_interval = 300.0
+    config.db.write_buffer_max_size = 100_000
+    database = Database()
+    assert database.db_path.startswith(str(tmp_path))
+    database.start()
+    yield database
+    database.stop()
+
+
+class TestStageTimer:
+    def test_context_manager_records_row(self, db):
+        with stage_timer("train.load_backgrounds", tag="test_v1"):
+            pass
+        assert db.flush(timeout=10) is True
+
+        rows = db.query_pipeline_stages(tag="test_v1")
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["stage"] == "train.load_backgrounds"
+        assert row["end_time"] >= row["start_time"]
+        assert row["duration_s"] == pytest.approx(row["end_time"] - row["start_time"])
+        assert row["metadata"] is None
+
+    def test_tag_defaults_to_save_tag(self, db):
+        get_config().checkpoint.save_tag = "test_v9"
+        with stage_timer("inference.viz"):
+            pass
+        assert db.flush(timeout=10) is True
+        assert len(db.query_pipeline_stages(tag="test_v9")) == 1
+
+    def test_nested_timers_produce_dotted_names(self, db):
+        with stage_timer("train.round_01", tag="test_v1"):
+            assert current_stage() == "train.round_01"
+            with stage_timer("data_generation", tag="test_v1"):
+                assert current_stage() == "train.round_01.data_generation"
+            with stage_timer("epochs", tag="test_v1"):
+                pass
+        assert current_stage() is None
+        assert db.flush(timeout=10) is True
+
+        names = [r["stage"] for r in db.query_pipeline_stages(tag="test_v1")]
+        # All resolve to full dot-names; rows come back in start_time order, so the
+        # umbrella (which started first) precedes its children
+        assert names == [
+            "train.round_01",
+            "train.round_01.data_generation",
+            "train.round_01.epochs",
+        ]
+
+    def test_deep_nesting(self, db):
+        with (
+            stage_timer("inference.preprocess_cadence_001", tag="test_v1"),
+            stage_timer("read_ed_on1", tag="test_v1"),
+        ):
+            pass
+        assert db.flush(timeout=10) is True
+        names = {r["stage"] for r in db.query_pipeline_stages(tag="test_v1")}
+        assert "inference.preprocess_cadence_001.read_ed_on1" in names
+
+    def test_decorator_usage(self, db):
+        @stage_timer("train.final_save", tag="test_v1")
+        def do_save():
+            return 42
+
+        assert do_save() == 42
+        assert do_save() == 42  # Reusable across calls (fresh enter/exit each time)
+        assert db.flush(timeout=10) is True
+        rows = db.query_pipeline_stages(stage="train.final_save", tag="test_v1")
+        assert len(rows) == 2
+
+    def test_exception_recorded_and_propagates(self, db):
+        with pytest.raises(RuntimeError, match="boom"), stage_timer("train.rf", tag="test_v1"):
+            raise RuntimeError("boom")
+        assert current_stage() is None  # Stack unwound despite the exception
+        assert db.flush(timeout=10) is True
+
+        rows = db.query_pipeline_stages(tag="test_v1")
+        assert len(rows) == 1
+        metadata = json.loads(rows[0]["metadata"])
+        assert metadata["status"] == "failed"
+        assert "boom" in metadata["error"]
+
+    def test_metadata_passthrough(self, db):
+        with stage_timer(
+            "train.round_01.data_generation", tag="test_v1", metadata={"source": "in-process"}
+        ):
+            pass
+        assert db.flush(timeout=10) is True
+        rows = db.query_pipeline_stages(tag="test_v1")
+        assert json.loads(rows[0]["metadata"]) == {"source": "in-process"}
+
+    def test_threads_do_not_share_nesting(self, db):
+        recorded = []
+
+        def worker():
+            with stage_timer("inference.preprocess_cadence_001", tag="test_v1"):
+                recorded.append(current_stage())
+
+        with stage_timer("train.round_01", tag="test_v1"):
+            thread = threading.Thread(target=worker)
+            thread.start()
+            thread.join()
+
+        # The worker thread's timer must NOT nest under the main thread's umbrella
+        assert recorded == ["inference.preprocess_cadence_001"]
+
+    def test_no_db_is_a_noop(self):
+        # No Database instance exists (conftest resets singletons): timing must degrade
+        # to a debug log, never an exception
+        assert Database._instance is None
+        with stage_timer("train.round_01"):
+            pass
+        record_stage("train.round_02", 1.0, 2.0)
+
+    def test_record_stage_explicit_timestamps(self, db):
+        record_stage(
+            "train.round_03.data_generation",
+            50.0,
+            80.0,
+            tag="test_v1",
+            metadata={"source": "producer"},
+        )
+        assert db.flush(timeout=10) is True
+        rows = db.query_pipeline_stages(tag="test_v1")
+        assert len(rows) == 1
+        assert rows[0]["start_time"] == 50.0
+        assert rows[0]["end_time"] == 80.0
+        assert rows[0]["duration_s"] == 30.0
+        assert json.loads(rows[0]["metadata"]) == {"source": "producer"}
+
+
+class TestMonitorAnnotationSpans:
+    def test_depth_filter_and_sort(self):
+        rows = [
+            {"stage": "train.round_01.epochs", "start_time": 10.0, "end_time": 20.0},
+            {"stage": "train.round_01", "start_time": 5.0, "end_time": 25.0},
+            {"stage": "train.load_backgrounds", "start_time": 1.0, "end_time": 4.0},
+            {"stage": "inference.infer_cadence_001.encode", "start_time": 30.0, "end_time": 31.0},
+            {"stage": "inference.viz", "start_time": 40.0, "end_time": 41.0},
+        ]
+        spans = select_annotation_spans(rows)
+        assert [s["stage"] for s in spans] == [
+            "train.load_backgrounds",
+            "train.round_01",
+            "inference.viz",
+        ]
+
+    def test_empty_input(self):
+        assert select_annotation_spans([]) == []
+
+
+def _row(stage, start, end, metadata=None):
+    return {
+        "stage": stage,
+        "start_time": start,
+        "end_time": end,
+        "duration_s": end - start,
+        "tag": "test_v1",
+        "metadata": json.dumps(metadata) if metadata else None,
+    }
+
+
+@pytest.fixture
+def synthetic_rows():
+    """A small two-round training run: round 1's data generation dominates (60 of 100 s)."""
+    return [
+        _row("train.load_backgrounds", 0.0, 10.0),
+        _row("train.round_01", 10.0, 110.0),
+        _row("train.round_01.data_generation", 10.0, 70.0, {"source": "in-process"}),
+        _row("train.round_01.epochs", 70.0, 100.0),
+        _row("train.round_01.plots", 100.0, 105.0),
+        _row("train.round_01.checkpoint_save", 105.0, 110.0),
+        _row("train.round_02", 110.0, 160.0),
+        _row("train.round_02.epochs", 110.0, 155.0),
+        _row("train.final_save", 160.0, 170.0),
+    ]
+
+
+class TestReportTreeMath:
+    def test_tree_structure_and_totals(self, synthetic_rows):
+        root = benchmark_report.build_stage_tree(synthetic_rows)
+        train = root.children["train"]
+
+        # Pure grouping node: total = sum of children (10 + 100 + 50 + 10)
+        assert train.spans == []
+        assert train.total_duration == pytest.approx(170.0)
+
+        round_01 = train.children["round_01"]
+        # Umbrella node with its own span: total = own span, not the children's sum
+        assert round_01.total_duration == pytest.approx(100.0)
+        assert round_01.children["data_generation"].total_duration == pytest.approx(60.0)
+        # Self time = umbrella minus children (100 - 60 - 30 - 5 - 5)
+        assert round_01.self_duration == pytest.approx(0.0)
+        assert train.children["round_02"].self_duration == pytest.approx(5.0)
+
+    def test_multiple_spans_accumulate_on_one_node(self):
+        rows = [
+            _row("inference.infer_cadence_001.encode", 0.0, 2.0),
+            _row("inference.infer_cadence_001.encode", 5.0, 6.0),
+        ]
+        root = benchmark_report.build_stage_tree(rows)
+        encode = root.children["inference"].children["infer_cadence_001"].children["encode"]
+        assert len(encode.spans) == 2
+        assert encode.total_duration == pytest.approx(3.0)
+
+    def test_concurrent_children_never_go_negative(self):
+        # Producer-style overlap: the child's span exceeds the parent's wall-clock
+        rows = [
+            _row("train.round_02", 100.0, 110.0),
+            _row("train.round_02.data_generation", 50.0, 108.0),
+        ]
+        root = benchmark_report.build_stage_tree(rows)
+        node = root.children["train"].children["round_02"]
+        assert node.self_duration == 0.0
+
+    def test_top_slowest_ranked_by_self_time(self, synthetic_rows):
+        root = benchmark_report.build_stage_tree(synthetic_rows)
+        slowest = benchmark_report.top_slowest(root, k=3)
+        # data_generation (60s, leaf) beats epochs (45s round 2) beats epochs (30s round 1)
+        assert slowest[0].full_name == "train.round_01.data_generation"
+        assert slowest[0].self_duration == pytest.approx(60.0)
+        assert slowest[1].full_name == "train.round_02.epochs"
+
+    def test_format_tree_lines(self, synthetic_rows):
+        root = benchmark_report.build_stage_tree(synthetic_rows)
+        lines = benchmark_report.format_tree(root)
+        text = "\n".join(lines)
+        assert "train" in text
+        assert "round_01" in text
+        assert "data_generation" in text
+        # data_generation is 60% of round_01's 100 s
+        datagen_line = next(line for line in lines if "data_generation" in line)
+        assert "60.0%" in datagen_line
+
+    def test_format_duration(self):
+        assert benchmark_report.format_duration(45.3) == "45.3s"
+        assert benchmark_report.format_duration(125) == "2m 05s"
+        assert benchmark_report.format_duration(8010) == "2h 13m"
+
+
+class TestReportSuggestions:
+    def _make_db(self, tmp_path, stage_rows, resource_rows=()):
+        db_path = str(tmp_path / "aetherscan.db")
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "CREATE TABLE pipeline_stages (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " stage TEXT NOT NULL, start_time REAL NOT NULL, end_time REAL NOT NULL,"
+            " duration_s REAL NOT NULL, tag TEXT, metadata TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE system_resources (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " timestamp REAL NOT NULL, resource_type TEXT NOT NULL,"
+            " resource_name TEXT NOT NULL, value REAL NOT NULL, unit TEXT, tag TEXT,"
+            " metadata TEXT)"
+        )
+        conn.executemany(
+            "INSERT INTO pipeline_stages (stage, start_time, end_time, duration_s, tag,"
+            " metadata) VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                (
+                    r["stage"],
+                    r["start_time"],
+                    r["end_time"],
+                    r["duration_s"],
+                    r["tag"],
+                    r["metadata"],
+                )
+                for r in stage_rows
+            ],
+        )
+        conn.executemany(
+            "INSERT INTO system_resources (timestamp, resource_type, resource_name, value,"
+            " unit, tag, metadata) VALUES (?, ?, ?, ?, 'percent', 'test_v1', NULL)",
+            resource_rows,
+        )
+        conn.commit()
+        conn.close()
+        return db_path
+
+    def test_data_generation_rule_fires(self, tmp_path, synthetic_rows):
+        db_path = self._make_db(tmp_path, synthetic_rows)
+        root = benchmark_report.build_stage_tree(synthetic_rows)
+        suggestions = benchmark_report.build_suggestions(root, db_path, "test_v1")
+        datagen = [s for s in suggestions if "data_generation" in s]
+        assert len(datagen) == 1
+        assert "round_01" in datagen[0]
+        assert "overlap-data-generation" in datagen[0]  # in-process source -> enable overlap
+
+    def test_fully_overlapped_producer_generation_is_quiet(self, tmp_path):
+        # Producer generated round 2's data entirely during round 1: the span is large
+        # relative to round 2's wall-clock, but round 2 never waited — no suggestion
+        rows = [
+            _row("train.round_01", 0.0, 100.0),
+            _row("train.round_01.epochs", 0.0, 100.0),
+            _row("train.round_02", 100.0, 150.0),
+            _row("train.round_02.data_generation", 10.0, 95.0, {"source": "producer"}),
+            _row("train.round_02.epochs", 100.0, 145.0),
+        ]
+        db_path = self._make_db(tmp_path, rows)
+        root = benchmark_report.build_stage_tree(rows)
+        suggestions = benchmark_report.build_suggestions(root, db_path, "test_v1")
+        assert not [s for s in suggestions if "data_generation" in s]
+
+    def test_producer_generation_that_stalled_the_round_fires(self, tmp_path):
+        # Generation ran past the point epochs could start: the round waited on it
+        rows = [
+            _row("train.round_02", 100.0, 200.0),
+            _row("train.round_02.data_generation", 50.0, 160.0, {"source": "producer"}),
+            _row("train.round_02.epochs", 160.0, 195.0),
+        ]
+        db_path = self._make_db(tmp_path, rows)
+        root = benchmark_report.build_stage_tree(rows)
+        suggestions = benchmark_report.build_suggestions(root, db_path, "test_v1")
+        stalled = [s for s in suggestions if "data_generation" in s]
+        assert len(stalled) == 1
+        assert "waited on background generation" in stalled[0]
+
+    def test_gpu_util_rule_fires(self, tmp_path, synthetic_rows):
+        # GPU samples inside round 1's epochs span (70-100 s) averaging ~10%
+        resource_rows = [(t, "gpu", "GPU:0_utilization", 10.0) for t in range(70, 100, 5)]
+        db_path = self._make_db(tmp_path, synthetic_rows, resource_rows)
+        root = benchmark_report.build_stage_tree(synthetic_rows)
+        suggestions = benchmark_report.build_suggestions(root, db_path, "test_v1")
+        assert any("input-bound" in s and "round_01.epochs" in s for s in suggestions)
+
+    def test_ram_rule_fires(self, tmp_path, synthetic_rows):
+        resource_rows = [(30.0, "ram", "system_total", 95.0)]
+        db_path = self._make_db(tmp_path, synthetic_rows, resource_rows)
+        root = benchmark_report.build_stage_tree(synthetic_rows)
+        suggestions = benchmark_report.build_suggestions(root, db_path, "test_v1")
+        ram = [s for s in suggestions if "RAM" in s]
+        assert len(ram) == 1
+        assert "95.0%" in ram[0]
+        # Attributed to the deepest span covering t=30: round_01.data_generation
+        assert "train.round_01.data_generation" in ram[0]
+
+    def test_preprocess_domination_rule_fires(self, tmp_path):
+        rows = [
+            _row("inference.preprocess_cadence_001", 0.0, 70.0),
+            _row("inference.infer_cadence_001", 70.0, 100.0),
+        ]
+        db_path = self._make_db(tmp_path, rows)
+        root = benchmark_report.build_stage_tree(rows)
+        suggestions = benchmark_report.build_suggestions(root, db_path, "test_v1")
+        assert any("energy-detection preprocessing" in s for s in suggestions)
+
+    def test_quiet_run_yields_no_suggestions(self, tmp_path):
+        rows = [
+            _row("train.round_01", 0.0, 100.0),
+            _row("train.round_01.data_generation", 0.0, 10.0),  # 10% < 30% threshold
+            _row("train.round_01.epochs", 10.0, 100.0),
+        ]
+        # Healthy GPU utilization during epochs
+        resource_rows = [(t, "gpu", "GPU:0_utilization", 85.0) for t in range(10, 100, 10)]
+        db_path = self._make_db(tmp_path, rows, resource_rows)
+        root = benchmark_report.build_stage_tree(rows)
+        assert benchmark_report.build_suggestions(root, db_path, "test_v1") == []
+
+
+class TestReportEndToEnd:
+    def test_load_rows_and_render_png(self, tmp_path, synthetic_rows):
+        db_path = TestReportSuggestions()._make_db(tmp_path, synthetic_rows)
+        rows = benchmark_report.load_rows(db_path, "test_v1")
+        assert len(rows) == len(synthetic_rows)
+        assert rows[0]["stage"] == "train.load_backgrounds"  # ORDER BY start_time
+
+        root = benchmark_report.build_stage_tree(rows)
+        png = str(tmp_path / "plots" / "benchmark_report_test_v1.png")
+        benchmark_report.render_report_png(root, rows, "test_v1", png)
+        assert os.path.exists(png)
+        assert os.path.getsize(png) > 0
+
+    def test_main_missing_tag_returns_nonzero(self, tmp_path, synthetic_rows, capsys):
+        db_path = TestReportSuggestions()._make_db(tmp_path, synthetic_rows)
+        assert benchmark_report.main(["--save-tag", "no_such_tag", "--db-path", db_path]) == 1
+
+    def test_main_end_to_end(self, tmp_path, synthetic_rows, capsys):
+        db_path = TestReportSuggestions()._make_db(tmp_path, synthetic_rows)
+        out_dir = str(tmp_path / "plots")
+        assert (
+            benchmark_report.main(
+                ["--save-tag", "test_v1", "--db-path", db_path, "--output-dir", out_dir]
+            )
+            == 0
+        )
+        captured = capsys.readouterr().out
+        assert "Benchmark report for tag 'test_v1'" in captured
+        assert "Suggestions:" in captured
+        assert os.path.exists(os.path.join(out_dir, "benchmark_report_test_v1.png"))

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -658,7 +658,7 @@ class TestRoundDataFlags:
         assert config.training.round_data_dir is None
         assert config.training.overlap_data_generation is True
         assert config.training.keep_round_data is False
-        assert config.training.data_gen_task_size == 256
+        assert config.training.data_gen_task_size == 64
 
     def test_data_gen_task_size_below_one_rejected(self):
         errors = collect_validation_errors(_parse(["train", "--data-gen-task-size", "0"]), None)

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -436,6 +436,49 @@ class TestInferenceCadences:
             db.query_inference_cadences(columns=["npy_path; DROP TABLE inference_cadences"])
 
 
+class TestPipelineStages:
+    def test_write_and_query_round_trip(self, db):
+        tag = "test_v1"
+        db.write_pipeline_stage("train.round_01", 100.0, 160.0, tag=tag, metadata='{"a": 1}')
+        assert db.flush(timeout=10) is True
+
+        rows = db.query_pipeline_stages(tag=tag)
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["stage"] == "train.round_01"
+        assert row["start_time"] == 100.0
+        assert row["end_time"] == 160.0
+        assert row["duration_s"] == 60.0  # derived at write time
+        assert json.loads(row["metadata"]) == {"a": 1}
+
+    def test_query_filters_and_ordering(self, db):
+        tag = "test_v1"
+        # Inserted out of chronological order on purpose
+        db.write_pipeline_stage("train.round_02", 200.0, 260.0, tag=tag)
+        db.write_pipeline_stage("train.round_01", 100.0, 160.0, tag=tag)
+        db.write_pipeline_stage("inference.viz", 300.0, 310.0, tag=tag)
+        db.write_pipeline_stage("train.round_01", 100.0, 150.0, tag="test_v2")
+        assert db.flush(timeout=10) is True
+
+        rows = db.query_pipeline_stages(tag=tag)
+        assert [r["stage"] for r in rows] == ["train.round_01", "train.round_02", "inference.viz"]
+
+        # stage accepts str or list; start/end bound the row's start_time
+        assert len(db.query_pipeline_stages(stage="inference.viz", tag=tag)) == 1
+        assert len(db.query_pipeline_stages(stage=["train.round_01", "train.round_02"])) == 3
+        assert [
+            r["stage"] for r in db.query_pipeline_stages(tag=tag, start_time=150.0, end_time=250.0)
+        ] == ["train.round_02"]
+
+    def test_column_projection_and_whitelist(self, db):
+        db.write_pipeline_stage("train.rf", 1.0, 2.0, tag="test_v1")
+        assert db.flush(timeout=10) is True
+        rows = db.query_pipeline_stages(tag="test_v1", columns=["stage", "duration_s"])
+        assert rows == [{"stage": "train.rf", "duration_s": 1.0}]
+        with pytest.raises(ValueError, match="Invalid column"):
+            db.query_pipeline_stages(columns=["stage; DROP TABLE pipeline_stages"])
+
+
 class TestSchemaMigration:
     # The v0 schema (pre-superseded) for the four tables the migration touches, trimmed to
     # the columns the assertions need plus everything NOT NULL.
@@ -581,6 +624,57 @@ class TestSchemaMigration:
             database.write_inference_cadence(npy_path="/a.npy", status="inferred", tag="test_v1")
             assert database.flush(timeout=10) is True
             assert len(database.query_inference_cadences(tag="test_v1")) == 1
+        finally:
+            database.stop()
+
+    def test_old_schema_gains_pipeline_stages_table(self):
+        """A pre-versioning database (v0: no pipeline_stages table) must come out of
+        _init_database() with the v4 stage-timing table present and usable."""
+        db_path = self._create_v0_db(get_config())
+        assert "pipeline_stages" not in self._table_names(db_path)
+
+        database = Database()
+        database.start()
+        try:
+            assert "pipeline_stages" in self._table_names(db_path)
+            assert self._user_version(db_path) == _SCHEMA_VERSION
+            database.write_pipeline_stage("train.round_01", 1.0, 2.5, tag="test_v1")
+            assert database.flush(timeout=10) is True
+            rows = database.query_pipeline_stages(tag="test_v1")
+            assert len(rows) == 1
+            assert rows[0]["duration_s"] == 1.5
+        finally:
+            database.stop()
+
+    def test_v2_schema_migrates_to_v4(self):
+        """A database stamped at v2 (superseded columns + inference_cadences already
+        present, no config_fingerprint, no pipeline_stages) must gain the v3
+        config_fingerprint column, the v4 pipeline_stages table, and the v4 stamp."""
+        config = get_config()
+        db_path = os.path.join(config.output_path, "db", "aetherscan.db")
+        os.makedirs(os.path.dirname(db_path), exist_ok=True)
+        conn = sqlite3.connect(db_path)
+        conn.executescript(self._V0_SCHEMA)
+        for table in self._MIGRATED_TABLES:
+            conn.execute(f"ALTER TABLE {table} ADD COLUMN superseded INTEGER DEFAULT 0")
+        conn.execute(
+            "CREATE TABLE inference_cadences (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " timestamp REAL NOT NULL, tag TEXT, csv_path TEXT, cadence_key TEXT,"
+            " npy_path TEXT NOT NULL, status TEXT NOT NULL, n_stamps INTEGER,"
+            " n_candidates INTEGER, confidence_summary TEXT, duration_s REAL,"
+            " superseded INTEGER DEFAULT 0)"
+        )
+        conn.execute("PRAGMA user_version = 2")
+        conn.commit()
+        conn.close()
+
+        database = Database()
+        try:
+            # v3 ALTER: the pre-existing inference_cadences table gains config_fingerprint
+            assert "config_fingerprint" in self._column_names(db_path, "inference_cadences")
+            # v4: the new stage-timing table is created
+            assert "pipeline_stages" in self._table_names(db_path)
+            assert self._user_version(db_path) == _SCHEMA_VERSION
         finally:
             database.stop()
 

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -669,12 +669,19 @@ class TestSchemaMigration:
         conn.close()
 
         database = Database()
+        database.start()
         try:
             # v3 ALTER: the pre-existing inference_cadences table gains config_fingerprint
             assert "config_fingerprint" in self._column_names(db_path, "inference_cadences")
             # v4: the new stage-timing table is created
             assert "pipeline_stages" in self._table_names(db_path)
             assert self._user_version(db_path) == _SCHEMA_VERSION
+            # ...and the table created during a v2->v4 migration is actually usable
+            database.write_pipeline_stage("train.round_01", 10.0, 12.5, tag="test_v2")
+            assert database.flush(timeout=10) is True
+            rows = database.query_pipeline_stages(tag="test_v2")
+            assert len(rows) == 1
+            assert rows[0]["duration_s"] == 2.5
         finally:
             database.stop()
 

--- a/tests/unit/test_round_data.py
+++ b/tests/unit/test_round_data.py
@@ -451,11 +451,16 @@ class TestProducerProtocol:
                 break
         return messages
 
-    def test_generate_emits_stats_progress_done(self, tmp_path):
+    def test_generate_emits_stats_progress_timing_done(self, tmp_path):
         messages = self._run(tmp_path, _stub_generate_ok, [("generate", 1, 10, 40)])
         kinds = [m[0] for m in messages]
-        assert kinds == ["stats", "progress", "done", "shutdown_ack"]
-        done = messages[2]
+        # Timing precedes done (queue FIFO: the drainer records the stage span before
+        # await_round unblocks)
+        assert kinds == ["stats", "progress", "timing", "done", "shutdown_ack"]
+        timing = messages[2]
+        assert timing[1] == 1
+        assert timing[2] <= timing[3]  # start_ts <= end_ts
+        done = messages[3]
         assert done[1] == 1
         assert done[2]["stub"] is True
 
@@ -594,6 +599,22 @@ class TestRoundDataProducerDrainer:
             "inject_duration",
         }
         assert all(w["tag"] == "test_v1" for w in producer._db.writes)
+
+    def test_timing_message_records_stage_span(self, producer, monkeypatch):
+        recorded = []
+        monkeypatch.setattr(
+            "aetherscan.round_data.record_stage",
+            lambda *args, **kwargs: recorded.append((args, kwargs)),
+        )
+        producer._result_queue.put(("timing", 3, 100.0, 160.0))
+        producer._result_queue.put(("done", 3, {"n_samples": 8}))
+        producer.await_round(3)  # FIFO: the timing message was handled before done
+        assert recorded == [
+            (
+                ("train.round_03.data_generation", 100.0, 160.0),
+                {"tag": "test_v1", "metadata": {"source": "producer"}},
+            )
+        ]
 
     def test_producer_death_unblocks_await_round(self, producer):
         producer._process.alive = False

--- a/tests/unit/test_run_state.py
+++ b/tests/unit/test_run_state.py
@@ -21,6 +21,7 @@ from aetherscan.run_state import (
     TrainingRunState,
     config_changed,
     config_fingerprint,
+    inference_config_fingerprint,
     load_run_state,
     run_state_path,
     save_run_state,
@@ -164,7 +165,7 @@ class TestConfigFingerprint:
         "data": {"num_target_backgrounds": 45000},
         "training": {"num_samples_beta_vae": 499200, "max_retries": 3, "retry_delay": 60},
         "gpu": {"num_replicas": None},
-        "inference": {"max_retries": 3, "parallel_coarse_chans": None},
+        "inference": {"max_retries": 3, "coarse_channel_log_interval": None},
         "hf": {
             "upload_after_training": False,
             "repo_id": "zachtheyek/aetherscan",
@@ -242,3 +243,70 @@ class TestConfigFingerprint:
         state = TrainingRunState(tag="final_v1", run_start_time=1.0, config_fingerprint="deadbeef")
         save_run_state(state, path)
         assert load_run_state(path).config_fingerprint == "deadbeef"
+
+
+class TestInferenceConfigFingerprint:
+    """inference_config_fingerprint(): the inference-side config-drift guard. The denylist must
+    keep inert knobs (I/O, batching, retry, viz, and the coarse_channel_log_interval progress-log
+    cadence) out of the hash, while result-affecting inference params and data-geometry changes
+    flip it."""
+
+    BASE = {
+        "inference": {
+            "classification_threshold": 0.99,
+            "stat_threshold": 2048.0,
+            "coarse_channel_log_interval": None,
+            "max_retries": 3,
+            "inference_viz_enabled": True,
+        },
+        "data": {
+            "downsample_factor": 8,
+            "width_bin": 4096,
+            "num_observations": 6,
+            "time_bins": 16,
+        },
+    }
+
+    def _mutate(self, section, key, value):
+        d = copy.deepcopy(self.BASE)
+        d[section][key] = value
+        return d
+
+    def test_stable_for_identical_config(self):
+        assert inference_config_fingerprint(self.BASE) == inference_config_fingerprint(
+            copy.deepcopy(self.BASE)
+        )
+
+    @pytest.mark.parametrize(
+        "section,key,value",
+        [
+            ("inference", "classification_threshold", 0.5),
+            ("inference", "stat_threshold", 1024.0),
+            ("data", "downsample_factor", 4),
+            ("data", "width_bin", 2048),
+            ("data", "num_observations", 4),
+            ("data", "time_bins", 32),
+        ],
+    )
+    def test_result_affecting_change_flips_fingerprint(self, section, key, value):
+        assert inference_config_fingerprint(self._mutate(section, key, value)) != (
+            inference_config_fingerprint(self.BASE)
+        )
+
+    @pytest.mark.parametrize(
+        "key,value",
+        [
+            # coarse_channel_log_interval is inert (progress-log cadence only); changing it must
+            # NOT invalidate stage-aware resume. Regression guard for the
+            # parallel_coarse_chans -> coarse_channel_log_interval rename: the denylist in
+            # run_state.py must track the new field name, else this knob leaks into the hash and
+            # a reused --save-tag needlessly re-infers every cadence.
+            ("coarse_channel_log_interval", 8),
+            ("max_retries", 9),
+            ("inference_viz_enabled", False),
+        ],
+    )
+    def test_inert_inference_change_keeps_fingerprint(self, key, value):
+        d = copy.deepcopy(self.BASE)
+        d["inference"][key] = value
+        assert inference_config_fingerprint(d) == inference_config_fingerprint(self.BASE)

--- a/utils/benchmark_report.py
+++ b/utils/benchmark_report.py
@@ -1,0 +1,529 @@
+#!/usr/bin/env python3
+"""
+Render a benchmarking report for one pipeline run from its pipeline_stages DB rows.
+
+Given a --save-tag (and optionally a --db-path), this tool:
+1. prints the run's stage tree — every recorded pipeline_stages span, grouped by its
+   hierarchical dot-name, with call counts, total/self durations, and percentages;
+2. writes plots/benchmark_report_{tag}.png: a flame-style stage timeline (one lane per
+   depth) plus a "top 10 slowest stages" table ranked by self time;
+3. prints a rules-driven "suggestions" section that joins pipeline_stages with
+   system_resources (e.g. "data generation ≥ 30% of round wall-clock", "GPU util < 40%
+   during epochs → input-bound").
+
+Reads the SQLite file directly (stdlib sqlite3 + numpy + matplotlib only — no aetherscan
+imports), so it also runs against a database fetched from a cluster with
+utils/fetch_run_outputs.sh:
+
+    python utils/benchmark_report.py --save-tag final_v1
+    python utils/benchmark_report.py --save-tag test_v18 --db-path /path/to/aetherscan.db
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import sqlite3
+import sys
+from dataclasses import dataclass, field
+
+import matplotlib
+
+matplotlib.use("Agg")  # Non-interactive backend for headless environments
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+
+# Thresholds for the rules-driven suggestions section
+DATA_GEN_ROUND_FRACTION = 0.30  # data_generation / round wall-clock
+GPU_UTIL_INPUT_BOUND = 40.0  # mean GPU % during epochs/encode below this -> input-bound
+PREPROCESS_WALL_FRACTION = 0.60  # summed ED preprocessing / inference wall-clock
+RAM_PEAK_WARN = 90.0  # peak system RAM % during the run
+
+# Timeline lane colors keyed by top-level stage family (fallback cycles matplotlib tab10)
+_FAMILY_COLORS = {"train": "tab:blue", "inference": "tab:green"}
+
+
+# ---------------------------------------------------------------------------
+# Stage tree
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StageNode:
+    """One node of the stage tree: a dot-name component plus its spans and children."""
+
+    name: str  # This component ("round_02"), not the full dotted name
+    full_name: str  # Full dotted name ("train.round_02")
+    spans: list[dict] = field(default_factory=list)  # Rows recorded exactly at this name
+    children: dict[str, StageNode] = field(default_factory=dict)
+
+    @property
+    def own_duration(self) -> float:
+        """Summed duration of the spans recorded exactly at this node's name."""
+        return sum(span["duration_s"] for span in self.spans)
+
+    @property
+    def total_duration(self) -> float:
+        """Own duration when this node has spans of its own (an umbrella span already
+        covers its children's time); otherwise the sum over children (a pure grouping
+        node like "train" that never gets its own row)."""
+        if self.spans:
+            return self.own_duration
+        return sum(child.total_duration for child in self.children.values())
+
+    @property
+    def self_duration(self) -> float:
+        """Time not covered by child stages: total - sum(child totals), floored at 0
+        (children running concurrently with the parent — e.g. producer data generation
+        overlapping a round — can sum past the parent's wall-clock)."""
+        return max(0.0, self.total_duration - sum(c.total_duration for c in self.children.values()))
+
+    def sorted_children(self) -> list[StageNode]:
+        """Children in chronological order (min span start), grouping nodes last-resort
+        by name so the tree is stable even for nodes without spans."""
+
+        def sort_key(node: StageNode):
+            starts = [s["start_time"] for s in node.iter_spans()]
+            return (min(starts) if starts else float("inf"), node.name)
+
+        return sorted(self.children.values(), key=sort_key)
+
+    def iter_spans(self):
+        yield from self.spans
+        for child in self.children.values():
+            yield from child.iter_spans()
+
+
+def build_stage_tree(rows: list[dict]) -> StageNode:
+    """
+    Fold pipeline_stages rows into a tree keyed by dot-name components. Returns a
+    synthetic root (name "", full_name "") whose children are the top-level families
+    ("train", "inference"). Rows sharing a name (retries, per-cadence repeats) accumulate
+    as multiple spans on one node.
+    """
+    root = StageNode(name="", full_name="")
+    for row in rows:
+        parts = str(row["stage"]).split(".")
+        node = root
+        for depth, part in enumerate(parts):
+            if part not in node.children:
+                node.children[part] = StageNode(name=part, full_name=".".join(parts[: depth + 1]))
+            node = node.children[part]
+        node.spans.append(row)
+    return root
+
+
+def format_duration(seconds: float) -> str:
+    """Compact human duration: 45.3s / 12m 05s / 2h 13m."""
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    if seconds < 3600:
+        minutes, secs = divmod(int(round(seconds)), 60)
+        return f"{minutes}m {secs:02d}s"
+    hours, rem = divmod(int(round(seconds)), 3600)
+    return f"{hours}h {rem // 60:02d}m"
+
+
+def format_tree(root: StageNode) -> list[str]:
+    """
+    Render the stage tree as aligned text lines. Percentages are relative to the parent
+    node's total (top-level families show 100%); n is the number of spans recorded at
+    that exact name (0 for pure grouping nodes).
+    """
+    lines = []
+
+    def _walk(node: StageNode, depth: int, parent_total: float):
+        pct = 100.0 * node.total_duration / parent_total if parent_total > 0 else 0.0
+        label = f"{'  ' * depth}{node.name}"
+        lines.append(
+            f"{label:<48}{len(node.spans):>4}  "
+            f"{format_duration(node.total_duration):>10}  {pct:6.1f}%"
+        )
+        for child in node.sorted_children():
+            _walk(child, depth + 1, node.total_duration)
+
+    header = f"{'stage':<48}{'n':>4}  {'total':>10}  {'% of parent':>7}"
+    lines.append(header)
+    lines.append("-" * len(header))
+    for top in root.sorted_children():
+        _walk(top, 0, top.total_duration)
+    return lines
+
+
+def collect_nodes(root: StageNode) -> list[StageNode]:
+    """Flatten the tree (excluding the synthetic root) in depth-first order."""
+    nodes: list[StageNode] = []
+
+    def _walk(node: StageNode):
+        for child in node.sorted_children():
+            nodes.append(child)
+            _walk(child)
+
+    _walk(root)
+    return nodes
+
+
+def top_slowest(root: StageNode, k: int = 10) -> list[StageNode]:
+    """Top-k nodes ranked by self time (time not attributed to any child stage) — the
+    stages where wall-clock actually went, rather than umbrella spans."""
+    nodes = [n for n in collect_nodes(root) if n.spans]
+    nodes.sort(key=lambda n: n.self_duration, reverse=True)
+    return nodes[:k]
+
+
+# ---------------------------------------------------------------------------
+# DB access
+# ---------------------------------------------------------------------------
+
+
+def load_rows(db_path: str, tag: str) -> list[dict]:
+    """Load this tag's pipeline_stages rows (chronological) as dicts."""
+    # contextlib.closing: sqlite3's context manager only commits/rolls back — it does NOT
+    # close the connection (same below)
+    with contextlib.closing(sqlite3.connect(db_path)) as conn:
+        conn.row_factory = sqlite3.Row
+        try:
+            cursor = conn.execute(
+                "SELECT stage, start_time, end_time, duration_s, tag, metadata "
+                "FROM pipeline_stages WHERE tag = ? ORDER BY start_time",
+                (tag,),
+            )
+        except sqlite3.OperationalError as e:
+            raise SystemExit(
+                f"Could not read pipeline_stages from {db_path}: {e}. "
+                f"(Database predates the benchmarking schema?)"
+            ) from e
+        return [dict(row) for row in cursor.fetchall()]
+
+
+def load_resource_series(db_path: str, tag: str, resource_type: str, name_like: str):
+    """(timestamps, values) arrays from system_resources for one tag + resource family."""
+    with contextlib.closing(sqlite3.connect(db_path)) as conn:
+        try:
+            cursor = conn.execute(
+                "SELECT timestamp, value FROM system_resources "
+                "WHERE tag = ? AND resource_type = ? AND resource_name LIKE ? "
+                "ORDER BY timestamp",
+                (tag, resource_type, name_like),
+            )
+            rows = cursor.fetchall()
+        except sqlite3.OperationalError:
+            rows = []
+    if not rows:
+        return np.array([]), np.array([])
+    arr = np.asarray(rows, dtype=np.float64)
+    return arr[:, 0], arr[:, 1]
+
+
+def mean_in_window(
+    timestamps: np.ndarray, values: np.ndarray, start: float, end: float
+) -> float | None:
+    """Mean of the samples falling inside [start, end], or None when there are none."""
+    if timestamps.size == 0:
+        return None
+    mask = (timestamps >= start) & (timestamps <= end)
+    if not mask.any():
+        return None
+    return float(values[mask].mean())
+
+
+# ---------------------------------------------------------------------------
+# Suggestions
+# ---------------------------------------------------------------------------
+
+
+def build_suggestions(root: StageNode, db_path: str, tag: str) -> list[str]:
+    """Apply the bottleneck heuristics and return human-readable suggestion strings."""
+    suggestions: list[str] = []
+
+    gpu_ts, gpu_vals = load_resource_series(db_path, tag, "gpu", "%_utilization")
+    ram_ts, ram_vals = load_resource_series(db_path, tag, "ram", "system_total")
+
+    train = root.children.get("train")
+    inference = root.children.get("inference")
+
+    # Rule 1: per-round data generation dominating the round's wall-clock
+    if train is not None:
+        for node in train.sorted_children():
+            if not node.name.startswith("round_") or not node.spans:
+                continue
+            datagen = node.children.get("data_generation")
+            if datagen is None or node.total_duration <= 0:
+                continue
+            frac = datagen.total_duration / node.total_duration
+            if frac >= DATA_GEN_ROUND_FRACTION:
+                source = None
+                for span in datagen.spans:
+                    if span.get("metadata"):
+                        source = json.loads(span["metadata"]).get("source")
+                if source == "in-process":
+                    fix = "enable --overlap-data-generation so it runs while epochs train"
+                else:
+                    # Producer path: generation runs in the background during the previous
+                    # round's epochs, so a big span only matters if this round actually
+                    # waited on it — i.e. generation was still running when the round
+                    # started. Fully-overlapped generation is free.
+                    datagen_end = max(s["end_time"] for s in datagen.spans)
+                    round_start = min(s["start_time"] for s in node.spans)
+                    if datagen_end <= round_start + 1.0:  # 1 s tolerance
+                        continue  # Fully overlapped — nothing to suggest
+                    fix = (
+                        "the round waited on background generation — raise worker "
+                        "count (manager.n_processes) / --data-gen-task-size, or reduce "
+                        "--num-samples-beta-vae"
+                    )
+                suggestions.append(
+                    f"{node.full_name}: data_generation took "
+                    f"{format_duration(datagen.total_duration)} = {frac:.0%} of the "
+                    f"round's wall-clock (>= {DATA_GEN_ROUND_FRACTION:.0%}) — {fix}."
+                )
+
+        # Rule 2: GPU utilization during epoch spans
+        for node in train.sorted_children():
+            epochs = node.children.get("epochs")
+            if epochs is None or not epochs.spans:
+                continue
+            for span in epochs.spans:
+                mean_util = mean_in_window(gpu_ts, gpu_vals, span["start_time"], span["end_time"])
+                if mean_util is not None and mean_util < GPU_UTIL_INPUT_BOUND:
+                    suggestions.append(
+                        f"{epochs.full_name}: mean GPU utilization {mean_util:.0f}% "
+                        f"(< {GPU_UTIL_INPUT_BOUND:.0f}%) — training is input-bound; "
+                        f"check the tf.data feed (batch sizes, host-side preprocessing)."
+                    )
+
+    # Rule 3: energy-detection preprocessing dominating inference wall-clock
+    if inference is not None:
+        preprocess_total = sum(
+            node.total_duration
+            for node in inference.children.values()
+            if node.name.startswith("preprocess_cadence_")
+        )
+        spans = list(inference.iter_spans())
+        wall = max(s["end_time"] for s in spans) - min(s["start_time"] for s in spans)
+        if wall > 0 and preprocess_total / wall >= PREPROCESS_WALL_FRACTION:
+            suggestions.append(
+                f"inference: energy-detection preprocessing summed to "
+                f"{format_duration(preprocess_total)} = {preprocess_total / wall:.0%} of "
+                f"the run's wall-clock (>= {PREPROCESS_WALL_FRACTION:.0%}) — it is the "
+                f"bottleneck; raise ED worker count (manager.n_processes) before anything "
+                f"GPU-side."
+            )
+
+        # Rule 2b: GPU utilization during per-cadence encode spans (averaged over spans)
+        encode_means = []
+        for node in inference.children.values():
+            encode = node.children.get("encode")
+            if encode is None:
+                continue
+            for span in encode.spans:
+                mean_util = mean_in_window(gpu_ts, gpu_vals, span["start_time"], span["end_time"])
+                if mean_util is not None:
+                    encode_means.append(mean_util)
+        if encode_means and float(np.mean(encode_means)) < GPU_UTIL_INPUT_BOUND:
+            suggestions.append(
+                f"inference: mean GPU utilization across encode spans is "
+                f"{np.mean(encode_means):.0f}% (< {GPU_UTIL_INPUT_BOUND:.0f}%) — encoding "
+                f"is input-bound; consider a larger --inf-batch-size."
+            )
+
+    # Rule 4: RAM pressure anywhere in the run
+    if ram_vals.size > 0:
+        peak = float(ram_vals.max())
+        if peak >= RAM_PEAK_WARN:
+            when = float(ram_ts[int(ram_vals.argmax())])
+            holder = None
+            for node in collect_nodes(root):
+                for span in node.spans:
+                    if span["start_time"] <= when <= span["end_time"] and (
+                        holder is None or len(node.full_name) > len(holder)
+                    ):
+                        holder = node.full_name
+            suggestions.append(
+                f"peak system RAM hit {peak:.1f}% (>= {RAM_PEAK_WARN:.0f}%)"
+                + (f" during {holder}" if holder else "")
+                + " — OOM risk; reduce chunk/sample sizes or disable keep_round_data."
+            )
+
+    return suggestions
+
+
+# ---------------------------------------------------------------------------
+# Plot
+# ---------------------------------------------------------------------------
+
+
+def render_report_png(root: StageNode, rows: list[dict], tag: str, output_path: str) -> None:
+    """Write the report figure: flame-style stage timeline + top-10-slowest table."""
+    run_start = min(row["start_time"] for row in rows)
+    run_end = max(row["end_time"] for row in rows)
+
+    fig, (ax_tl, ax_tb) = plt.subplots(
+        2,
+        1,
+        figsize=(16, 11),
+        gridspec_kw={"height_ratios": [3, 1.4]},
+    )
+    fig.suptitle(f"Aetherscan Pipeline: Benchmark Report ({tag})", fontsize=16, fontweight="bold")
+
+    # --- Timeline: one lane per dot-depth, bars colored by top-level family ---
+    max_depth = max(len(str(row["stage"]).split(".")) for row in rows)
+    fallback_colors = plt.cm.tab10(np.linspace(0, 1, 10))
+    families = sorted({str(row["stage"]).split(".")[0] for row in rows})
+
+    def family_color(stage: str):
+        family = stage.split(".")[0]
+        if family in _FAMILY_COLORS:
+            return _FAMILY_COLORS[family]
+        return fallback_colors[families.index(family) % 10]
+
+    run_minutes = max((run_end - run_start) / 60, 1e-9)
+    for row in rows:
+        depth = len(str(row["stage"]).split("."))
+        start_min = (row["start_time"] - run_start) / 60
+        width_min = max(row["duration_s"] / 60, run_minutes * 0.001)  # keep slivers visible
+        y = max_depth - depth  # depth 1 on top
+        ax_tl.barh(
+            y,
+            width_min,
+            left=start_min,
+            height=0.8,
+            color=family_color(str(row["stage"])),
+            alpha=0.75,
+            edgecolor="white",
+            linewidth=0.4,
+        )
+        # Leaf-component label inside the bar when there's room (>2.5% of the run width)
+        if width_min > 0.025 * run_minutes:
+            ax_tl.text(
+                start_min + width_min / 2,
+                y,
+                str(row["stage"]).split(".")[-1],
+                ha="center",
+                va="center",
+                fontsize=7,
+                color="black",
+                clip_on=True,
+            )
+
+    ax_tl.set_yticks(range(max_depth))
+    ax_tl.set_yticklabels([f"depth {max_depth - i}" for i in range(max_depth)], fontsize=9)
+    ax_tl.set_xlabel("Time since first stage (minutes)", fontsize=11, fontweight="bold")
+    ax_tl.set_title(
+        "Stage timeline (bars nest top-down by dot-depth; overlaps = concurrent stages)",
+        fontsize=11,
+    )
+    ax_tl.grid(True, axis="x", alpha=0.3)
+
+    # --- Top-10-slowest table (by self time) ---
+    ax_tb.axis("off")
+    slowest = top_slowest(root, k=10)
+    total_wall = max(run_end - run_start, 1e-9)
+    cells = [
+        [
+            node.full_name,
+            str(len(node.spans)),
+            format_duration(node.total_duration),
+            format_duration(node.self_duration),
+            f"{100.0 * node.self_duration / total_wall:.1f}%",
+        ]
+        for node in slowest
+    ]
+    table = ax_tb.table(
+        cellText=cells,
+        colLabels=["stage", "n", "total", "self", "self % of wall"],
+        colWidths=[0.52, 0.06, 0.14, 0.14, 0.14],
+        cellLoc="left",
+        loc="upper center",
+    )
+    table.auto_set_font_size(False)
+    table.set_fontsize(9)
+    table.scale(1.0, 1.4)
+    ax_tb.set_title("Top 10 slowest stages (by self time)", fontsize=11, y=0.95)
+
+    fig.tight_layout(rect=(0, 0, 1, 0.97))
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    fig.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def default_db_path() -> str:
+    output_path = os.environ.get(
+        "AETHERSCAN_OUTPUT_PATH", "/datax/scratch/zachy/outputs/aetherscan"
+    )
+    return os.path.join(output_path, "db", "aetherscan.db")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Print a stage-timing tree, write a benchmark report PNG, and flag "
+        "likely bottlenecks for one Aetherscan run."
+    )
+    parser.add_argument("--save-tag", required=True, help="Run tag to report on")
+    parser.add_argument(
+        "--db-path",
+        default=None,
+        help="Path to aetherscan.db (default: {AETHERSCAN_OUTPUT_PATH}/db/aetherscan.db)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Directory for the report PNG (default: <db parent>/../plots)",
+    )
+    args = parser.parse_args(argv)
+
+    db_path = args.db_path or default_db_path()
+    if not os.path.exists(db_path):
+        print(f"Database not found: {db_path}", file=sys.stderr)
+        return 1
+
+    rows = load_rows(db_path, args.save_tag)
+    if not rows:
+        print(f"No pipeline_stages rows found for tag {args.save_tag!r} in {db_path}")
+        return 1
+
+    root = build_stage_tree(rows)
+
+    print(f"Benchmark report for tag {args.save_tag!r} ({len(rows)} stage spans)")
+    print()
+    for line in format_tree(root):
+        print(line)
+
+    print()
+    total_wall = max(r["end_time"] for r in rows) - min(r["start_time"] for r in rows)
+    print(f"Run wall-clock (first stage start -> last stage end): {format_duration(total_wall)}")
+    print()
+    print("Top 10 slowest stages (by self time):")
+    for node in top_slowest(root, k=10):
+        print(
+            f"  {node.full_name:<52} total {format_duration(node.total_duration):>10}"
+            f"   self {format_duration(node.self_duration):>10}"
+        )
+
+    print()
+    print("Suggestions:")
+    suggestions = build_suggestions(root, db_path, args.save_tag)
+    if suggestions:
+        for suggestion in suggestions:
+            print(f"  - {suggestion}")
+    else:
+        print("  - No bottleneck heuristics triggered.")
+
+    output_dir = args.output_dir or os.path.join(os.path.dirname(os.path.dirname(db_path)), "plots")
+    output_path = os.path.join(output_dir, f"benchmark_report_{args.save_tag}.png")
+    render_report_png(root, rows, args.save_tag, output_path)
+    print()
+    print(f"Report figure written to {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/utils/benchmark_report.py
+++ b/utils/benchmark_report.py
@@ -302,16 +302,19 @@ def build_suggestions(root: StageNode, db_path: str, tag: str) -> list[str]:
             for node in inference.children.values()
             if node.name.startswith("preprocess_cadence_")
         )
+        # Guard against an inference subtree of pure grouping nodes with no measured spans
+        # (min/max over an empty sequence would raise); such a run has no wall to compare.
         spans = list(inference.iter_spans())
-        wall = max(s["end_time"] for s in spans) - min(s["start_time"] for s in spans)
-        if wall > 0 and preprocess_total / wall >= PREPROCESS_WALL_FRACTION:
-            suggestions.append(
-                f"inference: energy-detection preprocessing summed to "
-                f"{format_duration(preprocess_total)} = {preprocess_total / wall:.0%} of "
-                f"the run's wall-clock (>= {PREPROCESS_WALL_FRACTION:.0%}) — it is the "
-                f"bottleneck; raise ED worker count (manager.n_processes) before anything "
-                f"GPU-side."
-            )
+        if spans:
+            wall = max(s["end_time"] for s in spans) - min(s["start_time"] for s in spans)
+            if wall > 0 and preprocess_total / wall >= PREPROCESS_WALL_FRACTION:
+                suggestions.append(
+                    f"inference: energy-detection preprocessing summed to "
+                    f"{format_duration(preprocess_total)} = {preprocess_total / wall:.0%} of "
+                    f"the run's wall-clock (>= {PREPROCESS_WALL_FRACTION:.0%}) — it is the "
+                    f"bottleneck; raise ED worker count (manager.n_processes) before anything "
+                    f"GPU-side."
+                )
 
         # Rule 2b: GPU utilization during per-cadence encode spans (averaged over spans)
         encode_means = []
@@ -327,7 +330,7 @@ def build_suggestions(root: StageNode, db_path: str, tag: str) -> list[str]:
             suggestions.append(
                 f"inference: mean GPU utilization across encode spans is "
                 f"{np.mean(encode_means):.0f}% (< {GPU_UTIL_INPUT_BOUND:.0f}%) — encoding "
-                f"is input-bound; consider a larger --inf-batch-size."
+                f"is input-bound; consider a larger --per-replica-batch-size."
             )
 
     # Rule 4: RAM pressure anywhere in the run
@@ -449,7 +452,11 @@ def render_report_png(root: StageNode, rows: list[dict], tag: str, output_path: 
     ax_tb.set_title("Top 10 slowest stages (by self time)", fontsize=11, y=0.9)
 
     fig.tight_layout(rect=(0, 0, 1, 0.97))
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    # dirname is "" for a bare filename (cwd) — makedirs("") would raise, so only create
+    # a parent directory when output_path actually has one
+    out_dir = os.path.dirname(output_path)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
     fig.savefig(output_path, dpi=150, bbox_inches="tight")
     plt.close(fig)
 

--- a/utils/benchmark_report.py
+++ b/utils/benchmark_report.py
@@ -369,8 +369,12 @@ def render_report_png(root: StageNode, rows: list[dict], tag: str, output_path: 
     )
     fig.suptitle(f"Aetherscan Pipeline: Benchmark Report ({tag})", fontsize=16, fontweight="bold")
 
-    # --- Timeline: one lane per dot-depth, bars colored by top-level family ---
-    max_depth = max(len(str(row["stage"]).split(".")) for row in rows)
+    # --- Timeline: one lane per dot-depth actually present (grouping-only depths like a
+    # bare "train" never get spans of their own, so depth 1 is usually empty), bars
+    # colored by top-level family ---
+    depths_present = sorted({len(str(row["stage"]).split(".")) for row in rows})
+    lane_of = {depth: i for i, depth in enumerate(depths_present)}
+    n_lanes = len(depths_present)
     fallback_colors = plt.cm.tab10(np.linspace(0, 1, 10))
     families = sorted({str(row["stage"]).split(".")[0] for row in rows})
 
@@ -385,7 +389,7 @@ def render_report_png(root: StageNode, rows: list[dict], tag: str, output_path: 
         depth = len(str(row["stage"]).split("."))
         start_min = (row["start_time"] - run_start) / 60
         width_min = max(row["duration_s"] / 60, run_minutes * 0.001)  # keep slivers visible
-        y = max_depth - depth  # depth 1 on top
+        y = n_lanes - 1 - lane_of[depth]  # shallowest lane on top
         ax_tl.barh(
             y,
             width_min,
@@ -409,8 +413,8 @@ def render_report_png(root: StageNode, rows: list[dict], tag: str, output_path: 
                 clip_on=True,
             )
 
-    ax_tl.set_yticks(range(max_depth))
-    ax_tl.set_yticklabels([f"depth {max_depth - i}" for i in range(max_depth)], fontsize=9)
+    ax_tl.set_yticks(range(n_lanes))
+    ax_tl.set_yticklabels([f"depth {depth}" for depth in reversed(depths_present)], fontsize=9)
     ax_tl.set_xlabel("Time since first stage (minutes)", fontsize=11, fontweight="bold")
     ax_tl.set_title(
         "Stage timeline (bars nest top-down by dot-depth; overlaps = concurrent stages)",
@@ -437,12 +441,12 @@ def render_report_png(root: StageNode, rows: list[dict], tag: str, output_path: 
         colLabels=["stage", "n", "total", "self", "self % of wall"],
         colWidths=[0.52, 0.06, 0.14, 0.14, 0.14],
         cellLoc="left",
-        loc="upper center",
+        # Explicit bbox keeps the table below the axes title instead of overlapping it
+        bbox=(0.0, 0.0, 1.0, 0.86),
     )
     table.auto_set_font_size(False)
     table.set_fontsize(9)
-    table.scale(1.0, 1.4)
-    ax_tb.set_title("Top 10 slowest stages (by self time)", fontsize=11, y=0.95)
+    ax_tb.set_title("Top 10 slowest stages (by self time)", fontsize=11, y=0.9)
 
     fig.tight_layout(rect=(0, 0, 1, 0.97))
     os.makedirs(os.path.dirname(output_path), exist_ok=True)

--- a/utils/benchmark_report.py
+++ b/utils/benchmark_report.py
@@ -253,6 +253,11 @@ def build_suggestions(root: StageNode, db_path: str, tag: str) -> list[str]:
             datagen = node.children.get("data_generation")
             if datagen is None or node.total_duration <= 0:
                 continue
+            # Guard against a data_generation node that is a pure grouping node (children but
+            # no own span): the producer-overlap branch below takes max/min over datagen.spans,
+            # which would raise on an empty sequence (mirrors Rule 3's empty-spans guard).
+            if not datagen.spans:
+                continue
             frac = datagen.total_duration / node.total_duration
             if frac >= DATA_GEN_ROUND_FRACTION:
                 source = None


### PR DESCRIPTION
## Summary

Adds the benchmarking suite: always-on stage timing into a new `pipeline_stages` DB table, stage-band annotation of the resource-utilization plot, a report tool that turns the timings into a stage tree / timeline figure / bottleneck suggestions, and four standalone micro-benchmarks with per-machine baselines.

Closes #127

> [!NOTE]
> **Stacked PR.** Base branch is `integration/pr0910-base` — coordinator scaffolding that merges the in-flight train chain (#122, #126) and inference chain (#120, #125, #129). It is rebased onto `master` as its parents merge; this PR should be reviewed as the diff against that base.

## What's included

### 1. Always-on stage timers (`src/aetherscan/benchmark.py` + schema v3)

- `stage_timer("dotted.stage.name")` context manager / decorator and `record_stage()` write `(stage, start_time, end_time, duration_s, tag, metadata)` rows to a new `pipeline_stages` table through the existing writer queue — two timestamps plus one queue put, so the timers stay on in production. Failures are recorded (`status=failed` metadata) and re-raised; a missing DB degrades to a debug log.
- Nesting is automatic and thread-local: a timer entered while another is active on the same thread records relative to it, so `InferencePipeline.run_inference`'s `encode`/`rf`/`db_write` land under whatever umbrella the caller opened (`inference.infer_cadence_007.encode` in the streaming loop, `inference.infer.encode` on the legacy path) with zero name plumbing.
- Schema `PRAGMA user_version` bumped 2 → 3 (new table, no ALTER step — same pattern as v2); `write_pipeline_stage()` / `query_pipeline_stages()` follow the existing writer/whitelist conventions.
- Instrumented stages — train: `load_backgrounds`, per-round umbrella + `data_generation` / `epochs` / `plots` / `checkpoint_save`, `vae_plots`, `rf` umbrella + `data_generation` / `encode` / `fit`, `rf_plots`, `final_save`. Producer-generated round data is timed inside the producer process and reported over the result queue as a new `("timing", round_idx, start_ts, end_ts)` message (the DB writer queue is thread-only), sent before `"done"` so FIFO lands the span before `await_round` unblocks. Inference: per-cadence `preprocess_cadence_NNN` umbrella + per-ON-file `read_ed_onN` / `dedup` / `extract`, per-cadence `infer_cadence_NNN` umbrella + `load_lognorm` / `encode` / `rf` / `db_write`, plus `inference.viz`.

### 2. Annotated resource plot

`monitor._save_plot()` overlays this run's top-level spans (dot-names of depth ≤ 2) as labeled translucent bands on the CPU panel, gated on new config `monitor.annotate_stages` (default `True`, serialized in `to_dict()`; the monitor section has no CLI surface, so no flag / README regen). Fully exception-guarded — a broken overlay can never cost the resource plot.

### 3. Report tool (`utils/benchmark_report.py`)

`python utils/benchmark_report.py --save-tag <tag> [--db-path ...]` prints the stage tree (counts, total/self durations, % of parent), writes `plots/benchmark_report_{tag}.png` (flame-style timeline, one lane per dot-depth + top-10-slowest table ranked by self time), and prints rules-driven suggestions joining `pipeline_stages` with `system_resources`: data generation stalling a round (overlap-aware — a producer span fully overlapped with the previous round is free), GPU util < 40 % during epochs/encode (input-bound), ED preprocessing ≥ 60 % of inference wall-clock, peak RAM ≥ 90 % (attributed to the deepest covering span). Reads SQLite directly (stdlib + numpy + matplotlib), so it works on a DB fetched from a cluster.

### 4. Micro-benchmarks (`benchmarks/`)

`bench_normality.py`, `bench_injection.py`, `bench_lognorm_downsample.py`, `bench_pfb_vs_spline.py` — plain scripts (no framework, not collected by pytest) printing ops/s and writing JSON results; `benchmarks/README.md` documents usage and per-machine baselines.

## Verification

**Unit tests** — `PYTHONPATH=src pytest -m "not gpu and not cluster" -q` → **479 passed, 3 skipped** (arm64 venv, TF 2.17.1). New coverage: timer nesting / DB rows / failure recording / thread isolation, v0→v3 and v2→v3 migrations, `pipeline_stages` query filters + whitelist, monitor span selection, report tree math (umbrella vs grouping totals, self-time floor under concurrency, top-slowest ranking), every suggestion rule (incl. the fully-overlapped-producer quiet case), and the report CLI end-to-end.

**Cluster (blpc3; bla0 unreachable — see Deferred validation)** —
- Train smoke `test_v27` (5-GPU config: 2 rounds × 2 epochs, 200 samples): completed cleanly; 18 stage spans recorded; resource plot annotated with 7 bands (`load_backgrounds`, `round_01/02`, `vae_plots`, `rf`, `rf_plots`, `final_save`).
- Subset CSV inference `20260712_012912` (test_v17 model, 2 cadences, 94 667 snippets): completed cleanly; 23 spans; 5 bands on the resource plot.
- `utils/benchmark_report.py` run for both tags — abbreviated inference tree:

```
inference                                          0     23m 47s   100.0%
  preprocess_cadence_001                           1     14m 43s    61.9%
    read_ed_on1 / on2 / on3                        3    ~35s each
    dedup                                          1        0.2s
    extract                                        1     11m 09s    75.8%
  preprocess_cadence_002                           1      5m 27s    22.9%
  infer_cadence_001                                1      2m 23s    10.0%
    load_lognorm 1m 33s / encode 41.3s / rf 1.9s / db_write 0.0s
  infer_cadence_002                                1       38.8s
  viz                                              1       34.8s
Suggestions:
  - energy-detection preprocessing = 94% of wall-clock (>= 60%) — it is the bottleneck
  - mean GPU utilization across encode spans is 3% (< 40%) — encoding is input-bound
```

The train report correctly flags smoke-scale artifacts (data generation ≥ 30 % of round wall-clock, 2–3 % GPU during 2-epoch rounds → input-bound). Interesting real finding already: with the vectorized ED, per-ON-file detection is down to ~35 s (from ~45 min/cadence historically) and **stamp extraction is now the inference bottleneck** (11 m for 73 k stamps).

- Report PNGs + annotated resource plots are on blpc3 under `/datax/scratch/zachy/outputs/aetherscan/plots/` (`benchmark_report_{test_v27,20260712_012912}.png`, `resource_utilization_{test_v27,20260712_012912}.png`); the resource plots were also auto-uploaded to Slack by the pipeline. Fetch with `utils/fetch_run_outputs.sh`.
- Micro-benchmarks run in the NGC container on blpc3; baselines recorded in `benchmarks/README.md` (headline: 123x vectorized normality, 11.9x PFB vs spline).
- Cluster cleanup done: round_data + preprocessed dirs for the test tags removed, `/dev/shm` clean, `/tmp` logs removed, repo back on `master`.

**Deferred validation** — bla0 (Ampere) is currently unreachable, so the bla0 smoke could not be run; blpc3 covered both train and inference paths.

## AI disclosure

Implemented by Claude Code (Fable 5) end-to-end — design from PLAN.md §11, implementation, unit tests, cluster validation runs, and this PR — under human coordination; per AI_POLICY.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
