### PR TITLE
fix(monitor): cache psutil Process objects across intervals to fix child-CPU undercount

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -206,7 +206,7 @@ With 96+ child processes being recreated every interval, the majority reported `
 
 ### Status
 
-**Resolved.** `get_process_tree_stats()` now maintains a PID -> `psutil.Process` cache across monitoring intervals, so `cpu_percent(interval=0)` measures against the previous sample's baseline. Each newly spawned process contributes one `0.0` reading the first interval it is seen (accurate thereafter); PIDs that leave the tree are evicted from the cache. See [GitHub Issue #12](https://github.com/zachtheyek/Aetherscan/issues/12).
+**Closed.** `get_process_tree_stats()` now maintains a PID -> `psutil.Process` cache across monitoring intervals, so `cpu_percent(interval=0)` measures against the previous sample's baseline. Each newly spawned process contributes one `0.0` reading the first interval it is seen (accurate thereafter); PIDs that leave the tree are evicted from the cache. See [GitHub Issue #12](https://github.com/zachtheyek/Aetherscan/issues/12).
 
 ### Related Code
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -196,21 +196,17 @@ Aetherscan CPU usage is systematically lower than system total CPU usage in reso
 
 ### Cause
 
-The issue is in the `get_process_tree_stats()` function. Every monitoring interval, `process.children(recursive=True)` creates **new `psutil.Process` objects** for all child processes. When `cpu_percent(interval=0.0)` is called on a newly created Process object, psutil has no baseline CPU measurements to compare against, so it returns `0.0`.
+The issue was in the `get_process_tree_stats()` function. Every monitoring interval, `process.children(recursive=True)` created **new `psutil.Process` objects** for all child processes. When `cpu_percent(interval=0.0)` is called on a newly created Process object, psutil has no baseline CPU measurements to compare against, so it returns `0.0`.
 
-With 96+ child processes being recreated every interval, the majority report `0.0` CPU, leading to severe undercounting.
+With 96+ child processes being recreated every interval, the majority reported `0.0` CPU, leading to severe undercounting.
 
 ### Impact
 
-**Minor.** Resource utilization plots show inaccurate CPU values. Training and inference correctness are not affected.
-
-### Workaround
-
-For accurate CPU monitoring, use external tools like `htop`, `nvidia-smi`, or system monitoring dashboards.
+**Minor.** Resource utilization plots showed inaccurate CPU values. Training and inference correctness were not affected.
 
 ### Status
 
-**Open.** See [GitHub Issue #12](https://github.com/zachtheyek/Aetherscan/issues/12).
+**Resolved.** `get_process_tree_stats()` now maintains a PID -> `psutil.Process` cache across monitoring intervals, so `cpu_percent(interval=0)` measures against the previous sample's baseline. Each newly spawned process contributes one `0.0` reading the first interval it is seen (accurate thereafter); PIDs that leave the tree are evicted from the cache. See [GitHub Issue #12](https://github.com/zachtheyek/Aetherscan/issues/12).
 
 ### Related Code
 

--- a/src/aetherscan/monitor/monitor.py
+++ b/src/aetherscan/monitor/monitor.py
@@ -54,33 +54,46 @@ def select_annotation_spans(rows: list[dict], max_depth: int = _ANNOTATION_MAX_D
     return spans
 
 
-# BUG:
-# system total CPU usage appears "unnormalized" compared to aetherscan CPU usage (aetherscan CPU & RAM sometimes exceeds system total)
-# https://github.com/zachtheyek/Aetherscan/issues/12
-def get_process_tree_stats(process: psutil.Process) -> dict[str, float]:
+def get_process_tree_stats(
+    process: psutil.Process, proc_cache: dict[int, psutil.Process] | None = None
+) -> dict[str, float]:
     """
     Sum CPU and RAM usage across `process` and its descendants (the multiprocessing pool
     workers it spawned), returning {cpu_percent, ram_percent, ram_bytes, ram_gb}.
+
+    `proc_cache` maps PID -> psutil.Process and should persist across calls when CPU accuracy
+    matters: cpu_percent(interval=0) measures against the baseline recorded by the previous
+    call on the *same* Process object, so a freshly created object always reads 0.0 (issue
+    #12's undercount). With a persistent cache, each PID is accurate from its second sample
+    onward (a new PID contributes one 0.0 reading when first seen), and PIDs that leave the
+    tree are evicted. Without a cache (None), every call reads 0.0 CPU per process — fine for
+    RAM-only callers.
 
     cpu_percent is normalized against the system core count (0-100). ram_bytes uses PSS
     (Proportional Set Size) rather than RSS so shared pages aren't double-counted across the
     process tree — summing RSS would let the total exceed system RAM. Dead children that vanish
     mid-iteration are silently skipped.
     """
+    if proc_cache is None:
+        proc_cache = {}
+
     try:
         # Get all processes in tree (main + children)
         processes = [process]
         with contextlib.suppress(psutil.NoSuchProcess):
             processes.extend(process.children(recursive=True))
 
-        # Aggregate CPU and RAM usage across all processes
+        # Aggregate CPU and RAM usage across all processes, measuring through the cached
+        # Process object for any PID seen on a previous call — children() returns brand-new
+        # objects every call, which would reset the cpu_percent baseline each interval
         total_cpu = 0.0
         total_ram_bytes = 0
 
         for proc in processes:
+            cached = proc_cache.setdefault(proc.pid, proc)
             try:
                 # CPU: Get percentage (can be >100% for multi-core usage)
-                cpu = proc.cpu_percent(interval=0.0)  # Non-blocking
+                cpu = cached.cpu_percent(interval=0.0)  # Non-blocking
                 total_cpu += cpu
 
                 # RAM: Get PSS (Proportional Set Size)
@@ -88,12 +101,23 @@ def get_process_tree_stats(process: psutil.Process) -> dict[str, float]:
                 # RSS counts shared pages once per process, so summing RSS across a process tree
                 # can exceed system total RAM. PSS divides shared pages by # of sharing processes,
                 # making it additive and accurate when summing across multiple processes.
-                mem_info = proc.memory_full_info()
+                mem_info = cached.memory_full_info()
                 total_ram_bytes += mem_info.pss
 
-            except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
-                # Process may have died between children() and cpu_percent() or memory_info() calls
+            except psutil.NoSuchProcess:
+                # Process died between children() and the stat calls — drop it immediately
+                proc_cache.pop(proc.pid, None)
                 continue
+            except (psutil.AccessDenied, psutil.ZombieProcess):
+                # Still exists (just unreadable/unreaped) — keep the cache entry; it gets
+                # evicted below once the PID leaves the tree
+                continue
+
+        # Evict cached entries for PIDs no longer in the tree so dead pool workers don't
+        # accumulate across a long run
+        tree_pids = {proc.pid for proc in processes}
+        for pid in set(proc_cache) - tree_pids:
+            del proc_cache[pid]
 
         # Convert CPU to percentage of total system CPU
         num_cores = psutil.cpu_count() or 0
@@ -173,6 +197,10 @@ class ResourceMonitor:
         # Get main process ID
         self.process = psutil.Process(os.getpid())
 
+        # PID -> psutil.Process cache reused across monitoring intervals so per-child
+        # cpu_percent(interval=0) has a baseline from the previous sample (issue #12)
+        self._proc_cache: dict[int, psutil.Process] = {}
+
         # Detect GPUs
         self._detect_gpus()
 
@@ -248,8 +276,9 @@ class ResourceMonitor:
 
     def _get_process_tree_stats(self):
         """Convenience wrapper returning (cpu_percent_total, ram_percent) from
-        get_process_tree_stats() against the monitor's own root process."""
-        stats = get_process_tree_stats(self.process)
+        get_process_tree_stats() against the monitor's own root process, threading the
+        persistent Process cache through so per-child CPU readings are accurate."""
+        stats = get_process_tree_stats(self.process, self._proc_cache)
         return stats["cpu_percent"], stats["ram_percent"]
 
     def _get_gpu_stats(self):

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -1,0 +1,194 @@
+"""Unit tests for aetherscan.monitor.get_process_tree_stats(): the PID -> Process cache
+that fixes issue #12's CPU undercount (a freshly created psutil.Process reads 0.0 on its
+first cpu_percent(interval=0) call, and children() manufactures fresh objects every call).
+
+Importing aetherscan.monitor pulls TensorFlow at collection (monitor.py imports tf for GPU
+detection) — same as most unit modules. The tests themselves drive the pure function with
+fake Process objects; no monitor instance, GPU, or cluster data involved.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import psutil
+import pytest
+
+from aetherscan.monitor import get_process_tree_stats
+
+
+class FakeProcess:
+    """Mimics the psutil.Process surface get_process_tree_stats() touches.
+
+    cpu_percent() reproduces psutil's documented behavior for interval=0: the first call on
+    a given object has no baseline and returns 0.0; subsequent calls return `cpu`.
+    """
+
+    def __init__(self, pid: int, cpu: float = 0.0, pss: int = 0):
+        self.pid = pid
+        self.cpu_calls = 0
+        self._cpu = cpu
+        self._pss = pss
+        self.dead = False
+        self.access_denied = False
+
+    def cpu_percent(self, interval: float = 0.0) -> float:
+        if self.dead:
+            raise psutil.NoSuchProcess(self.pid)
+        if self.access_denied:
+            raise psutil.AccessDenied(self.pid)
+        self.cpu_calls += 1
+        return 0.0 if self.cpu_calls == 1 else self._cpu
+
+    def memory_full_info(self):
+        if self.dead:
+            raise psutil.NoSuchProcess(self.pid)
+        return SimpleNamespace(pss=self._pss)
+
+
+class FakeRoot(FakeProcess):
+    """Root process whose children() manufactures brand-new FakeProcess objects on every
+    call — exactly what psutil.Process.children(recursive=True) does, and the reason the
+    cache is needed. `spawned` records every manufactured child for identity assertions."""
+
+    def __init__(self, pid: int = 1, cpu: float = 0.0, pss: int = 0):
+        super().__init__(pid, cpu, pss)
+        self.child_specs: list[tuple[int, float, int]] = []  # (pid, cpu, pss)
+        self.spawned: list[FakeProcess] = []
+
+    def children(self, recursive: bool = False) -> list[FakeProcess]:
+        procs = [FakeProcess(pid, cpu, pss) for pid, cpu, pss in self.child_specs]
+        self.spawned.extend(procs)
+        return procs
+
+
+@pytest.fixture(autouse=True)
+def _system_totals(monkeypatch):
+    """Pin core count (4) and total RAM (10_000 bytes) so normalization is deterministic."""
+    monkeypatch.setattr(psutil, "cpu_count", lambda: 4)
+    monkeypatch.setattr(
+        psutil, "virtual_memory", lambda: SimpleNamespace(total=10_000, percent=0.0)
+    )
+
+
+class TestProcessCache:
+    def test_cached_object_reused_for_stable_pid(self):
+        root = FakeRoot()
+        root.child_specs = [(2, 100.0, 0)]
+        cache: dict[int, FakeProcess] = {}
+
+        get_process_tree_stats(root, cache)
+        first_seen = root.spawned[0]
+        get_process_tree_stats(root, cache)
+
+        # Second call manufactured a fresh object for pid 2, but measurement went through
+        # the cached first-seen object (fresh one untouched)
+        assert cache[2] is first_seen
+        assert first_seen.cpu_calls == 2
+        assert root.spawned[1].cpu_calls == 0
+
+    def test_cpu_accurate_from_second_sample(self):
+        root = FakeRoot(cpu=40.0)
+        root.child_specs = [(2, 100.0, 0), (3, 100.0, 0)]
+        cache: dict[int, FakeProcess] = {}
+
+        first = get_process_tree_stats(root, cache)
+        second = get_process_tree_stats(root, cache)
+
+        # First sample: every object is new -> all 0.0 (the one-time cost the fix accepts)
+        assert first["cpu_percent"] == 0.0
+        # Second sample: (40 + 100 + 100) / 4 cores
+        assert second["cpu_percent"] == pytest.approx(60.0)
+
+    def test_new_pid_contributes_one_zero_reading(self):
+        root = FakeRoot()
+        root.child_specs = [(2, 100.0, 0)]
+        cache: dict[int, FakeProcess] = {}
+
+        get_process_tree_stats(root, cache)
+        root.child_specs.append((3, 60.0, 0))
+
+        # pid 2 is warm (100.0); pid 3 is new -> 0.0 this interval
+        second = get_process_tree_stats(root, cache)
+        assert second["cpu_percent"] == pytest.approx(100.0 / 4)
+
+        # Next interval both are warm
+        third = get_process_tree_stats(root, cache)
+        assert third["cpu_percent"] == pytest.approx((100.0 + 60.0) / 4)
+
+    def test_departed_pids_evicted_from_cache(self):
+        root = FakeRoot()
+        root.child_specs = [(2, 0.0, 0), (3, 0.0, 0)]
+        cache: dict[int, FakeProcess] = {}
+
+        get_process_tree_stats(root, cache)
+        assert set(cache) == {1, 2, 3}
+
+        root.child_specs = [(2, 0.0, 0)]
+        get_process_tree_stats(root, cache)
+        assert set(cache) == {1, 2}
+
+    def test_nosuchprocess_evicts_and_skips(self):
+        root = FakeRoot(cpu=40.0)
+        root.child_specs = [(2, 100.0, 0)]
+        cache: dict[int, FakeProcess] = {}
+
+        get_process_tree_stats(root, cache)
+        # pid 2 dies between children() enumeration and the stat calls
+        cache[2].dead = True
+
+        stats = get_process_tree_stats(root, cache)
+        assert 2 not in cache
+        assert stats["cpu_percent"] == pytest.approx(40.0 / 4)  # root still counted
+
+    def test_access_denied_skipped_but_kept_in_cache(self):
+        root = FakeRoot(cpu=40.0)
+        root.child_specs = [(2, 100.0, 0)]
+        cache: dict[int, FakeProcess] = {}
+
+        get_process_tree_stats(root, cache)
+        cache[2].access_denied = True
+
+        stats = get_process_tree_stats(root, cache)
+        assert stats["cpu_percent"] == pytest.approx(40.0 / 4)
+        assert 2 in cache  # process still exists; only this sample is skipped
+
+
+class TestAggregation:
+    def test_ram_sums_pss_across_tree(self):
+        root = FakeRoot(pss=1_000)
+        root.child_specs = [(2, 0.0, 2_000), (3, 0.0, 3_000)]
+
+        stats = get_process_tree_stats(root, {})
+        assert stats["ram_bytes"] == 6_000
+        assert stats["ram_gb"] == pytest.approx(6_000 / 1e9)
+        assert stats["ram_percent"] == pytest.approx(60.0)  # of the pinned 10_000 total
+
+    def test_no_cache_still_aggregates_ram(self):
+        # RAM-only callers (manager._get_memory_usage) pass no cache and build a fresh root
+        # Process object per call; PSS aggregation must work regardless, while CPU stays at
+        # the no-baseline 0.0
+        for _ in range(2):
+            root = FakeRoot(cpu=40.0, pss=1_000)
+            root.child_specs = [(2, 100.0, 2_000)]
+            stats = get_process_tree_stats(root)
+            assert stats["cpu_percent"] == 0.0
+            assert stats["ram_bytes"] == 3_000
+
+    def test_unreadable_root_returns_zeros(self):
+        # AccessDenied from children() escapes the NoSuchProcess suppression and lands in
+        # the outer guard, which degrades to all-zero stats instead of raising
+        root = FakeRoot()
+
+        def _raise(recursive: bool = False):
+            raise psutil.AccessDenied(root.pid)
+
+        root.children = _raise
+
+        stats = get_process_tree_stats(root, {})
+        assert stats == {
+            "cpu_percent": 0.0,
+            "ram_percent": 0.0,
+            "ram_bytes": 0,
+            "ram_gb": 0.0,
+        }


### PR DESCRIPTION
Closes #12

## What changed

`get_process_tree_stats()` rebuilt `psutil.Process` objects for every child on every monitoring interval (`process.children(recursive=True)`) and then called `cpu_percent(interval=0.0)` on them. psutil's documented behavior is to return `0.0` on the first `cpu_percent` call for a newly created `Process` object (no baseline), so the multiprocessing pool workers reported ~0 CPU every interval and the "Aetherscan" process-tree line sat far below "System Total" during data generation — issue #12's Option 1 (cache Process objects) implemented as recommended.

- `src/aetherscan/monitor/monitor.py`:
  - `get_process_tree_stats(process, proc_cache=None)` now threads a PID -> `psutil.Process` cache through the per-process loop: known PIDs reuse the cached object (accurate from their second sample), new PIDs are inserted and contribute one `0.0` reading, PIDs raising `NoSuchProcess` are evicted immediately, and PIDs that leave the tree are evicted after each pass. PSS-based RAM aggregation and core-count normalization are unchanged.
  - `ResourceMonitor` owns the persistent cache (`self._proc_cache`, initialized next to `self.process`) and passes it via `_get_process_tree_stats()`, so the 1 Hz monitor loop gets accurate per-child CPU from the second sample onward.
  - Removed the stale `# BUG:` marker above the function (the top-of-file `# BUG:` about missing plot sections is a different, still-open observation and was left alone).
