### PR TITLE
fix: PFB follow-up nit cleanup — plot decimation, duplicate-CSV fail-fast, ratio zero-floor, stale-stamp test (#155)

### DIFF
--- a/src/aetherscan/inference_viz.py
+++ b/src/aetherscan/inference_viz.py
@@ -390,6 +390,7 @@ def plot_bandpass_flattening(
     # single source of truth for how a channel is read/despiked/flattened, and duplicating
     # that here would let the figure drift from what detection actually does.
     from aetherscan.preprocessing import (  # noqa: PLC0415
+        _decimate_for_plot,
         _fit_channel_bandpass,
         _pfb_flatten_bandpass,
     )
@@ -437,10 +438,25 @@ def plot_bandpass_flattening(
             overlay_label = "spline fit"
 
         ax_raw, ax_flat = axes[row]
-        ax_raw.plot(raw, lw=0.6, color="tab:blue", label="raw integrated spectrum")
-        ax_raw.plot(overlay, lw=1.2, ls="--", color="tab:orange", label=overlay_label)
+        # Decimated to a min/max envelope: full-resolution lines are ~1M points each at
+        # GBT scale, which makes rendering slow and memory-heavy for no visual gain.
+        ax_raw.plot(
+            *_decimate_for_plot(raw), lw=0.6, color="tab:blue", label="raw integrated spectrum"
+        )
+        ax_raw.plot(
+            *_decimate_for_plot(overlay),
+            lw=1.2,
+            ls="--",
+            color="tab:orange",
+            label=overlay_label,
+        )
         ax_raw.set_ylabel(f"coarse channel {ch}\nintegrated power")
-        ax_flat.plot(flat, lw=0.6, color="tab:green", label="flattened integrated spectrum")
+        ax_flat.plot(
+            *_decimate_for_plot(flat),
+            lw=0.6,
+            color="tab:green",
+            label="flattened integrated spectrum",
+        )
         if row == 0:
             ax_raw.legend(loc="upper right", fontsize=8)
             ax_flat.legend(loc="upper right", fontsize=8)

--- a/src/aetherscan/pfb.py
+++ b/src/aetherscan/pfb.py
@@ -141,4 +141,6 @@ def edge_mid_power_ratio(spectrum: np.ndarray) -> float:
     band = max(1, n // _RATIO_BAND_FRACTION)
     edge = 0.5 * (float(spectrum[:band].mean()) + float(spectrum[-band:].mean()))
     mid = float(spectrum[n // 2 - band // 2 : n // 2 + band // 2 + 1].mean())
-    return edge / mid
+    # Defensive floor (mirroring equalize_passband's): an all-zero — e.g. fully masked —
+    # channel would otherwise raise ZeroDivisionError on the Python-float divide.
+    return edge / max(mid, 1e-30)

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -323,7 +323,9 @@ def _decimate_for_plot(
     binned = padded.reshape(max_points, bin_size)
     offsets = np.arange(max_points) * bin_size
     pairs = np.stack([offsets + binned.argmin(axis=1), offsets + binned.argmax(axis=1)], axis=1)
-    idx = np.minimum(np.sort(pairs, axis=1).reshape(-1), n - 1)
+    # np.unique dedupes + keeps ascending order: a constant-valued bin has argmin==argmax, which
+    # would otherwise emit the same (idx, y) point twice; deduping halves those bins for free.
+    idx = np.unique(np.minimum(np.sort(pairs, axis=1).reshape(-1), n - 1))
     return idx, y[idx]
 
 

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -67,6 +67,9 @@ _BANDPASS_SAMPLE_CHANNELS = 3
 # The PFB static-response sanity check samples more channels and takes a median (not a mean),
 # so a single RFI-heavy channel doesn't skew the statistic.
 _PFB_MISMATCH_SAMPLE_CHANNELS = 9
+# Target bin count for _decimate_for_plot: spectrum lines in the bandpass debug/viz figures
+# are reduced to at most 2 * this many points (a min/max pair per bin) before plotting.
+_PLOT_MAX_POINTS_PER_LINE = 4096
 
 
 def _init_worker(shm_name, shape, dtype):
@@ -296,6 +299,32 @@ def _pfb_flatten_bandpass(channel: np.ndarray, response_path: str) -> np.ndarray
     # The spline-vs-PFB detection comparison in the PR body is the empirical arbiter.
     """
     return equalize_passband(channel, _load_pfb_response(response_path))
+
+
+def _decimate_for_plot(
+    y: np.ndarray, max_points: int = _PLOT_MAX_POINTS_PER_LINE
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Reduce a long 1-D line to at most 2 * max_points (x, y) points for plotting, via a per-bin
+    min/max envelope: each of max_points equal bins contributes its extremes at their true
+    indices, so narrowband features (RFI spikes, hits) survive where a plain stride would
+    usually miss them. At GBT scale this turns each ~1M-point matplotlib line in the bandpass
+    figures into ~8k points. Returns (x_indices, values); inputs already at or below the
+    budget pass through unchanged. Unpack into ax.plot(*_decimate_for_plot(y), ...).
+    """
+    y = np.asarray(y)
+    n = y.shape[0]
+    if n <= 2 * max_points:
+        return np.arange(n), y
+    bin_size = -(-n // max_points)  # ceil division
+    # Edge-pad the tail bin; padded positions duplicate y[-1], and any argmin/argmax landing
+    # there is clipped back to n - 1 below, so no synthetic value can be selected.
+    padded = np.pad(y, (0, bin_size * max_points - n), mode="edge")
+    binned = padded.reshape(max_points, bin_size)
+    offsets = np.arange(max_points) * bin_size
+    pairs = np.stack([offsets + binned.argmin(axis=1), offsets + binned.argmax(axis=1)], axis=1)
+    idx = np.minimum(np.sort(pairs, axis=1).reshape(-1), n - 1)
+    return idx, y[idx]
 
 
 def _sliding_normality_k2(channel: np.ndarray, window_size: int, step_size: int) -> np.ndarray:
@@ -1233,11 +1262,29 @@ class DataPreprocessor:
         Group every CSV in config.data.inference_files into per-cadence work units without
         processing anything. Returns one PendingCadence (valid group + target .npy path) per
         valid cadence, in CSV order — the unit list the streaming inference loop iterates.
+        Raises ValueError when two inference_files entries share a basename stem (their
+        output dir and stamp filenames would collide).
         """
         inference_files = self.config.data.inference_files
         if not inference_files:
             logger.warning("plan_cadences() called with no inference_files configured")
             return []
+
+        # Fail fast on duplicate CSV basename stems: both the tag-scoped default output dir
+        # and the per-cadence stamp .npy names are keyed on the stem, so two entries like
+        # runA/x.csv and runB/x.csv would silently share a directory (and/or stamp filenames)
+        # and cross-resume each other's cadences.
+        stem_sources: dict[str, str] = {}
+        for csv_filename in inference_files:
+            stem = os.path.splitext(os.path.basename(csv_filename))[0]
+            if stem in stem_sources:
+                raise ValueError(
+                    f"Duplicate inference CSV basename stem '{stem}' "
+                    f"('{stem_sources[stem]}' vs '{csv_filename}'): output directories and "
+                    f"stamp filenames are keyed on the basename, so these entries would "
+                    f"overwrite/resume each other. Rename one so basenames are unique."
+                )
+            stem_sources[stem] = csv_filename
 
         # Output directory resolution: an explicit --preprocess-output-dir is used as-is
         # (shared across CSVs); otherwise each CSV gets its own tag-scoped default,
@@ -1941,10 +1988,25 @@ class DataPreprocessor:
                 overlay_label = "spline fit"
 
             ax_raw, ax_flat = axes[row]
-            ax_raw.plot(raw, lw=0.6, color="tab:blue", label="raw integrated spectrum")
-            ax_raw.plot(overlay, lw=1.2, ls="--", color="tab:orange", label=overlay_label)
+            # Decimated to a min/max envelope: full-resolution lines are ~1M points each at
+            # GBT scale, which makes rendering slow and memory-heavy for no visual gain.
+            ax_raw.plot(
+                *_decimate_for_plot(raw), lw=0.6, color="tab:blue", label="raw integrated spectrum"
+            )
+            ax_raw.plot(
+                *_decimate_for_plot(overlay),
+                lw=1.2,
+                ls="--",
+                color="tab:orange",
+                label=overlay_label,
+            )
             ax_raw.set_ylabel(f"coarse channel {ch}\nintegrated power")
-            ax_flat.plot(flat, lw=0.6, color="tab:green", label="flattened integrated spectrum")
+            ax_flat.plot(
+                *_decimate_for_plot(flat),
+                lw=0.6,
+                color="tab:green",
+                label="flattened integrated spectrum",
+            )
             if row == 0:
                 ax_raw.legend(loc="upper right", fontsize=8)
                 ax_flat.legend(loc="upper right", fontsize=8)

--- a/tests/unit/test_pfb.py
+++ b/tests/unit/test_pfb.py
@@ -229,3 +229,8 @@ class TestEdgeMidPowerRatio:
         expected = edge_mid_power_ratio(response)
         measured = edge_mid_power_ratio(np.ones(_FINE))
         assert abs(measured - expected) / expected > 0.05
+
+    def test_all_zero_spectrum_does_not_raise(self):
+        # A fully masked channel: the defensive mid floor turns 0/0 into 0.0, not
+        # ZeroDivisionError.
+        assert edge_mid_power_ratio(np.zeros(_FINE)) == 0.0

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -829,6 +829,14 @@ class TestDecimateForPlot:
         x, out = _decimate_for_plot(y, max_points=1024)
         assert np.all(np.diff(x) >= 0)
         assert x.min() >= 0 and x.max() <= y.shape[0] - 1
+
+    def test_constant_bins_are_deduped(self):
+        # A constant line makes every bin's argmin == argmax; the indices must be deduped to
+        # strictly increasing (one point per bin), not emit each index twice.
+        y = np.full(100_000, 3.14)
+        x, out = _decimate_for_plot(y, max_points=1024)
+        assert np.all(np.diff(x) > 0)  # strictly increasing → no duplicate points
+        assert x.shape[0] <= 1024
         np.testing.assert_array_equal(out, y[x])
 
 

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -26,6 +26,7 @@ from aetherscan.preprocessing import (
     ED_STAT_HIST_EDGES,
     DataPreprocessor,
     PendingCadence,
+    _decimate_for_plot,
     _energy_detect_channel_worker,
     _extract_stamps_worker,
     _fit_channel_bandpass,
@@ -797,6 +798,40 @@ class TestPfbResponseMismatchWarning:
         assert abs(edge_mid_power_ratio(np.ones(512)) - expected) / expected > 0.05
 
 
+class TestDecimateForPlot:
+    """_decimate_for_plot reduces long spectrum lines to a per-bin min/max envelope so the
+    bandpass debug/viz figures don't render ~1M-point matplotlib lines at GBT scale."""
+
+    def test_short_input_passes_through(self):
+        y = np.arange(100, dtype=np.float64)
+        x, out = _decimate_for_plot(y, max_points=64)
+        np.testing.assert_array_equal(x, np.arange(100))
+        np.testing.assert_array_equal(out, y)
+
+    def test_long_input_respects_point_budget(self):
+        rng = np.random.default_rng(11)
+        y = rng.normal(size=100_000)
+        x, out = _decimate_for_plot(y, max_points=1024)
+        assert out.shape[0] <= 2 * 1024
+        assert x.shape == out.shape
+
+    def test_envelope_preserves_narrowband_spike(self):
+        # The property a plain stride lacks: a single-bin spike (RFI/hit) must survive.
+        y = np.zeros(100_000)
+        y[54_321] = 7.0
+        x, out = _decimate_for_plot(y, max_points=1024)
+        assert out.max() == 7.0
+        assert 54_321 in x
+
+    def test_indices_are_sorted_and_in_range(self):
+        rng = np.random.default_rng(12)
+        y = rng.normal(size=99_991)  # prime length: exercises the padded tail bin
+        x, out = _decimate_for_plot(y, max_points=1024)
+        assert np.all(np.diff(x) >= 0)
+        assert x.min() >= 0 and x.max() <= y.shape[0] - 1
+        np.testing.assert_array_equal(out, y[x])
+
+
 class TestPlanCadencesOutputDir:
     """plan_cadences resolves the .npy output dir per CSV: tag-scoped default under
     {data_path}/inference/preprocessed/, with an explicit --preprocess-output-dir shared
@@ -822,10 +857,27 @@ class TestPlanCadencesOutputDir:
 
         config.checkpoint.save_tag = "test_v1"
         first = DataPreprocessor().plan_cadences()
+        # Plant a stale stamp from the old tag's attempt at exactly the path resume keys on
+        with open(first[0].npy_path, "wb") as f:
+            f.write(b"stale")
         config.checkpoint.save_tag = "test_v2"
         second = DataPreprocessor().plan_cadences()
 
         assert os.path.dirname(first[0].npy_path) != os.path.dirname(second[0].npy_path)
+        # The new tag's unit must not see the old stamp — process_pending_cadence would
+        # otherwise resume-skip the cadence off the stale file.
+        assert not os.path.exists(second[0].npy_path)
+
+    def test_duplicate_csv_basenames_rejected(self, initialized_runtime, make_inference_csv):
+        # Same basename in different subdirectories would collide into one tag-scoped
+        # output dir (and shared stamp filenames) — plan_cadences fails fast instead.
+        config = get_config()
+        make_inference_csv("run_a/subset.csv")
+        make_inference_csv("run_b/subset.csv")
+        config.data.inference_files = ["run_a/subset.csv", "run_b/subset.csv"]
+
+        with pytest.raises(ValueError, match="subset"):
+            DataPreprocessor().plan_cadences()
 
     def test_explicit_override_shared_across_csvs(
         self, initialized_runtime, make_inference_csv, tmp_path


### PR DESCRIPTION
Closes #155

Implements the four still-live nits from the #125 code-review follow-up. The other two sub-items live on elsewhere: PP-2 (mismatch-warning heuristic) was already mitigated on `master` in `dcb05f6`, and its principled replacement plus PP-3 (cheaper sanity-check reads) are tracked in #156 — closing this issue does not close those.

## What changed

- **PP-4 — decimate the bandpass figures' spectrum lines.** New shared helper `_decimate_for_plot` in `preprocessing.py`: a per-bin min/max envelope that reduces a line to at most 2×4096 `(x, y)` points while keeping narrowband features (RFI spikes, hits) at their true indices — a plain stride would usually drop them. Used for every spectrum line in both `DataPreprocessor._plot_bandpass_overlay` (the opt-in `--bandpass-debug-plot` artifact) and `inference_viz.plot_bandpass_flattening` (the standard per-run figure), so neither renders ~1M-point matplotlib lines at GBT scale anymore. `inference_viz` imports it from `preprocessing` alongside the private helpers it already reaches into by design.
- **PP-5 — reject duplicate inference-CSV basenames up front.** `plan_cadences` now raises a `ValueError` naming both colliding entries when two `config.data.inference_files` entries share a basename stem. Previously e.g. `runA/x.csv` and `runB/x.csv` silently collapsed into one tag-scoped output dir, and their stamp `.npy` names could cross-resume each other's cadences.
- **pfb-3 — zero-floor in `edge_mid_power_ratio`.** `edge / max(mid, 1e-30)` (mirroring `equalize_passband`'s `np.maximum(response, 1e-10)` floor), so an all-zero / fully masked channel yields `0.0` instead of `ZeroDivisionError`. Behavior-neutral for any realistic spectrum.
- **F2 — strengthen `test_new_tag_gets_clean_directory`.** The test now plants a stale stamp at the first tag's exact `npy_path` and asserts the second tag's unit doesn't see it (which would trigger the resume-skip), instead of only checking that the two dirnames differ.

Tests shipped: `TestDecimateForPlot` (passthrough, point budget, spike preservation, sorted/in-range indices incl. the padded tail bin), `test_duplicate_csv_basenames_rejected`, `test_all_zero_spectrum_does_not_raise`, plus the F2 hardening above.

## Verification

- `pytest tests/unit/test_pfb.py tests/unit/test_preprocessing.py -m "not gpu and not cluster" -q` — **133 passed** locally (TF venv).
- `pytest tests/unit/test_inference_viz.py -m "not gpu and not cluster" -q` — **19 passed** locally (TF venv).
- `ruff check` + `ruff format --check` clean on all five changed files; all pre-commit hooks passed on commit.
- Full suite deferred to CI.

## Maintainer decisions applied

- **PP-5 resolved as fail-fast `ValueError`**, not a path-hash suffix on the stem (the issue offered both). Rationale: simpler, zero risk of surprising directory names, and the operator fix (rename a CSV) is trivial. Veto by preferring the hash-suffix variant if silently-working matters more than explicitness.
- **The PP-5 duplicate check runs unconditionally**, including when `--preprocess-output-dir` is set — with an explicit shared dir the stamp filenames (`{csv_stem}_{group_key}.npy`) are still stem-keyed, so duplicates can still cross-resume there.
- **Decimation budget fixed at 4096 bins** (≤8192 points per line) as a module constant, not a config option — no configurability was requested and the value is generous for a 14-inch-wide axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
