### PR TITLE
Live Streamlit dashboard over the pipeline SQLite DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,9 @@ The Aetherscan training pipeline exposes the following CLI flags to the user. Re
 
 ```
 usage: train [-h] [--data-path DATA_PATH] [--model-path MODEL_PATH]
-             [--output-path OUTPUT_PATH] [--vae-latent-dim VAE_LATENT_DIM]
+             [--output-path OUTPUT_PATH] [--dashboard | --no-dashboard]
+             [--dashboard-port DASHBOARD_PORT]
+             [--vae-latent-dim VAE_LATENT_DIM]
              [--vae-dense-layer-size VAE_DENSE_LAYER_SIZE]
              [--vae-kernel-size VAE_KERNEL_SIZE VAE_KERNEL_SIZE]
              [--vae-beta VAE_BETA] [--vae-alpha VAE_ALPHA]
@@ -475,6 +477,14 @@ options:
   --output-path OUTPUT_PATH
                         Path to output directory (overrides
                         AETHERSCAN_OUTPUT_PATH environment variable)
+  --dashboard, --no-dashboard
+                        Auto-launch the live monitoring dashboard
+                        (utils/dashboard.py) for this run; SSH-forward the
+                        port to view it (default: on). Use --no-dashboard to
+                        disable
+  --dashboard-port DASHBOARD_PORT
+                        Port for the auto-launched live dashboard (default:
+                        8501)
   --vae-latent-dim VAE_LATENT_DIM
                         Dimensionality of the VAE latent space (bottleneck
                         size)
@@ -718,7 +728,9 @@ The Aetherscan inference pipeline exposes the following CLI flags to the user. R
 
 ```
 usage: inference [-h] [--data-path DATA_PATH] [--model-path MODEL_PATH]
-                 [--output-path OUTPUT_PATH] [--num-replicas NUM_REPLICAS]
+                 [--output-path OUTPUT_PATH] [--dashboard | --no-dashboard]
+                 [--dashboard-port DASHBOARD_PORT]
+                 [--num-replicas NUM_REPLICAS]
                  [--gpu-memory-limit-mb GPU_MEMORY_LIMIT_MB]
                  [--async-allocator | --no-async-allocator]
                  [--test-files TEST_FILES [TEST_FILES ...]]
@@ -761,6 +773,14 @@ options:
   --output-path OUTPUT_PATH
                         Path to output directory (overrides
                         AETHERSCAN_OUTPUT_PATH environment variable)
+  --dashboard, --no-dashboard
+                        Auto-launch the live monitoring dashboard
+                        (utils/dashboard.py) for this run; SSH-forward the
+                        port to view it (default: on). Use --no-dashboard to
+                        disable
+  --dashboard-port DASHBOARD_PORT
+                        Port for the auto-launched live dashboard (default:
+                        8501)
   --num-replicas NUM_REPLICAS
                         Number of GPUs to use for the distributed strategy. If
                         omitted, the strategy uses every GPU visible to TF;

--- a/environment.yml
+++ b/environment.yml
@@ -32,6 +32,9 @@ dependencies:
   - astropy>=6.1,<7
   - matplotlib>=3.9,<3.10
   - joblib>=1.4,<2
+  # pandas backs the dashboard's data layer (utils/dashboard.py). The NGC base image
+  # ships it, so requirements-container.txt omits it; conda must provide it here.
+  - pandas>=2.0,<3
   # setuptools provides pkg_resources, which blimpy (transitive via setigen)
   # imports at module load. Recent pip / Python releases dropped setuptools
   # from the bootstrap, so we install it explicitly. Upper-bound at <81 because
@@ -60,3 +63,8 @@ dependencies:
       # Model weight distribution via the HuggingFace Hub — pin range mirrors
       # requirements-container.txt (see the rationale there).
       - huggingface_hub>=1.21,<1.22
+      # Live monitoring dashboard (utils/dashboard.py). Kept in lockstep with
+      # requirements-container.txt; streamlit 1.39 coexists with TF 2.17 (protobuf 4.x)
+      # and numpy<2. plotly is pure-Python.
+      - streamlit>=1.39,<1.41
+      - plotly>=5.24,<6

--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -31,3 +31,10 @@ huggingface_hub>=1.21,<1.22
 # once blimpy migrates off pkg_resources (upstream issue).
 setuptools>=70,<81
 setigen
+# Live monitoring dashboard (utils/dashboard.py, auto-launched by main.py). streamlit 1.39
+# per SECURITY.md's version policy (proven, >=6-month-old); it accepts protobuf>=3.20,<6 and
+# numpy>=1.23, so it coexists with TF 2.17's protobuf 4.x pin and the numpy<2 ceiling (pyarrow
+# /tornado/altair pulled transitively). plotly is pure-Python (no numpy ABI coupling). pandas
+# is already shipped by the NGC base, so it is not repinned here.
+streamlit>=1.39,<1.41
+plotly>=5.24,<6

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -214,6 +214,18 @@ def _add_train_flags_to(parser):
         default=None,
         help="Path to output directory (overrides AETHERSCAN_OUTPUT_PATH environment variable)",
     )
+    parser.add_argument(
+        "--dashboard",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Auto-launch the live monitoring dashboard (utils/dashboard.py) for this run; SSH-forward the port to view it (default: on). Use --no-dashboard to disable",
+    )
+    parser.add_argument(
+        "--dashboard-port",
+        type=int,
+        default=None,
+        help="Port for the auto-launched live dashboard (default: 8501)",
+    )
 
     # BetaVAE model configuration
     parser.add_argument(
@@ -691,6 +703,18 @@ def _add_inference_flags_to(parser):
         default=None,
         help="Path to output directory (overrides AETHERSCAN_OUTPUT_PATH environment variable)",
     )
