### PR TITLE
PFB sanity check: residual-flatness statistic + banded float32 reads

### DIFF
--- a/docs/PREPROCESSING.md
+++ b/docs/PREPROCESSING.md
@@ -99,11 +99,17 @@ detection statistic below is built from skewness and kurtosis — *central* mome
 cancels) normalized by powers of the variance (scale cancels) — so only the bandpass *shape*
 matters, and both methods remove exactly that. `taps_per_channel` (default 12, the
 GBT/Breakthrough Listen value) is **instrument-dependent** and must match the backend that
-produced the `.h5`; a cheap per-file sanity check (`_warn_on_pfb_response_mismatch`) compares
-the measured edge/mid power ratio of a few sampled channels against the theoretical
-response's (`pfb.edge_mid_power_ratio`) and warns once per file when they disagree by > 5 % —
-the cue to fix the tap count or use `--bandpass-method spline`. `--bandpass-debug-plot` saves
-a raw-vs-flattened overlay for visual confirmation.
+produced the `.h5`; a cheap residual-flatness sanity check (`_warn_on_pfb_response_mismatch`)
+flattens several sampled channels of each cadence's primary ON file with the active response
+and compares the median flattened edge/mid power ratio (`pfb.edge_mid_power_ratio`) against
+1.0 — i.e. it asks directly whether dividing by `H` actually flattens the data — warning once
+per file when the deviation exceeds ~10 %. The warning is **informational**: the residual
+still carries analog-frontend tilt and edge RFI the response doesn't model, so only a large
+or consistent deviation across files points at a wrong tap count (fallback:
+`--bandpass-method spline`); the threshold stays provisional until the pfb_taps-vs-backend
+characterization fixes the legitimate baseline. Only the edge/mid bands of each sampled
+channel are read (float32, time-integrated on read), keeping the check cheap at GBT scale.
+`--bandpass-debug-plot` saves a raw-vs-flattened overlay for visual confirmation.
 
 **Provenance of the GBT/BL parameters.** The defaults `pfb_taps_per_channel = 12`, the Hamming
 window, and the sinc prototype aren't guesses: the GBT Breakthrough Listen backend PFB was

--- a/src/aetherscan/pfb.py
+++ b/src/aetherscan/pfb.py
@@ -126,6 +126,21 @@ def equalize_passband(channel: np.ndarray, response: np.ndarray) -> np.ndarray:
     return channel / np.maximum(response, 1e-10)
 
 
