### PR TITLE
test/docs: pin the CASPER GBT512 bug=true PFB response delta as negligible

### DIFF
--- a/docs/PREPROCESSING.md
+++ b/docs/PREPROCESSING.md
@@ -110,10 +110,15 @@ window, and the sinc prototype aren't guesses: the GBT Breakthrough Listen backe
 confirmed as the CASPER `GBT512` configuration — `nchan=1024, ntaps=12, width=1.0,
 window=hamming, lpf=sinc` (from
 [PFBPassband.jl](https://github.com/david-macmahon/PFBPassband.jl)) — which is exactly what
-[`pfb.py`](../src/aetherscan/pfb.py) models. One caveat: that reference config also carries a
-`bug=true` flag capturing a sinc-approximation quirk in the real hardware, whereas `pfb.py`
-computes the sinc exactly. The resulting modeled-vs-hardware difference is small and is tracked
-in issue #180.
+[`pfb.py`](../src/aetherscan/pfb.py) models. That reference config also carries a `bug=true`
+flag: the CASPER coefficient generator omits the half-sample offset from the sinc argument
+(`sinc((n − N/2) / nchan)` instead of the bug-free `sinc((n + 0.5 − N/2) / nchan)`,
+`N = ntaps × nchan`), so the real hardware runs a sinc mis-centered by half a sample relative
+to its Hamming window while `pfb.py` models the bug-free design. That deviation is quantified
+and negligible (issue #180): the folded per-channel power responses agree to ~10⁻⁵ (relative)
+at a typical GBT geometry (64 coarse channels, 12 taps) — bounded below 10⁻⁴ by a unit test in
+[`test_pfb.py`](../tests/unit/test_pfb.py) and 3–4 orders of magnitude under the 5 %
+mismatch-warning tolerance — so `pfb.py` keeps the exact bug-free form.
 
 ### The detection statistic: vectorized D'Agostino–Pearson
 

--- a/src/aetherscan/pfb.py
+++ b/src/aetherscan/pfb.py
@@ -15,6 +15,15 @@ zero with a truncated cosine product (cos(x/2)*cos(x/4)*cos(x/8) for |x| < 0.01)
 numerical shortcut, while np.sinc evaluates the same normalized sinc exactly — the unit tests
 pin the two filter designs against each other.
 
+A separate, unrelated quirk lives in the instrument itself: the CASPER GBT512 configuration
+(PFBPassband.jl) carries bug=true — the hardware's coefficient generation omits the
+half-sample offset from the sinc argument (sinc evaluated at (n - N/2) / nchan instead of the
+bug-free (n + 0.5 - N/2) / nchan, N = taps * nchan), mis-centering the sinc by half a sample
+relative to the Hamming window. firdes below is exactly the bug-free design; the two folded
+power responses agree to ~1e-5 (relative) at a typical GBT geometry (64 coarse channels,
+12 taps — bounded < 1e-4 by the unit tests, shrinking as N grows), orders of magnitude below
+the 5% mismatch-warning tolerance, so the exact bug-free form is kept (issue #180).
+
 The response depends on (fine_per_coarse, num_coarse_channels, taps_per_channel) only, so
 gen_coarse_channel_response is lru_cached: each process pays the one-time FFT (seconds at
 full GBT resolution), after which equalizing a channel is a single vectorized divide.

--- a/tests/unit/test_pfb.py
+++ b/tests/unit/test_pfb.py
@@ -1,7 +1,9 @@
 """Unit tests for aetherscan.pfb: windowed-sinc filter design (cross-checked against a
-transcription of the bliss C++ sinc approximation), the folded coarse-channel response's
-shape properties (symmetry, mid-band peak, edge rolloff), equalization flatness on synthetic
-PFB-shaped noise, and the edge/mid power-ratio validation statistic."""
+transcription of the bliss C++ sinc approximation and against the CASPER GBT512 reference
+from PFBPassband.jl, including the hardware's bug=true half-step-offset quirk), the folded
+coarse-channel response's shape properties (symmetry, mid-band peak, edge rolloff),
+equalization flatness on synthetic PFB-shaped noise, and the edge/mid power-ratio
+validation statistic."""
 
 from __future__ import annotations
 
@@ -44,6 +46,40 @@ def _cpp_firdes(num_taps: int, fc: float) -> np.ndarray:
     return out
 
 
+def _casper_firdes(taps_per_channel: int, nchan: int, bug: bool) -> np.ndarray:
+    """Transcription of PFBPassband.jl's coefficient formula (src/PFBPassband.jl, coefs!):
+
+        window(n) .* lpf.(width .* (((0:n-1) .+ 0.5*(1-bug)) ./ nchan .- ntaps/2))
+
+    with the CASPER GBT512 preset window=hamming, lpf=sinc, width=1.0 (src/casperpfbs.jl).
+    bug=True reproduces the CASPER coefficient-generation bug ("exclude half-step offset
+    when pfb.bug is true"): the half-sample offset is omitted from the sinc argument,
+    mis-centering the sinc by half a sample relative to the (unchanged) Hamming window.
+    Transcribed here (test-only, no Julia dependency) to pin aetherscan's exact-sinc design
+    against the hardware reference — see issue #180."""
+    width = 1.0  # GBT512 preset
+    n = taps_per_channel * nchan
+    k = np.arange(n, dtype=np.float64)
+    # PFBPassband's hamming (0.54 + 0.46*cospi(range(-1, 1, n))) == np.hamming(n)
+    window = 0.54 - 0.46 * np.cos(2.0 * np.pi * k / (n - 1))
+    offset = 0.5 * (1.0 - bug)
+    return window * np.sinc(width * ((k + offset) / nchan - taps_per_channel / 2.0))
+
+
+def _fold_response(prototype: np.ndarray, fine_per_coarse: int, num_coarse: int) -> np.ndarray:
+    """Fold an arbitrary prototype filter into the per-coarse-channel power response,
+    replicating gen_coarse_channel_response's algorithm (zero-pad -> |fftshift(FFT)|^2 ->
+    slice half a coarse channel off each end -> sum spans -> normalize to peak 1.0)."""
+    full_len = num_coarse * fine_per_coarse
+    padded = np.zeros(full_len, dtype=np.float64)
+    padded[: prototype.size] = prototype
+    spectrum = np.abs(np.fft.fftshift(np.fft.fft(padded))) ** 2
+    half_fine = fine_per_coarse // 2
+    sliced = spectrum[half_fine : full_len - half_fine]
+    response = sliced.reshape(num_coarse - 1, fine_per_coarse).sum(axis=0)
+    return response / response.max()
+
+
 class TestFirdes:
     @pytest.mark.parametrize(
         ("num_taps", "fc"),
@@ -59,6 +95,38 @@ class TestFirdes:
         # Windowed-sinc design is symmetric about the center tap (linear phase)
         h = firdes(_TAPS * _NUM_COARSE, 1.0 / _NUM_COARSE)
         np.testing.assert_allclose(h, h[::-1], atol=1e-15)
+
+
+class TestCasperGbt512:
+    """Codifies issue #180: aetherscan's firdes is exactly the bug-free CASPER GBT512 design,
+    and the real hardware's bug=true response differs from the modeled one negligibly."""
+
+    @pytest.mark.parametrize("nchan", [4, 64, 512, 1024])
+    def test_firdes_equals_casper_bug_free_design(self, nchan):
+        # bug=False must reproduce firdes to machine precision (measured ~1e-16): aetherscan
+        # models the bug-free CASPER filter, at 12 taps/channel across the GBT geometry family
+        # up to the true GBT512 nchan=1024.
+        ours = firdes(_TAPS * nchan, 1.0 / nchan)
+        reference = _casper_firdes(_TAPS, nchan, bug=False)
+        np.testing.assert_allclose(ours, reference, rtol=0.0, atol=1e-12)
+
+    def test_bug_true_response_delta_negligible(self):
+        # GBT-like geometry: 64 coarse channels of 512 fine channels, 12 taps.
+        fine, num_coarse = 512, 64
+        response_exact = gen_coarse_channel_response(fine, num_coarse, _TAPS)
+
+        # Sanity-pin the test-side fold against the production fold given the same prototype,
+        # so the assertion below measures the prototype difference and nothing else.
+        refolded = _fold_response(firdes(_TAPS * num_coarse, 1.0 / num_coarse), fine, num_coarse)
+        np.testing.assert_allclose(refolded, response_exact, rtol=0.0, atol=1e-12)
+
+        response_bug = _fold_response(_casper_firdes(_TAPS, num_coarse, bug=True), fine, num_coarse)
+        rel_delta = np.abs(response_bug - response_exact) / response_exact
+        # Measured ~9.4e-6 at this geometry (shrinks as taps*nchan grows; ~2.5e-3 only for a
+        # degenerate 4-coarse-channel fold): 3-4 orders of magnitude below the 5% mismatch
+        # warning tolerance, so keeping the exact bug-free design over the hardware's bug=true
+        # form is a negligible modeling deviation.
+        assert float(rel_delta.max()) < 1e-4
 
 
 class TestGenCoarseChannelResponse:


### PR DESCRIPTION
Closes #180

## What this resolves

Issue #180 asked whether Aetherscan's PFB response model matches the real GBT hardware, given that the confirmed CASPER `GBT512` configuration carries `bug=true`. Investigation (against PFBPassband.jl's source) settled both open questions, and per the issue's own decision rule ("if negligible → document it and keep exact-sinc") this lands as a **test + docs PR with no production behavior change**:

1. **What `bug=true` actually is** — it is *not* bliss's near-zero sinc-evaluation shortcut (the issue's hedge resolves to no; those are unrelated). PFBPassband.jl's `coefs!` computes `window(n) .* lpf.(width .* (((0:n-1) .+ 0.5*(1-bug)) ./ nchan .- ntaps/2))`: `bug=true` **omits the half-sample offset** from the sinc argument (`sinc((n − N/2)/nchan)` instead of the bug-free `sinc((n + 0.5 − N/2)/nchan)`, `N = ntaps × nchan`), mis-centering the sinc by half a sample relative to the Hamming window.
2. **Aetherscan == the bug-free design** — `firdes` is algebraically identical to PFBPassband's `bug=false` filter (PFBPassband's hamming == `np.hamming`); verified to ~1e-16 numerically.
3. **The delta is negligible** — folded per-channel power responses (bug-free model vs the hardware's `bug=true` form) differ by **~9.4e-6 relative at a GBT-like geometry** (64 coarse channels, 512 fine, 12 taps; ~2.5e-3 only for a degenerate 4-coarse fold, shrinking as `N` grows). That is 3–4 orders of magnitude below the 5% mismatch-warning tolerance and cannot explain the 13–16% warnings from #125 (the #156 frontend attribution stands).

## Changes

- `tests/unit/test_pfb.py`: `_casper_firdes(taps_per_channel, nchan, bug)` (transcription of the `coefs!` formula, GBT512 preset) and `_fold_response` (test-side replica of the production fold). New `TestCasperGbt512`:
  - **Test A** pins `firdes()` == CASPER `bug=False` at `atol=1e-12` across nchan ∈ {4, 64, 512, 1024} (measured ~1e-16).
  - **Test B** sanity-pins the test-side fold against `gen_coarse_channel_response` bit-for-bit (so the comparison isolates the prototype difference), then asserts the bug-vs-exact folded-response max relative delta `< 1e-4` at fine=512 / ncoarse=64 / taps=12 (measured ~9.4e-6).
- `src/aetherscan/pfb.py`: module docstring gains a paragraph stating what `bug=true` is (half-step-offset omission, distinct from the bliss sinc shortcut documented just above it) and the quantified bound. Docstring only — no code change.
- `docs/PREPROCESSING.md`: the "difference is small and is tracked in issue #180" open-question wording replaced with the mechanism and the measured numbers.

## Maintainer decisions applied

- **No `casper_bug` flag on `firdes`/`gen_coarse_channel_response`.** The gameplan marked this optional ("if it makes test B cleaner"). A test-side `_fold_response` helper (bit-exact-pinned against the production fold) was cleaner and keeps the production surface untouched; the hardware-matching prototype exists in the test file (`_casper_firdes(..., bug=True)`) for future cross-checks. Easy to add later if you want the mode in `pfb.py` itself.
- **Issue task 4 (real-data residual-flatness cross-check) not included.** Given the ~1e-5 headroom under the 5% tolerance, it rides on #156's residual-flatness statistic rather than blocking this closure — matching the triage assessment.
- The docstring/docs state the `< 1e-4` bound as holding "at GBT-scale coarse-channel counts" — the delta is ~2.5e-3 for a degenerate 4-coarse-channel fold, so the bound is deliberately scoped, not universal.

## Verification

- `tests/unit/test_pfb.py`: **24/24 passed** locally in the TF venv (`-m "not gpu and not cluster"`; the file itself is numpy-only). Full suite deferred to CI.
- Standalone numpy reproduction of both coefficient formulas confirmed the triage numbers before writing the tests (firdes vs bug=False ~1e-16; response delta 9.4e-6 at ncoarse=64, 2.5e-3 at ncoarse=4).
- `ruff` lint + format and all pre-commit hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
