### PR TITLE
fix: guard the resume footgun — round_XX load-tag validation, no silent latest-tag fallback, qualified success

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,9 @@ PYTHONPATH=src python -m aetherscan.main train \
     --save-tag test_v1
 ```
 
+> [!WARNING]
+> Per-round checkpoints live under `checkpoints/` — `--load-tag round_XX` without `--load-dir checkpoints` is rejected at validation (it used to silently resume from the newest stale model in the models root instead).
+
 **Training with an explicit per-GPU memory cap (e.g. on an older Ampere GPU with lower VRAM)**
 
 ```bash

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -28,6 +28,10 @@ logger = logging.getLogger(__name__)
 # runs can be labelled meaningfully without being forced into the test_vX / final_vX shapes.
 _TAG_PATTERN = re.compile(r"^(?:\d{8}_\d{6}|final_v\d+|round_\d+|test_v\d+)$")
 
+# The round_XX subset of _TAG_PATTERN: per-round checkpoints are saved under the checkpoints/
+# subdirectory, so loading one requires --load-dir checkpoints (issue #142)
+_ROUND_TAG_PATTERN = re.compile(r"^round_\d+$")
+
 # sklearn's RandomForestClassifier accepts these string values for max_features
 _RF_MAX_FEATURES_STR_VALUES = {"sqrt", "log2"}
 
@@ -1945,6 +1949,30 @@ def collect_validation_errors(
                     current=load_tag,
                     message=f"--load-tag must match one of: YYYYMMDD_HHMMSS, final_vX, round_XX, test_vX; got {load_tag!r}",
                     fix_kind="format",
+                )
+            )
+
+        # Resume footgun (issue #142): per-round checkpoints are saved under the checkpoints/
+        # subdirectory, so `--load-tag round_XX` without `--load-dir checkpoints` searches the
+        # models root instead and used to silently resume from a stale, unrelated model.
+        load_dir = _resolve(args, "load_dir", config.checkpoint.load_dir)
+        if (
+            load_tag is not None
+            and _ROUND_TAG_PATTERN.match(load_tag)
+            and load_dir != "checkpoints"
+        ):
+            errors.append(
+                ValidationError(
+                    field="checkpoint.load_dir",
+                    current=load_dir,
+                    message=(
+                        f"--load-tag {load_tag!r} names a per-round checkpoint, and those are "
+                        f"saved under the 'checkpoints/' subdirectory — pass --load-dir "
+                        f"checkpoints to resume from it. (If you genuinely keep a final model "
+                        f"tagged {load_tag!r} in the models root, re-save it under a final_vX "
+                        f"or test_vX tag and load that instead.)"
+                    ),
+                    fix_kind="cross_param",
                 )
             )
 

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -168,7 +168,8 @@ def _report_final_training_status(pipeline) -> None:
     Extracted from train_command so the exit contract is unit-testable: a fully-successful run
     exits 0, a run with any recorded non-critical stage failure (vae_plots/rf_plots/hf_upload that
     never recovered across attempts) exits 1, and a missing pipeline exits 1 rather than reporting