+    parser.add_argument(
+        "--dashboard",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Auto-launch the live monitoring dashboard (utils/dashboard.py) for this run; SSH-forward the port to view it (default: on). Use --no-dashboard to disable",
+    )
+    parser.add_argument(
+        "--dashboard-port",
+        type=int,
+        default=None,
+        help="Port for the auto-launched live dashboard (default: 8501)",
+    )
 
     # GPU configuration
     parser.add_argument(
@@ -998,6 +1022,10 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
         config.model_path = args.model_path
     if hasattr(args, "output_path") and args.output_path is not None:
         config.output_path = args.output_path
+    if hasattr(args, "dashboard") and args.dashboard is not None:
+        config.monitor.dashboard_enabled = args.dashboard
+    if hasattr(args, "dashboard_port") and args.dashboard_port is not None:
+        config.monitor.dashboard_port = args.dashboard_port
 
     # BetaVAE configuration
     if hasattr(args, "vae_latent_dim") and args.vae_latent_dim is not None:

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -49,6 +49,10 @@ class MonitorConfig:
     # as labeled translucent bands on the resource plot's CPU panel, so utilization
     # plateaus are attributable to pipeline stages at a glance
     annotate_stages: bool = True
+    # Live monitoring dashboard (utils/dashboard.py) auto-launched by main.py at run start;
+    # --no-dashboard opts out. Served headless on dashboard_port (SSH-forward to reach it).
+    dashboard_enabled: bool = True
+    dashboard_port: int = 8501
 
 
 @dataclass
@@ -548,6 +552,8 @@ class Config:
                 "monitor_interval": self.monitor.monitor_interval,
                 "monitor_retry_delay": self.monitor.monitor_retry_delay,
                 "annotate_stages": self.monitor.annotate_stages,
+                "dashboard_enabled": self.monitor.dashboard_enabled,
+                "dashboard_port": self.monitor.dashboard_port,
             },
             "logger": {
                 "console_level": self.logger.console_level,

--- a/src/aetherscan/dashboard_launcher.py
+++ b/src/aetherscan/dashboard_launcher.py
@@ -1,0 +1,127 @@
+"""
+Auto-launch the live monitoring dashboard (utils/dashboard.py) alongside a train/inference run.
+
+main.py calls launch_dashboard() once at startup (after the DB is initialized). It spawns a
+headless Streamlit server as a detached subprocess pointed at this run's DB + tag, logs the
+SSH-forward instructions, and registers an atexit hook to tear it down. Fully guarded: a missing
+streamlit, a missing dashboard.py, or any spawn failure degrades to a warning — the dashboard is
+optional observability and must never fail the pipeline. Opt out with --no-dashboard
+(config.monitor.dashboard_enabled = False).
+"""
+
+from __future__ import annotations
+
+import atexit
+import importlib.util
+import logging
+import os
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+from aetherscan.config import get_config
+from aetherscan.db import get_db
+
+logger = logging.getLogger(__name__)
+
+# utils/dashboard.py sits at the repo root; this module is src/aetherscan/dashboard_launcher.py
+_DASHBOARD_SCRIPT = Path(__file__).resolve().parents[2] / "utils" / "dashboard.py"
+
+
+def build_dashboard_command(
+    python_exe: str,
+    dashboard_script: str,
+    db_path: str,
+    tag: str,
+    plots_dir: str,
+    port: int,
+) -> list[str]:
+    """Construct the `python -m streamlit run ...` argv. Streamlit's own flags precede `--`;
+    everything after `--` is forwarded to dashboard.py's argparse. Pure/testable."""
+    return [
+        python_exe,
+        "-m",
+        "streamlit",
+        "run",
+        dashboard_script,
+        "--server.port",
+        str(port),
+        "--server.headless",
+        "true",
+        "--browser.gatherUsageStats",
+        "false",
+        "--",
+        "--db-path",
+        db_path,
+        "--tag",
+        tag,
+        "--plots-dir",
+        plots_dir,
+    ]
+
+
+def _terminate(proc: subprocess.Popen) -> None:
+    """Best-effort teardown at interpreter exit (no logging — runs during shutdown)."""
+    if proc.poll() is not None:
+        return
+    try:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+    except Exception:
+        pass
+
+
+def launch_dashboard() -> subprocess.Popen | None:
+    """Spawn the headless Streamlit dashboard for this run, or return None (disabled / failed)."""
+    config = get_config()
+    if config is None or not config.monitor.dashboard_enabled:
+        return None
+
+    if not _DASHBOARD_SCRIPT.is_file():
+        logger.warning(f"Dashboard not launched: {_DASHBOARD_SCRIPT} not found")
+        return None
+
+    if importlib.util.find_spec("streamlit") is None:
+        logger.warning(
+            "Dashboard skipped: streamlit not installed. Rebuild the NGC container (.sif) or the "
+            "conda env after the streamlit/plotly deps landed, or run with --no-dashboard."
+        )
+        return None
+
+    db = get_db()
+    db_path = (
+        db.db_path if db is not None else os.path.join(config.output_path, "db", "aetherscan.db")
+    )
+    tag = config.checkpoint.save_tag
+    plots_dir = os.path.join(config.output_path, "plots")
+    port = config.monitor.dashboard_port
+
+    cmd = build_dashboard_command(
+        sys.executable, str(_DASHBOARD_SCRIPT), db_path, tag, plots_dir, port
+    )
+
+    try:
+        # start_new_session detaches the server from the pipeline's process group so a SIGINT to
+        # the pipeline doesn't also kill the dashboard mid-write; atexit tears it down cleanly.
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except (OSError, ValueError) as e:
+        logger.warning(f"Dashboard failed to launch (is streamlit installed?): {e}")
+        return None
+
+    atexit.register(_terminate, proc)
+    host = socket.gethostname()
+    logger.info(
+        f"Live dashboard for '{tag}' on port {port}. Reach it with: "
+        f"ssh -L {port}:localhost:{port} {host}  then open http://localhost:{port}"
+    )
+    return proc

--- a/src/aetherscan/dashboard_launcher.py
+++ b/src/aetherscan/dashboard_launcher.py
@@ -3,18 +3,21 @@ Auto-launch the live monitoring dashboard (utils/dashboard.py) alongside a train
 
 main.py calls launch_dashboard() once at startup (after the DB is initialized). It spawns a
 headless Streamlit server as a detached subprocess pointed at this run's DB + tag, logs the
-SSH-forward instructions, and registers an atexit hook to tear it down. Fully guarded: a missing
-streamlit, a missing dashboard.py, or any spawn failure degrades to a warning — the dashboard is
-optional observability and must never fail the pipeline. Opt out with --no-dashboard
+SSH-forward instructions, and registers atexit + SIGTERM/SIGINT teardown so the server is reaped
+whether the pipeline exits gracefully or is signal-killed. Fully guarded: a missing streamlit, a
+missing dashboard.py, a port already in use, or any spawn failure degrades to a warning — the
+dashboard is optional observability and must never fail the pipeline. Opt out with --no-dashboard
 (config.monitor.dashboard_enabled = False).
 """
 
 from __future__ import annotations
 
 import atexit
+import contextlib
 import importlib.util
 import logging
 import os
+import signal
 import socket
 import subprocess
 import sys
@@ -61,18 +64,63 @@ def build_dashboard_command(
     ]
 
 
+def _port_in_use(port: int) -> bool:
+    """True if `port` can't be bound on localhost — i.e. a concurrent run's dashboard already holds
+    it. Best-effort probe; either way the caller only ever warns, never fails the pipeline."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind(("127.0.0.1", port))
+    except OSError:
+        return True
+    return False
+
+
 def _terminate(proc: subprocess.Popen) -> None:
-    """Best-effort teardown at interpreter exit (no logging — runs during shutdown)."""
+    """Best-effort teardown (no logging — may run during interpreter shutdown or in a signal
+    handler). The dashboard is spawned with start_new_session=True, so it leads its own process
+    group; signal the whole group (killpg) to reap Streamlit AND any grandchildren, not just the
+    direct child."""
     if proc.poll() is not None:
         return
+
+    def _signal_group(sig: int) -> None:
+        try:
+            os.killpg(os.getpgid(proc.pid), sig)
+        except (ProcessLookupError, PermissionError, OSError):
+            # group already gone, or getpgid raced the exit — fall back to the direct child
+            with contextlib.suppress(Exception):
+                proc.send_signal(sig)
+
     try:
-        proc.terminate()
+        _signal_group(signal.SIGTERM)
         try:
             proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
-            proc.kill()
+            _signal_group(signal.SIGKILL)
     except Exception:
         pass
+
+
+def _install_signal_teardown(proc: subprocess.Popen) -> None:
+    """Reap the dashboard on SIGTERM/SIGINT too — atexit hooks do NOT run on a signal-kill, and
+    the new-session detachment means a process-group signal to the pipeline never reaches the
+    dashboard. Each handler tears down the dashboard, restores the previous disposition, and
+    re-raises the signal so the pipeline's own shutdown proceeds exactly as before (no logging in
+    the handler — that can deadlock). Signal handlers can only be installed from the main thread."""
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            prev = signal.getsignal(sig)
+        except (ValueError, OSError):
+            continue  # not the main thread / unsupported — atexit still covers graceful exits
+
+        def _handler(signum, frame, _prev=prev):
+            _terminate(proc)
+            signal.signal(signum, _prev if callable(_prev) else signal.SIG_DFL)
+            os.kill(os.getpid(), signum)  # re-deliver so the pipeline shuts down as it would have
+
+        with contextlib.suppress(ValueError, OSError):
+            signal.signal(sig, _handler)
 
 
 def launch_dashboard() -> subprocess.Popen | None:
@@ -100,13 +148,25 @@ def launch_dashboard() -> subprocess.Popen | None:
     plots_dir = os.path.join(config.output_path, "plots")
     port = config.monitor.dashboard_port
 
+    if _port_in_use(port):
+        # A concurrent run on this node already holds the port. Don't spawn a Streamlit that would
+        # exit immediately (stderr is DEVNULL'd) and, worse, don't log an SSH-forward line that
+        # would tunnel the user to the OTHER run's dashboard — a wrong-tag/wrong-DB footgun.
+        logger.warning(
+            f"Dashboard skipped: port {port} is already in use (another run's dashboard?). "
+            f"Free the port or pass --dashboard-port to pick another."
+        )
+        return None
+
     cmd = build_dashboard_command(
         sys.executable, str(_DASHBOARD_SCRIPT), db_path, tag, plots_dir, port
     )
 
     try:
-        # start_new_session detaches the server from the pipeline's process group so a SIGINT to
-        # the pipeline doesn't also kill the dashboard mid-write; atexit tears it down cleanly.
+        # start_new_session puts the server in its own session/process group so a Ctrl-C sent to
+        # the pipeline's whole foreground group doesn't kill it mid-write; teardown is instead
+        # driven deterministically by our atexit hook (graceful exit) and SIGTERM/SIGINT handlers
+        # (signal-kill), both of which killpg the new group to reap Streamlit + any grandchildren.
         proc = subprocess.Popen(
             cmd,
             stdout=subprocess.DEVNULL,
@@ -119,6 +179,7 @@ def launch_dashboard() -> subprocess.Popen | None:
         return None
 
     atexit.register(_terminate, proc)
+    _install_signal_teardown(proc)
     host = socket.gethostname()
     logger.info(
         f"Live dashboard for '{tag}' on port {port}. Reach it with: "

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -26,6 +26,7 @@ from aetherscan.cli import (
     validate_args,
 )
 from aetherscan.config import get_config, init_config
+from aetherscan.dashboard_launcher import launch_dashboard
 from aetherscan.db import get_db, init_db
 from aetherscan.hf_hub import resolve_inference_artifacts
 from aetherscan.inference import InferencePipeline, run_inference_pipeline, summarize_confidences
@@ -872,6 +873,14 @@ def main():
     except Exception as e:
         logger.error(f"Failed to initialize resource monitor: {e}")
         sys.exit(1)
+
+    # Auto-launch the live monitoring dashboard (opt out with --no-dashboard). Fully guarded:
+    # a missing streamlit or a spawn failure only warns — the dashboard is optional observability
+    # and must never abort the run.
+    try:
+        launch_dashboard()
+    except Exception as e:
+        logger.warning(f"Dashboard launch skipped: {e}")
 
     try:
         # Fail-early save-tag dedup guards: hard-stop before any expensive work when an

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -284,6 +284,17 @@ def test_run_summary(conn):
     assert summ["peak_ram_pct"] == pytest.approx(42.2)
 
 
+def test_run_summary_no_stages_uses_resources(conn):
+    # exercise the `elif not resources.empty` wall-clock branch: no stages, so the span comes from
+    # the resource timestamps (220 - 100), and latest_stage is None
+    res = dashboard.load_resources(conn, "t1")
+    empty_stages = dashboard.load_stages(conn, "nope")
+    summ = dashboard.run_summary(res, empty_stages)
+    assert summ["wall_s"] == 120.0
+    assert summ["n_stages"] == 0
+    assert summ["latest_stage"] is None
+
+
 def test_list_png_artifacts_and_default_dir(tmp_path):
     plots = tmp_path / "plots"
     (plots / "inference" / "t1").mkdir(parents=True)

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -1,19 +1,20 @@
-"""Unit tests for utils/dashboard.py's pure data layer (the SQL/shaping functions that back
-the live Streamlit dashboard). The Streamlit/plotly render layer is not imported here — it is
-loaded lazily inside dashboard.render(), so this test needs only pandas + sqlite3."""
+"""Unit tests for utils/dashboard.py's pure data layer (the SQL/shaping/PCA/artifact helpers that
+back the live Streamlit dashboard). The Streamlit/plotly render layer is not imported here — it is
+loaded lazily inside dashboard.render(), so this test needs only numpy + pandas + sqlite3."""
 
 from __future__ import annotations
 
 import importlib.util
+import json
 import sqlite3
 import sys
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 # utils/ is not a package — load the dashboard tool straight from its file (same pattern as
-# test_benchmark.py loads benchmark_report). Registering in sys.modules before exec keeps any
-# in-module name resolution well-defined.
+# test_benchmark.py loads benchmark_report).
 _DASHBOARD_PATH = Path(__file__).resolve().parents[2] / "utils" / "dashboard.py"
 _spec = importlib.util.spec_from_file_location("dashboard", _DASHBOARD_PATH)
 dashboard = importlib.util.module_from_spec(_spec)
@@ -32,27 +33,38 @@ def _build_db(path):
             id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp REAL, model_name TEXT,
             stat_name TEXT, value REAL, round_number INTEGER, epoch_number INTEGER,
             tag TEXT, superseded INTEGER DEFAULT 0);
+        CREATE TABLE injection_stats (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp REAL, stat_name TEXT, value REAL,
+            round_number INTEGER, signal_type TEXT, injection_stage TEXT, is_finite INTEGER,
+            slope_clamped INTEGER, tag TEXT, superseded INTEGER DEFAULT 0);
+        CREATE TABLE latent_snapshots (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp REAL, model_name TEXT,
+            round_number INTEGER, epoch_number INTEGER, step_number INTEGER,
+            signal_type TEXT, latent_vector TEXT, tag TEXT, superseded INTEGER DEFAULT 0);
+        CREATE TABLE inference_results (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp REAL, prediction INTEGER,
+            confidence REAL, target TEXT, band TEXT, frequency_mhz REAL, tag TEXT,
+            superseded INTEGER DEFAULT 0);
+        CREATE TABLE inference_cadences (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp REAL, tag TEXT, status TEXT,
+            duration_s REAL, n_stamps INTEGER, n_candidates INTEGER, superseded INTEGER DEFAULT 0);
         CREATE TABLE pipeline_stages (
             id INTEGER PRIMARY KEY AUTOINCREMENT, stage TEXT, start_time REAL, end_time REAL,
             duration_s REAL, tag TEXT, metadata TEXT);
         """
     )
     for ts in (100.0, 160.0, 220.0):
-        conn.execute(
-            "INSERT INTO system_resources (timestamp,resource_type,resource_name,value,unit,tag)"
-            " VALUES (?,?,?,?,?,?)",
-            (ts, "cpu", "system_total", 50.0, "percent", "t1"),
-        )
-        conn.execute(
-            "INSERT INTO system_resources (timestamp,resource_type,resource_name,value,unit,tag)"
-            " VALUES (?,?,?,?,?,?)",
-            (ts, "ram", "system_total", 40.0 + ts / 100, "percent", "t1"),
-        )
-        conn.execute(
-            "INSERT INTO system_resources (timestamp,resource_type,resource_name,value,unit,tag)"
-            " VALUES (?,?,?,?,?,?)",
-            (ts, "gpu", "GPU0_utilization", 30.0, "percent", "t1"),
-        )
+        for rt, rn, v in (
+            ("cpu", "system_total", 50.0),
+            ("ram", "system_total", 40.0 + ts / 100),
+            ("gpu", "GPU0_utilization", 30.0),
+        ):
+            conn.execute(
+                "INSERT INTO system_resources (timestamp,resource_type,resource_name,value,unit,tag)"
+                " VALUES (?,?,?,?,?,?)",
+                (ts, rt, rn, v, "percent", "t1"),
+            )
+    # beta_vae loss (3 epochs) + a superseded row + an rf-model row that must be excluded
     for ep, v in enumerate([1.0, 0.5, 0.2], start=1):
         conn.execute(
             "INSERT INTO training_stats"
@@ -60,22 +72,74 @@ def _build_db(path):
             " VALUES (?,?,?,?,?,?,?,?)",
             (100.0 + ep, "beta_vae", "total_loss", v, 1, ep, "t1", 0),
         )
-    # A superseded row that MUST be excluded from the loss curve
     conn.execute(
         "INSERT INTO training_stats"
         " (timestamp,model_name,stat_name,value,round_number,epoch_number,tag,superseded)"
         " VALUES (?,?,?,?,?,?,?,?)",
         (999.0, "beta_vae", "total_loss", 42.0, 1, 1, "t1", 1),
     )
-    for stage, st, et, tag in (
-        ("train.round_01", 100.0, 220.0, "t1"),
-        ("train.round_01.data_generation", 100.0, 160.0, "t1"),
-        ("inference.infer_cadence_001", 300.0, 330.0, "t2"),
+    conn.execute(
+        "INSERT INTO training_stats"
+        " (timestamp,model_name,stat_name,value,round_number,epoch_number,tag,superseded)"
+        " VALUES (?,?,?,?,?,?,?,?)",
+        (105.0, "rf", "total_loss", 7.0, 1, 1, "t1", 0),
+    )
+    # injection_stats
+    for i, (sig, fin, clamp) in enumerate([("eti", 1, 0), ("rfi", 0, 1), ("eti", 1, 0)]):
+        conn.execute(
+            "INSERT INTO injection_stats"
+            " (timestamp,stat_name,value,round_number,signal_type,injection_stage,is_finite,"
+            "slope_clamped,tag,superseded) VALUES (?,?,?,?,?,?,?,?,?,?)",
+            (100.0 + i, "global_mean", float(i), 1, sig, "A", fin, clamp, "t1", 0),
+        )
+    # latent snapshots: two frames; the LATEST (round1/epoch2/step0) has 2 rows
+    conn.execute(
+        "INSERT INTO latent_snapshots"
+        " (timestamp,model_name,round_number,epoch_number,step_number,signal_type,latent_vector,tag,superseded)"
+        " VALUES (?,?,?,?,?,?,?,?,?)",
+        (1, "beta_vae", 1, 1, 0, "true", json.dumps([0.0, 1.0, 2.0]), "t1", 0),
+    )
+    conn.execute(
+        "INSERT INTO latent_snapshots"
+        " (timestamp,model_name,round_number,epoch_number,step_number,signal_type,latent_vector,tag,superseded)"
+        " VALUES (?,?,?,?,?,?,?,?,?)",
+        (2, "beta_vae", 1, 2, 0, "true", json.dumps([1.0, 0.0, 1.0]), "t1", 0),
+    )
+    conn.execute(
+        "INSERT INTO latent_snapshots"
+        " (timestamp,model_name,round_number,epoch_number,step_number,signal_type,latent_vector,tag,superseded)"
+        " VALUES (?,?,?,?,?,?,?,?,?)",
+        (2, "beta_vae", 1, 2, 0, "false", json.dumps([3.0, 3.0, 3.0]), "t1", 0),
+    )
+    # inference_results: 1 candidate (prediction=1) + 1 non-candidate + 1 superseded candidate
+    conn.execute(
+        "INSERT INTO inference_results (timestamp,prediction,confidence,target,band,frequency_mhz,tag,superseded)"
+        " VALUES (?,?,?,?,?,?,?,?)",
+        (1, 1, 0.95, "HIP1", "C", 1420.0, "t1", 0),
+    )
+    conn.execute(
+        "INSERT INTO inference_results (timestamp,prediction,confidence,target,band,frequency_mhz,tag,superseded)"
+        " VALUES (?,?,?,?,?,?,?,?)",
+        (1, 0, 0.10, "HIP1", "C", 1421.0, "t1", 0),
+    )
+    conn.execute(
+        "INSERT INTO inference_results (timestamp,prediction,confidence,target,band,frequency_mhz,tag,superseded)"
+        " VALUES (?,?,?,?,?,?,?,?)",
+        (1, 1, 0.99, "HIP1", "C", 1422.0, "t1", 1),
+    )
+    conn.execute(
+        "INSERT INTO inference_cadences (timestamp,tag,status,duration_s,n_stamps,n_candidates,superseded)"
+        " VALUES (?,?,?,?,?,?,?)",
+        (1, "t1", "inferred", 12.5, 100, 1, 0),
+    )
+    for stage, st, et in (
+        ("train.round_01", 100.0, 220.0),
+        ("train.round_01.data_generation", 100.0, 160.0),
     ):
         conn.execute(
             "INSERT INTO pipeline_stages (stage,start_time,end_time,duration_s,tag,metadata)"
             " VALUES (?,?,?,?,?,?)",
-            (stage, st, et, et - st, tag, None),
+            (stage, st, et, et - st, "t1", None),
         )
     conn.commit()
     conn.close()
@@ -83,7 +147,8 @@ def _build_db(path):
 
 @pytest.fixture
 def db_path(tmp_path):
-    path = str(tmp_path / "aetherscan.db")
+    path = str(tmp_path / "db" / "aetherscan.db")
+    Path(path).parent.mkdir(parents=True)
     _build_db(path)
     return path
 
@@ -105,41 +170,113 @@ def test_connect_ro_is_read_only(db_path):
 
 
 def test_list_tags(conn):
-    assert dashboard.list_tags(conn) == ["t1", "t2"]
+    assert dashboard.list_tags(conn) == ["t1"]
 
 
 def test_load_resources(conn):
     res = dashboard.load_resources(conn, "t1")
-    assert len(res) == 9  # 3 timestamps x 3 series
+    assert len(res) == 9
     assert set(res["resource_type"]) == {"cpu", "ram", "gpu"}
 
 
-def test_load_training_stats_excludes_superseded(conn):
-    tr = dashboard.load_training_stats(conn, "t1")
-    assert len(tr) == 3  # the superseded row is dropped
-    assert list(tr["value"]) == [1.0, 0.5, 0.2]  # ordered by round/epoch
+def test_load_training_stats_filters_model_superseded_and_statset(conn):
+    df = dashboard.load_training_stats(conn, "t1", dashboard._LOSS_STATS)
+    # 3 live beta_vae total_loss rows: rf-model row + superseded row excluded
+    assert len(df) == 3
+    assert list(df["value"]) == [1.0, 0.5, 0.2]
+    # a stat not in the requested set is not returned
+    assert dashboard.load_training_stats(conn, "t1", ["clipping_rate"]).empty
 
 
-def test_load_stages_derives_depth_and_orders(conn):
+def test_load_injection_stats_excludes_superseded(conn):
+    inj = dashboard.load_injection_stats(conn, "t1")
+    assert len(inj) == 3
+    assert set(inj["signal_type"]) == {"eti", "rfi"}
+
+
+def test_load_latent_snapshots_latest_picks_last_frame(conn):
+    snaps = dashboard.load_latent_snapshots_latest(conn, "t1")
+    # latest frame is round1/epoch2/step0 which has 2 rows (true + false), not the epoch1 row
+    assert len(snaps) == 2
+    assert set(snaps["signal_type"]) == {"true", "false"}
+
+
+def test_parse_latent_matrix_and_pca(conn):
+    snaps = dashboard.load_latent_snapshots_latest(conn, "t1")
+    mat, labels = dashboard.parse_latent_matrix(snaps)
+    assert mat.shape == (2, 3)
+    assert len(labels) == 2
+    proj = dashboard.pca_2d(mat)
+    assert proj.shape == (2, 2)
+
+
+def test_parse_latent_matrix_drops_malformed(conn):
+    df = dashboard.load_latent_snapshots_latest(conn, "t1").copy()
+    df.loc[len(df)] = {"signal_type": "bad", "latent_vector": "not json"}
+    mat, labels = dashboard.parse_latent_matrix(df)
+    assert mat.shape[0] == 2  # the malformed row is dropped
+    assert "bad" not in labels
+
+
+def test_pca_2d_empty_and_1d():
+    assert dashboard.pca_2d(np.empty((0, 0))).shape == (0, 2)
+    proj = dashboard.pca_2d(np.array([[1.0], [2.0], [3.0]]))  # d==1 -> zero-filled 2nd col
+    assert proj.shape == (3, 2)
+    assert np.allclose(proj[:, 1], 0.0)
+
+
+def test_load_inference_results_excludes_superseded(conn):
+    res = dashboard.load_inference_results(conn, "t1")
+    assert len(res) == 2  # the superseded candidate is dropped
+    assert (res["prediction"] == 1).sum() == 1
+
+
+def test_load_inference_cadences(conn):
+    cad = dashboard.load_inference_cadences(conn, "t1")
+    assert len(cad) == 1
+    assert cad.iloc[0]["status"] == "inferred"
+
+
+def test_load_stages_derives_depth(conn):
     st = dashboard.load_stages(conn, "t1")
-    assert len(st) == 2
     assert set(st["depth"]) == {2, 3}
-    assert st.iloc[0]["stage"] == "train.round_01"  # earliest start first
+
+
+def test_missing_tables_return_empty(tmp_path):
+    # a DB with only system_resources — every other loader must degrade to an empty frame
+    path = str(tmp_path / "bare.db")
+    c = sqlite3.connect(path)
+    c.executescript(
+        "CREATE TABLE system_resources (timestamp REAL, resource_type TEXT,"
+        " resource_name TEXT, value REAL, unit TEXT, tag TEXT);"
+    )
+    c.close()
+    conn = dashboard.connect_ro(path)
+    assert dashboard.load_stages(conn, "t1").empty
+    assert dashboard.load_inference_results(conn, "t1").empty
+    assert dashboard.load_inference_cadences(conn, "t1").empty
+    assert dashboard.load_latent_snapshots_latest(conn, "t1").empty
+    conn.close()
 
 
 def test_run_summary(conn):
     res = dashboard.load_resources(conn, "t1")
     st = dashboard.load_stages(conn, "t1")
     summ = dashboard.run_summary(res, st)
-    assert summ["wall_s"] == 120.0  # 220 - 100
-    assert summ["n_stages"] == 2
-    assert summ["latest_stage"] == "train.round_01.data_generation"  # latest-started span
+    assert summ["wall_s"] == 120.0
+    assert summ["latest_stage"] == "train.round_01.data_generation"
     assert summ["peak_ram_pct"] == pytest.approx(42.2)
 
 
-def test_empty_tag_is_safe(conn):
-    empty = dashboard.load_stages(conn, "nope")
-    assert empty.empty
-    summ = dashboard.run_summary(dashboard.load_resources(conn, "nope"), empty)
-    assert summ["n_stages"] == 0
-    assert summ["latest_stage"] is None
+def test_list_png_artifacts_and_default_dir(tmp_path):
+    plots = tmp_path / "plots"
+    (plots / "inference" / "t1").mkdir(parents=True)
+    (plots / "beta_vae_loss_curves_t1.png").write_bytes(b"x")
+    (plots / "inference" / "t1" / "stamp_gallery_t1.png").write_bytes(b"y")
+    (plots / "notes.txt").write_text("ignore me")
+    arts = dashboard.list_png_artifacts(str(plots))
+    names = {a["name"] for a in arts}
+    assert names == {"beta_vae_loss_curves_t1.png", "stamp_gallery_t1.png"}  # .txt ignored
+    assert dashboard.list_png_artifacts(str(tmp_path / "nonexistent")) == []
+    # default_plots_dir derives {output}/plots from {output}/db/aetherscan.db
+    assert dashboard.default_plots_dir(str(tmp_path / "db" / "aetherscan.db")) == str(plots)

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -218,6 +218,22 @@ def test_parse_latent_matrix_drops_malformed(conn):
     assert "bad" not in labels
 
 
+def test_parse_latent_matrix_drops_nonfinite(conn):
+    # json.loads accepts NaN/Infinity; such rows must be dropped so the downstream SVD (pca_2d)
+    # can't blow up ("SVD did not converge") on a live run with unstable latents.
+    df = dashboard.load_latent_snapshots_latest(conn, "t1").copy()
+    df.loc[len(df)] = {
+        "signal_type": "naninf",
+        "latent_vector": json.dumps([float("nan"), 1.0, 2.0]),
+    }
+    mat, labels = dashboard.parse_latent_matrix(df)
+    assert mat.shape[0] == 2  # only the 2 finite rows survive
+    assert "naninf" not in labels
+    assert np.isfinite(mat).all()
+    # and the projection is computable (no LinAlgError)
+    assert dashboard.pca_2d(mat).shape == (2, 2)
+
+
 def test_pca_2d_empty_and_1d():
     assert dashboard.pca_2d(np.empty((0, 0))).shape == (0, 2)
     proj = dashboard.pca_2d(np.array([[1.0], [2.0], [3.0]]))  # d==1 -> zero-filled 2nd col

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -1,0 +1,145 @@
+"""Unit tests for utils/dashboard.py's pure data layer (the SQL/shaping functions that back
+the live Streamlit dashboard). The Streamlit/plotly render layer is not imported here — it is
+loaded lazily inside dashboard.render(), so this test needs only pandas + sqlite3."""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# utils/ is not a package — load the dashboard tool straight from its file (same pattern as
+# test_benchmark.py loads benchmark_report). Registering in sys.modules before exec keeps any
+# in-module name resolution well-defined.
+_DASHBOARD_PATH = Path(__file__).resolve().parents[2] / "utils" / "dashboard.py"
+_spec = importlib.util.spec_from_file_location("dashboard", _DASHBOARD_PATH)
+dashboard = importlib.util.module_from_spec(_spec)
+sys.modules["dashboard"] = dashboard
+_spec.loader.exec_module(dashboard)
+
+
+def _build_db(path):
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE system_resources (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp REAL, resource_type TEXT,
+            resource_name TEXT, value REAL, unit TEXT, tag TEXT);
+        CREATE TABLE training_stats (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp REAL, model_name TEXT,
+            stat_name TEXT, value REAL, round_number INTEGER, epoch_number INTEGER,
+            tag TEXT, superseded INTEGER DEFAULT 0);
+        CREATE TABLE pipeline_stages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, stage TEXT, start_time REAL, end_time REAL,
+            duration_s REAL, tag TEXT, metadata TEXT);
+        """
+    )
+    for ts in (100.0, 160.0, 220.0):
+        conn.execute(
+            "INSERT INTO system_resources (timestamp,resource_type,resource_name,value,unit,tag)"
+            " VALUES (?,?,?,?,?,?)",
+            (ts, "cpu", "system_total", 50.0, "percent", "t1"),
+        )
+        conn.execute(
+            "INSERT INTO system_resources (timestamp,resource_type,resource_name,value,unit,tag)"
+            " VALUES (?,?,?,?,?,?)",
+            (ts, "ram", "system_total", 40.0 + ts / 100, "percent", "t1"),
+        )
+        conn.execute(
+            "INSERT INTO system_resources (timestamp,resource_type,resource_name,value,unit,tag)"
+            " VALUES (?,?,?,?,?,?)",
+            (ts, "gpu", "GPU0_utilization", 30.0, "percent", "t1"),
+        )
+    for ep, v in enumerate([1.0, 0.5, 0.2], start=1):
+        conn.execute(
+            "INSERT INTO training_stats"
+            " (timestamp,model_name,stat_name,value,round_number,epoch_number,tag,superseded)"
+            " VALUES (?,?,?,?,?,?,?,?)",
+            (100.0 + ep, "beta_vae", "total_loss", v, 1, ep, "t1", 0),
+        )
+    # A superseded row that MUST be excluded from the loss curve
+    conn.execute(
+        "INSERT INTO training_stats"
+        " (timestamp,model_name,stat_name,value,round_number,epoch_number,tag,superseded)"
+        " VALUES (?,?,?,?,?,?,?,?)",
+        (999.0, "beta_vae", "total_loss", 42.0, 1, 1, "t1", 1),
+    )
+    for stage, st, et, tag in (
+        ("train.round_01", 100.0, 220.0, "t1"),
+        ("train.round_01.data_generation", 100.0, 160.0, "t1"),
+        ("inference.infer_cadence_001", 300.0, 330.0, "t2"),
+    ):
+        conn.execute(
+            "INSERT INTO pipeline_stages (stage,start_time,end_time,duration_s,tag,metadata)"
+            " VALUES (?,?,?,?,?,?)",
+            (stage, st, et, et - st, tag, None),
+        )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = str(tmp_path / "aetherscan.db")
+    _build_db(path)
+    return path
+
+
+@pytest.fixture
+def conn(db_path):
+    c = dashboard.connect_ro(db_path)
+    yield c
+    c.close()
+
+
+def test_connect_ro_is_read_only(db_path):
+    conn = dashboard.connect_ro(db_path)
+    with pytest.raises(sqlite3.OperationalError):
+        conn.execute(
+            "INSERT INTO pipeline_stages (stage,start_time,end_time,duration_s) VALUES ('x',0,1,1)"
+        )
+    conn.close()
+
+
+def test_list_tags(conn):
+    assert dashboard.list_tags(conn) == ["t1", "t2"]
+
+
+def test_load_resources(conn):
+    res = dashboard.load_resources(conn, "t1")
+    assert len(res) == 9  # 3 timestamps x 3 series
+    assert set(res["resource_type"]) == {"cpu", "ram", "gpu"}
+
+
+def test_load_training_stats_excludes_superseded(conn):
+    tr = dashboard.load_training_stats(conn, "t1")
+    assert len(tr) == 3  # the superseded row is dropped
+    assert list(tr["value"]) == [1.0, 0.5, 0.2]  # ordered by round/epoch
+
+
+def test_load_stages_derives_depth_and_orders(conn):
+    st = dashboard.load_stages(conn, "t1")
+    assert len(st) == 2
+    assert set(st["depth"]) == {2, 3}
+    assert st.iloc[0]["stage"] == "train.round_01"  # earliest start first
+
+
+def test_run_summary(conn):
+    res = dashboard.load_resources(conn, "t1")
+    st = dashboard.load_stages(conn, "t1")
+    summ = dashboard.run_summary(res, st)
+    assert summ["wall_s"] == 120.0  # 220 - 100
+    assert summ["n_stages"] == 2
+    assert summ["latest_stage"] == "train.round_01.data_generation"  # latest-started span
+    assert summ["peak_ram_pct"] == pytest.approx(42.2)
+
+
+def test_empty_tag_is_safe(conn):
+    empty = dashboard.load_stages(conn, "nope")
+    assert empty.empty
+    summ = dashboard.run_summary(dashboard.load_resources(conn, "nope"), empty)
+    assert summ["n_stages"] == 0
+    assert summ["latest_stage"] is None

