### PR TITLE
ci: release concurrency guard + Python 3.11 matrix/classifier consistency

### DIFF
--- a/.claude/skills/aetherscan-repo-context/SKILL.md
+++ b/.claude/skills/aetherscan-repo-context/SKILL.md
@@ -184,7 +184,7 @@ The `tests/` suite splits along a hardware axis:
 - **`tests/unit/`** — fast, hardware-independent, one `test_<module>.py` per source module. This is the CI surface; everything here must pass on a CPU-only runner.
 - **`tests/integration/`** — `gpu`/`cluster`-marked end-to-end smokes (`test_train_smoke.py`, `test_inference_smoke.py`) that launch `python -m aetherscan.main ...` as a real subprocess on a cluster, against cluster-resident data/models. Not run in CI.
 
-**Default selection — exactly what CI runs** (`.github/workflows/tests.yml`, on Python 3.10 and 3.12), no GPUs or cluster data needed:
+**Default selection — exactly what CI runs** (`.github/workflows/tests.yml`, on Python 3.10, 3.11, and 3.12), no GPUs or cluster data needed:
 
 ```bash
 pytest -m "not gpu and not cluster" -q

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,12 @@ on:
         type: boolean
         default: true
 
+# Never let two release runs for the same ref execute publish steps concurrently (e.g. an
+# accidental double tag-push). No cancellation — an in-flight publish must run to completion.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,11 +20,12 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
-      # Let both Python versions report rather than cancelling the sibling on first failure
+      # Let every Python version report rather than cancelling the siblings on first failure
       fail-fast: false
       matrix:
-        # The two supported runtimes: conda env (3.10) and NGC container (3.12)
-        python-version: ["3.10", "3.12"]
+        # The two supported runtimes — conda env (3.10) and NGC container (3.12) — plus 3.11,
+        # which requires-python (pyproject.toml) permits and the classifiers claim
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       # Pull repo contents into GitHub Actions runner

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -567,7 +567,7 @@ pytest tests/unit/test_db.py::TestFlushSentinel -q
 
 - Every non-integration test runs isolated: `tests/conftest.py` points `AETHERSCAN_{DATA,MODEL,OUTPUT}_PATH` at a pytest `tmp_path`, resets all singletons (`Config`, `ResourceManager`, `Database`, `Logger`, `ResourceMonitor`) via their `_reset()` hooks, and re-runs `init_config()` — so tests never touch real data or leak state into each other.
 - Synthetic data factories are provided as fixtures: `make_background_npy` (tiny background plates), `make_h5_observation` (tiny filterbank-style `.h5` files), and `make_inference_csv` (tiny cadence-grouping CSVs).
-- CI (`.github/workflows/tests.yml`) runs the default selection on Ubuntu with `tensorflow-cpu==2.17.*` + the pins from `requirements-container.txt`, on Python 3.10 and 3.12 (the conda and container runtimes respectively). A few tests assert Linux-only behavior (e.g. PSS-based memory accounting) and self-skip elsewhere.
+- CI (`.github/workflows/tests.yml`) runs the default selection on Ubuntu with `tensorflow-cpu==2.17.*` + the pins from `requirements-container.txt`, on Python 3.10, 3.11, and 3.12 (3.10 and 3.12 being the conda and container runtimes respectively, 3.11 the in-between version `requires-python` permits). A few tests assert Linux-only behavior (e.g. PSS-based memory accounting) and self-skip elsewhere.
 
 ### Writing tests
 

--- a/docs/GITHUB_AUTOMATION.md
+++ b/docs/GITHUB_AUTOMATION.md
@@ -51,8 +51,9 @@ This is a required check — the same hooks you run locally, so a green local
 ### `tests.yml`
 
 **Trigger:** every PR, pushes to master, `workflow_dispatch`.
-Runs `pytest -m "not gpu and not cluster" -q` on Python 3.10 **and** 3.12 (the conda and NGC
-container runtimes; `fail-fast: false`), with `tensorflow-cpu==2.17.*` standing in for the
+Runs `pytest -m "not gpu and not cluster" -q` on Python 3.10, 3.11, **and** 3.12 (the full
+`requires-python` range — 3.10 and 3.12 are the conda and NGC container runtimes;
+`fail-fast: false`), with `tensorflow-cpu==2.17.*` standing in for the
 container's GPU build. Details in [`TESTING.md`](TESTING.md). Its run history is the data
 source for the flaky-test tracker below.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -181,8 +181,8 @@ identical hit sets on real data (see [`PREPROCESSING.md`](PREPROCESSING.md)).
 ## CI
 
 [`.github/workflows/tests.yml`](../.github/workflows/tests.yml) runs on every PR and on
-pushes to master, on Python **3.10 and 3.12** (the conda and NGC-container runtimes,
-`fail-fast: false` so both report):
+pushes to master, on Python **3.10, 3.11, and 3.12** (the full `requires-python` range —
+3.10 and 3.12 are the conda and NGC-container runtimes; `fail-fast: false` so all report):
 
 ```
 pip install "tensorflow-cpu==2.17.*" -r requirements-container.txt h5py hdf5plugin pandas psutil pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ classifiers = [
     # revisit in every release PR per docs/RELEASE.md)
     "Development Status :: 2 - Pre-Alpha",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Operating System :: Unix",
     "Environment :: GPU :: NVIDIA CUDA :: 12 :: 12.4",


### PR DESCRIPTION
Closes #179

Implements the two items still open on #179 (per the owner's 2026-07-21 comment).

## What changed

**Item 1 — release concurrency guard** (`.github/workflows/release.yml`): added the workflow-level `concurrency:` block from the issue — group `release-${{ github.ref }}`, `cancel-in-progress: false` — so two release runs for the same ref (accidental double tag-push, or a dry run overlapping a real release) can never execute publish steps concurrently, while an in-flight publish is never cancelled.

**Item 3 — py3.11 consistency**: `requires-python = ">=3.10,<3.13"` permits 3.11, but the classifiers and CI matrix covered only 3.10/3.12. Resolved in the claim-it-and-test-it direction:
- `.github/workflows/tests.yml`: matrix is now `["3.10", "3.11", "3.12"]`
- `pyproject.toml`: added the `Programming Language :: Python :: 3.11` classifier
- Doc drift this creates is fixed in the same commit: `docs/TESTING.md`, `docs/GITHUB_AUTOMATION.md`, `CONTRIBUTING.md` (Testing section), and the repo-context skill all described the matrix as "3.10 and 3.12"

**Item 2 (signed-tag enforcement) is not in this PR** — it already landed on master via #133 (commit 9e9396f): the `guard` job rejects lightweight tags and tags whose GPG signature GitHub does not verify.

## Maintainer decisions applied

- **3.11: full CI leg + classifier (claims it and tests it)** rather than the classifier-only alternative. Fallback you can pick instead: drop the 3.11 matrix leg and keep only the classifier (`requires-python` already permits 3.11, and nothing in the stack is 3.11-hostile given 3.10 and 3.12 both pass) — say the word and I'll trim it. Tightening `requires-python` to exclude 3.11 was considered and rejected as the worst option.
- Since `tests.yml` is `workflow_call`-ed by the release CD as its test gate, the 3.11 leg also becomes a release gate. That is consistent with "claims it and tests it" but worth being aware of.

## Verification

- `python -c "yaml.safe_load(...)"` on both edited workflows (parse OK) and `tomllib.load` on `pyproject.toml` (parse OK; classifiers now 3.10/3.11/3.12).
- All pre-commit hooks passed on commit (incl. `check yaml`, `check toml`).
- No Python source changed, so no unit tests apply — the real verification is CI itself: this PR's checks will run the new 3-leg matrix, including the fresh 3.11 leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)