### PR TITLE
build(deps): raise setuptools + python-dotenv floors past the W30 security advisories

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -39,8 +39,9 @@ dependencies:
   # imports at module load. Recent pip / Python releases dropped setuptools
   # from the bootstrap, so we install it explicitly. Upper-bound at <81 because
   # setuptools 81 removed pkg_resources as a vendored submodule -- revisit
-  # once blimpy migrates off pkg_resources (upstream issue).
-  - setuptools>=70,<81
+  # once blimpy migrates off pkg_resources (upstream issue). Floor >=78.1.1 per
+  # GHSA-5rjg-fvgr-3xxf (CVE-2025-47273, path traversal; fixed in 78.1.1).
+  - setuptools>=78.1.1,<81
   # Conda-only deps (the NGC base image already ships h5py / psutil / pytest
   # so requirements-container.txt doesn't pin them).
   - h5py=3.11.*
@@ -60,7 +61,9 @@ dependencies:
       - umap-learn>=0.5.6,<0.6
       - shap>=0.46.0,<0.47
       - slack-sdk>=3.31.0,<4
-      - python-dotenv>=1.0,<2
+      # Floor >=1.2.2 per GHSA-mf9w-mj56-hr94 (CVE-2026-28684, set_key symlink
+      # following; fixed in 1.2.2).
+      - python-dotenv>=1.2.2,<2
       # Model weight distribution via the HuggingFace Hub — pin range mirrors
       # requirements-container.txt (see the rationale there).
       - huggingface_hub>=1.21,<1.22

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,11 +40,13 @@ dependencies = [
     "umap-learn>=0.5.6,<0.6",
     "shap>=0.46.0,<0.47",
     "slack-sdk>=3.31.0,<4",
-    "python-dotenv>=1.0,<2",
+    # Floor >=1.2.2 per GHSA-mf9w-mj56-hr94 (CVE-2026-28684; fixed in 1.2.2).
+    "python-dotenv>=1.2.2,<2",
     "huggingface_hub>=1.21,<1.22",
     # setuptools provides pkg_resources, which blimpy (transitive via setigen) imports at
     # module load; <81 because setuptools 81 removed the vendored pkg_resources.
-    "setuptools>=70,<81",
+    # Floor >=78.1.1 per GHSA-5rjg-fvgr-3xxf (CVE-2025-47273; fixed in 78.1.1).
+    "setuptools>=78.1.1,<81",
     "setigen>=2.6,<3",
     # The NGC base image provides these implicitly (so requirements-container.txt omits
     # them); a pip install has no base image to lean on and must declare them. Ranges

--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -19,7 +19,9 @@ imageio>=2.34,<3
 umap-learn>=0.5.6,<0.6
 shap>=0.46.0,<0.47
 slack-sdk>=3.31.0,<4
-python-dotenv>=1.0,<2
+# Floor >=1.2.2 per GHSA-mf9w-mj56-hr94 (CVE-2026-28684, set_key symlink following;
+# fixed in 1.2.2).
+python-dotenv>=1.2.2,<2
 # Model weight distribution via the HuggingFace Hub (upload after training, download for
 # inference). 1.21 per SECURITY.md's version policy: two minors below the latest stable
 # (1.23) at pin time, newer than the newest >=6-month-old release.
@@ -28,8 +30,9 @@ huggingface_hub>=1.21,<1.22
 # imports at module load. Recent pip / Python releases dropped setuptools
 # from the bootstrap, so we install it explicitly. Upper-bound at <81 because
 # setuptools 81 removed pkg_resources as a vendored submodule -- revisit
-# once blimpy migrates off pkg_resources (upstream issue).
-setuptools>=70,<81
+# once blimpy migrates off pkg_resources (upstream issue). Floor >=78.1.1 per
+# GHSA-5rjg-fvgr-3xxf (CVE-2025-47273, path traversal; fixed in 78.1.1).
+setuptools>=78.1.1,<81
 # Range covers the proven 2.6/2.7 line (2.7.0 in current use) and blocks a future
 # major-version break; keep in lockstep with environment.yml and pyproject.toml.
 setigen>=2.6,<3


### PR DESCRIPTION
Closes #174

Actions the two security findings from the W30 dependency report; both were independently re-verified against the GitHub advisory API and the current manifests during the 2026-07-22 triage.

## Security floor bumps (the change)

| Dep | Advisory | Severity | Old range | New range |
|---|---|---|---|---|
| setuptools | GHSA-5rjg-fvgr-3xxf (CVE-2025-47273, `PackageIndex.download` path traversal, fixed 78.1.1) | HIGH | `>=70,<81` | `>=78.1.1,<81` |
| python-dotenv | GHSA-mf9w-mj56-hr94 (CVE-2026-28684, `set_key` symlink following, fixed 1.2.2) | MODERATE | `>=1.0,<2` | `>=1.2.2,<2` |

Applied in lockstep across `environment.yml` / `requirements-container.txt` / `pyproject.toml` (the W30 report named only the first two; pyproject carries a third copy of both pins per its own lockstep header). `aetherscan.def` needs no edit — it installs `requirements-container.txt`. **The container should be rebuilt at the next scheduled rebuild to pick up the new floors** (already queued for the release prep; no urgency — see below).

Ceilings are untouched: `<81` (vendored `pkg_resources` for blimpy) and `<2` stay.

**Honest framing:** this is declared-range hardening, not an active-vuln fix. Fresh resolves already install patched versions (setuptools 80.x, python-dotenv 1.2.2) inside the old ranges, and neither vulnerable code path is reachable from this repo (`PackageIndex.download` is never invoked — setuptools exists solely for `pkg_resources`; only `load_dotenv`/`find_dotenv` are called, never `set_key`). The floors stop a constrained or cached resolve from ever admitting a vulnerable version, per SECURITY.md's advisory-override rule.

## W30 items deliberately NOT actioned here (dispositions)

- **h5py / psutil / pytest bumps — declined.** These mirror the frozen NGC 25.02-final image (`environment.yml` marks them conda-only for container parity); bumping breaks intentional parity for zero benefit.
- **actions/checkout\@v5, setup-python\@v5, github-script\@v7 — no action**, already at policy targets (the report concedes this).
- **huggingface_hub range refresh — declined**, no advisory; the single-minor window is deliberate.
- **claude-code-action refresh + actions/cache v3→v4 + ruff/gitleaks pre-commit patch bumps — deferred to the #59+#140 workflows-hardening PR** (next in the implementation queue), where action pinning is the theme. Target rule agreed there: newest 1.0.x that is both ≥6 months old and ≥v1.0.102 (clears the node20 deprecation under the advisory-override case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)