--- a/tests/unit/test_dashboard_launcher.py
+++ b/tests/unit/test_dashboard_launcher.py
@@ -1,9 +1,28 @@
-"""Unit tests for aetherscan.dashboard_launcher.build_dashboard_command — the pure argv builder
-for the auto-launched Streamlit dashboard (the spawn itself is I/O and not unit-tested)."""
+"""Unit tests for aetherscan.dashboard_launcher: the pure argv builder plus the safety-critical
+guard paths of launch_dashboard (the dashboard is optional observability and must never fail or
+hang the pipeline). The actual Streamlit spawn is I/O and stays untested; every guard around it is
+mocked here."""
 
 from __future__ import annotations
 
-from aetherscan.dashboard_launcher import build_dashboard_command
+import signal
+import subprocess
+from unittest import mock
+
+from aetherscan.dashboard_launcher import (
+    _terminate,
+    build_dashboard_command,
+    launch_dashboard,
+)
+
+
+def _fake_config(enabled=True, port=8501, output_path="/out", save_tag="t1"):
+    cfg = mock.MagicMock()
+    cfg.monitor.dashboard_enabled = enabled
+    cfg.monitor.dashboard_port = port
+    cfg.output_path = output_path
+    cfg.checkpoint.save_tag = save_tag
+    return cfg
 
 
 def test_build_dashboard_command_structure():
