### PR TITLE
ci: SHA-pin all workflow actions + claude-code-action v1.0.102 + pre-commit hook bumps

### DIFF
--- a/.github/workflows/auto-assign-author.yml
+++ b/.github/workflows/auto-assign-author.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Assign author to issue/PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const sender = context.payload.sender;

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@58dbe8ed6879f0d3b02ac295b20d5fdfe7733e0c # v1.0.85
+        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "claude[bot]"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude-contribution-check.yml
+++ b/.github/workflows/claude-contribution-check.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Contribution Check
-        uses: anthropics/claude-code-action@58dbe8ed6879f0d3b02ac295b20d5fdfe7733e0c # v1.0.85
+        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-contribution-check.yml
+++ b/.github/workflows/claude-contribution-check.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude-dependency-check.yml
+++ b/.github/workflows/claude-dependency-check.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.guard.outputs.already_filed != 'true'
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           # Manifests are read from the working tree; no git history needed.
           fetch-depth: 1

--- a/.github/workflows/claude-dependency-check.yml
+++ b/.github/workflows/claude-dependency-check.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Run Claude Dependency Check
         if: steps.guard.outputs.already_filed != 'true'
-        uses: anthropics/claude-code-action@58dbe8ed6879f0d3b02ac295b20d5fdfe7733e0c # v1.0.85
+        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-flaky-test-tracker.yml
+++ b/.github/workflows/claude-flaky-test-tracker.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Run Claude Flaky Test Tracker
         if: steps.guard.outputs.already_filed != 'true'
-        uses: anthropics/claude-code-action@58dbe8ed6879f0d3b02ac295b20d5fdfe7733e0c # v1.0.85
+        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-flaky-test-tracker.yml
+++ b/.github/workflows/claude-flaky-test-tracker.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.guard.outputs.already_filed != 'true'
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           # Used to read the current test + exercised code when diagnosing the top offender.
           fetch-depth: 1

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Issue Triage
-        uses: anthropics/claude-code-action@58dbe8ed6879f0d3b02ac295b20d5fdfe7733e0c # v1.0.85
+        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "claude[bot]"

--- a/.github/workflows/claude-release-notes.yml
+++ b/.github/workflows/claude-release-notes.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.dedup.outputs.already_commented != 'true'
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           # The diff comes from `gh pr diff` (GitHub API), and no local git tools are
           # in the allowlist, so a shallow checkout is sufficient.

--- a/.github/workflows/claude-release-notes.yml
+++ b/.github/workflows/claude-release-notes.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Run Claude Release Notes
         if: steps.dedup.outputs.already_commented != 'true'
-        uses: anthropics/claude-code-action@58dbe8ed6879f0d3b02ac295b20d5fdfe7733e0c # v1.0.85
+        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-style-check.yml
+++ b/.github/workflows/claude-style-check.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.guard.outputs.already_filed != 'true'
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           # The diff comes from `gh pr diff` (GitHub API), and no local git tools are
           # in the allowlist, so a shallow checkout is sufficient.

--- a/.github/workflows/claude-style-check.yml
+++ b/.github/workflows/claude-style-check.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Run Claude Style Check
         if: steps.guard.outputs.already_filed != 'true'
-        uses: anthropics/claude-code-action@58dbe8ed6879f0d3b02ac295b20d5fdfe7733e0c # v1.0.85
+        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-update-docs.yml
+++ b/.github/workflows/claude-update-docs.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Run Claude Documentation Analysis
         if: steps.guard.outputs.already_filed != 'true'
-        uses: anthropics/claude-code-action@58dbe8ed6879f0d3b02ac295b20d5fdfe7733e0c # v1.0.85
+        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-update-docs.yml
+++ b/.github/workflows/claude-update-docs.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.guard.outputs.already_filed != 'true'
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           # The diff comes from `gh pr diff` (GitHub API).
           # We also run utils/print_cli_help.py (contract (a) below) off the checked-out tree,