-    a false success.
+    a false success. A run that skipped RF training because a pre-loaded RF was already trained
+    exits 0 but with a warning annotation instead of the unqualified success line (issue #142).
     """
     if pipeline is None:
         # Defensive: the retry loop always sets pipeline or sys.exit(1)s first, and
@@ -193,6 +194,19 @@ def _report_final_training_status(pipeline) -> None:
         )
         logger.error("=" * 60)
         sys.exit(1)
+
+    # Qualified success (issue #142): a run whose RF stage was skipped because an
+    # already-trained Random Forest was pre-loaded (e.g. resumed from the wrong tag) must not
+    # report unqualified success — the saved RF was never trained on this run's encoder.
+    skipped_rf_tag = getattr(pipeline, "rf_training_skipped_from_tag", None)
+    if skipped_rf_tag:
+        logger.warning("=" * 60)
+        logger.warning(
+            f"Training completed, but Random Forest training was SKIPPED — the saved RF was "
+            f"loaded from tag '{skipped_rf_tag}', not trained during this run"
+        )
+        logger.warning("=" * 60)
+        return
 
     logger.info("=" * 60)
     logger.info("Training completed successfully!")

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -198,6 +198,9 @@ def _report_final_training_status(pipeline) -> None:
     # Qualified success (issue #142): a run whose RF stage was skipped because an
     # already-trained Random Forest was pre-loaded (e.g. resumed from the wrong tag) must not
     # report unqualified success — the saved RF was never trained on this run's encoder.
+    # Ordering is intentional: the failed_stages branch above exits(1) first, so a run that
+    # both had a permanent stage failure AND skipped RF reports the failure (the stronger
+    # signal), never this qualified-success annotation.
     skipped_rf_tag = getattr(pipeline, "rf_training_skipped_from_tag", None)
     if skipped_rf_tag:
         logger.warning("=" * 60)

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -316,11 +316,17 @@ def _resolve_load_tag(base_dir: str, tag: str | None) -> str:
     if tag is not None:
         if _model_pair_exists(base_dir, tag):
             return tag
-        raise FileNotFoundError(
+        msg = (
             f"No models tagged '{tag}' in {base_dir} — refusing to fall back to the latest tag "
-            f"for an explicitly requested tag. If you meant to resume from a per-round "
-            f"checkpoint, pass --load-dir checkpoints"
+            f"for an explicitly requested tag."
         )
+        # The per-round-checkpoint hint only helps for a round_XX tag; for any other explicit
+        # tag (e.g. a typo'd final_v2) it's a red herring, so only append it for round tags.
+        if re.fullmatch(r"round_\d+", tag):
+            msg += (
+                " If you meant to resume from a per-round checkpoint, pass --load-dir checkpoints"
+            )
+        raise FileNotFoundError(msg)
 
     # NOTE: use a more sensible default
     logger.info("No tag specified. Defaulting to 'final'")

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -982,6 +982,14 @@ class TrainingPipeline:
         # Initialize RF model as None
         self.rf_model = None
 
+        # Tag an already-trained RF was loaded from (set by load_models); lets
+        # train_random_forest name the stale source when it skips retraining (issue #142)
+        self._rf_loaded_from_tag: str | None = None
+
+        # Set when train_random_forest skips because a pre-loaded RF was already trained —
+        # main.py annotates the terminal status instead of reporting unqualified success
+        self.rf_training_skipped_from_tag: str | None = None
+
         # Background round-data producer (created in train_beta_vae when
         # overlap_data_generation is enabled; None otherwise)
         self._round_producer: RoundDataProducer | None = None
@@ -2256,7 +2264,19 @@ class TrainingPipeline:
             self.rf_model = RandomForestModel()
 
         elif self.rf_model.is_trained:
-            logger.info("Random Forest classifier already trained. Exiting training loop.")
+            # A pre-loaded, already-trained RF short-circuits the whole stage — make the skip
+            # loud and record it, or a resume from the wrong tag ships a stale RF while the
+            # run reports unqualified success (issue #142)
+            source_tag = self._rf_loaded_from_tag or "unknown"
+            logger.warning("=" * 60)
+            logger.warning(
+                f"RF training SKIPPED: an already-trained Random Forest (loaded from tag "
+                f"'{source_tag}') is in memory — no new Random Forest will be trained for "
+                f"save tag '{self.config.checkpoint.save_tag}'; the loaded model is reused "
+                f"as-is"
+            )
+            logger.warning("=" * 60)
+            self.rf_training_skipped_from_tag = source_tag
             return
 
         # # BUG:
@@ -6522,6 +6542,7 @@ class TrainingPipeline:
                     self.rf_model = RandomForestModel()
 
                 self.rf_model.load(rf_path)
+                self._rf_loaded_from_tag = tag
                 logger.info("Random Forest loaded successfully")
             else:
                 logger.info(

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -297,6 +297,50 @@ def get_latest_tag(checkpoints_dir: str) -> str:
     return tag
 
 
+def _model_pair_exists(base_dir: str, tag: str) -> bool:
+    """True when the encoder/decoder pair for `tag` both exist in base_dir."""
+    return os.path.exists(os.path.join(base_dir, f"vae_encoder_{tag}.keras")) and os.path.exists(
+        os.path.join(base_dir, f"vae_decoder_{tag}.keras")
+    )
+
+
+def _resolve_load_tag(base_dir: str, tag: str | None) -> str:
+    """
+    Resolve the tag load_models() should load from base_dir.
+
+    An explicitly requested tag must exist: raising FileNotFoundError beats the old silent
+    get_latest_tag() fallback, which could resume training from a stale, unrelated model while
+    reporting success (issue #142). Only the tag=None default may fall back to the latest tag
+    present in base_dir.
+    """
+    if tag is not None:
+        if _model_pair_exists(base_dir, tag):
+            return tag
+        raise FileNotFoundError(
+            f"No models tagged '{tag}' in {base_dir} — refusing to fall back to the latest tag "
+            f"for an explicitly requested tag. If you meant to resume from a per-round "
+            f"checkpoint, pass --load-dir checkpoints"
+        )
+
+    # NOTE: use a more sensible default
+    logger.info("No tag specified. Defaulting to 'final'")
+    if _model_pair_exists(base_dir, "final"):
+        return "final"
+
+    logger.warning(f"No models tagged as 'final' in {base_dir}")
+    logger.warning(f"Looking for latest tag in {base_dir} instead")
+
+    latest = get_latest_tag(
+        base_dir
+    )  # get_latest_tag() will raise an error if no valid tags exist in base_dir
+    logger.info(f"Tag 'final' not found. Loading latest model with tag: '{latest}'")
+
+    # Sanity check: get_latest_tag() only returns tags whose pair existed at scan time
+    if not _model_pair_exists(base_dir, latest):
+        raise FileNotFoundError("Models not found")
+    return latest
+
+
 def compute_expected_std(layer):
     """Compute expected std based on initializer."""
     weights = layer.get_weights()
@@ -6439,43 +6483,23 @@ class TrainingPipeline:
             logger.info(f"Saved Random Forest to {rf_path}")
 
     def load_models(self, tag: str | None = None, dir: str | None = None):
-        """Load model weights"""
-        if tag is None:
-            # NOTE: use a more sensible default
-            logger.info("No tag specified. Defaulting to 'final'")
-            tag = "final"
-        original_tag = tag
+        """Load model weights.
 
-        # Construct filepaths
+        An explicit `tag` must exist in the target directory (FileNotFoundError otherwise);
+        only the tag=None default falls back to 'final' and then the latest tag present —
+        see _resolve_load_tag() and issue #142.
+        """
         if dir is not None:
             base_dir = os.path.join(self.config.model_path, dir)
-            encoder_path = os.path.join(base_dir, f"vae_encoder_{tag}.keras")
-            decoder_path = os.path.join(base_dir, f"vae_decoder_{tag}.keras")
-            rf_path = os.path.join(base_dir, f"random_forest_{tag}.joblib")
         else:
             base_dir = self.config.model_path
-            encoder_path = os.path.join(base_dir, f"vae_encoder_{tag}.keras")
-            decoder_path = os.path.join(base_dir, f"vae_decoder_{tag}.keras")
-            rf_path = os.path.join(base_dir, f"random_forest_{tag}.joblib")
 
-        if not (os.path.exists(encoder_path) and os.path.exists(decoder_path)):
-            # If the specified path doesn't exist, try to find the latest tag from base_dir
-            logger.warning(f"No models tagged as '{original_tag}' in {base_dir}")
-            logger.warning(f"Looking for latest tag in {base_dir} instead")
+        tag = _resolve_load_tag(base_dir, tag)
 
-            tag = get_latest_tag(
-                base_dir
-            )  # get_latest_tag() will raise an error if no valid tags exist in base_dir
-            logger.info(f"Tag '{original_tag}' not found. Loading latest model with tag: '{tag}'")
-
-            # Reconstruct paths with new tag
-            encoder_path = os.path.join(base_dir, f"vae_encoder_{tag}.keras")
-            decoder_path = os.path.join(base_dir, f"vae_decoder_{tag}.keras")
-            rf_path = os.path.join(base_dir, f"random_forest_{tag}.joblib")
-
-            # Sanity check: if paths still don't exist, raise an error
-            if not (os.path.exists(encoder_path) and os.path.exists(decoder_path)):
-                raise FileNotFoundError("Models not found")
+        # Construct filepaths
+        encoder_path = os.path.join(base_dir, f"vae_encoder_{tag}.keras")
+        decoder_path = os.path.join(base_dir, f"vae_decoder_{tag}.keras")
+        rf_path = os.path.join(base_dir, f"random_forest_{tag}.joblib")
 
         # Load the models
         try:

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -129,6 +129,23 @@ class TestSemanticChecks:
         errors = collect_validation_errors(_parse(["train", "--load-tag", "bogus"]), None)
         assert any(e.field == "checkpoint.load_tag" and e.fix_kind == "format" for e in errors)
 
+    def test_round_load_tag_without_checkpoints_load_dir_rejected(self):
+        # The #142 resume footgun: per-round checkpoints live under checkpoints/, so a bare
+        # `--load-tag round_XX` would search the models root and silently load a stale model.
+        errors = collect_validation_errors(_parse(["train", "--load-tag", "round_01"]), None)
+        assert any(e.field == "checkpoint.load_dir" and e.fix_kind == "cross_param" for e in errors)
+
+    def test_round_load_tag_with_checkpoints_load_dir_passes(self):
+        errors = collect_validation_errors(
+            _parse(["train", "--load-tag", "round_01", "--load-dir", "checkpoints"]), None
+        )
+        assert not any(e.field == "checkpoint.load_dir" for e in errors)
+
+    def test_final_load_tag_without_load_dir_passes(self):
+        # A final model legitimately lives in the models root — no load-dir required.
+        errors = collect_validation_errors(_parse(["train", "--load-tag", "final_v1"]), None)
+        assert not any(e.field == "checkpoint.load_dir" for e in errors)
+
     def test_num_samples_divisible_by_4(self):
         errors = collect_validation_errors(_parse(["train", "--num-samples-beta-vae", "202"]), None)
         assert any(e.field == "training.num_samples_beta_vae" and e.divisor == 4 for e in errors)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -7,6 +7,7 @@ preprocessing stubbed out."""
 from __future__ import annotations
 
 import json
+import logging
 import types
 
 import numpy as np
@@ -42,6 +43,16 @@ class TestReportFinalTrainingStatus:
         with pytest.raises(SystemExit) as exc:
             main._report_final_training_status(None)
         assert exc.value.code == 1
+
+    def test_rf_skip_annotates_success_instead_of_unqualified(self, caplog):
+        # A run whose RF stage was skipped (pre-loaded already-trained RF, issue #142) still
+        # exits 0, but the terminal message must be the skip warning, not plain success.
+        pipeline = _pipeline_with([])
+        pipeline.rf_training_skipped_from_tag = "test_v27"
+        with caplog.at_level(logging.INFO, logger="aetherscan.main"):
+            main._report_final_training_status(pipeline)  # no SystemExit
+        assert any("SKIPPED" in r.message and "test_v27" in r.message for r in caplog.records)
+        assert not any("completed successfully" in r.message for r in caplog.records)
 
 
 @pytest.fixture

--- a/tests/unit/test_train_utils.py
+++ b/tests/unit/test_train_utils.py
@@ -6,7 +6,9 @@ training stage machine (skip-if-done / record-failure semantics against a stub p
 
 from __future__ import annotations
 
+import logging
 import os
+import types
 
 import numpy as np
 import pytest
@@ -128,6 +130,26 @@ class TestResolveLoadTag:
     def test_default_empty_dir_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError):
             _resolve_load_tag(str(tmp_path), None)
+
+
+class TestTrainRandomForestSkipIsLoud:
+    def test_pretrained_rf_skip_warns_and_records_source_tag(self, caplog):
+        """The is_trained early-return (issue #142) must warn loudly, name the tag the stale
+        RF was loaded from, and set the marker main.py uses to qualify the terminal status."""
+        pipeline = TrainingPipeline.__new__(TrainingPipeline)
+        pipeline.config = get_config()
+        pipeline._resumed = False
+        pipeline.rf_model = types.SimpleNamespace(is_trained=True)
+        pipeline._rf_loaded_from_tag = "test_v27"
+        pipeline.rf_training_skipped_from_tag = None
+
+        with caplog.at_level(logging.WARNING, logger="aetherscan.train"):
+            pipeline.train_random_forest()
+
+        assert pipeline.rf_training_skipped_from_tag == "test_v27"
+        assert any(
+            "RF training SKIPPED" in r.message and "test_v27" in r.message for r in caplog.records
+        )
 
 
 class _PipelineStub:

--- a/tests/unit/test_train_utils.py
+++ b/tests/unit/test_train_utils.py
@@ -117,6 +117,20 @@ class TestResolveLoadTag:
         with pytest.raises(FileNotFoundError, match="round_01"):
             _resolve_load_tag(str(tmp_path), "round_01")
 
+    def test_missing_round_tag_message_hints_checkpoints(self, tmp_path):
+        # The per-round-checkpoint hint is relevant only for a round_XX tag.
+        _touch_pair(tmp_path, "test_v27")
+        with pytest.raises(FileNotFoundError, match="--load-dir checkpoints"):
+            _resolve_load_tag(str(tmp_path), "round_01")
+
+    def test_missing_non_round_tag_message_omits_checkpoints_hint(self, tmp_path):
+        # For a non-round explicit tag (e.g. a typo'd final_v2) the checkpoints hint is a
+        # red herring and must not appear.
+        _touch_pair(tmp_path, "final_v1")
+        with pytest.raises(FileNotFoundError) as excinfo:
+            _resolve_load_tag(str(tmp_path), "final_v2")
+        assert "--load-dir checkpoints" not in str(excinfo.value)
+
     def test_default_prefers_final(self, tmp_path):
         _touch_pair(tmp_path, "final")
         _touch_pair(tmp_path, "round_09")

--- a/tests/unit/test_train_utils.py
+++ b/tests/unit/test_train_utils.py
@@ -25,6 +25,7 @@ from aetherscan.run_state import (
 from aetherscan.train import (
     TrainingPipeline,
     _execute_training_stages,
+    _resolve_load_tag,
     _select_positive_class_shap,
     archive_directory,
     check_encoder_trained,
@@ -98,6 +99,35 @@ class TestGetLatestTag:
             f.write("stub")
         with pytest.raises(FileNotFoundError, match="No valid model pairs"):
             get_latest_tag(str(d))
+
+
+class TestResolveLoadTag:
+    """The load_models() tag decision (issue #142): an explicit missing tag must fail loud
+    instead of silently substituting the latest tag present in base_dir."""
+
+    def test_explicit_existing_tag_returned(self, tmp_path):
+        _touch_pair(tmp_path, "round_03")
+        assert _resolve_load_tag(str(tmp_path), "round_03") == "round_03"
+
+    def test_explicit_missing_tag_raises_instead_of_falling_back(self, tmp_path):
+        # The old fallback would have loaded the stale test_v27 model and reported success.
+        _touch_pair(tmp_path, "test_v27")
+        with pytest.raises(FileNotFoundError, match="round_01"):
+            _resolve_load_tag(str(tmp_path), "round_01")
+
+    def test_default_prefers_final(self, tmp_path):
+        _touch_pair(tmp_path, "final")
+        _touch_pair(tmp_path, "round_09")
+        assert _resolve_load_tag(str(tmp_path), None) == "final"
+
+    def test_default_falls_back_to_latest(self, tmp_path):
+        _touch_pair(tmp_path, "round_02")
+        _touch_pair(tmp_path, "test_v1")
+        assert _resolve_load_tag(str(tmp_path), None) == "round_02"
+
+    def test_default_empty_dir_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            _resolve_load_tag(str(tmp_path), None)
 
 
 class _PipelineStub:


### PR DESCRIPTION
Closes #142

Guards against the resume footgun found in the #117 crash/resume verification: `--load-tag round_XX` without `--load-dir checkpoints` silently loaded a stale, unrelated final model from the models root, skipped RF training, and still reported "Training completed successfully!". Three focused commits, one per layer:

## 1. Fail fast at validation (`cli.py`)

`collect_validation_errors` now emits a `ValidationError` (field `checkpoint.load_dir`, `fix_kind="cross_param"`) when the resolved `load_tag` matches `^round_\d+$` but the resolved `load_dir` is not `checkpoints`. The message is worded as guidance per the issue's false-positive caveat — a final model could legitimately carry a `round_XX` tag in the models root, and the message says how to proceed in that case (re-save under a `final_vX`/`test_vX` tag). A matching `[!WARNING]` note was added to README's *Resume from checkpoint* example. No CLI flags or help strings changed, so the README CLI Reference needed no regeneration.

## 2. No silent latest-tag fallback for an explicit tag (`train.py`) — deliberate behavior change

`load_models()` previously fell back to `get_latest_tag(base_dir)` whenever the requested tag was missing — for **any** explicit tag, not just `round_XX` (a typo'd `--load-tag final_v2` had the same failure mode). The tag decision is now extracted into a pure helper `_resolve_load_tag(base_dir, tag)`:

- explicit `tag` that exists → returned unchanged
- explicit `tag` that is missing → **`FileNotFoundError`** (new behavior)
- `tag=None` → `'final'`, then the latest tag present in `base_dir` (old fallback preserved)

**Call-site audit** (all in-repo callers verified):

| Call site | Tag | Effect |
|---|---|---|
| `train.py` `__init__` explicit-flags resume (`tag=config.checkpoint.load_tag`) | explicit (or None if only `--load-dir` given) | fails loud on a missing explicit tag — caught, logged, and re-raised exactly as before |
| `train.py` `__init__` manifest-driven resume (`tag="round_XX", dir="checkpoints"`) | explicit | the checkpoint exists per the manifest; a manually deleted one now fails loud instead of resuming from the wrong round |
| `train_random_forest()` encoder reload, both attempts | `tag=None` | fallback preserved, unchanged |

## 3. Qualified success (`train.py` + `main.py`)

- `load_models()` records the tag an already-trained RF was loaded from.
- The `is_trained` early-return in `train_random_forest()` is upgraded from a one-line INFO to a framed WARNING naming that tag, and sets `rf_training_skipped_from_tag` on the pipeline.
- `_report_final_training_status()` replaces the unqualified "Training completed successfully!" with a skip warning when the marker is set. Exit code stays 0 (the VAE work is real; nothing "permanently failed" in the stage-machine sense).

## Verification

- Unit tests locally in the TF venv: `tests/unit/test_cli_validation.py`, `tests/unit/test_cli_help_sync.py`, `tests/unit/test_train_utils.py`, `tests/unit/test_main.py` with `-m "not gpu and not cluster"` — **172 passed**. Full suite deferred to CI.
- `ruff check` + `ruff format` via pre-commit on every commit (all hooks passed).
- New tests: 3 validation-guard cases in `test_cli_validation.py`; 5 `_resolve_load_tag` cases + the loud-skip test in `test_train_utils.py`; 1 qualified-terminal-status case in `test_main.py`. The full `load_models()` weight-loading path itself still needs TF models and remains covered by the gpu-marked smokes.

## Maintainer decisions applied

- **Fix 2 is a behavior change**: an explicit `--load-tag` that doesn't exist now raises `FileNotFoundError` instead of loading the latest tag. Any out-of-repo workflow relying on the old fallback for explicit tags will now fail loud — per the issue's item (2), this is the intent, but veto if you rely on it.
- **RF-skip marker is in-memory, not persisted**: `rf_training_skipped_from_tag` lives on the pipeline object rather than in the run manifest (avoids a `TrainingRunState` schema change and stale-marker cleanup). Edge case: if the skip happens on attempt N and a *later* retry attempt resumes past `rf_train` via the manifest, the terminal annotation is lost — the framed WARNING from the skipping attempt remains in the log.
- **Qualified success still exits 0** (warning annotation only); the issue left exit semantics open, and treating the skip like a permanently-failed stage (exit 1) seemed too strong given the loaded RF may be exactly what the operator wanted.
- **Validation guard fires for any `load_dir != "checkpoints"`** (including custom subdirs), matching the triage gameplan; the guidance wording covers the escape hatch.
- **Docs**: README got the one-line footgun warning per the gameplan; `docs/TRAINING_PIPELINE.md` was left untouched (its resume section already documents the correct command and the escape hatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