@@ -38,3 +57,110 @@ def test_build_dashboard_command_structure():
 def test_port_is_stringified():
     cmd = build_dashboard_command("py", "d.py", "db", "t", "p", 9000)
     assert "9000" in cmd and 9000 not in cmd  # streamlit needs a string port
+
+
+_MOD = "aetherscan.dashboard_launcher"
+
+
+def test_launch_returns_none_when_config_missing():
+    with mock.patch(f"{_MOD}.get_config", return_value=None):
+        assert launch_dashboard() is None
+
+
+def test_launch_returns_none_when_disabled():
+    with mock.patch(f"{_MOD}.get_config", return_value=_fake_config(enabled=False)):
+        assert launch_dashboard() is None
+
+
+def test_launch_returns_none_when_script_missing():
+    with (
+        mock.patch(f"{_MOD}.get_config", return_value=_fake_config()),
+        mock.patch(f"{_MOD}._DASHBOARD_SCRIPT") as script,
+    ):
+        script.is_file.return_value = False
+        assert launch_dashboard() is None
+
+
+def test_launch_returns_none_when_streamlit_absent():
+    with (
+        mock.patch(f"{_MOD}.get_config", return_value=_fake_config()),
+        mock.patch(f"{_MOD}._DASHBOARD_SCRIPT") as script,
+        mock.patch(f"{_MOD}.importlib.util.find_spec", return_value=None),
+    ):
+        script.is_file.return_value = True
+        assert launch_dashboard() is None
+
+
+def test_launch_returns_none_when_port_in_use():
+    with (
+        mock.patch(f"{_MOD}.get_config", return_value=_fake_config()),
+        mock.patch(f"{_MOD}._DASHBOARD_SCRIPT") as script,
+        mock.patch(f"{_MOD}.importlib.util.find_spec", return_value=object()),
+        mock.patch(f"{_MOD}.get_db", return_value=None),
+        mock.patch(f"{_MOD}._port_in_use", return_value=True),
+        mock.patch(f"{_MOD}.subprocess.Popen") as popen,
+    ):
+        script.is_file.return_value = True
+        assert launch_dashboard() is None
+        popen.assert_not_called()  # never spawn a doomed Streamlit on a taken port
+
+
+def test_launch_returns_none_when_spawn_raises():
+    # A Popen failure (OSError/ValueError) must degrade to None, never propagate to the pipeline.
+    with (
+        mock.patch(f"{_MOD}.get_config", return_value=_fake_config()),
+        mock.patch(f"{_MOD}._DASHBOARD_SCRIPT") as script,
+        mock.patch(f"{_MOD}.importlib.util.find_spec", return_value=object()),
+        mock.patch(f"{_MOD}.get_db", return_value=None),
+        mock.patch(f"{_MOD}._port_in_use", return_value=False),
+        mock.patch(f"{_MOD}.subprocess.Popen", side_effect=OSError("boom")),
+    ):
+        script.is_file.return_value = True
+        assert launch_dashboard() is None
+
+
+def test_launch_spawns_and_registers_teardown():
+    proc = mock.MagicMock()
+    with (
+        mock.patch(f"{_MOD}.get_config", return_value=_fake_config(port=8600)),
+        mock.patch(f"{_MOD}._DASHBOARD_SCRIPT") as script,
+        mock.patch(f"{_MOD}.importlib.util.find_spec", return_value=object()),
+        mock.patch(f"{_MOD}.get_db", return_value=None),
+        mock.patch(f"{_MOD}._port_in_use", return_value=False),
+        mock.patch(f"{_MOD}.subprocess.Popen", return_value=proc) as popen,
+        mock.patch(f"{_MOD}.atexit.register") as atexit_reg,
+        mock.patch(f"{_MOD}._install_signal_teardown") as sig_teardown,
+    ):
+        script.is_file.return_value = True
+        script.__str__ = lambda self: "/repo/utils/dashboard.py"
+        result = launch_dashboard()
+        assert result is proc
+        # detached so a filling pipe / group signal can't hang or kill the pipeline
+        kwargs = popen.call_args.kwargs
+        assert kwargs["stdout"] == subprocess.DEVNULL
+        assert kwargs["stderr"] == subprocess.DEVNULL
+        assert kwargs["stdin"] == subprocess.DEVNULL
+        assert kwargs["start_new_session"] is True
+        atexit_reg.assert_called_once_with(_terminate, proc)
+        sig_teardown.assert_called_once_with(proc)
+
+
+def test_terminate_noop_when_already_dead():
+    proc = mock.MagicMock()
+    proc.poll.return_value = 0  # already exited
+    with mock.patch(f"{_MOD}.os.killpg") as killpg:
+        _terminate(proc)
+        killpg.assert_not_called()
+
+
+def test_terminate_escalates_to_sigkill_on_timeout():
+    proc = mock.MagicMock()
+    proc.poll.return_value = None  # still running
+    proc.wait.side_effect = subprocess.TimeoutExpired(cmd="x", timeout=5)
+    with (
+        mock.patch(f"{_MOD}.os.getpgid", return_value=4321),
+        mock.patch(f"{_MOD}.os.killpg") as killpg,
+    ):
+        _terminate(proc)
+        sigs = [c.args[1] for c in killpg.call_args_list]
+        assert sigs == [signal.SIGTERM, signal.SIGKILL]  # graceful then forced, whole group

--- a/tests/unit/test_dashboard_launcher.py
+++ b/tests/unit/test_dashboard_launcher.py
@@ -1,0 +1,40 @@
+"""Unit tests for aetherscan.dashboard_launcher.build_dashboard_command — the pure argv builder
+for the auto-launched Streamlit dashboard (the spawn itself is I/O and not unit-tested)."""
+
+from __future__ import annotations
+
+from aetherscan.dashboard_launcher import build_dashboard_command
+
+
+def test_build_dashboard_command_structure():
+    cmd = build_dashboard_command(
+        "/usr/bin/python",
+        "/repo/utils/dashboard.py",
+        "/out/db/aetherscan.db",
+        "final_v1",
+        "/out/plots",
+        8501,
+    )
+    # `python -m streamlit run <script>` up front
+    assert cmd[:5] == ["/usr/bin/python", "-m", "streamlit", "run", "/repo/utils/dashboard.py"]
+
+    # streamlit's own flags precede `--`; dashboard.py's argparse args follow it
+    sep = cmd.index("--")
+    streamlit_flags = cmd[5:sep]
+    script_args = cmd[sep + 1 :]
+
+    assert "--server.headless" in streamlit_flags
+    assert streamlit_flags[streamlit_flags.index("--server.port") + 1] == "8501"
+    assert script_args == [
+        "--db-path",
+        "/out/db/aetherscan.db",
+        "--tag",
+        "final_v1",
+        "--plots-dir",
+        "/out/plots",
+    ]
+
+
+def test_port_is_stringified():
+    cmd = build_dashboard_command("py", "d.py", "db", "t", "p", 9000)
+    assert "9000" in cmd and 9000 not in cmd  # streamlit needs a string port

--- a/utils/dashboard.py
+++ b/utils/dashboard.py
@@ -93,7 +93,7 @@ def load_resources(conn: sqlite3.Connection, tag: str) -> pd.DataFrame:
 
 def load_training_stats(conn: sqlite3.Connection, tag: str, stats: list[str]) -> pd.DataFrame:
     """Non-superseded beta_vae training_stats for `tag` limited to `stats` (and their val_
-    counterparts), ordered so curves plot in run order. Adds a monotonic `step` column."""
+    counterparts), ordered so curves plot in run order (round, epoch, timestamp)."""
     wanted = list(stats) + [f"val_{s}" for s in stats]
     placeholders = ",".join("?" * len(wanted))
     df = pd.read_sql_query(
@@ -184,7 +184,8 @@ def load_stages(conn: sqlite3.Connection, tag: str) -> pd.DataFrame:
 
 def parse_latent_matrix(snapshots: pd.DataFrame) -> tuple[np.ndarray, list[str]]:
     """Parse a latent_snapshots frame's JSON latent_vector column into an (n, d) float array +
-    the matching signal_type labels. Rows whose vector is malformed or ragged are dropped."""
+    the matching signal_type labels. Rows whose vector is malformed, ragged, or non-finite
+    (NaN/inf — json.loads accepts these and they blow up the downstream SVD) are dropped."""
     vecs, labels = [], []
     for _, row in snapshots.iterrows():
         try:
@@ -199,7 +200,12 @@ def parse_latent_matrix(snapshots: pd.DataFrame) -> tuple[np.ndarray, list[str]]
     width = len(vecs[0])
     keep = [(v, s) for v, s in zip(vecs, labels, strict=False) if len(v) == width]
     mat = np.array([v for v, _ in keep], dtype=float)
-    return mat, [s for _, s in keep]
+    labels_keep = [s for _, s in keep]
+    if mat.size:
+        finite = np.isfinite(mat).all(axis=1)
+        mat = mat[finite]
+        labels_keep = [s for s, f in zip(labels_keep, finite, strict=False) if f]
+    return mat, labels_keep
 
 
 def pca_2d(matrix: np.ndarray) -> np.ndarray:

--- a/utils/dashboard.py
+++ b/utils/dashboard.py
@@ -224,21 +224,31 @@ def pca_2d(matrix: np.ndarray) -> np.ndarray:
 
 
 def list_png_artifacts(plots_dir: str, limit: int = 60) -> list[dict]:
-    """Every *.png/*.gif under plots_dir (recursive), newest first: {path, name, rel, mtime}."""
+    """Every *.png/*.gif under plots_dir (recursive), newest first: {path, name, rel, mtime}.
+
+    Containment: plots_dir is realpath-resolved and every returned file's realpath is verified to
+    stay within that root, so a symlink inside the tree can't make the gallery serve a file from
+    outside the run's plots directory. (The dashboard is a single-operator local tool pointed at
+    their own run via the launch args, but this keeps the file-serving surface tightly bounded.)
+    """
     if not plots_dir or not os.path.isdir(plots_dir):
         return []
+    base = os.path.realpath(plots_dir)
     found = []
-    for root, _dirs, files in os.walk(plots_dir):
+    for root, _dirs, files in os.walk(base):
         for f in files:
-            if f.lower().endswith((".png", ".gif")):
-                p = os.path.join(root, f)
-                try:
-                    mtime = os.path.getmtime(p)
-                except OSError:
-                    continue
-                found.append(
-                    {"path": p, "name": f, "rel": os.path.relpath(p, plots_dir), "mtime": mtime}
-                )
+            if not f.lower().endswith((".png", ".gif")):
+                continue
+            real = os.path.realpath(os.path.join(root, f))
+            if real != base and not real.startswith(base + os.sep):
+                continue  # symlink escaping the plots tree — never serve it
+            try:
+                mtime = os.path.getmtime(real)
+            except OSError:
+                continue
+            found.append(
+                {"path": real, "name": f, "rel": os.path.relpath(real, base), "mtime": mtime}
+            )
     found.sort(key=lambda d: d["mtime"], reverse=True)
     return found[:limit]
 
@@ -315,7 +325,10 @@ def render(args: argparse.Namespace) -> None:  # pragma: no cover - requires Str
 
     with st.sidebar:
         st.header("Aetherscan run")
-        db_path = st.text_input("DB path", value=args.db_path)
+        # DB + plots paths come from the launch args only (NOT browser-editable text inputs), so a
+        # hosted instance can't be repointed at arbitrary filesystem paths from the browser.
+        db_path = args.db_path
+        st.caption(f"DB: `{db_path}`")
         try:
             conn = connect_ro(db_path)
         except sqlite3.OperationalError as e:
@@ -328,7 +341,8 @@ def render(args: argparse.Namespace) -> None:  # pragma: no cover - requires Str
         default_idx = tags.index(args.tag) if args.tag in tags else len(tags) - 1
         tag = st.selectbox("Tag", tags, index=default_idx)
         refresh = st.number_input("Auto-refresh (s, 0=off)", 0, 600, value=args.refresh)
-        plots_dir = st.text_input("Plots dir", value=args.plots_dir or default_plots_dir(db_path))
+        plots_dir = args.plots_dir or default_plots_dir(db_path)
+        st.caption(f"Plots: `{plots_dir}`")
 
     resources = load_resources(conn, tag)
     stages = load_stages(conn, tag)

--- a/utils/dashboard.py
+++ b/utils/dashboard.py
@@ -20,6 +20,11 @@ To watch a run on a cluster, SSH-forward the port:  ssh -L 8501:localhost:8501 b
 Read-only (mode=ro); the pipeline's writer-thread journaling makes concurrent reads safe. The data
 layer (load_* / parse / pca helpers) is pure and unit-tested against a synthetic DB; the Streamlit
 UI (render*) is a thin rendering shell that imports plotly/streamlit lazily.
+
+Auto-refresh uses a blocking `time.sleep(refresh) + st.rerun()` — deliberately version-robust (works
+on any Streamlit), at the cost of freezing sidebar/tooltip interaction during the sleep window. For
+a smoother non-blocking refresh, `pip install streamlit-autorefresh` (or use `st.fragment(run_every=)`
+on Streamlit >= 1.33) and swap it in.
 """
 
 from __future__ import annotations
@@ -261,12 +266,13 @@ def default_plots_dir(db_path: str) -> str:
 
 def run_summary(resources: pd.DataFrame, stages: pd.DataFrame) -> dict:
     """Headline dict: wall-clock span, #stages, latest stage, peak system RAM %."""
-    bounds = []
+    t_start: float | None = None
+    t_end: float | None = None
     if not stages.empty:
-        bounds = [stages["start_time"].min(), stages["end_time"].max()]
+        t_start, t_end = stages["start_time"].min(), stages["end_time"].max()
     elif not resources.empty:
-        bounds = [resources["timestamp"].min(), resources["timestamp"].max()]
-    wall = (bounds[1] - bounds[0]) if bounds else 0.0
+        t_start, t_end = resources["timestamp"].min(), resources["timestamp"].max()
+    wall = (t_end - t_start) if t_start is not None else 0.0
 
     latest_stage = None
     if not stages.empty:
@@ -336,6 +342,7 @@ def render(args: argparse.Namespace) -> None:  # pragma: no cover - requires Str
             st.stop()
         tags = list_tags(conn)
         if not tags:
+            conn.close()
             st.warning("No run tags found in this DB yet.")
             st.stop()
         default_idx = tags.index(args.tag) if args.tag in tags else len(tags) - 1
@@ -344,180 +351,200 @@ def render(args: argparse.Namespace) -> None:  # pragma: no cover - requires Str
         plots_dir = args.plots_dir or default_plots_dir(db_path)
         st.caption(f"Plots: `{plots_dir}`")
 
-    resources = load_resources(conn, tag)
-    stages = load_stages(conn, tag)
-    summary = run_summary(resources, stages)
+    try:
+        resources = load_resources(conn, tag)
+        stages = load_stages(conn, tag)
+        summary = run_summary(resources, stages)
 
-    st.title(f"Aetherscan — {tag}")
-    c1, c2, c3, c4 = st.columns(4)
-    c1.metric("Wall clock", _fmt_duration(summary["wall_s"]))
-    c2.metric("Stage spans", summary["n_stages"])
-    c3.metric("Latest stage", summary["latest_stage"] or "—")
-    c4.metric("Peak sys RAM", f"{summary['peak_ram_pct']:.0f}%" if summary["peak_ram_pct"] else "—")
+        st.title(f"Aetherscan — {tag}")
+        c1, c2, c3, c4 = st.columns(4)
+        c1.metric("Wall clock", _fmt_duration(summary["wall_s"]))
+        c2.metric("Stage spans", summary["n_stages"])
+        c3.metric("Latest stage", summary["latest_stage"] or "—")
+        c4.metric(
+            "Peak sys RAM", f"{summary['peak_ram_pct']:.0f}%" if summary["peak_ram_pct"] else "—"
+        )
 
-    tabs = st.tabs(
-        ["Training", "Injection", "Latent", "Resources", "Stages", "Inference", "All plots (PNG)"]
-    )
+        tabs = st.tabs(
+            [
+                "Training",
+                "Injection",
+                "Latent",
+                "Resources",
+                "Stages",
+                "Inference",
+                "All plots (PNG)",
+            ]
+        )
 
-    # --- Training loss + stability ----------------------------------------
-    with tabs[0]:
-        loss = load_training_stats(conn, tag, _LOSS_STATS)
-        stab = load_training_stats(conn, tag, _STABILITY_STATS)
-        if loss.empty and stab.empty:
-            st.caption("No beta_vae training_stats yet.")
-        for title, df in (("Loss curves", loss), ("Training stability", stab)):
-            if df.empty:
-                continue
-            st.subheader(title)
-            d = df.copy()
-            d["kind"] = d["stat_name"].str.replace("^val_", "", regex=True)
-            d["split"] = np.where(d["stat_name"].str.startswith("val_"), "val", "train")
-            for kind in sorted(d["kind"].unique()):
-                sub = d[d["kind"] == kind].copy()
-                sub["step"] = range(len(sub))
-                fig = px.line(sub, x="step", y="value", color="split", title=kind)
-                fig.update_layout(height=240, margin={"l": 10, "r": 10, "t": 40, "b": 10})
-                st.plotly_chart(fig, use_container_width=True)
-
-    # --- Injection stats ---------------------------------------------------
-    with tabs[1]:
-        inj = load_injection_stats(conn, tag)
-        if inj.empty:
-            st.caption("No injection_stats yet.")
-        else:
-            st.subheader("Injection stability (per round)")
-            stability = (
-                inj.assign(nonfinite=1 - inj["is_finite"].fillna(1))
-                .groupby("round_number")[["nonfinite", "slope_clamped"]]
-                .mean()
-                .reset_index()
-            )
-            fig = px.line(
-                stability,
-                x="round_number",
-                y=["nonfinite", "slope_clamped"],
-                title="mean non-finite / slope-clamp rate",
-                markers=True,
-            )
-            fig.update_layout(height=260, margin={"l": 10, "r": 10, "t": 40, "b": 10})
-            st.plotly_chart(fig, use_container_width=True)
-
-            st.subheader("Injected-signal / intensity stat distributions")
-            stat = st.selectbox("stat_name", sorted(inj["stat_name"].unique()))
-            sub = inj[(inj["stat_name"] == stat) & inj["value"].notna()]
-            color = "signal_type" if sub["signal_type"].notna().any() else None
-            fig = px.histogram(sub, x="value", color=color, barmode="overlay", nbins=60, title=stat)
-            fig.update_layout(height=300, margin={"l": 10, "r": 10, "t": 40, "b": 10})
-            st.plotly_chart(fig, use_container_width=True)
-
-    # --- Latent scatter (live PCA of the latest snapshot) ------------------
-    with tabs[2]:
-        snaps = load_latent_snapshots_latest(conn, tag)
-        mat, labels = parse_latent_matrix(snaps)
-        if mat.shape[0] == 0:
-            st.caption("No latent_snapshots yet.")
-        else:
-            proj = pca_2d(mat)
-            df = pd.DataFrame({"pc1": proj[:, 0], "pc2": proj[:, 1], "signal_type": labels})
-            st.subheader(f"Latent space — latest snapshot (PCA of {mat.shape[0]}×{mat.shape[1]})")
-            fig = px.scatter(df, x="pc1", y="pc2", color="signal_type", opacity=0.7)
-            fig.update_layout(height=520, margin={"l": 10, "r": 10, "t": 10, "b": 10})
-            st.plotly_chart(fig, use_container_width=True)
-            st.caption(
-                "Cheap PCA projection; the pipeline's saved UMAP animation is under All plots."
-            )
-
-    # --- Resource utilization ---------------------------------------------
-    with tabs[3]:
-        if resources.empty:
-            st.caption("No system_resources yet.")
-        else:
-            r = resources.copy()
-            r["t_min"] = (r["timestamp"] - r["timestamp"].min()) / 60.0
-            r["series"] = r["resource_type"] + ":" + r["resource_name"]
-            for rtype in ("cpu", "ram", "gpu"):
-                sub = r[r["resource_type"] == rtype]
-                if sub.empty:
+        # --- Training loss + stability ----------------------------------------
+        with tabs[0]:
+            loss = load_training_stats(conn, tag, _LOSS_STATS)
+            stab = load_training_stats(conn, tag, _STABILITY_STATS)
+            if loss.empty and stab.empty:
+                st.caption("No beta_vae training_stats yet.")
+            for title, df in (("Loss curves", loss), ("Training stability", stab)):
+                if df.empty:
                     continue
-                fig = px.line(sub, x="t_min", y="value", color="series", title=rtype.upper())
+                st.subheader(title)
+                d = df.copy()
+                d["kind"] = d["stat_name"].str.replace("^val_", "", regex=True)
+                d["split"] = np.where(d["stat_name"].str.startswith("val_"), "val", "train")
+                for kind in sorted(d["kind"].unique()):
+                    sub = d[d["kind"] == kind].copy()
+                    sub["step"] = range(len(sub))
+                    fig = px.line(sub, x="step", y="value", color="split", title=kind)
+                    fig.update_layout(height=240, margin={"l": 10, "r": 10, "t": 40, "b": 10})
+                    st.plotly_chart(fig, use_container_width=True)
+
+        # --- Injection stats ---------------------------------------------------
+        with tabs[1]:
+            inj = load_injection_stats(conn, tag)
+            if inj.empty:
+                st.caption("No injection_stats yet.")
+            else:
+                st.subheader("Injection stability (per round)")
+                stability = (
+                    inj.assign(nonfinite=1 - inj["is_finite"].fillna(1))
+                    .groupby("round_number")[["nonfinite", "slope_clamped"]]
+                    .mean()
+                    .reset_index()
+                )
+                fig = px.line(
+                    stability,
+                    x="round_number",
+                    y=["nonfinite", "slope_clamped"],
+                    title="mean non-finite / slope-clamp rate",
+                    markers=True,
+                )
+                fig.update_layout(height=260, margin={"l": 10, "r": 10, "t": 40, "b": 10})
+                st.plotly_chart(fig, use_container_width=True)
+
+                st.subheader("Injected-signal / intensity stat distributions")
+                stat = st.selectbox("stat_name", sorted(inj["stat_name"].unique()))
+                sub = inj[(inj["stat_name"] == stat) & inj["value"].notna()]
+                color = "signal_type" if sub["signal_type"].notna().any() else None
+                fig = px.histogram(
+                    sub, x="value", color=color, barmode="overlay", nbins=60, title=stat
+                )
+                fig.update_layout(height=300, margin={"l": 10, "r": 10, "t": 40, "b": 10})
+                st.plotly_chart(fig, use_container_width=True)
+
+        # --- Latent scatter (live PCA of the latest snapshot) ------------------
+        with tabs[2]:
+            snaps = load_latent_snapshots_latest(conn, tag)
+            mat, labels = parse_latent_matrix(snaps)
+            if mat.shape[0] == 0:
+                st.caption("No latent_snapshots yet.")
+            else:
+                proj = pca_2d(mat)
+                df = pd.DataFrame({"pc1": proj[:, 0], "pc2": proj[:, 1], "signal_type": labels})
+                st.subheader(
+                    f"Latent space — latest snapshot (PCA of {mat.shape[0]}×{mat.shape[1]})"
+                )
+                fig = px.scatter(df, x="pc1", y="pc2", color="signal_type", opacity=0.7)
+                fig.update_layout(height=520, margin={"l": 10, "r": 10, "t": 10, "b": 10})
+                st.plotly_chart(fig, use_container_width=True)
+                st.caption(
+                    "Cheap PCA projection; the pipeline's saved UMAP animation is under All plots."
+                )
+
+        # --- Resource utilization ---------------------------------------------
+        with tabs[3]:
+            if resources.empty:
+                st.caption("No system_resources yet.")
+            else:
+                r = resources.copy()
+                r["t_min"] = (r["timestamp"] - r["timestamp"].min()) / 60.0
+                r["series"] = r["resource_type"] + ":" + r["resource_name"]
+                for rtype in ("cpu", "ram", "gpu"):
+                    sub = r[r["resource_type"] == rtype]
+                    if sub.empty:
+                        continue
+                    fig = px.line(sub, x="t_min", y="value", color="series", title=rtype.upper())
+                    fig.update_layout(
+                        height=260,
+                        margin={"l": 10, "r": 10, "t": 40, "b": 10},
+                        xaxis_title="minutes",
+                        yaxis_title="%",
+                    )
+                    st.plotly_chart(fig, use_container_width=True)
+
+        # --- Stage timeline ----------------------------------------------------
+        with tabs[4]:
+            if stages.empty:
+                st.caption("No pipeline_stages yet (needs PR #134's benchmarking layer).")
+            else:
+                s = stages.copy()
+                t0 = s["start_time"].min()
+                s["start_min"] = (s["start_time"] - t0) / 60.0
+                s["dur_min"] = (s["end_time"] - s["start_time"]) / 60.0
+                s["family"] = s["stage"].str.split(".").str[0]
+                palette = px.colors.qualitative.Plotly
+                fig = go.Figure()
+                for i, fam in enumerate(sorted(s["family"].unique())):
+                    sub = s[s["family"] == fam]
+                    fig.add_bar(
+                        x=sub["dur_min"],
+                        base=sub["start_min"],
+                        y=sub["stage"],
+                        orientation="h",
+                        name=fam,
+                        marker_color=palette[i % len(palette)],
+                        customdata=sub[["duration_s", "depth"]],
+                        hovertemplate="%{y}<br>%{customdata[0]:.1f}s (depth %{customdata[1]})<extra></extra>",
+                    )
+                fig.update_yaxes(autorange="reversed")
+                fig.update_xaxes(title="minutes since first stage")
                 fig.update_layout(
-                    height=260,
-                    margin={"l": 10, "r": 10, "t": 40, "b": 10},
-                    xaxis_title="minutes",
-                    yaxis_title="%",
+                    height=max(300, 22 * s["stage"].nunique()),
+                    margin={"l": 10, "r": 10, "t": 20, "b": 10},
+                    barmode="overlay",
                 )
                 st.plotly_chart(fig, use_container_width=True)
 
-    # --- Stage timeline ----------------------------------------------------
-    with tabs[4]:
-        if stages.empty:
-            st.caption("No pipeline_stages yet (needs PR #134's benchmarking layer).")
-        else:
-            s = stages.copy()
-            t0 = s["start_time"].min()
-            s["start_min"] = (s["start_time"] - t0) / 60.0
-            s["dur_min"] = (s["end_time"] - s["start_time"]) / 60.0
-            s["family"] = s["stage"].str.split(".").str[0]
-            palette = px.colors.qualitative.Plotly
-            fig = go.Figure()
-            for i, fam in enumerate(sorted(s["family"].unique())):
-                sub = s[s["family"] == fam]
-                fig.add_bar(
-                    x=sub["dur_min"],
-                    base=sub["start_min"],
-                    y=sub["stage"],
-                    orientation="h",
-                    name=fam,
-                    marker_color=palette[i % len(palette)],
-                    customdata=sub[["duration_s", "depth"]],
-                    hovertemplate="%{y}<br>%{customdata[0]:.1f}s (depth %{customdata[1]})<extra></extra>",
-                )
-            fig.update_yaxes(autorange="reversed")
-            fig.update_xaxes(title="minutes since first stage")
-            fig.update_layout(
-                height=max(300, 22 * s["stage"].nunique()),
-                margin={"l": 10, "r": 10, "t": 20, "b": 10},
-                barmode="overlay",
-            )
-            st.plotly_chart(fig, use_container_width=True)
+        # --- Inference candidates ---------------------------------------------
+        with tabs[5]:
+            results = load_inference_results(conn, tag)
+            cadences = load_inference_cadences(conn, tag)
+            if results.empty and cadences.empty:
+                st.caption("No inference_results / inference_cadences yet.")
+            if not results.empty:
+                cands = results[results["prediction"] == 1]
+                st.subheader(f"Candidate confidence ({len(cands)} candidates)")
+                if not cands.empty:
+                    fig = px.histogram(cands, x="confidence", nbins=40)
+                    fig.update_layout(height=240, margin={"l": 10, "r": 10, "t": 10, "b": 10})
+                    st.plotly_chart(fig, use_container_width=True)
+                    for dim in ("target", "band"):
+                        if cands[dim].notna().any():
+                            counts = cands[dim].value_counts().reset_index()
+                            counts.columns = [dim, "candidates"]
+                            fig = px.bar(
+                                counts, x=dim, y="candidates", title=f"candidates per {dim}"
+                            )
+                            fig.update_layout(
+                                height=240, margin={"l": 10, "r": 10, "t": 40, "b": 10}
+                            )
+                            st.plotly_chart(fig, use_container_width=True)
+            if not cadences.empty:
+                st.subheader("Per-cadence manifest")
+                st.dataframe(cadences, use_container_width=True)
 