@@ -92,7 +92,7 @@ jobs:
       # local run regardless of whatever default python the runner image happens to ship.
       - name: Set up Python
         if: steps.guard.outputs.already_filed != 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Run Claude Assistant
         id: claude
-        uses: anthropics/claude-code-action@58dbe8ed6879f0d3b02ac295b20d5fdfe7733e0c # v1.0.85
+        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Allow the Claude automation bots

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,17 +22,17 @@ jobs:
     steps:
       # Pull repo contents into GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       # Install the correct Python version
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.10"
 
       # Cache reusable pip components (wheels/tarballs) between workflow runs
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           # Cache directory
           path: ~/.cache/pip
@@ -41,7 +41,7 @@ jobs:
 
       # Cache ruff outputs to skip unchanged files between workflow runs
       - name: Cache Ruff
-        uses: actions/cache@v3
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           # Cache directory (must match cache_dir in pyproject.toml)
           path: .ruff_cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       dry_run: ${{ steps.resolve.outputs.dry_run }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Enforce a signed release tag
         if: github.event_name == 'push'
@@ -137,7 +137,7 @@ jobs:
 
       - name: Set up Python
         if: needs.guard.outputs.dry_run != 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -178,10 +178,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 
@@ -205,7 +205,7 @@ jobs:
           echo "Wheel smoke passed: aetherscan.__version__ == $INSTALLED"
 
       - name: Upload distribution artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist
           path: dist/
@@ -222,7 +222,7 @@ jobs:
       id-token: write
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist
           path: dist/
@@ -261,10 +261,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist
           path: dist/

--- a/.github/workflows/sync-pr-labels.yml
+++ b/.github/workflows/sync-pr-labels.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Sync labels from linked issues to PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             // 'good first issue' describes an issue's difficulty, not a PR — don't sync it onto PRs.
@@ -103,7 +103,7 @@ jobs:
 
     steps:
       - name: Sync new label to PRs that link this issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             // 'good first issue' describes an issue's difficulty, not a PR — don't sync it onto PRs.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,12 +29,12 @@ jobs:
     steps:
       # Pull repo contents into GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       # Install the matrix Python version, with built-in pip caching keyed on the
       # dependency pins (invalidates when requirements-container.txt changes)
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 repos:
   # Ruff - fast Python linter and formatter
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.4
+    rev: v0.14.14
     hooks:
       # Run linter
       - id: ruff
@@ -41,6 +41,6 @@ repos:
 
   # Scan for sensitive data (secrets, credentials, etc.)
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.29.0
+    rev: v8.29.1
     hooks:
       - id: gitleaks


### PR DESCRIPTION
Closes #59
Closes #140

## What changed

One workflows-hardening pass, three focused commits:

**1. SHA-pin every remaining tag-pinned action (#140).** All 27 tag-pinned `uses:` lines across the 14 files in `.github/workflows/` now carry a full commit SHA plus a trailing `# vX.Y.Z` comment:

| Action | Old ref | New pin | Count |
|---|---|---|---|
| actions/checkout | `@v5` | `fbc6f399...` # v5.1.0 | 14 |
| actions/setup-python | `@v5` | `a26af69b...` # v5.6.0 | 5 |
| actions/cache | `@v3` | `0057852b...` # v4.3.0 | 2 |
| actions/upload-artifact | `@v4` | `ea165f8d...` # v4.6.2 | 1 |
| actions/download-artifact | `@v4` | `d3f86a10...` # v4.3.0 | 2 |
| actions/github-script | `@v7` | `f28e40c7...` # v7.1.0 | 3 |

Every SHA was resolved via the GitHub API and verified to be the exact commit its named release tag points to. For everything except `actions/cache`, the pinned commit is what the moving major tag resolves to **today**, so this freezes current CI behavior rather than changing any version. The local reusable-workflow reference (`release.yml` -> `./.github/workflows/tests.yml`) is not pinnable and is unchanged; `pre-commit/action` and `pypa/gh-action-pypi-publish` were already SHA-pinned.

**2. claude-code-action v1.0.85 -> v1.0.102 (#59).** All 9 workflows using `anthropics/claude-code-action` move from `58dbe8ed...` # v1.0.85 to `5d5c10a4...` # v1.0.102. v1.0.85 vendors `oven-sh/setup-bun` v2.1.2 (`using: node20`), which fires the Node.js 20 deprecation annotation on every Claude workflow run. v1.0.102 (2026-04-20) is the first release shipping setup-bun v2.2.0 — verified by reading `action.yml` at the pinned commit (pins setup-bun `0c5077e5`) and confirming that setup-bun commit declares `using: "node24"`. The issue's fallback (`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`) is deliberately **not** added: runners already force Node 24 and the workflows succeed, so the env var is obsolete — this bump removes the warning noise at the source. Also resolves the identical recommendation in the weekly dependency-check issue #174.

**3. Pre-commit hook bumps (deferred from #188).** `.pre-commit-config.yaml`: `astral-sh/ruff-pre-commit` v0.14.4 -> v0.14.14 and `gitleaks` v8.29.0 -> v8.29.1 (both patch-level). `pre-commit run --all-files` passes with the new versions — no new lint findings, no autofixes, so no source changes ride along. (ruff-pre-commit now reports the `ruff` hook id as a legacy alias of `ruff-check`; it still works, left as-is to keep the diff minimal.)

## Why no dependabot.yml

The pin-freshness role #140 assigned to Dependabot is already covered: the weekly `claude-dependency-check.yml` explicitly audits `.github/workflows/*.yml` action pins (it is what produced the v1.0.150 recommendation in #174). Adding Dependabot's `github-actions` ecosystem would duplicate that with a second bot — matching the owner's 2026-07-21 comment on #140.

## xdist monkeypatch item (#140, item 2)

Stays dormant by design, per the issue's own scope statement: pytest-xdist is not adopted anywhere (dev deps and CI run plain serial pytest), and the patch in `test_near_zero_slope_is_clamped` already targets the exact module-attribute reference the code under test resolves. No action until thread-level test parallelism is ever introduced; nothing in this PR touches it.

## Maintainer decisions applied

- **actions/cache v3 -> v4 major bump** (pre-commit.yml, 2 steps): a rider on the pinning pass rather than a pure freeze. v3 is an aging major; v4.3.0 (2025-09-24) is ~10 months seasoned, well past SECURITY.md's bar. Both cache steps use only `path`/`key` inputs, which are unchanged in v4. Veto by re-pinning to `6f8efc29...` (v3's current target) if preferred.
- **claude-code-action target = v1.0.102, not v1.0.150 (#174's rec) or latest (v1.0.179)**: no release both clears the node20 deprecation (>= v1.0.102, first shipped 2026-04-20) and meets the normal 6-month lag (<= 2026-01-22) — the constraint set is empty. Per SECURITY.md's advisory-override case, the deprecation on the current pin overrides the lag; v1.0.102 is the oldest release clearing it (~3 months in the wild, the most seasoning available) and the smallest behavioral jump from v1.0.85 (17 patch releases vs 65+). Residual risk either way: any bump across this range changes the action's own behavior — worth watching the first few claude-code-review/claude.yml runs.
- **Pinned first-party actions at the moving tag's current target** (e.g. checkout v5.1.0, released 2026-07-20): CI already runs these commits via the moving tags, so freezing them is the no-behavior-change choice even where the release is recent.

## Verification

- `grep -E "uses: " .github/workflows/*.yml` shows every external action pinned to a 40-char SHA with a version comment; the only non-SHA `uses:` is the local reusable `./.github/workflows/tests.yml`.
- Every SHA cross-checked against its release tag via `gh api` (annotated tags dereferenced to commits — the claude-code-action tag object dereferences to commit `5d5c10a4...`).
- `pre-commit run --all-files` green locally with the bumped hooks (includes `check-yaml` over all edited workflow files, plus ruff lint+format repo-wide).
- No Python code changed, so no pytest run applies; CI on this PR is the real proof that every pin resolves, and the absence of the Node.js deprecation annotation on this PR's own Claude workflow runs verifies #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