+def edge_mid_band_slices(n: int) -> tuple[slice, slice, slice]:
+    """
+    Return the (left edge, mid, right edge) bin slices edge_mid_power_ratio evaluates over a
+    coarse channel of n bins: the outermost n // 16 bins on each side and a central band of
+    the same width (_RATIO_BAND_FRACTION). Exposed so callers that only need the ratio can
+    read just these bands from disk (see preprocessing._flattened_edge_mid_ratio) while
+    staying bin-exact with edge_mid_power_ratio.
+    """
+    band = max(1, n // _RATIO_BAND_FRACTION)
+    left = slice(0, band)
+    mid = slice(n // 2 - band // 2, n // 2 + band // 2 + 1)
+    right = slice(n - band, n)
+    return left, mid, right
+
+
 def edge_mid_power_ratio(spectrum: np.ndarray) -> float:
     """
     Mean power in the coarse-channel edge bands relative to the mid band.
@@ -133,14 +148,14 @@ def edge_mid_power_ratio(spectrum: np.ndarray) -> float:
     spectrum is a 1-D per-bin power array over one coarse channel (either the theoretical
     response H or a time-integrated data channel). Both the edge band (outermost n // 16 bins
     on each side) and the mid band (a central band of the same n // 16 width) use
-    _RATIO_BAND_FRACTION. Comparing this ratio between H and real data is the cheap sanity
-    check (after the bliss `validate` flag) for whether the configured static response
-    actually matches the recording.
+    _RATIO_BAND_FRACTION (see edge_mid_band_slices). Applied to a channel flattened by the
+    static response (data / H), a ratio near 1.0 is the cheap residual-flatness sanity check
+    (after the bliss `validate` flag) for whether the configured response actually matches
+    the recording.
     """
-    n = spectrum.shape[0]
-    band = max(1, n // _RATIO_BAND_FRACTION)
-    edge = 0.5 * (float(spectrum[:band].mean()) + float(spectrum[-band:].mean()))
-    mid = float(spectrum[n // 2 - band // 2 : n // 2 + band // 2 + 1].mean())
+    left, mid, right = edge_mid_band_slices(spectrum.shape[0])
+    edge = 0.5 * (float(spectrum[left].mean()) + float(spectrum[right].mean()))
+    mid_mean = float(spectrum[mid].mean())
     # Defensive floor (mirroring equalize_passband's): an all-zero — e.g. fully masked —
     # channel would otherwise raise ZeroDivisionError on the Python-float divide.
-    return edge / max(mid, 1e-30)
+    return edge / max(mid_mean, 1e-30)

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -40,7 +40,7 @@ from aetherscan.data_generation import log_norm
 from aetherscan.db import get_db
 from aetherscan.logger import init_worker_logging
 from aetherscan.manager import get_manager
-from aetherscan.pfb import edge_mid_power_ratio, equalize_passband, gen_coarse_channel_response
+from aetherscan.pfb import edge_mid_band_slices, equalize_passband, gen_coarse_channel_response
 
 logger = logging.getLogger(__name__)
 
@@ -53,9 +53,12 @@ _GLOBAL_CHUNK_DATA = None
 _GLOBAL_SHAPE = None
 _GLOBAL_DTYPE = None
 
-# PFB static-response sanity check: warn when a file's measured edge/mid power ratio
-# disagrees with the theoretical response's by more than this relative tolerance.
-_PFB_RATIO_MISMATCH_TOL = 0.05
+# PFB static-response sanity check: warn when the median flattened (divided-by-H) edge/mid
+# power ratio deviates from 1.0 by more than this. ~0.10 is a provisional threshold — the
+# residual still carries the analog-frontend tilt, whose legitimate baseline is only fixed by
+# the deferred pfb_taps-vs-backend characterization — so the warning stays informational
+# (#180 bounds the response-model error itself at ~1e-5, so H is not the confounder).
+_PFB_RESIDUAL_FLATNESS_TOL = 0.10
 # Fixed log-spaced bin edges for the energy-detection statistic summary histograms
 # accumulated by _energy_detect_channel_worker. The edges are identical for every channel /
 # file / cadence, so per-channel counts combine by plain addition; the range spans sub-noise
@@ -1574,8 +1577,9 @@ class DataPreprocessor:
 
             # One stage span per ON file (read + DC spike + bandpass flatten + threshold)
             with stage_timer(f"read_ed_on{on_source_idx + 1}"):
-                if pfb_active:
-                    # Cheap static-response sanity check (once per file, not per channel)
+                if pfb_active and on_source_idx == 0:
+                    # Cheap residual-flatness sanity check — primary ON file only: the static
+                    # response is a property of the backend, shared by every file of the cadence
                     self._warn_on_pfb_response_mismatch(on_h5, n_coarse_total)
 
                 tasks = [
@@ -1895,57 +1899,96 @@ class DataPreprocessor:
         _remove_dc_spike(channel, width, 1)
         return channel
 
+    def _flattened_edge_mid_ratio(
+        self, h5_path: str, channel_index: int, response: np.ndarray
+    ) -> float:
+        """
+        Edge/mid power ratio of one coarse channel AFTER flattening by the static response H.
+
+        Reads only the bands edge_mid_power_ratio actually evaluates (edge_mid_band_slices:
+        the outermost width // 16 bins each side plus a central band of the same width) as
+        native float32 and time-integrates each immediately — ~10x less I/O than the
+        full-channel float64 read of _read_despiked_channel, and no fp64 blowup, which is what
+        keeps the per-file sanity check cheap at GBT scale. The DC spike (2 bins at
+        width // 2) sits inside the mid band; its interpolation (_remove_dc_spike) is linear,
+        so it commutes with the time mean and is replicated on the integrated slice. Matches
+        edge_mid_power_ratio(equalize_passband(channel, response).mean(axis=0)) on the
+        despiked full read, up to float32-read rounding (pinned by a unit test).
+        """
+        width = self.config.inference.coarse_channel_width
+        time_bins = self.config.data.time_bins
+        start = channel_index * width
+        left, mid, right = edge_mid_band_slices(width)
+        # Widen the mid slice so the DC-spike interpolation sources (up to 3 bins around
+        # width // 2, see _remove_dc_spike) are always present.
+        lo = max(0, min(mid.start, width // 2 - 3))
+        hi = max(mid.stop, width // 2 + 3)
+        with h5py.File(h5_path, "r") as hf:
+            data = hf["data"]
+            left_int = data[:time_bins, 0, start + left.start : start + left.stop].mean(axis=0)
+            right_int = data[:time_bins, 0, start + right.start : start + right.stop].mean(axis=0)
+            mid_int = data[:time_bins, 0, start + lo : start + hi].mean(axis=0)
+        dc = width // 2 - lo
+        mid_int[dc] = (mid_int[dc + 1] + mid_int[dc - 3]) / 2
+        mid_int[dc - 1] = (mid_int[dc + 2] + mid_int[dc - 2]) / 2
+        mid_int = mid_int[mid.start - lo : mid.stop - lo]
+
+        # Same divide-by-H (with equalize_passband's defensive floor) as the real flattener;
+        # per-bin division commutes with the time mean, so integrating first is equivalent.
+        floor = np.maximum(response, 1e-10)
+        edge = 0.5 * (
+            float((left_int / floor[left]).mean()) + float((right_int / floor[right]).mean())
+        )
+        return edge / float((mid_int / floor[mid]).mean())
+
     def _warn_on_pfb_response_mismatch(self, h5_path: str, n_coarse_total: int) -> None:
         """
-        Heuristic sanity check of the static PFB response against the recording (after the bliss
-        `validate` flag): compare the file's median edge/mid power ratio — measured over several
-        coarse channels sampled evenly across the band — with the theoretical response's, and
-        log an INFORMATIONAL warning once per file (never per channel) when they disagree by
-        more than _PFB_RATIO_MISMATCH_TOL.
+        Residual-flatness sanity check of the static PFB response against the recording (after
+        the bliss `validate` flag): flatten several coarse channels — sampled evenly across the
+        band — with the active response H, and log an INFORMATIONAL warning once per file
+        (never per channel) when the median flattened edge/mid power ratio deviates from 1.0
+        by more than _PFB_RESIDUAL_FLATNESS_TOL.
 
-        This comparison is deliberately coarse and is EXPECTED to show a moderate mismatch even
-        when the response is correct: the measured ratio is taken on RAW (unflattened) data, so
-        it also carries the analog-frontend passband tilt and edge RFI that the pure response H
-        does not model. A median over several channels resists a single RFI-heavy channel, but
-        the frontend contribution is systematic and does not cancel — so a small disagreement is
-        normal, and only a LARGE or CONSISTENT one (across many files) is diagnostic of a wrong
-        --pfb-taps-per-channel. A principled threshold needs the analog-frontend baseline, which
-        is the deferred pfb_taps-vs-backend characterization.
+        This directly measures the operational question — does dividing by H actually flatten
+        the data? — so, unlike the raw-vs-pure-ratio comparison it replaced, the
+        analog-frontend passband tilt contributes only a small residual baseline rather than
+        the entire statistic (and #180's characterization bounds the response-model error at
+        ~1e-5, so H itself is not a confounder). The residual still includes that frontend
+        tilt and any edge RFI, so a moderate deviation can be benign and the threshold stays
+        provisional/informational until the deferred pfb_taps-vs-backend characterization
+        fixes the legitimate baseline; a LARGE or CONSISTENT deviation (across many files) is
+        the actionable signal of a wrong --pfb-taps-per-channel. Only the edge and mid bands
+        of each sampled channel are read (see _flattened_edge_mid_ratio), keeping the check
+        cheap; it runs on the cadence's primary ON file only, since the response is a static
+        property of the backend shared by every file.
         """
-        # TODO: replace this raw-vs-pure comparison with a residual-flatness statistic — flatten
-        # the sampled channels with the active response (divide by H) and compare the flattened
-        # edge/mid ratio against ~1.0. That directly measures whether dividing by H flattens the
-        # data and is far less confounded by the frontend tilt / RFI, giving a meaningful
-        # threshold. Land it with the pfb_taps-per-channel backend characterization (which fixes
-        # the legitimate baseline), and read the sampled channels more cheaply (float32/strided)
-        # — the full-resolution float64 reads make this check non-cheap at GBT scale. See #156.
         width = self.config.inference.coarse_channel_width
         taps = self.config.inference.pfb_taps_per_channel
         try:
             response = gen_coarse_channel_response(width, n_coarse_total, taps)
-            expected = edge_mid_power_ratio(response)
             # Median (not mean) so a single RFI-heavy sampled channel doesn't skew the statistic.
             ratios = [
-                edge_mid_power_ratio(self._read_despiked_channel(h5_path, ch).mean(axis=0))
+                self._flattened_edge_mid_ratio(h5_path, ch, response)
                 for ch in self._sample_channel_indices(
                     n_coarse_total, _PFB_MISMATCH_SAMPLE_CHANNELS
                 )
             ]
-            measured = float(np.median(ratios))
+            median = float(np.median(ratios))
         except Exception as e:
             logger.warning(f"PFB static-response sanity check failed for {h5_path}: {e}")
             return
 
-        rel_diff = abs(measured - expected) / expected
-        if rel_diff > _PFB_RATIO_MISMATCH_TOL:
+        deviation = abs(median - 1.0)
+        if deviation > _PFB_RESIDUAL_FLATNESS_TOL:
             logger.warning(
-                f"{h5_path}: median edge/mid power ratio {measured:.3f} differs from the static "
-                f"PFB response's {expected:.3f} by {rel_diff:.1%} (heuristic sanity check — "
-                f"informational). The measured ratio is taken on raw data, so it also reflects "
-                f"analog-frontend tilt and edge RFI the pure response does not model; a moderate "
-                f"gap is expected. Investigate only a large or consistent mismatch across many "
-                f"files: it may mean --pfb-taps-per-channel (currently {taps}) is wrong for this "
-                f"backend, in which case --bandpass-method spline is the data-driven fallback."
+                f"{h5_path}: median flattened edge/mid power ratio {median:.3f} deviates from "
+                f"1.0 by {deviation:.1%} after dividing by the static PFB response "
+                f"(residual-flatness sanity check — informational). The residual also reflects "
+                f"analog-frontend tilt and edge RFI the response does not model, so a moderate "
+                f"deviation can be benign. Investigate a large or consistent deviation across "
+                f"many files: it may mean --pfb-taps-per-channel (currently {taps}) is wrong "
+                f"for this backend, in which case --bandpass-method spline is the data-driven "
+                f"fallback."
             )
 
     def _plot_bandpass_overlay(

--- a/tests/unit/test_pfb.py
+++ b/tests/unit/test_pfb.py
@@ -13,6 +13,7 @@ import numpy as np
 import pytest
 
 from aetherscan.pfb import (
+    edge_mid_band_slices,
     edge_mid_power_ratio,
     equalize_passband,
     firdes,
@@ -222,15 +223,24 @@ class TestEdgeMidPowerRatio:
         # Edge bands sit on the rolloff, mid band on the passband peak
         assert 0.3 < ratio < 0.8
 
-    def test_flat_vs_response_disagree_beyond_tolerance(self):
-        # The pair the mismatch warning distinguishes: a recording without the PFB shape
-        # (ratio ~1) vs the theoretical response — far more than 5% apart.
+    def test_flat_recording_divided_by_response_deviates_from_one(self):
+        # The pair the residual-flatness warning distinguishes: a correctly flattened channel
+        # (ratio ~1) vs an unshaped recording divided by H — far more than 10% from 1.0.
         response = gen_coarse_channel_response(_FINE, _NUM_COARSE, _TAPS)
-        expected = edge_mid_power_ratio(response)
-        measured = edge_mid_power_ratio(np.ones(_FINE))
-        assert abs(measured - expected) / expected > 0.05
+        residual_ratio = edge_mid_power_ratio(np.ones(_FINE) / response)
+        assert abs(residual_ratio - 1.0) > 0.10
 
     def test_all_zero_spectrum_does_not_raise(self):
         # A fully masked channel: the defensive mid floor turns 0/0 into 0.0, not
         # ZeroDivisionError.
         assert edge_mid_power_ratio(np.zeros(_FINE)) == 0.0
+
+    def test_band_slices_agree_with_ratio(self):
+        # The banded reader relies on edge_mid_band_slices covering exactly the bins
+        # edge_mid_power_ratio evaluates
+        spectrum = np.linspace(1.0, 3.0, _FINE) ** 2
+        left, mid, right = edge_mid_band_slices(_FINE)
+        edge = 0.5 * (spectrum[left].mean() + spectrum[right].mean())
+        assert edge / spectrum[mid].mean() == pytest.approx(
+            edge_mid_power_ratio(spectrum), rel=1e-12
+        )

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -21,7 +21,7 @@ from skimage.transform import downscale_local_mean
 
 from aetherscan.config import get_config
 from aetherscan.data_generation import log_norm
-from aetherscan.pfb import edge_mid_power_ratio, gen_coarse_channel_response
+from aetherscan.pfb import edge_mid_power_ratio, equalize_passband, gen_coarse_channel_response
 from aetherscan.preprocessing import (
     ED_STAT_HIST_EDGES,
     DataPreprocessor,
@@ -752,19 +752,21 @@ class TestBandpassFlattenerSelection:
         np.testing.assert_allclose(flattener(shaped), 1.0, rtol=1e-12)
 
 
-class TestPfbResponseMismatchWarning:
-    """_warn_on_pfb_response_mismatch compares the file's measured edge/mid power ratio with
-    the static response's, warning once per file when they disagree by more than 5%."""
+class TestPfbResidualFlatnessWarning:
+    """_warn_on_pfb_response_mismatch flattens sampled channels with the active response H and
+    warns once per file when the median flattened edge/mid power ratio deviates from 1.0 by
+    more than _PFB_RESIDUAL_FLATNESS_TOL."""
 
-    def _make_obs(self, tmp_path, shaped: bool, n_chans=1024, width=512):
+    def _make_obs(self, tmp_path, taps: int | None, n_chans=1024, width=512):
+        # taps=None -> flat noise (no PFB shaping); taps=k -> noise x H(k taps)
         import h5py  # noqa: PLC0415
 
         rng = np.random.default_rng(51)
         data = rng.normal(1000.0, 5.0, size=(16, 1, n_chans)).astype(np.float32)
-        if shaped:
-            response = gen_coarse_channel_response(width, n_chans // width, 12)
+        if taps is not None:
+            response = gen_coarse_channel_response(width, n_chans // width, taps)
             data *= np.tile(response, n_chans // width).astype(np.float32)
-        path = tmp_path / ("shaped.h5" if shaped else "flat.h5")
+        path = tmp_path / f"obs_taps_{taps}.h5"
         with h5py.File(path, "w") as hf:
             hf.create_dataset("data", data=data)
         return str(path)
@@ -776,26 +778,53 @@ class TestPfbResponseMismatchWarning:
         config.inference.pfb_taps_per_channel = 12
         return config
 
+    @staticmethod
+    def _flatness_warnings(caplog):
+        return [r for r in caplog.records if "flattened edge/mid power ratio" in r.message]
+
+    def test_true_taps_recording_does_not_warn(self, tmp_path, initialized_runtime, caplog):
+        # noise x H(true taps): dividing by the active H flattens it, ratio ~1.0
+        self._configure()
+        h5_path = self._make_obs(tmp_path, taps=12)
+        with caplog.at_level("WARNING", logger="aetherscan.preprocessing"):
+            DataPreprocessor()._warn_on_pfb_response_mismatch(h5_path, n_coarse_total=2)
+        assert self._flatness_warnings(caplog) == []
+
+    def test_wrong_taps_recording_warns(self, tmp_path, initialized_runtime, caplog):
+        # noise x H(4 taps) flattened by H(12 taps): the residual keeps a strong scallop
+        self._configure()
+        h5_path = self._make_obs(tmp_path, taps=4)
+        with caplog.at_level("WARNING", logger="aetherscan.preprocessing"):
+            DataPreprocessor()._warn_on_pfb_response_mismatch(h5_path, n_coarse_total=2)
+        assert len(self._flatness_warnings(caplog)) == 1  # once per file, not per channel
+
     def test_flat_recording_warns(self, tmp_path, initialized_runtime, caplog):
+        # Unshaped noise: dividing by H imprints the inverse scallop, ratio far from 1.0
         self._configure()
-        h5_path = self._make_obs(tmp_path, shaped=False)
+        h5_path = self._make_obs(tmp_path, taps=None)
         with caplog.at_level("WARNING", logger="aetherscan.preprocessing"):
             DataPreprocessor()._warn_on_pfb_response_mismatch(h5_path, n_coarse_total=2)
-        mismatch_warnings = [r for r in caplog.records if "edge/mid power ratio" in r.message]
-        assert len(mismatch_warnings) == 1  # once per file, not per channel
+        assert len(self._flatness_warnings(caplog)) == 1
 
-    def test_pfb_shaped_recording_does_not_warn(self, tmp_path, initialized_runtime, caplog):
+    def test_band_slice_reader_matches_full_read(self, tmp_path, initialized_runtime):
+        # The banded float32 reader must agree with the despiked full-channel float64
+        # reference (read, despike, time-integrate, divide by H, edge/mid ratio)
         self._configure()
-        h5_path = self._make_obs(tmp_path, shaped=True)
-        with caplog.at_level("WARNING", logger="aetherscan.preprocessing"):
-            DataPreprocessor()._warn_on_pfb_response_mismatch(h5_path, n_coarse_total=2)
-        assert [r for r in caplog.records if "edge/mid power ratio" in r.message] == []
-
-    def test_ratio_statistic_separates_the_two(self):
-        # The underlying statistic the check relies on (sanity of the 5% tolerance)
+        h5_path = self._make_obs(tmp_path, taps=12)
         response = gen_coarse_channel_response(512, 2, 12)
-        expected = edge_mid_power_ratio(response)
-        assert abs(edge_mid_power_ratio(np.ones(512)) - expected) / expected > 0.05
+        preprocessor = DataPreprocessor()
+        for ch in (0, 1):
+            channel = preprocessor._read_despiked_channel(h5_path, ch)
+            reference = edge_mid_power_ratio(equalize_passband(channel, response).mean(axis=0))
+            banded = preprocessor._flattened_edge_mid_ratio(h5_path, ch, response)
+            assert banded == pytest.approx(reference, rel=1e-4)
+
+    def test_flatness_statistic_separates_true_from_wrong_taps(self):
+        # The underlying statistic the check relies on (sanity of the ~0.10 tolerance)
+        h_true = gen_coarse_channel_response(512, 2, 12)
+        h_wrong = gen_coarse_channel_response(512, 2, 4)
+        assert abs(edge_mid_power_ratio(h_true / h_true) - 1.0) < 0.10
+        assert abs(edge_mid_power_ratio(h_wrong / h_true) - 1.0) > 0.10
 
 
 class TestDecimateForPlot:


### PR DESCRIPTION
Closes #156

Reworks the PFB static-response sanity check from the interim raw-vs-pure heuristic into the residual-flatness statistic proposed in #156 (option 3), and folds in the cost reduction #156 absorbed from #155's PP-3.

## What changed

**The statistic** (`_warn_on_pfb_response_mismatch`, `src/aetherscan/preprocessing.py`): per sampled channel, time-integrate, divide by the active response `H`, and take the edge/mid power ratio of the **flattened** spectrum; the check now compares the median across sampled channels against **1.0** instead of comparing a raw ratio against the pure response's. This directly measures the operational question — "does dividing by `H` actually flatten the data?" — so the analog-frontend tilt contributes only a small residual baseline rather than the entire bias that made the old check fire at 13-17% on correct-taps cluster data. New constant `_PFB_RESIDUAL_FLATNESS_TOL = 0.10` replaces `_PFB_RATIO_MISMATCH_TOL = 0.05`; the warning keeps its informational framing (see decisions below). The inline `# TODO` pointing at #156 is dropped.

**Cheap banded reads** (new `_flattened_edge_mid_ratio`): the ratio only touches the outer `width // 16` bins each side plus a same-width central band, so the check now reads exactly those three h5 band slices as native float32 and time-integrates immediately — replacing the full-channel float64 read (~128 MB/channel at GBT scale, ~12 MB now). The DC spike sits inside the mid band; its interpolation is linear, so it commutes with the time mean and is replicated on the integrated mid slice (with a widened slice so the interpolation source bins are always present). `_read_despiked_channel` is kept for the overlay plots (`_plot_bandpass_overlay`, `inference_viz`). A small `pfb.edge_mid_band_slices` helper is factored out of `edge_mid_power_ratio` so the banded reader and the ratio can never disagree about band definitions.

**Call site**: the check now runs once per cadence on the primary ON file only (previously all 3 ON files) — the response is a static property of the backend, shared by every file of the cadence.

**Measured separations** (basis for the 0.10 tolerance, computed with this branch's code): true taps → |median−1| ≈ 0.0003; wrong taps=4 → 0.31 (test geometry) / 0.14 (GBT geometry); flat recording → 0.71-1.29. Honest caveat: neighboring wrong taps (8, 16) land at ~0.07-0.08 at GBT geometry, just under 0.10 — consistent with #156's position that a principled threshold needs the pfb_taps-vs-backend characterization; until then the check reliably flags gross mismatches and stays informational. #180's quantification (model error ~1e-5) removes `H` itself as a confounder.

**Tests** (`tests/unit/test_preprocessing.py`, `tests/unit/test_pfb.py`): the old `TestPfbResponseMismatchWarning` class is replaced by `TestPfbResidualFlatnessWarning` — synthetic noise×H(true taps) → no warning; noise×H(wrong taps=4) → warning fires once per file; flat noise → warning; the banded float32 reader pinned against the despiked full-read float64 reference (`rel=1e-4`); tolerance-separation sanity check. `test_pfb.py` gains a band-slices/ratio agreement test and updates the stale 5%-framing test to the residual statistic.

**Docs**: `docs/PREPROCESSING.md`'s mismatch-warning paragraph rewritten for the new statistic (flattened ratio vs 1.0, ~10% informational threshold, primary-ON-only, banded float32 reads).

## Verification

- `tests/unit/test_preprocessing.py`: 110/110 passed locally in the TF venv (`-m "not gpu and not cluster"`).
- `tests/unit/test_pfb.py`: 20/20 passed locally in the TF venv.
- `ruff check` + `ruff format --check` clean on all changed files; all pre-commit hooks passed at commit.
- Full suite deferred to CI.

## Maintainer decisions applied

- **`_PFB_RESIDUAL_FLATNESS_TOL = 0.10`** as the starting threshold, per the issue's "~0.10, calibrate on cluster data". As measured above, taps=8/16 sit just under it at GBT geometry — deliberate, since the framing stays informational until the taps-vs-backend characterization settles the frontend baseline.
- **Primary-ON-only**: the issue offered "fewer channels of fewer ON files" as optional; I took the fewer-files half (1 of 3 ON files) and kept `_PFB_MISMATCH_SAMPLE_CHANNELS = 9`. Trivial to revert to per-ON-file if you prefer the redundancy.
- **`pfb.edge_mid_band_slices` added as a public pfb.py function** (with `edge_mid_power_ratio` refactored over it) rather than duplicating the band arithmetic in preprocessing.py — chosen so the pinning test can't silently drift.
- **DC-spike handling**: replicated the exact 2-bin interpolation on the integrated mid slice (the issue allowed "or exclude that bin"); interpolation keeps the banded reader numerically pinned to the full-read reference.
- Left `docs/INFERENCE_PIPELINE.md`'s overlay-plot row untouched — its "edge/mid-ratio warning fires on the same condition" phrasing remains accurate (more so, now that the statistic measures residual scalloping directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