-    # --- Inference candidates ---------------------------------------------
-    with tabs[5]:
-        results = load_inference_results(conn, tag)
-        cadences = load_inference_cadences(conn, tag)
-        if results.empty and cadences.empty:
-            st.caption("No inference_results / inference_cadences yet.")
-        if not results.empty:
-            cands = results[results["prediction"] == 1]
-            st.subheader(f"Candidate confidence ({len(cands)} candidates)")
-            if not cands.empty:
-                fig = px.histogram(cands, x="confidence", nbins=40)
-                fig.update_layout(height=240, margin={"l": 10, "r": 10, "t": 10, "b": 10})
-                st.plotly_chart(fig, use_container_width=True)
-                for dim in ("target", "band"):
-                    if cands[dim].notna().any():
-                        counts = cands[dim].value_counts().reset_index()
-                        counts.columns = [dim, "candidates"]
-                        fig = px.bar(counts, x=dim, y="candidates", title=f"candidates per {dim}")
-                        fig.update_layout(height=240, margin={"l": 10, "r": 10, "t": 40, "b": 10})
-                        st.plotly_chart(fig, use_container_width=True)
-        if not cadences.empty:
-            st.subheader("Per-cadence manifest")
-            st.dataframe(cadences, use_container_width=True)
+        # --- All plots (PNG gallery) ------------------------------------------
+        with tabs[6]:
+            pngs = list_png_artifacts(plots_dir)
+            if not pngs:
+                st.caption(f"No plot PNGs under {plots_dir} yet.")
+            else:
+                st.caption(f"{len(pngs)} figures under {plots_dir} (newest first)")
+                cols = st.columns(2)
+                for i, art in enumerate(pngs):
+                    with cols[i % 2]:
+                        st.image(art["path"], caption=art["rel"], use_container_width=True)
 
-    # --- All plots (PNG gallery) ------------------------------------------
-    with tabs[6]:
-        pngs = list_png_artifacts(plots_dir)
-        if not pngs:
-            st.caption(f"No plot PNGs under {plots_dir} yet.")
-        else:
-            st.caption(f"{len(pngs)} figures under {plots_dir} (newest first)")
-            cols = st.columns(2)
-            for i, art in enumerate(pngs):
-                with cols[i % 2]:
-                    st.image(art["path"], caption=art["rel"], use_container_width=True)
-
-    conn.close()
+    finally:
+        conn.close()
 
     if refresh and refresh > 0:
         # sleep()+rerun() is the version-robust live refresh (works on any Streamlit); for a

--- a/utils/dashboard.py
+++ b/utils/dashboard.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""
+Live dashboard for an Aetherscan pipeline run, read straight from its SQLite DB.
+
+Renders, in one auto-refreshing page: resource utilization (CPU/RAM/GPU over time),
+training-loss curves, and the stage timeline (pipeline_stages, from the #134 benchmarking
+layer). Like utils/benchmark_report.py it is STANDALONE — no `aetherscan` imports, only
+stdlib sqlite3 + pandas + plotly + streamlit — so it runs against a live run's DB or one
+fetched from a cluster with utils/fetch_run_outputs.sh.
+
+    pip install streamlit plotly pandas          # not pipeline/container deps
+    streamlit run utils/dashboard.py -- --db-path /path/to/aetherscan.db --tag final_v1
+
+To watch a run on a cluster, SSH-forward the port and read the DB where it lives:
+    ssh -L 8501:localhost:8501 blpc3
+    # then on the cluster: streamlit run utils/dashboard.py -- --db-path .../aetherscan.db
+
+Read-only: opens the DB with mode=ro; the pipeline's writer-thread journaling makes
+concurrent reads safe. The data layer (load_* functions) is pure and unit-tested against a
+synthetic DB; the Streamlit UI is a thin rendering shell on top.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+
+import pandas as pd
+
+# --------------------------------------------------------------------------- #
+# Data layer — pure, unit-testable, no Streamlit                              #
+# --------------------------------------------------------------------------- #
+
+# Non-superseded filter reused across the supersede-aware tables
+_ALIVE = "COALESCE(superseded, 0) = 0"
+
+
+def connect_ro(db_path: str) -> sqlite3.Connection:
+    """Open the DB strictly read-only (won't create/lock a missing file for writing)."""
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def list_tags(conn: sqlite3.Connection) -> list[str]:
+    """All run tags present anywhere in the DB, most-recent-looking first."""
+    tags: set[str] = set()
+    for table in ("pipeline_stages", "system_resources", "training_stats"):
+        try:
+            rows = conn.execute(
+                f"SELECT DISTINCT tag FROM {table} WHERE tag IS NOT NULL"  # noqa: S608 (fixed table names)
+            ).fetchall()
+            tags.update(r[0] for r in rows)
+        except sqlite3.OperationalError:
+            continue  # table absent in an older schema
+    return sorted(tags)
+
+
+def load_resources(conn: sqlite3.Connection, tag: str) -> pd.DataFrame:
+    """system_resources rows for `tag` as a tidy frame (timestamp, resource_type,
+    resource_name, value, unit), ordered by time."""
+    return pd.read_sql_query(
+        "SELECT timestamp, resource_type, resource_name, value, unit "
+        "FROM system_resources WHERE tag = ? ORDER BY timestamp",
+        conn,
+        params=(tag,),
+    )
+
+
+def load_training_stats(conn: sqlite3.Connection, tag: str) -> pd.DataFrame:
+    """Non-superseded training_stats for `tag` (model_name, stat_name, value, round_number,
+    epoch_number, timestamp), ordered so loss curves plot in run order."""
+    return pd.read_sql_query(
+        "SELECT timestamp, model_name, stat_name, value, round_number, epoch_number "
+        f"FROM training_stats WHERE tag = ? AND {_ALIVE} "
+        "ORDER BY round_number, epoch_number, timestamp",
+        conn,
+        params=(tag,),
+    )
+
+
+def load_stages(conn: sqlite3.Connection, tag: str) -> pd.DataFrame:
+    """pipeline_stages spans for `tag` (stage, start_time, end_time, duration_s, metadata,
+    plus a derived `depth` = dot-name component count), ordered by start."""
+    df = pd.read_sql_query(
+        "SELECT stage, start_time, end_time, duration_s, metadata "
+        "FROM pipeline_stages WHERE tag = ? ORDER BY start_time",
+        conn,
+        params=(tag,),
+    )
+    if not df.empty:
+        df["depth"] = df["stage"].str.split(".").str.len()
+    return df
+
+
+def run_summary(resources: pd.DataFrame, stages: pd.DataFrame) -> dict:
+    """Small headline dict: wall-clock span, #stages, latest stage, peak system RAM %."""
+    starts = []
+    if not stages.empty:
+        starts = [stages["start_time"].min(), stages["end_time"].max()]
+    elif not resources.empty:
+        starts = [resources["timestamp"].min(), resources["timestamp"].max()]
+    wall = (starts[1] - starts[0]) if starts else 0.0
+
+    latest_stage = None
+    if not stages.empty:
+        latest_stage = stages.sort_values("start_time")["stage"].iloc[-1]
+
+    peak_ram = None
+    if not resources.empty:
+        ram = resources[
+            (resources["resource_type"] == "ram") & (resources["resource_name"] == "system_total")
+        ]
+        if not ram.empty:
+            peak_ram = float(ram["value"].max())
+
+    return {
+        "wall_s": float(wall),
+        "n_stages": int(len(stages)),
+        "latest_stage": latest_stage,
+        "peak_ram_pct": peak_ram,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Streamlit UI — thin shell over the data layer                               #
+# --------------------------------------------------------------------------- #
+
+
+def _parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description="Live Aetherscan run dashboard")
+    ap.add_argument("--db-path", required=True, help="Path to aetherscan.db")
+    ap.add_argument("--tag", default=None, help="Run tag (else pick in the sidebar)")
+    ap.add_argument("--refresh", type=int, default=10, help="Auto-refresh seconds (0 = off)")
+    # Streamlit passes script args after `--`; ignore anything it injects
+    args, _ = ap.parse_known_args()
+    return args
+
+
+def _fmt_duration(seconds: float) -> str:
+    seconds = int(seconds)
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    if h:
+        return f"{h}h{m:02d}m"
+    if m:
+        return f"{m}m{s:02d}s"
+    return f"{s}s"
+
+
+def render(args: argparse.Namespace) -> None:  # pragma: no cover - requires Streamlit runtime
+    import plotly.express as px  # noqa: PLC0415 (kept out of module scope so the data layer imports without plotly/streamlit)
+    import plotly.graph_objects as go  # noqa: PLC0415
+    import streamlit as st  # noqa: PLC0415
+
+    st.set_page_config(page_title="Aetherscan live", layout="wide")
+
+    with st.sidebar:
+        st.header("Aetherscan run")
+        db_path = st.text_input("DB path", value=args.db_path)
+        try:
+            conn = connect_ro(db_path)
+        except sqlite3.OperationalError as e:
+            st.error(f"Cannot open DB read-only: {e}")
+            st.stop()
+        tags = list_tags(conn)
+        if not tags:
+            st.warning("No run tags found in this DB yet.")
+            st.stop()
+        default_idx = tags.index(args.tag) if args.tag in tags else len(tags) - 1
+        tag = st.selectbox("Tag", tags, index=default_idx)
+        refresh = st.number_input("Auto-refresh (s, 0=off)", 0, 600, value=args.refresh)
+
+    resources = load_resources(conn, tag)
+    stages = load_stages(conn, tag)
+    training = load_training_stats(conn, tag)
+    summary = run_summary(resources, stages)
+
+    st.title(f"Aetherscan — {tag}")
+    c1, c2, c3, c4 = st.columns(4)
+    c1.metric("Wall clock", _fmt_duration(summary["wall_s"]))
+    c2.metric("Stage spans", summary["n_stages"])
+    c3.metric("Latest stage", summary["latest_stage"] or "—")
+    c4.metric("Peak sys RAM", f"{summary['peak_ram_pct']:.0f}%" if summary["peak_ram_pct"] else "—")
+
+    # --- Training loss -----------------------------------------------------
+    st.subheader("Training loss")
+    if training.empty:
+        st.caption("No training_stats yet.")
+    else:
+        training = training.copy()
+        training["step"] = range(len(training))
+        for stat in sorted(training["stat_name"].unique()):
+            sub = training[training["stat_name"] == stat]
+            fig = px.line(
+                sub,
+                x="step",
+                y="value",
+                color="round_number",
+                title=stat,
+                markers=False,
+            )
+            fig.update_layout(height=260, margin={"l": 10, "r": 10, "t": 40, "b": 10})
+            st.plotly_chart(fig, use_container_width=True)
+
+    # --- Resource utilization ---------------------------------------------
+    st.subheader("Resource utilization")
+    if resources.empty:
+        st.caption("No system_resources yet.")
+    else:
+        r = resources.copy()
+        r["t_min"] = (r["timestamp"] - r["timestamp"].min()) / 60.0
+        r["series"] = r["resource_type"] + ":" + r["resource_name"]
+        for rtype in ("cpu", "ram", "gpu"):
+            sub = r[r["resource_type"] == rtype]
+            if sub.empty:
+                continue
+            fig = px.line(sub, x="t_min", y="value", color="series", title=rtype.upper())
+            fig.update_layout(
+                height=260,
+                margin={"l": 10, "r": 10, "t": 40, "b": 10},
+                xaxis_title="minutes",
+                yaxis_title="%",
+            )
+            st.plotly_chart(fig, use_container_width=True)
+
+    # --- Stage timeline ----------------------------------------------------
+    st.subheader("Stage timeline")
+    if stages.empty:
+        st.caption("No pipeline_stages yet.")
+    else:
+        s = stages.copy()
+        t0 = s["start_time"].min()
+        s["start_min"] = (s["start_time"] - t0) / 60.0
+        s["dur_min"] = (s["end_time"] - s["start_time"]) / 60.0
+        s["family"] = s["stage"].str.split(".").str[0]
+        # Numeric Gantt via horizontal bars with an explicit base (px.timeline assumes
+        # datetime x-axes, which mis-renders float "minutes"). One trace per family for color.
+        palette = px.colors.qualitative.Plotly
+        fig = go.Figure()
+        for i, fam in enumerate(sorted(s["family"].unique())):
+            sub = s[s["family"] == fam]
+            fig.add_bar(
+                x=sub["dur_min"],
+                base=sub["start_min"],
+                y=sub["stage"],
+                orientation="h",
+                name=fam,
+                marker_color=palette[i % len(palette)],
+                customdata=sub[["duration_s", "depth"]],
+                hovertemplate="%{y}<br>%{customdata[0]:.1f}s (depth %{customdata[1]})<extra></extra>",
+            )
+        fig.update_yaxes(autorange="reversed")
+        fig.update_xaxes(title="minutes since first stage")
+        fig.update_layout(
+            height=max(300, 22 * s["stage"].nunique()),
+            margin={"l": 10, "r": 10, "t": 20, "b": 10},
+            barmode="overlay",
+        )
+        st.plotly_chart(fig, use_container_width=True)
+
+    conn.close()
+
+    if refresh and refresh > 0:
+        # Re-run the whole script every `refresh` seconds for a live view. sleep()+rerun() is
+        # the version-robust way (works on any Streamlit); for a smoother non-blocking refresh,
+        # `pip install streamlit-autorefresh` and swap in st_autorefresh().
+        import time  # noqa: PLC0415
+
+        time.sleep(refresh)
+        st.rerun()
+
+
+def main() -> None:  # pragma: no cover
+    render(_parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/dashboard.py
+++ b/utils/dashboard.py
@@ -2,29 +2,34 @@
 """
 Live dashboard for an Aetherscan pipeline run, read straight from its SQLite DB.
 
-Renders, in one auto-refreshing page: resource utilization (CPU/RAM/GPU over time),
-training-loss curves, and the stage timeline (pipeline_stages, from the #134 benchmarking
-layer). Like utils/benchmark_report.py it is STANDALONE — no `aetherscan` imports, only
-stdlib sqlite3 + pandas + plotly + streamlit — so it runs against a live run's DB or one
-fetched from a cluster with utils/fetch_run_outputs.sh.
+Renders, in one auto-refreshing page, every run metric that is reconstructable from the DB —
+resource utilization (CPU/RAM/GPU), beta-VAE loss + stability curves, the signal-injection
+stats suite, a live latent-space scatter, the stage timeline (PR #134), and inference candidate
+stats — plus a gallery of every saved plot PNG (RF diagnostics, latent traversals, inference
+figures) as it appears on disk.
 
-    pip install streamlit plotly pandas          # not pipeline/container deps
+Like utils/benchmark_report.py it is STANDALONE — no `aetherscan` imports, only stdlib sqlite3 +
+numpy + pandas + plotly + streamlit — so it runs against a live run's DB or one fetched from a
+cluster with utils/fetch_run_outputs.sh. main.py auto-launches it (--no-dashboard to opt out); it
+can also be run by hand:
+
     streamlit run utils/dashboard.py -- --db-path /path/to/aetherscan.db --tag final_v1
 
-To watch a run on a cluster, SSH-forward the port and read the DB where it lives:
-    ssh -L 8501:localhost:8501 blpc3
-    # then on the cluster: streamlit run utils/dashboard.py -- --db-path .../aetherscan.db
+To watch a run on a cluster, SSH-forward the port:  ssh -L 8501:localhost:8501 blpc3
 
-Read-only: opens the DB with mode=ro; the pipeline's writer-thread journaling makes
-concurrent reads safe. The data layer (load_* functions) is pure and unit-tested against a
-synthetic DB; the Streamlit UI is a thin rendering shell on top.
+Read-only (mode=ro); the pipeline's writer-thread journaling makes concurrent reads safe. The data
+layer (load_* / parse / pca helpers) is pure and unit-tested against a synthetic DB; the Streamlit
+UI (render*) is a thin rendering shell that imports plotly/streamlit lazily.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
+import os
 import sqlite3
 
+import numpy as np
 import pandas as pd
 
 # --------------------------------------------------------------------------- #
@@ -34,6 +39,17 @@ import pandas as pd
 # Non-superseded filter reused across the supersede-aware tables
 _ALIVE = "COALESCE(superseded, 0) = 0"
 
+# beta-VAE stat_names split into the two training figures (train.py loss curves / stability)
+_LOSS_STATS = [
+    "total_loss",
+    "reconstruction_loss",
+    "kl_loss",
+    "true_loss",
+    "false_loss",
+    "learning_rate",
+]
+_STABILITY_STATS = ["clipping_rate", "gradient_norm_mean", "gradient_norm_std", "gradient_norm_max"]
+
 
 def connect_ro(db_path: str) -> sqlite3.Connection:
     """Open the DB strictly read-only (won't create/lock a missing file for writing)."""
@@ -42,13 +58,22 @@ def connect_ro(db_path: str) -> sqlite3.Connection:
     return conn
 
 
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)
+        ).fetchone()
+        is not None
+    )
+
+
 def list_tags(conn: sqlite3.Connection) -> list[str]:
-    """All run tags present anywhere in the DB, most-recent-looking first."""
+    """All run tags present anywhere in the DB, sorted."""
     tags: set[str] = set()
-    for table in ("pipeline_stages", "system_resources", "training_stats"):
+    for table in ("pipeline_stages", "system_resources", "training_stats", "inference_cadences"):
         try:
             rows = conn.execute(
-                f"SELECT DISTINCT tag FROM {table} WHERE tag IS NOT NULL"  # noqa: S608 (fixed table names)
+                f"SELECT DISTINCT tag FROM {table} WHERE tag IS NOT NULL"  # noqa: S608 (fixed names)
             ).fetchall()
             tags.update(r[0] for r in rows)
         except sqlite3.OperationalError:
@@ -57,8 +82,7 @@ def list_tags(conn: sqlite3.Connection) -> list[str]:
 
 
 def load_resources(conn: sqlite3.Connection, tag: str) -> pd.DataFrame:
-    """system_resources rows for `tag` as a tidy frame (timestamp, resource_type,
-    resource_name, value, unit), ordered by time."""
+    """system_resources rows for `tag` (timestamp, resource_type, resource_name, value, unit)."""
     return pd.read_sql_query(
         "SELECT timestamp, resource_type, resource_name, value, unit "
         "FROM system_resources WHERE tag = ? ORDER BY timestamp",
@@ -67,21 +91,86 @@ def load_resources(conn: sqlite3.Connection, tag: str) -> pd.DataFrame:
     )
 
 
