### PR TITLE
misc: post-v1 nit sweep (#163, #167, #176 n1/n2)

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -108,6 +108,16 @@ indirectly today; a direct test would only harden against future refactors):
   are only caught *implicitly* (via the broad `except` and the sampled checksum). The checksum
   is a probabilistic smoke test by design (see `round_data._array_checksum`), so these aren't
   integrity guarantees; a truncation test would at least pin the current behavior.
+- **Stage-timing *wiring* in the real train/inference paths** (issue #167 item 4): the
+  `stage_timer`/`record_stage` machinery and the report consumers are unit-tested against
+  synthetic `pipeline_stages` rows, but nothing at unit level asserts that the real pipeline
+  code paths emit the expected span names at the expected places (e.g. `train.round_NN`,
+  `train.round_NN.data_generation`, `inference.infer_cadence_NNN`). Driving the real
+  `train_round`/`_infer_cadence` in a unit test would need heavy TF-stack mocking for modest
+  signal, so this stays a cluster-smoke-only concern — mitigated by the shared
+  `round_stage_name()` helper (pins producer/trainer name agreement) and by
+  `test_round_data.py`'s timing test, which drives the real drainer-to-`record_stage` path
+  with a real span name.
 
 ## Markers
 

--- a/src/aetherscan/benchmark.py
+++ b/src/aetherscan/benchmark.py
@@ -81,9 +81,12 @@ def record_stage(
         # Late imports keep this module import-light and avoid any import-cycle risk
         # (db imports config + manager; nothing imports benchmark back).
         from aetherscan.config import get_config  # noqa: PLC0415
-        from aetherscan.db import get_db  # noqa: PLC0415
+        from aetherscan.db.db import Database  # noqa: PLC0415
 
-        db = get_db()
+        # Read the singleton directly (not via get_db()): a missing DB is an expected,
+        # already-handled case here, and get_db() logs a WARNING on every miss — noise
+        # that could reach Slack. This is a read, not an instantiation.
+        db = Database._instance
         if db is None:
             logger.debug(f"No database instance — dropping stage timing for {stage!r}")
             return

--- a/src/aetherscan/dashboard_launcher.py
+++ b/src/aetherscan/dashboard_launcher.py
@@ -117,7 +117,11 @@ def _install_signal_teardown(proc: subprocess.Popen) -> None:
 
         def _handler(signum, frame, _prev=prev):
             _terminate(proc)
-            signal.signal(signum, _prev if callable(_prev) else signal.SIG_DFL)
+            # Restore callables AND SIG_IGN as-is (collapsing SIG_IGN to SIG_DFL would let the
+            # re-delivery below kill a process that was ignoring the signal); anything else
+            # (SIG_DFL, None from a non-Python handler) falls back to SIG_DFL.
+            restore = _prev if callable(_prev) or _prev == signal.SIG_IGN else signal.SIG_DFL
+            signal.signal(signum, restore)
             os.kill(os.getpid(), signum)  # re-deliver so the pipeline shuts down as it would have
 
         with contextlib.suppress(ValueError, OSError):

--- a/src/aetherscan/hf_hub.py
+++ b/src/aetherscan/hf_hub.py
@@ -312,7 +312,6 @@ def compute_rf_metrics(model_path: str, tag: str) -> dict[str, Any] | None:
 def generate_model_card(
     *,
     tag: str,
-    repo_id: str,
     config_dict: dict[str, Any],
     metrics: dict[str, Any] | None,
     versions: dict[str, str],
@@ -485,7 +484,6 @@ def upload_run_to_hf(
     public_config = _sanitize_config_for_upload(config_dict)
     card = generate_model_card(
         tag=tag,
-        repo_id=repo_id,
         config_dict=public_config,
         metrics=compute_rf_metrics(model_path, tag),
         versions=_collect_library_versions(),

--- a/tests/unit/test_benchmark.py
+++ b/tests/unit/test_benchmark.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import logging
 import os
 import sqlite3
 import sys
@@ -140,13 +141,19 @@ class TestStageTimer:
         # The worker thread's timer must NOT nest under the main thread's umbrella
         assert recorded == ["inference.preprocess_cadence_001"]
 
-    def test_no_db_is_a_noop(self):
+    def test_no_db_is_a_noop(self, caplog):
         # No Database instance exists (conftest resets singletons): timing must degrade
         # to a debug log, never an exception
         assert Database._instance is None
-        with stage_timer("train.round_01"):
-            pass
-        record_stage("train.round_02", 1.0, 2.0)
+        with caplog.at_level(logging.DEBUG, logger="aetherscan.benchmark"):
+            with stage_timer("train.round_01"):
+                pass
+            record_stage("train.round_02", 1.0, 2.0)
+        # The missing-DB path logs the documented debug message (one per dropped span)...
+        debug_messages = [r.message for r in caplog.records if r.levelno == logging.DEBUG]
+        assert sum("No database instance" in m for m in debug_messages) == 2
+        # ...and nothing louder: no WARNING+ from any logger (INFO+ can reach Slack)
+        assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
 
     def test_record_stage_explicit_timestamps(self, db):
         record_stage(

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -249,6 +249,18 @@ class TestSemanticChecks:
         assert {"inference.rf_path", "inference.config_path"} <= fields
         assert "inference.encoder_path" not in fields
 
+    def test_inference_artifact_partial_trio_from_config_rejected(self, tmp_path):
+        # The trio check must count paths sourced from a loaded saved config (the
+        # `_resolve(args, ..., config.inference.*)` fallback), not just CLI flags: a
+        # config-side encoder_path with no flags is still a partial trio.
+        encoder = tmp_path / "vae_encoder_test_v1.keras"
+        encoder.touch()
+        get_config().inference.encoder_path = str(encoder)
+        errors = collect_validation_errors(_parse(["inference"]), None)
+        fields = {e.field for e in errors if e.fix_kind == "file_exists"}
+        assert {"inference.rf_path", "inference.config_path"} <= fields
+        assert "inference.encoder_path" not in fields
+
     def test_inference_artifact_full_trio_must_exist_on_disk(self):
         errors = collect_validation_errors(
             _parse(

--- a/tests/unit/test_dashboard_launcher.py
+++ b/tests/unit/test_dashboard_launcher.py
@@ -5,11 +5,13 @@ mocked here."""
 
 from __future__ import annotations
 
+import os
 import signal
 import subprocess
 from unittest import mock
 
 from aetherscan.dashboard_launcher import (
+    _install_signal_teardown,
     _terminate,
     build_dashboard_command,
     launch_dashboard,
@@ -76,6 +78,9 @@ def test_launch_returns_none_when_script_missing():
     with (
         mock.patch(f"{_MOD}.get_config", return_value=_fake_config()),
         mock.patch(f"{_MOD}._DASHBOARD_SCRIPT") as script,
+        # Truthy spec: in a streamlit-absent env the later find_spec guard also returns None,
+        # which would mask a deleted is_file guard — pin the None to the guard under test.
+        mock.patch(f"{_MOD}.importlib.util.find_spec", return_value=object()),
     ):
         script.is_file.return_value = False
         assert launch_dashboard() is None
@@ -143,6 +148,27 @@ def test_launch_spawns_and_registers_teardown():
         assert kwargs["start_new_session"] is True
         atexit_reg.assert_called_once_with(_terminate, proc)
         sig_teardown.assert_called_once_with(proc)
+
+
+def test_signal_teardown_restores_sig_ign_disposition():
+    # A prior SIG_IGN disposition must be restored as SIG_IGN, not collapsed to SIG_DFL —
+    # the handler's re-delivery would otherwise terminate a process that was ignoring the
+    # signal (latent: the real pipeline always installs a callable handler first).
+    proc = mock.MagicMock()
+    proc.poll.return_value = 0  # already exited -> _terminate is a no-op
+    originals = {sig: signal.getsignal(sig) for sig in (signal.SIGTERM, signal.SIGINT)}
+    try:
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        _install_signal_teardown(proc)
+        handler = signal.getsignal(signal.SIGTERM)
+        assert callable(handler)
+        with mock.patch(f"{_MOD}.os.kill") as kill:
+            handler(signal.SIGTERM, None)
+            kill.assert_called_once_with(os.getpid(), signal.SIGTERM)
+        assert signal.getsignal(signal.SIGTERM) == signal.SIG_IGN
+    finally:
+        for sig, prev in originals.items():
+            signal.signal(sig, prev)
 
 
 def test_terminate_noop_when_already_dead():

--- a/tests/unit/test_hf_hub.py
+++ b/tests/unit/test_hf_hub.py
@@ -437,7 +437,6 @@ class TestGenerateModelCard:
     def _card(self, metrics=None):
         return generate_model_card(
             tag="test_v17",
-            repo_id="zachtheyek/aetherscan",
             config_dict=get_config().to_dict(),
             metrics=metrics,
             versions={"python": "3.10.0", "tensorflow": "2.17.1"},

--- a/tests/unit/test_round_data.py
+++ b/tests/unit/test_round_data.py
@@ -602,10 +602,14 @@ class TestRoundDataProducerDrainer:
 
     def test_timing_message_records_stage_span(self, producer, monkeypatch):
         recorded = []
-        monkeypatch.setattr(
-            "aetherscan.round_data.record_stage",
-            lambda *args, **kwargs: recorded.append((args, kwargs)),
-        )
+
+        def fake_record_stage(*args, **kwargs):
+            # FIFO guard: the span must be recorded BEFORE the done message resolves the
+            # round — a reversed (done-before-timing) drain order would trip this.
+            assert 3 not in producer._results
+            recorded.append((args, kwargs))
+
+        monkeypatch.setattr("aetherscan.round_data.record_stage", fake_record_stage)
         producer._result_queue.put(("timing", 3, 100.0, 160.0))
         producer._result_queue.put(("done", 3, {"n_samples": 8}))
         producer.await_round(3)  # FIFO: the timing message was handled before done


### PR DESCRIPTION
Closes #163
Closes #167
Refs #176 (nits n1/n2 only — the console entry point lands in its own PR)

Post-v1 nit sweep bundling the seven code/test nits from the #130, #134, and #170 review follow-ups. One focused commit per issue.

## #163 — HF model card + trio validation (`e0d7617`)

- **Dropped `generate_model_card`'s unused `repo_id` param** (`src/aetherscan/hf_hub.py`), plus the `repo_id=repo_id` call-site arg in `upload_run_to_hf` and the test-helper kwarg in `tests/unit/test_hf_hub.py`. Dropping beats rendering it: the card is uploaded into that very repo, so the id adds nothing.
- **Added `test_inference_artifact_partial_trio_from_config_rejected`** (`tests/unit/test_cli_validation.py`): sources `encoder_path` from `config.inference` (no CLI flag) and asserts the partial-trio errors fire for the two missing paths — pinning that `n_provided` counts the args-or-config merged values, the previously untested branch.

## #167 — benchmark timing nits (`9fbeb2b`)

- **`record_stage()` now reads `Database._instance` directly** instead of `get_db()`, so DB-less runs log the documented debug message without `get_db()`'s WARNING firing first (INFO+ can reach Slack). This is a read of the singleton, not an instantiation — the accessor rule is respected (tests already read `_instance` the same way).
- **`test_no_db_is_a_noop` asserts the debug downgrade via caplog**: exactly 2 dropped-span debug records, zero WARNING+ records — a silent-swallow regression is now distinguishable.
- **`test_timing_message_records_stage_span` strictly enforces FIFO**: the patched `record_stage` asserts the round is not yet resolved in `producer._results` at call time. (The drainer swallows handler exceptions, but a tripped assert leaves `recorded` empty so the final equality assert still fails — reversal is caught either way.)
- **Item 4 closed by documentation**: added a bullet to docs/TESTING.md "Coverage and deliberate gaps" recording span-name wiring in the real train/inference paths as a cluster-smoke-only concern, mitigated by `round_stage_name()` and the real-drainer timing test.

## #176 — dashboard launcher nits n1/n2 (`88fdefe`)

- **n1**: `_install_signal_teardown`'s restore now preserves a prior `SIG_IGN` disposition (previously collapsed to `SIG_DFL`, so the re-delivered signal would kill a process that was ignoring it — latent only, the real pipeline installs a callable handler first). New unit test installs `SIG_IGN`, drives the handler with `os.kill` patched, and asserts the disposition survives.
- **n2**: `test_launch_returns_none_when_script_missing` now patches `find_spec` to a truthy spec (mirroring its sibling tests), so the `None` return can only come from the `is_file` guard under test.
- The `aetherscan-dashboard` console entry point from the issue thread is deliberately **not** here — #176 stays open for it (hence Refs, not Closes).

## Verification

- Locally in the TF venv: `pytest tests/unit/test_hf_hub.py tests/unit/test_cli_validation.py tests/unit/test_benchmark.py tests/unit/test_round_data.py tests/unit/test_dashboard_launcher.py -m "not gpu and not cluster"` — **219 passed**.
- `ruff` + `ruff-format` pre-commit hooks pass on all changed files.
- Full suite deferred to CI. No `cli.py` flag/help changes, so no README CLI Reference regeneration needed.

## Maintainer decisions applied

- **#167 item 4 is closed by documentation, not by tests**: the issue framed it as "decide whether the mock scaffolding is worth it" — this PR takes the accept-the-gap path (TESTING.md bullet, wiring verification stays cluster-smoke-only). Veto by reverting the docs/TESTING.md hunk and reopening the item if you want the mocked `train_round`/`_infer_cadence` guard instead.
- **#163 item 1 drops `repo_id` rather than rendering it** in the card (the issue offered both options); simplicity-first since the card lives inside that repo.
- **#176 is intentionally not closed** — the owner-requested console entry point remains; only the two body nits land here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
