### PR TITLE
PR #129 follow-ups: viz-collection guards, legacy --test-files supersede, inference-viz correctness nits

### DIFF
--- a/src/aetherscan/inference_viz.py
+++ b/src/aetherscan/inference_viz.py
@@ -34,6 +34,7 @@ from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
+import h5py
 import numpy as np
 from matplotlib.figure import Figure
 
@@ -143,12 +144,14 @@ class InferenceVizCollector:
             )
         )
 
-        self._reservoir_add(results["latents"], predictions.astype(bool))
+        self._budget_fill_add(results["latents"], predictions.astype(bool))
 
-    def _reservoir_add(self, latents: np.ndarray, is_candidate: np.ndarray) -> None:
-        """Fold one cadence's latents into the bounded projection pool: cadence-level
-        features (obs latents concatenated), candidates always kept, non-candidates only
-        while the global budget lasts."""
+    def _budget_fill_add(self, latents: np.ndarray, is_candidate: np.ndarray) -> None:
+        """Fold one cadence's latents into the bounded projection pool by first-come greedy
+        budget-fill (not reservoir sampling): cadence-level features (obs latents
+        concatenated), candidates always kept; non-candidates fill whatever global budget
+        remains, uniformly subsampled WITHIN this cadence when they'd overflow it (later
+        cadences get nothing once the budget is spent)."""
         config = get_config()
         features = prepare_latent_features(
             np.asarray(latents), config.data.num_observations
@@ -268,15 +271,17 @@ def _key_label(key: tuple, max_len: int = 28) -> str:
 def plot_ed_stat_distributions(
     records: list[CadenceVizRecord], metadatas: dict[str, dict]
 ) -> str | None:
-    """Histogram of the D'Agostino-Pearson k2 statistic over ALL windows (not just hits),
-    log-log, per-ON-file overlay + total, with the detection threshold marked. Sourced from
-    the fixed-bin histograms the ED workers accumulate into each cadence's metadata."""
+    """Histogram of the D'Agostino-Pearson k2 statistic over all finite windows (not just
+    hits — the ED workers histogram only finite k2 values), log-log, per-ON-file overlay +
+    total, with the detection threshold marked. Sourced from the fixed-bin histograms the
+    ED workers accumulate into each cadence's metadata."""
     config = get_config()
     tag = config.checkpoint.save_tag
     stat_threshold = config.inference.stat_threshold
 
     edges: np.ndarray | None = None
     per_on_totals: np.ndarray | None = None
+    contributing: set[str] = set()  # npy_paths whose histograms actually landed in the totals
     for record in records:
         metadata = metadatas.get(record.npy_path)
         ed_hist = (metadata or {}).get("ed_stat_hist")
@@ -294,6 +299,7 @@ def plot_ed_stat_distributions(
             logger.warning(f"Viz: {record.npy_path} has unexpected ED hist shape; skipping it")
             continue
         per_on_totals += counts
+        contributing.add(record.npy_path)
 
     if edges is None or per_on_totals is None or per_on_totals.sum() == 0:
         logger.info("Viz: no ED statistic histograms available; skipping ed_stat_distributions")
@@ -318,8 +324,10 @@ def plot_ed_stat_distributions(
         stat_threshold, color="red", ls="--", lw=1.2, label=f"threshold ({stat_threshold:g})"
     )
     # Exact above-threshold count from the workers' hit lists (the histogram bins are fixed,
-    # so the threshold generally falls inside a bin — summing bins would be approximate)
-    above = sum(int((metadatas.get(r.npy_path) or {}).get("n_raw_hits") or 0) for r in records)
+    # so the threshold generally falls inside a bin — summing bins would be approximate).
+    # Summed over the SAME cadence subset that built the histogram, so the above/total pair
+    # stays consistent when a mismatched-bins/shape cadence was dropped above.
+    above = sum(int(metadatas[p].get("n_raw_hits") or 0) for p in contributing)
     total = int(per_on_totals.sum())
     ax.set_xscale("log")
     ax.set_yscale("log")
@@ -327,8 +335,8 @@ def plot_ed_stat_distributions(
     ax.set_ylabel("window count")
     ax.set_title(
         f"Energy-detection statistic distribution ({tag})\n"
-        f"{total:,} windows, {above:,} above threshold "
-        f"({len([r for r in records if metadatas.get(r.npy_path)])} cadence(s))"
+        f"{total:,} finite windows, {above:,} above threshold "
+        f"({len(contributing)} cadence(s))"
     )
     ax.legend(fontsize=8)
     ax.grid(True, which="both", alpha=0.2)
@@ -411,9 +419,20 @@ def plot_bandpass_flattening(
         logger.info("Viz: no readable ON-source .h5 available; skipping bandpass_flattening")
         return None
 
+    if n_chans <= 0:
+        # Header lacks nchans: fall back to the data width, mirroring preprocessing's
+        # int(header.get("nchans", data_shape[-1])) — detection processed such a cadence
+        # fine, so the figure must not silently lose it. Shape access reads h5 metadata
+        # only (no decompression), so plain h5py suffices.
+        with h5py.File(h5_path, "r") as hf:
+            n_chans = int(hf["data"].shape[-1])
+
     n_coarse_total = n_chans // width
     if n_coarse_total == 0:
-        logger.info("Viz: file narrower than one coarse channel; skipping bandpass_flattening")
+        logger.info(
+            f"Viz: file width ({n_chans} fine channels) is narrower than one coarse channel "
+            f"({width}); skipping bandpass_flattening"
+        )
         return None
 
     bandpass_flatten = preprocessor._get_bandpass_flattener(n_coarse_total)

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -34,7 +34,12 @@ from aetherscan.inference_viz import InferenceVizCollector, render_inference_vis
 from aetherscan.logger import init_logger
 from aetherscan.manager import get_manager, init_manager, register_logger
 from aetherscan.monitor import init_monitor
-from aetherscan.preprocessing import DataPreprocessor, derive_cadence_provenance
+from aetherscan.preprocessing import (
+    CadenceResult,
+    DataPreprocessor,
+    PendingCadence,
+    derive_cadence_provenance,
+)
 from aetherscan.run_state import inference_config_fingerprint
 from aetherscan.tag_guards import enforce_tag_guards
 from aetherscan.train import run_training_pipeline
@@ -322,8 +327,8 @@ class NonRetryableInferenceError(RuntimeError):
 def _infer_cadence(
     pipeline: InferencePipeline,
     preprocessor: DataPreprocessor,
-    unit,
-    cadence_result,
+    unit: PendingCadence,
+    cadence_result: CadenceResult,
     config_fingerprint: str,
 ) -> dict:
     """
@@ -500,12 +505,20 @@ def _run_streaming_csv_inference(
         totals["n_cadences"] += 1
         totals["n_skipped"] += 1
         if collector is not None:
-            collector.record_skipped(
-                unit.group.key,
-                unit.npy_path,
-                DataPreprocessor.cadence_metadata_path(unit.npy_path),
-                manifest_row,
-            )
+            # Viz collection must never fail the pass: a collector bug degrades the plots,
+            # not the science (the render phase has the same contract via _viz_safe)
+            try:
+                collector.record_skipped(
+                    unit.group.key,
+                    unit.npy_path,
+                    DataPreprocessor.cadence_metadata_path(unit.npy_path),
+                    manifest_row,
+                )
+            except Exception as e:
+                logger.error(
+                    f"Viz collection failed for skipped cadence {unit.group.key} ({e}); "
+                    f"plots will be degraded; run continues"
+                )
         logger.info(
             f"Cadence {unit.group.key}: already inferred under tag {tag} "
             f"({n_snippets} snippets, {n_candidates} candidate(s)); skipping"
@@ -591,14 +604,23 @@ def _run_streaming_csv_inference(
                     totals["n_cadences"] += 1
 
                     if collector is not None:
-                        collector.record_processed(
-                            cadence_result.key,
-                            cadence_result.npy_path,
-                            cadence_result.metadata_path,
-                            results["provenance"],
-                            results,
-                            results["duration_s"],
-                        )
+                        # Same contract as record_skipped above: an exception here would
+                        # abort the whole pass after the cadence's inference already
+                        # succeeded — swallow it and degrade the plots instead
+                        try:
+                            collector.record_processed(
+                                cadence_result.key,
+                                cadence_result.npy_path,
+                                cadence_result.metadata_path,
+                                results["provenance"],
+                                results,
+                                results["duration_s"],
+                            )
+                        except Exception as e:
+                            logger.error(
+                                f"Viz collection failed for cadence {cadence_result.key} "
+                                f"({e}); plots will be degraded; run continues"
+                            )
 
                     logger.info(
                         f"Cadence {cadence_result.key} ({totals['n_cadences']} done, "
@@ -630,6 +652,36 @@ def _run_streaming_csv_inference(
             render_inference_visualizations(collector, preprocessor, totals)
 
     return totals
+
+
+def _run_legacy_test_files_inference(
+    preprocessor: DataPreprocessor, strategy: tf.distribute.Strategy
+) -> dict:
+    """Legacy --test-files path: load + infer in one shot. The load repeats on retry (the
+    old cross-attempt cadence_data cache is gone — the manifest made it obsolete on the
+    streaming path, and holding a catalog-sized array across attempts was its only
+    remaining use).
+
+    Before the fresh positives land, any inference_results rows a dead attempt wrote for
+    this npy_path are retired — the legacy counterpart of _infer_cadence's
+    supersede-on-retry step 1; without it a failure after partial writes plus a retry
+    would leave duplicate live candidate rows for the same npy_path.
+    """
+    config = get_config()
+    db = get_db()
+    npy_path = config.data.test_files[0]  # TODO: handle multiple test_files properly
+
+    with stage_timer("inference.load_lognorm"):
+        cadence_data = preprocessor.load_inference_data().astype(np.float32)
+
+    db.mark_superseded("inference_results", config.checkpoint.save_tag, npy_path=npy_path)
+    results = run_inference_pipeline(
+        cadence_data=cadence_data,
+        npy_path=npy_path,
+        strategy=strategy,
+    )
+    del cadence_data
+    return results
 
 
 # NOTE: we need to load the saved config from the corresponding training run, but when/where should we do that, and how does that play with apply_args_to_config()?
@@ -703,18 +755,9 @@ def inference_command():
                         "nothing to load for inference"
                     )
                     sys.exit(1)
-                # Legacy --test-files path: load + infer in one shot. The load repeats on
-                # retry (the old cross-attempt cadence_data cache is gone — the manifest
-                # made it obsolete on the streaming path, and holding a catalog-sized
-                # array across attempts was its only remaining use).
-                with stage_timer("inference.load_lognorm"):
-                    cadence_data = preprocessor.load_inference_data().astype(np.float32)
-                results = run_inference_pipeline(
-                    cadence_data=cadence_data,
-                    npy_path=config.data.test_files[0],  # TODO: handle multiple test_files properly
-                    strategy=strategy,
-                )
-                del cadence_data
+                # Legacy --test-files path: load + infer in one shot, with stale rows from
+                # a dead attempt superseded first (see _run_legacy_test_files_inference)
+                results = _run_legacy_test_files_inference(preprocessor, strategy)
             break  # success
 
         except KeyboardInterrupt:

--- a/tests/unit/test_inference_viz.py
+++ b/tests/unit/test_inference_viz.py
@@ -205,6 +205,37 @@ class TestFigureSmoke:
     def test_ed_stat_distributions(self, collector, metadatas):
         _assert_figure(plot_ed_stat_distributions(collector.records, metadatas))
 
+    def test_ed_stat_distributions_drops_mismatched_bins_consistently(
+        self, tmp_path, collector, metadatas, monkeypatch
+    ):
+        """A cadence dropped for mismatched ED-hist bins must be excluded from the title's
+        above-threshold and cadence counts too — otherwise the above/total pair mixes
+        different cadence subsets."""
+        npy_path, metadata_path, metadata = _write_cadence_artifacts(tmp_path, "cad_bad", ("C",))
+        metadata["ed_stat_hist"]["bin_edges"] = [
+            float(e) * 2.0 for e in metadata["ed_stat_hist"]["bin_edges"]
+        ]
+        metadata["n_raw_hits"] = 10_000  # would visibly poison 'above' if not excluded
+        with open(metadata_path, "w") as f:
+            json.dump(metadata, f)
+        collector.record_processed(("C",), npy_path, metadata_path, {}, _fake_results(), 1.0)
+        metadatas[npy_path] = metadata
+
+        captured: dict[str, str] = {}
+
+        def _capture(fig, filename, slack_title):
+            captured["title"] = fig.axes[0].get_title()
+            return filename
+
+        monkeypatch.setattr("aetherscan.inference_viz._save_and_upload", _capture)
+        assert plot_ed_stat_distributions(collector.records, metadatas) is not None
+
+        title = captured["title"]
+        # Only the two good cadences contribute: 3 * N_STAMPS raw hits each
+        assert f"{2 * 3 * N_STAMPS} above threshold" in title
+        assert "(2 cadence(s))" in title
+        assert "finite windows" in title
+
     def test_ed_hit_spectrum(self, collector, metadatas):
         _assert_figure(plot_ed_hit_spectrum(collector.records, metadatas))
 
@@ -233,6 +264,28 @@ class TestFigureSmoke:
         coll.record_processed(("H",), npy_path, metadata_path, {}, _fake_results(), 1.0)
         with open(metadata_path) as f:
             metas = {npy_path: json.load(f)}
+        _assert_figure(plot_bandpass_flattening(DataPreprocessor(), coll.records, metas))
+
+    def test_bandpass_flattening_header_without_nchans(
+        self, tmp_path, initialized_runtime, collector, make_h5_observation
+    ):
+        """A header lacking nchans must fall back to the h5 data width (mirroring
+        preprocessing's fallback) and still render, not silently skip the figure."""
+        config = get_config()
+        config.manager.n_processes = 1
+        config.inference.coarse_channel_width = 512
+        config.inference.bandpass_method = "spline"
+        config.inference.spline_order = 4
+        h5_path = make_h5_observation("viz_obs_nonchans.h5", n_chans=2048)
+        npy_path, metadata_path, metadata = _write_cadence_artifacts(
+            tmp_path, "cad_h5_nonchans", ("H2",), h5_paths=[str(h5_path)] * 6
+        )
+        del metadata["header"]["nchans"]
+        with open(metadata_path, "w") as f:
+            json.dump(metadata, f)
+        coll = InferenceVizCollector()
+        coll.record_processed(("H2",), npy_path, metadata_path, {}, _fake_results(), 1.0)
+        metas = {npy_path: metadata}
         _assert_figure(plot_bandpass_flattening(DataPreprocessor(), coll.records, metas))
 
     def test_candidate_gallery_and_per_candidate(self, initialized_runtime, collector):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -15,6 +15,7 @@ import pytest
 
 from aetherscan import main
 from aetherscan.config import get_config
+from aetherscan.db import get_db
 from aetherscan.main import NonRetryableInferenceError, _run_streaming_csv_inference
 from aetherscan.preprocessing import CadenceGroup, CadenceResult, DataPreprocessor, PendingCadence
 from aetherscan.run_state import STAGE_RF_PLOTS, STAGE_VAE_PLOTS, TrainingRunState
@@ -129,7 +130,11 @@ class _StubPreprocessor:
             metadata_path=metadata_path,
         )
 
-    def load_inference_data(self, override_filepaths):
+    def load_inference_data(self, override_filepaths=None):
+        # override_filepaths=None mirrors the legacy --test-files call shape, which loads
+        # the configured test_files with no arguments
+        if override_filepaths is None:
+            override_filepaths = [get_config().data.test_files[0]]
         self.loaded_paths.extend(override_filepaths)
         return np.load(override_filepaths[0])
 
@@ -155,6 +160,12 @@ class _StubPipeline:
         n = data.shape[0]
         proba = np.linspace(0.05, 0.95, n)
         predictions = (proba > 0.9).astype(int)
+        # Mirror the real pipeline's side effect: positives land in inference_results, so
+        # supersede-on-retry tests gate on actual candidate rows (not an empty query)
+        db = get_db()
+        tag = get_config().checkpoint.save_tag
+        for idx in np.nonzero(predictions)[0]:
+            db.write_inference_result(npy_path, int(idx), 1, float(proba[idx]), tag=tag)
         return {
             "n_cadence_snippets": n,
             "n_processed": n,
@@ -297,8 +308,13 @@ class TestStreamingResumeStateMachine:
         _run_streaming_csv_inference(preprocessor, strategy=None)
         assert db.flush(timeout=10) is True
 
+        # Exactly the fresh attempt's candidate row is live (the stub writes one positive
+        # per cadence at confidence 0.95): no double-up, and it wasn't swept up by the
+        # supersede that retired the stale row
         live = db.query_inference_result(tag="test_v1", npy_path=npy_path)
-        assert all(r["superseded"] == 0 for r in live)
+        assert len(live) == 1
+        assert live[0]["superseded"] == 0
+        assert live[0]["confidence"] == pytest.approx(0.95)
         everything = db.query_inference_result(
             tag="test_v1", npy_path=npy_path, include_superseded=True
         )
@@ -306,10 +322,12 @@ class TestStreamingResumeStateMachine:
         assert len(stale) == 1
         assert stale[0]["confidence"] == 0.999
 
-    def test_preprocessing_artifacts_skip_to_inference(self, stubbed_streaming, tmp_path):
-        """A cadence with a stamp .npy but no 'inferred' manifest row (killed between
-        stages) must skip preprocessing and go straight to inference — via the real
-        DataPreprocessor.process_pending_cadence resume path."""
+    def test_preprocessing_artifact_resume_skips_reprocessing(self, stubbed_streaming, tmp_path):
+        """A cadence with a stamp .npy on disk resumes off it: the real
+        DataPreprocessor.process_pending_cadence returns the stored stamp count without
+        re-running energy detection. (Preprocessing-artifact resume only — the streaming
+        loop's handoff of the resumed cadence to the inference stage is not exercised
+        here.)"""
         db, make_preprocessor = stubbed_streaming
         stub = make_preprocessor(keys=[("A", "1")])
         unit = stub.units[0]
@@ -319,6 +337,70 @@ class TestStreamingResumeStateMachine:
         result = real.process_pending_cadence(unit)
         assert result is not None
         assert result.n_hits == 4  # from the existing .npy, not a re-run
+
+    def test_viz_collection_failure_never_fails_the_pass(self, stubbed_streaming, monkeypatch):
+        """A collector bug must degrade the plots, not the science: cadences still complete
+        (and resume) normally when record_processed / record_skipped raise."""
+        db, make_preprocessor = stubbed_streaming
+        get_config().inference.inference_viz_enabled = True
+
+        class _ExplodingCollector:
+            def __init__(self, *args, **kwargs):
+                self.records: list = []
+
+            def record_processed(self, *args, **kwargs):
+                raise RuntimeError("simulated collector bug")
+
+            def record_skipped(self, *args, **kwargs):
+                raise RuntimeError("simulated collector bug")
+
+        monkeypatch.setattr(main, "InferenceVizCollector", _ExplodingCollector)
+        monkeypatch.setattr(main, "render_inference_visualizations", lambda *a, **k: None)
+
+        totals = _run_streaming_csv_inference(make_preprocessor(), strategy=None)
+        assert totals["n_cadences"] == 2  # record_processed raised for both; pass unaffected
+
+        # Retry pass resumes both cadences off the manifest -> exercises the
+        # record_skipped guard the same way
+        totals = _run_streaming_csv_inference(make_preprocessor(), strategy=None)
+        assert totals["n_skipped"] == 2
+
+
+class TestLegacyTestFilesSupersede:
+    def test_stale_rows_superseded_before_rerun(self, stubbed_streaming, monkeypatch):
+        """The legacy --test-files path must retire a dead attempt's partial positives
+        before the re-run's rows land — one live set for the npy_path, no duplicates
+        (mirrors _infer_cadence's supersede-on-retry step on the streaming path)."""
+        db, make_preprocessor = stubbed_streaming
+        stub = make_preprocessor(keys=[("A", "1")])
+        unit = stub.units[0]
+        stub.process_pending_cadence(unit)  # lay down a real .npy for the no-arg load
+        get_config().data.test_files = [unit.npy_path]
+
+        # Simulate a dead attempt's partial write for this file under the same tag
+        db.write_inference_result(unit.npy_path, 0, 1, 0.999, tag="test_v1")
+        assert db.flush(timeout=10) is True
+
+        def fake_run_inference_pipeline(cadence_data, npy_path, strategy):
+            db.write_inference_result(npy_path, 1, 1, 0.7, tag="test_v1")
+            n = int(cadence_data.shape[0])
+            return {"n_cadence_snippets": n, "n_processed": n, "n_candidates": 1}
+
+        monkeypatch.setattr(main, "run_inference_pipeline", fake_run_inference_pipeline)
+
+        results = main._run_legacy_test_files_inference(stub, strategy=None)
+        assert results["n_candidates"] == 1
+
+        assert db.flush(timeout=10) is True
+        live = db.query_inference_result(tag="test_v1", npy_path=unit.npy_path)
+        assert len(live) == 1  # exactly the fresh attempt's row survives un-superseded
+        assert live[0]["superseded"] == 0
+        assert live[0]["confidence"] == pytest.approx(0.7)
+        everything = db.query_inference_result(
+            tag="test_v1", npy_path=unit.npy_path, include_superseded=True
+        )
+        stale = [r for r in everything if r["superseded"] == 1]
+        assert [r["confidence"] for r in stale] == [0.999]
 
     def test_all_cadences_no_stamps_is_non_retryable(self, stubbed_streaming, monkeypatch):
         db, make_preprocessor = stubbed_streaming


### PR DESCRIPTION
Closes #158

Implements all eight follow-up nits from the #129 code review, verified against current `master` before implementation.

## Robustness (`src/aetherscan/main.py`)

- **SM-2 — viz collection can no longer fail the pass.** Both collector call sites in the streaming loop (`record_skipped` on the resume path, `record_processed` after a successful cadence) are now wrapped in `try/except Exception` + `logger.error`. Previously only the *render* phase was `_viz_safe`-guarded; an exception in `record_processed` would have aborted the whole pass after the cadence's inference already succeeded. Now a future collector bug degrades the plots and the run continues.
- **SM-4 — legacy `--test-files` retries no longer duplicate `inference_results` rows.** The legacy branch body is extracted into `_run_legacy_test_files_inference`, which calls `db.mark_superseded("inference_results", tag, npy_path=...)` before `run_inference_pipeline` — the legacy counterpart of `_infer_cadence`'s supersede-on-retry step 1. Previously a failure after partial positive writes plus a retry left the first attempt's live rows *and* a second full set for the same `npy_path`.
- **SM-3 — type annotations.** `_infer_cadence`'s `unit`/`cadence_result` params are now annotated `PendingCadence`/`CadenceResult` (import extended accordingly).

## Visualization correctness (`src/aetherscan/inference_viz.py`)

- **viz-3 — `nchans` fallback.** `plot_bandpass_flattening` now mirrors preprocessing's `int(header.get("nchans", data_shape[-1]))`: when the header lacks `nchans` it reads the h5 `data` width (shape metadata only — no decompression, so plain h5py suffices) instead of hitting the graceful skip with a misleading "narrower than one coarse channel" message. Per the triage re-verification this had reduced from "proceeds broken with `n_chans=0`" to "skips with the wrong message" on current master — implemented accordingly: fallback restores the figure, and the genuinely-narrow skip message now reports the actual widths.
- **viz-4 — ed-stat above/total subset + wording.** The accumulation loop now tracks the `npy_path`s that actually landed in `per_on_totals`; the title's above-threshold count and cadence count are computed over that same subset, so a cadence dropped for mismatched bins/shape can't skew the `above`/`total` pair. Docstring and title now say "finite windows" (the ED workers histogram only finite k2 values).
- **viz-2 — `_reservoir_add` renamed to `_budget_fill_add`.** The implementation is first-come greedy budget-fill, not reservoir sampling; the docstring now says so and also documents the within-cadence uniform subsample at the budget margin. No test or external caller referenced the old name.

## Test adequacy (`tests/unit/`)

- **F2 — supersede test is no longer vacuous.** `_StubPipeline.run_inference` now writes its positives to `inference_results` via `get_db()` (mirroring the real pipeline's side effect), so `test_stale_inference_results_superseded_on_retry` actually gates the "fresh rows land un-superseded, exactly one live set" claim instead of asserting over an empty query.
- **F4 — overstating test renamed.** `test_preprocessing_artifacts_skip_to_inference` → `test_preprocessing_artifact_resume_skips_reprocessing`, with a docstring that states it covers the preprocessing-artifact resume only (nothing reaches the inference-stage handoff).
- New tests: collector-guard containment (`test_viz_collection_failure_never_fails_the_pass`, exercising both guards across a fresh pass and a manifest-resume pass), legacy-path supersede (`TestLegacyTestFilesSupersede`), header-without-`nchans` bandpass render, and mismatched-bins exclusion from the ed-stat title.

## Verification

- `ruff check` + `ruff format --check` clean on all four changed files; all pre-commit hooks passed on both commits.
- `pytest tests/unit/test_main.py tests/unit/test_inference_viz.py -m "not gpu and not cluster"` in the local TF venv: **37 passed** (covers every changed surface plus the new tests). Full suite deferred to CI.

## Maintainer decisions applied

- **SM-2 guard granularity:** wrapped the two call sites in `main.py` rather than the metric-append internals of the collector (the gameplan allowed either) — keeps the containment at the same layer as the per-cadence failure containment it extends, and one guard per call site covers any future collector bug.
- **SM-4 helper scope:** implemented the gameplan's primary option (supersede by `npy_path`/tag before the legacy re-run via a small extracted helper) rather than the alternative of routing the legacy path through the full manifest/resume machinery.
- **Legacy stub load shape:** `_StubPreprocessor.load_inference_data` gained an `override_filepaths=None` default so the same stub serves both the streaming and legacy call shapes (no second stub class).
- **viz-4:** left the per-figure drop *warning* as the annotation of dropped cadences (no extra on-figure annotation), per the "align the two sums" half of the issue's either/or.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
