### PR TITLE
fix(train): runtime divisibility assert for effective_batch_size vs global train batch

### DIFF
--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -1811,9 +1811,10 @@ def collect_validation_errors(
         if all(v is not None for v in (prb, eb, prvb, lvc, nsb, nsr, tvs)):
             if num_replicas is None:
                 logger.warning(
-                    "GPU count unknown (no --num-replicas and TF reports 0 GPUs or is "
-                    "unavailable) — skipping cross-replica divisibility checks. Pass "
-                    "--num-replicas explicitly to run them."
+                    "GPU count unknown (TF reports 0 GPUs or is unavailable) — skipping "
+                    "cross-replica divisibility checks; they need a TF-visible GPU count "
+                    "even when --num-replicas is passed. The effective-batch-size check "
+                    "re-runs at training time once the real replica count is known."
                 )
             elif num_replicas < 1:
                 # _resolve_num_replicas would have raised before we got here for a real

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -534,6 +534,18 @@ def prepare_distributed_train_dataset(
     global_train_batch_size = per_replica_batch_size * num_replicas
     global_val_batch_size = per_replica_val_batch_size * num_replicas
 
+    # NOTE: runtime backstop for the cross-replica check cli.py's collect_validation_errors
+    # skips when TF can't see the GPUs at validation time (#143). n_train is trimmed to a
+    # multiple of effective_batch_size below, so an indivisible combination would make the
+    # train generator emit a partial trailing global batch every epoch (split unevenly across
+    # replicas) and silently degrade accumulation_steps. Message mirrors the validator's so
+    # guidance is identical.
+    if effective_batch_size % global_train_batch_size != 0:
+        raise ValueError(
+            f"--effective-batch-size ({effective_batch_size}) must be divisible by "
+            f"per_replica_batch_size * num_replicas ({global_train_batch_size})"
+        )
+
     # Stratified train/val split to ensure both sets contain proportional representation
     # of all 4 signal types (false_no_signal, false_with_rfi, true_only_eti, true_eti_rfi).
     # This is necessary because generation arranges labels sequentially within

--- a/tests/unit/test_train_datasets.py
+++ b/tests/unit/test_train_datasets.py
@@ -77,6 +77,17 @@ class TestPrepareDistributedTrainDataset:
         assert y.shape == (4, *_SAMPLE_SHAPE)
         results["_train_holder"].clear()
 
+    def test_indivisible_effective_batch_raises(self):
+        """Runtime backstop for the validation-time skip (#143): an effective batch size that
+        isn't a multiple of per_replica_batch_size * num_replicas must fail loudly with the
+        validator's guidance, not emit a partial trailing global batch every epoch."""
+        with pytest.raises(
+            ValueError,
+            match=r"--effective-batch-size \(8\) must be divisible by "
+            r"per_replica_batch_size \* num_replicas \(3\)",
+        ):
+            _build(_make_data(), shuffle=True, prb=3, eb=8)
+
     def test_epoch_covers_train_indices_exactly_once(self):
         results = _build(_make_data(), shuffle=True)
         n_batches_per_epoch = results["train_steps"] * results["accumulation_steps"]


### PR DESCRIPTION
Closes #143

## What

Runtime backstop for the gap between "validation skipped" and "runtime proceeds anyway" (#143, from the #117 final review):

- **`src/aetherscan/train.py`** — `prepare_distributed_train_dataset` now raises `ValueError` immediately after computing `global_train_batch_size` when `effective_batch_size % global_train_batch_size != 0`, reusing the exact message text of the cli.py validator's `eb % global_train_batch` check so the guidance is identical whichever layer fires.
- **`src/aetherscan/cli.py`** — reworded the skip warning in `collect_validation_errors`. Per `_resolve_num_replicas`'s contract, `None` is returned whenever TF is unavailable or reports 0 GPUs *even if `--num-replicas` was passed*, so the old "Pass --num-replicas explicitly to run them" guidance was misleading. The new text says the checks need a TF-visible GPU count and notes the effective-batch-size check now re-runs at training time.
- **`tests/unit/test_train_datasets.py`** — new `test_indivisible_effective_batch_raises` (eb=8, per-replica batch 3, 1 replica) asserting the ValueError fires with the validator's guidance text.

## Why the single check suffices

`n_train` is trimmed to a multiple of `effective_batch_size`, so `eb % gtb == 0` implies every epoch slice in the train generator is a whole global batch **and** makes `accumulation_steps = eb // gtb` exact. The val side is structurally safe (`n_val_trimmed` trims to the runtime global val batch size) and the viz dataset pads — so no further asserts were added. The RF encode path keeps its existing `_distributed_encode` step-count drift guard.

Not a #117 regression (the validation skip pre-dates it); #117's whole-global-batch generators are what turn the unguarded case into a partial batch rather than a silently dropped remainder.

## Verification

- `tests/unit/test_train_datasets.py`: **10/10 passed** locally in the TF venv (`-m "not gpu and not cluster"`), including the new test.
- `tests/unit/test_cli_validation.py`: **100/100 passed** locally in the TF venv (safety check for the cli.py wording change; no test asserts on the warning text).
- `ruff check` + `ruff format` pass (pre-commit hooks all green).
- Full suite deferred to CI.

No README CLI Reference regeneration needed: the cli.py change touches only a `logger.warning` string, not argparse flags/help.

## Maintainer decisions applied

- **cli.py skip-warning reword included** — the triage gameplan marked this "optional (same PR, one line)"; I included it because the old text actively misstates `_resolve_num_replicas`'s behavior. Revert the cli.py hunk if you'd rather keep the wording change out of this fix.
- **No val/viz asserts added** — per the gameplan's simplicity-first call (both paths are already structurally safe, rationale above); veto if you'd prefer belt-and-braces asserts on all three paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