-def load_training_stats(conn: sqlite3.Connection, tag: str) -> pd.DataFrame:
-    """Non-superseded training_stats for `tag` (model_name, stat_name, value, round_number,
-    epoch_number, timestamp), ordered so loss curves plot in run order."""
-    return pd.read_sql_query(
-        "SELECT timestamp, model_name, stat_name, value, round_number, epoch_number "
-        f"FROM training_stats WHERE tag = ? AND {_ALIVE} "
+def load_training_stats(conn: sqlite3.Connection, tag: str, stats: list[str]) -> pd.DataFrame:
+    """Non-superseded beta_vae training_stats for `tag` limited to `stats` (and their val_
+    counterparts), ordered so curves plot in run order. Adds a monotonic `step` column."""
+    wanted = list(stats) + [f"val_{s}" for s in stats]
+    placeholders = ",".join("?" * len(wanted))
+    df = pd.read_sql_query(
+        "SELECT timestamp, stat_name, value, round_number, epoch_number "
+        f"FROM training_stats WHERE tag = ? AND model_name = 'beta_vae' AND {_ALIVE} "
+        f"AND stat_name IN ({placeholders}) "  # noqa: S608 (placeholders are bound params)
         "ORDER BY round_number, epoch_number, timestamp",
+        conn,
+        params=(tag, *wanted),
+    )
+    return df
+
+
+def load_injection_stats(conn: sqlite3.Connection, tag: str) -> pd.DataFrame:
+    """Non-superseded injection_stats for `tag` (stat_name, value, signal_type, injection_stage,
+    round_number, is_finite, slope_clamped, timestamp)."""
+    return pd.read_sql_query(
+        "SELECT timestamp, stat_name, value, signal_type, injection_stage, round_number, "
+        "is_finite, slope_clamped "
+        f"FROM injection_stats WHERE tag = ? AND {_ALIVE} ORDER BY timestamp",
+        conn,
+        params=(tag,),
+    )
+
+
+def load_latent_snapshots_latest(conn: sqlite3.Connection, tag: str) -> pd.DataFrame:
+    """The most recent latent_snapshots frame for `tag` (all rows sharing the max
+    round/epoch/step), as (signal_type, latent_vector[JSON]). Empty if none."""
+    if not _table_exists(conn, "latent_snapshots"):
+        return pd.DataFrame(columns=["signal_type", "latent_vector"])
+    key = conn.execute(
+        "SELECT round_number, epoch_number, step_number FROM latent_snapshots "
+        f"WHERE tag = ? AND {_ALIVE} "
+        "ORDER BY round_number DESC, epoch_number DESC, step_number DESC LIMIT 1",
+        (tag,),
+    ).fetchone()
+    if key is None:
+        return pd.DataFrame(columns=["signal_type", "latent_vector"])
+    return pd.read_sql_query(
+        "SELECT signal_type, latent_vector FROM latent_snapshots "
+        f"WHERE tag = ? AND {_ALIVE} AND round_number = ? AND epoch_number = ? AND step_number = ?",
+        conn,
+        params=(tag, key["round_number"], key["epoch_number"], key["step_number"]),
+    )
+
+
+def load_inference_results(conn: sqlite3.Connection, tag: str) -> pd.DataFrame:
+    """Non-superseded inference_results for `tag` (prediction, confidence, target, band,
+    frequency_mhz). Empty frame if the table is absent."""
+    if not _table_exists(conn, "inference_results"):
+        return pd.DataFrame(columns=["prediction", "confidence", "target", "band", "frequency_mhz"])
+    return pd.read_sql_query(
+        "SELECT prediction, confidence, target, band, frequency_mhz "
+        f"FROM inference_results WHERE tag = ? AND {_ALIVE}",
+        conn,
+        params=(tag,),
+    )
+
+
+def load_inference_cadences(conn: sqlite3.Connection, tag: str) -> pd.DataFrame:
+    """Non-superseded inference_cadences manifest rows for `tag` (status, duration_s, n_stamps,
+    n_candidates). Empty frame if the table is absent."""
+    if not _table_exists(conn, "inference_cadences"):
+        return pd.DataFrame(columns=["status", "duration_s", "n_stamps", "n_candidates"])
+    return pd.read_sql_query(
+        "SELECT status, duration_s, n_stamps, n_candidates "
+        f"FROM inference_cadences WHERE tag = ? AND {_ALIVE}",
         conn,
         params=(tag,),
     )
 
 
 def load_stages(conn: sqlite3.Connection, tag: str) -> pd.DataFrame:
-    """pipeline_stages spans for `tag` (stage, start_time, end_time, duration_s, metadata,
-    plus a derived `depth` = dot-name component count), ordered by start."""
+    """pipeline_stages spans for `tag` (stage, start_time, end_time, duration_s, metadata) plus a
+    derived `depth` (dot-name component count), ordered by start. Empty if the table is absent."""
+    if not _table_exists(conn, "pipeline_stages"):
+        return pd.DataFrame(columns=["stage", "start_time", "end_time", "duration_s", "metadata"])
     df = pd.read_sql_query(
         "SELECT stage, start_time, end_time, duration_s, metadata "
         "FROM pipeline_stages WHERE tag = ? ORDER BY start_time",
@@ -93,14 +182,75 @@ def load_stages(conn: sqlite3.Connection, tag: str) -> pd.DataFrame:
     return df
 
 
+def parse_latent_matrix(snapshots: pd.DataFrame) -> tuple[np.ndarray, list[str]]:
+    """Parse a latent_snapshots frame's JSON latent_vector column into an (n, d) float array +
+    the matching signal_type labels. Rows whose vector is malformed or ragged are dropped."""
+    vecs, labels = [], []
+    for _, row in snapshots.iterrows():
+        try:
+            v = json.loads(row["latent_vector"])
+        except (TypeError, ValueError):
+            continue
+        if isinstance(v, list) and v:
+            vecs.append(v)
+            labels.append(row["signal_type"])
+    if not vecs:
+        return np.empty((0, 0)), []
+    width = len(vecs[0])
+    keep = [(v, s) for v, s in zip(vecs, labels, strict=False) if len(v) == width]
+    mat = np.array([v for v, _ in keep], dtype=float)
+    return mat, [s for _, s in keep]
+
+
+def pca_2d(matrix: np.ndarray) -> np.ndarray:
+    """Project (n, d) -> (n, 2) via mean-centered SVD (numpy-only PCA; no sklearn). Returns a
+    (n, 2) array; if d < 2 the missing component(s) are zero-filled."""
+    if matrix.size == 0 or matrix.shape[0] == 0:
+        return np.empty((0, 2))
+    centered = matrix - matrix.mean(axis=0, keepdims=True)
+    # economy SVD; right singular vectors are the principal axes
+    _, _, vt = np.linalg.svd(centered, full_matrices=False)
+    comps = vt[:2] if vt.shape[0] >= 2 else vt
+    proj = centered @ comps.T
+    if proj.shape[1] == 1:  # degenerate d==1
+        proj = np.hstack([proj, np.zeros((proj.shape[0], 1))])
+    return proj
+
+
+def list_png_artifacts(plots_dir: str, limit: int = 60) -> list[dict]:
+    """Every *.png/*.gif under plots_dir (recursive), newest first: {path, name, rel, mtime}."""
+    if not plots_dir or not os.path.isdir(plots_dir):
+        return []
+    found = []
+    for root, _dirs, files in os.walk(plots_dir):
+        for f in files:
+            if f.lower().endswith((".png", ".gif")):
+                p = os.path.join(root, f)
+                try:
+                    mtime = os.path.getmtime(p)
+                except OSError:
+                    continue
+                found.append(
+                    {"path": p, "name": f, "rel": os.path.relpath(p, plots_dir), "mtime": mtime}
+                )
+    found.sort(key=lambda d: d["mtime"], reverse=True)
+    return found[:limit]
+
+
+def default_plots_dir(db_path: str) -> str:
+    """Infer {output_path}/plots from the DB path (…/{output_path}/db/aetherscan.db)."""
+    db_dir = os.path.dirname(os.path.abspath(db_path))  # …/db
+    return os.path.join(os.path.dirname(db_dir), "plots")
+
+
 def run_summary(resources: pd.DataFrame, stages: pd.DataFrame) -> dict:
-    """Small headline dict: wall-clock span, #stages, latest stage, peak system RAM %."""
-    starts = []
+    """Headline dict: wall-clock span, #stages, latest stage, peak system RAM %."""
+    bounds = []
     if not stages.empty:
-        starts = [stages["start_time"].min(), stages["end_time"].max()]
+        bounds = [stages["start_time"].min(), stages["end_time"].max()]
     elif not resources.empty:
-        starts = [resources["timestamp"].min(), resources["timestamp"].max()]
-    wall = (starts[1] - starts[0]) if starts else 0.0
+        bounds = [resources["timestamp"].min(), resources["timestamp"].max()]
+    wall = (bounds[1] - bounds[0]) if bounds else 0.0
 
     latest_stage = None
     if not stages.empty:
@@ -123,7 +273,7 @@ def run_summary(resources: pd.DataFrame, stages: pd.DataFrame) -> dict:
 
 
 # --------------------------------------------------------------------------- #
-# Streamlit UI — thin shell over the data layer                               #
+# Streamlit UI — thin shell over the data layer (imports plotly/streamlit lazily)
 # --------------------------------------------------------------------------- #
 
 
@@ -131,9 +281,11 @@ def _parse_args() -> argparse.Namespace:
     ap = argparse.ArgumentParser(description="Live Aetherscan run dashboard")
     ap.add_argument("--db-path", required=True, help="Path to aetherscan.db")
     ap.add_argument("--tag", default=None, help="Run tag (else pick in the sidebar)")
+    ap.add_argument(
+        "--plots-dir", default=None, help="Plots dir (default: inferred from --db-path)"
+    )
     ap.add_argument("--refresh", type=int, default=10, help="Auto-refresh seconds (0 = off)")
-    # Streamlit passes script args after `--`; ignore anything it injects
-    args, _ = ap.parse_known_args()
+    args, _ = ap.parse_known_args()  # streamlit injects extra args after `--`
     return args
 
 
@@ -149,7 +301,7 @@ def _fmt_duration(seconds: float) -> str:
 
 
 def render(args: argparse.Namespace) -> None:  # pragma: no cover - requires Streamlit runtime
-    import plotly.express as px  # noqa: PLC0415 (kept out of module scope so the data layer imports without plotly/streamlit)
+    import plotly.express as px  # noqa: PLC0415 (lazy so the data layer imports without plotly)
     import plotly.graph_objects as go  # noqa: PLC0415
     import streamlit as st  # noqa: PLC0415
 
@@ -170,10 +322,10 @@ def render(args: argparse.Namespace) -> None:  # pragma: no cover - requires Str
         default_idx = tags.index(args.tag) if args.tag in tags else len(tags) - 1
         tag = st.selectbox("Tag", tags, index=default_idx)
         refresh = st.number_input("Auto-refresh (s, 0=off)", 0, 600, value=args.refresh)
+        plots_dir = st.text_input("Plots dir", value=args.plots_dir or default_plots_dir(db_path))
 
     resources = load_resources(conn, tag)
     stages = load_stages(conn, tag)
-    training = load_training_stats(conn, tag)
     summary = run_summary(resources, stages)
 
     st.title(f"Aetherscan — {tag}")
@@ -183,88 +335,173 @@ def render(args: argparse.Namespace) -> None:  # pragma: no cover - requires Str
     c3.metric("Latest stage", summary["latest_stage"] or "—")
     c4.metric("Peak sys RAM", f"{summary['peak_ram_pct']:.0f}%" if summary["peak_ram_pct"] else "—")
 
-    # --- Training loss -----------------------------------------------------
-    st.subheader("Training loss")
-    if training.empty:
-        st.caption("No training_stats yet.")
-    else:
-        training = training.copy()
-        training["step"] = range(len(training))
-        for stat in sorted(training["stat_name"].unique()):
-            sub = training[training["stat_name"] == stat]
+    tabs = st.tabs(
+        ["Training", "Injection", "Latent", "Resources", "Stages", "Inference", "All plots (PNG)"]
+    )
+
+    # --- Training loss + stability ----------------------------------------
+    with tabs[0]:
+        loss = load_training_stats(conn, tag, _LOSS_STATS)
+        stab = load_training_stats(conn, tag, _STABILITY_STATS)
+        if loss.empty and stab.empty:
+            st.caption("No beta_vae training_stats yet.")
+        for title, df in (("Loss curves", loss), ("Training stability", stab)):
+            if df.empty:
+                continue
+            st.subheader(title)
+            d = df.copy()
+            d["kind"] = d["stat_name"].str.replace("^val_", "", regex=True)
+            d["split"] = np.where(d["stat_name"].str.startswith("val_"), "val", "train")
+            for kind in sorted(d["kind"].unique()):
+                sub = d[d["kind"] == kind].copy()
+                sub["step"] = range(len(sub))
+                fig = px.line(sub, x="step", y="value", color="split", title=kind)
+                fig.update_layout(height=240, margin={"l": 10, "r": 10, "t": 40, "b": 10})
+                st.plotly_chart(fig, use_container_width=True)
+
+    # --- Injection stats ---------------------------------------------------
+    with tabs[1]:
+        inj = load_injection_stats(conn, tag)
+        if inj.empty:
+            st.caption("No injection_stats yet.")
+        else:
+            st.subheader("Injection stability (per round)")
+            stability = (
+                inj.assign(nonfinite=1 - inj["is_finite"].fillna(1))
+                .groupby("round_number")[["nonfinite", "slope_clamped"]]
+                .mean()
+                .reset_index()
+            )
             fig = px.line(
-                sub,
-                x="step",
-                y="value",
-                color="round_number",
-                title=stat,
-                markers=False,
+                stability,
+                x="round_number",
+                y=["nonfinite", "slope_clamped"],
+                title="mean non-finite / slope-clamp rate",
+                markers=True,
             )
             fig.update_layout(height=260, margin={"l": 10, "r": 10, "t": 40, "b": 10})
             st.plotly_chart(fig, use_container_width=True)
 
+            st.subheader("Injected-signal / intensity stat distributions")
+            stat = st.selectbox("stat_name", sorted(inj["stat_name"].unique()))
+            sub = inj[(inj["stat_name"] == stat) & inj["value"].notna()]
+            color = "signal_type" if sub["signal_type"].notna().any() else None
+            fig = px.histogram(sub, x="value", color=color, barmode="overlay", nbins=60, title=stat)
+            fig.update_layout(height=300, margin={"l": 10, "r": 10, "t": 40, "b": 10})
+            st.plotly_chart(fig, use_container_width=True)
+
+    # --- Latent scatter (live PCA of the latest snapshot) ------------------
+    with tabs[2]:
+        snaps = load_latent_snapshots_latest(conn, tag)
+        mat, labels = parse_latent_matrix(snaps)
+        if mat.shape[0] == 0:
+            st.caption("No latent_snapshots yet.")
+        else:
+            proj = pca_2d(mat)
+            df = pd.DataFrame({"pc1": proj[:, 0], "pc2": proj[:, 1], "signal_type": labels})
+            st.subheader(f"Latent space — latest snapshot (PCA of {mat.shape[0]}×{mat.shape[1]})")
+            fig = px.scatter(df, x="pc1", y="pc2", color="signal_type", opacity=0.7)
+            fig.update_layout(height=520, margin={"l": 10, "r": 10, "t": 10, "b": 10})
+            st.plotly_chart(fig, use_container_width=True)
+            st.caption(
+                "Cheap PCA projection; the pipeline's saved UMAP animation is under All plots."
+            )
+
     # --- Resource utilization ---------------------------------------------
-    st.subheader("Resource utilization")
-    if resources.empty:
-        st.caption("No system_resources yet.")
-    else:
-        r = resources.copy()
-        r["t_min"] = (r["timestamp"] - r["timestamp"].min()) / 60.0
-        r["series"] = r["resource_type"] + ":" + r["resource_name"]
-        for rtype in ("cpu", "ram", "gpu"):
-            sub = r[r["resource_type"] == rtype]
-            if sub.empty:
-                continue
-            fig = px.line(sub, x="t_min", y="value", color="series", title=rtype.upper())
+    with tabs[3]:
+        if resources.empty:
+            st.caption("No system_resources yet.")
+        else:
+            r = resources.copy()
+            r["t_min"] = (r["timestamp"] - r["timestamp"].min()) / 60.0
+            r["series"] = r["resource_type"] + ":" + r["resource_name"]
+            for rtype in ("cpu", "ram", "gpu"):
+                sub = r[r["resource_type"] == rtype]
+                if sub.empty:
+                    continue
+                fig = px.line(sub, x="t_min", y="value", color="series", title=rtype.upper())
+                fig.update_layout(
+                    height=260,
+                    margin={"l": 10, "r": 10, "t": 40, "b": 10},
+                    xaxis_title="minutes",
+                    yaxis_title="%",
+                )
+                st.plotly_chart(fig, use_container_width=True)
+
+    # --- Stage timeline ----------------------------------------------------
+    with tabs[4]:
+        if stages.empty:
+            st.caption("No pipeline_stages yet (needs PR #134's benchmarking layer).")
+        else:
+            s = stages.copy()
+            t0 = s["start_time"].min()
+            s["start_min"] = (s["start_time"] - t0) / 60.0
+            s["dur_min"] = (s["end_time"] - s["start_time"]) / 60.0
+            s["family"] = s["stage"].str.split(".").str[0]
+            palette = px.colors.qualitative.Plotly
+            fig = go.Figure()
+            for i, fam in enumerate(sorted(s["family"].unique())):
+                sub = s[s["family"] == fam]
+                fig.add_bar(
+                    x=sub["dur_min"],
+                    base=sub["start_min"],
+                    y=sub["stage"],
+                    orientation="h",
+                    name=fam,
+                    marker_color=palette[i % len(palette)],
+                    customdata=sub[["duration_s", "depth"]],
+                    hovertemplate="%{y}<br>%{customdata[0]:.1f}s (depth %{customdata[1]})<extra></extra>",
+                )
+            fig.update_yaxes(autorange="reversed")
+            fig.update_xaxes(title="minutes since first stage")
             fig.update_layout(
-                height=260,
-                margin={"l": 10, "r": 10, "t": 40, "b": 10},
-                xaxis_title="minutes",
-                yaxis_title="%",
+                height=max(300, 22 * s["stage"].nunique()),
+                margin={"l": 10, "r": 10, "t": 20, "b": 10},
+                barmode="overlay",
             )
             st.plotly_chart(fig, use_container_width=True)
 
-    # --- Stage timeline ----------------------------------------------------
-    st.subheader("Stage timeline")
-    if stages.empty:
-        st.caption("No pipeline_stages yet.")
-    else:
-        s = stages.copy()
-        t0 = s["start_time"].min()
-        s["start_min"] = (s["start_time"] - t0) / 60.0
-        s["dur_min"] = (s["end_time"] - s["start_time"]) / 60.0
-        s["family"] = s["stage"].str.split(".").str[0]
-        # Numeric Gantt via horizontal bars with an explicit base (px.timeline assumes
-        # datetime x-axes, which mis-renders float "minutes"). One trace per family for color.
-        palette = px.colors.qualitative.Plotly
-        fig = go.Figure()
-        for i, fam in enumerate(sorted(s["family"].unique())):
-            sub = s[s["family"] == fam]
-            fig.add_bar(
-                x=sub["dur_min"],
-                base=sub["start_min"],
-                y=sub["stage"],
-                orientation="h",
-                name=fam,
-                marker_color=palette[i % len(palette)],
-                customdata=sub[["duration_s", "depth"]],
-                hovertemplate="%{y}<br>%{customdata[0]:.1f}s (depth %{customdata[1]})<extra></extra>",
-            )
-        fig.update_yaxes(autorange="reversed")
-        fig.update_xaxes(title="minutes since first stage")
-        fig.update_layout(
-            height=max(300, 22 * s["stage"].nunique()),
-            margin={"l": 10, "r": 10, "t": 20, "b": 10},
-            barmode="overlay",
-        )
-        st.plotly_chart(fig, use_container_width=True)
+    # --- Inference candidates ---------------------------------------------
+    with tabs[5]:
+        results = load_inference_results(conn, tag)
+        cadences = load_inference_cadences(conn, tag)
+        if results.empty and cadences.empty:
+            st.caption("No inference_results / inference_cadences yet.")
+        if not results.empty:
+            cands = results[results["prediction"] == 1]
+            st.subheader(f"Candidate confidence ({len(cands)} candidates)")
+            if not cands.empty:
+                fig = px.histogram(cands, x="confidence", nbins=40)
+                fig.update_layout(height=240, margin={"l": 10, "r": 10, "t": 10, "b": 10})
+                st.plotly_chart(fig, use_container_width=True)
+                for dim in ("target", "band"):
+                    if cands[dim].notna().any():
+                        counts = cands[dim].value_counts().reset_index()
+                        counts.columns = [dim, "candidates"]
+                        fig = px.bar(counts, x=dim, y="candidates", title=f"candidates per {dim}")
+                        fig.update_layout(height=240, margin={"l": 10, "r": 10, "t": 40, "b": 10})
+                        st.plotly_chart(fig, use_container_width=True)
+        if not cadences.empty:
+            st.subheader("Per-cadence manifest")
+            st.dataframe(cadences, use_container_width=True)
+
+    # --- All plots (PNG gallery) ------------------------------------------
+    with tabs[6]:
+        pngs = list_png_artifacts(plots_dir)
+        if not pngs:
+            st.caption(f"No plot PNGs under {plots_dir} yet.")
+        else:
+            st.caption(f"{len(pngs)} figures under {plots_dir} (newest first)")
+            cols = st.columns(2)
+            for i, art in enumerate(pngs):
+                with cols[i % 2]:
+                    st.image(art["path"], caption=art["rel"], use_container_width=True)
 
     conn.close()
 
     if refresh and refresh > 0:
-        # Re-run the whole script every `refresh` seconds for a live view. sleep()+rerun() is
-        # the version-robust way (works on any Streamlit); for a smoother non-blocking refresh,
-        # `pip install streamlit-autorefresh` and swap in st_autorefresh().
+        # sleep()+rerun() is the version-robust live refresh (works on any Streamlit); for a
+        # smoother non-blocking refresh, `pip install streamlit-autorefresh` and swap it in.
         import time  # noqa: PLC0415
 
         time.sleep(refresh)


### PR DESCRIPTION
Closes #169.

Adds `utils/dashboard.py` — a live, auto-refreshing Streamlit dashboard that reads a run's SQLite DB and shows **resource utilization** (CPU/RAM/GPU), **training-loss curves**, and the **#134 stage timeline** in one page.

### Design
- **Standalone / no `aetherscan` imports** (stdlib `sqlite3` + pandas + plotly + streamlit), mirroring `benchmark_report.py`'s cluster-portable design — runs against a live run's DB *or* one fetched with `fetch_run_outputs.sh`. Opened read-only (`mode=ro`); the writer thread's journaling makes concurrent reads safe.
- **Testable data layer** (`connect_ro` / `list_tags` / `load_resources` / `load_training_stats` / `load_stages` / `run_summary`) — pure functions, unit-tested against a synthetic DB in `tests/unit/test_dashboard.py` (superseded-row filter, derived stage depth, run summary, empty-tag safety, read-only enforcement). `plotly`/`streamlit` are imported lazily inside `render()`, so the module and its tests import with only pandas (which CI already installs).
- **No new pipeline/container deps**: `streamlit`/`plotly` are a dev/ops install (`pip install streamlit plotly pandas`), documented in the module docstring along with the SSH port-forward to reach a cluster DB.

### Usage
```
pip install streamlit plotly pandas
streamlit run utils/dashboard.py -- --db-path /path/to/aetherscan.db --tag final_v1
```

Requested during the #134 review session. Branches off master (independent of #134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)