- `KNOWN_ISSUES.md` section 6: status flipped to **Resolved** with a description of the fix; Cause/Impact moved to past tense; the now-moot Workaround subsection removed.
- `tests/unit/test_monitor.py` (new): drives the pure function with fake Process objects that mimic psutil's first-call-returns-0.0 semantics and children()-returns-fresh-objects behavior. Covers: cached-object reuse for a stable PID, 0.0-first/accurate-second sampling, one-time 0.0 for newly appeared PIDs, eviction of departed and `NoSuchProcess` PIDs, `AccessDenied` skip-but-keep, PSS aggregation, the no-cache (RAM-only) path, and the all-zeros outer guard. Note: the module imports TensorFlow at collection (monitor.py imports tf for GPU detection), same as most unit modules — no `gpu`/`cluster` marker needed since the tests never touch a GPU.

## Verification

- `tests/unit/test_monitor.py`: 9/9 passed locally in the TF venv (macOS, Python 3.12).
- `tests/unit/test_manager.py` (regression for the second `get_process_tree_stats` caller, `_get_memory_usage`): 14 passed, 3 skipped (Linux-only PSS skips on macOS).
- pre-commit `ruff` + `ruff-format` passed on the changed files; full pre-commit hook set passed at commit time.
- Full suite deferred to CI. Behavior on a real multiprocessing run (blue line tracking orange in the resource plot) is only verifiable on a cluster run — not exercised here.

## Maintainer decisions applied

- **`proc_cache` is an optional parameter (default `None` = throwaway dict)** rather than required: the only other caller, `manager._get_memory_usage()`, reads `ram_gb` only and builds a fresh root `Process` per call, so it keeps its exact prior behavior with zero diff to `manager.py`. Making it required would have forced a cosmetic edit there.
- **`AccessDenied`/`ZombieProcess` entries stay cached** (only `NoSuchProcess` or leaving the tree evicts): the process still exists, so keeping its baseline is strictly better for the next sample.
- **No PID-reuse identity check**: if the OS recycles a dead worker's PID within one ~1 s interval, the stale cached object yields one skewed sample before normal eviction/replacement. Guarding this (create-time comparison per process per interval) adds a syscall per process per tick for a rare, self-healing case — left out per the issue's Option 1 scope.
- **KNOWN_ISSUES.md Workaround subsection removed** (it advised external tools like htop) since the section is now Resolved; the section itself is kept for history, matching how other resolved/won't-fix sections remain in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)