### PR TITLE
PR #120 follow-ups: ED file validation, streaming load, CLI suggestions, config guard, test coverage

### DIFF
--- a/docs/INFERENCE_PIPELINE.md
+++ b/docs/INFERENCE_PIPELINE.md
@@ -175,9 +175,12 @@ than after ~30 h of training.)
    - provenance derived from the group key + metadata JSON
      (`preprocessing.derive_cadence_provenance`): target, session, band, cadence id, header
      `tstart`, first `.h5` path, and the per-stamp center frequencies;
-   - stamps loaded via `load_inference_data(override_filepaths=[npy_path])` (log-norm only
-     for downsampled stamps; legacy full-width files also get downsampled — see
-     [`PREPROCESSING.md`](PREPROCESSING.md));
+   - stamps loaded via `load_inference_data(override_filepaths=[npy_path], parallel=False)`
+     (log-norm only for downsampled stamps; legacy full-width files also get downsampled —
+     see [`PREPROCESSING.md`](PREPROCESSING.md)). `parallel=False` forces the sequential
+     in-process branch: the prefetch thread is already driving the persistent
+     energy-detection pool at full width, and a second per-chunk pool would double-subscribe
+     the CPU for a single cheap vectorized log-norm;
    - `mark_superseded("inference_results", tag, npy_path=...)` — partial positives from a
      dead attempt are retired *before* fresh rows land;
    - `run_inference()` (below), then a superseding `inference_cadences` row with

--- a/docs/PREPROCESSING.md
+++ b/docs/PREPROCESSING.md
@@ -236,6 +236,9 @@ downsample-at-extraction) need only per-cadence log-norm, run vectorized in the 
 (`_lognorm_worker`); legacy full-width files (4096) keep the historical
 downsample-then-log-norm path. Any other width is an error (skipped with a log). The loaded
 array must survive strict [0, 1] / NaN / Inf checks before inference proceeds.
+`parallel=False` forces the sequential in-process branch (no chunk pool / SHM) — the
+streaming per-cadence path uses it so the loader never competes with the persistent
+energy-detection pool for cores.
 
 **Log-normalization** (`data_generation.log_norm`): `y = log(x + 10⁻¹⁰)` shifted by its
 minimum and scaled by its range into [0, 1], per observation. With `return_params=True` it

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -2533,12 +2533,16 @@ def _build_suggestion_block(errors: list[ValidationError], num_replicas: int | N
     config = get_config()
     simple = [e for e in errors if e.fix_kind != "cross_param"]
     cross = [e for e in errors if e.fix_kind == "cross_param"]
-    proposals: dict[str, object] = {}
+    # Keyed on (field, fix_kind): distinct violations of the SAME field (e.g. the
+    # stamp_width equality and divisibility checks both firing) must not silently
+    # overwrite each other's proposal — one flag line per violation is honest, even
+    # when that repeats a flag with different candidate values.
+    proposals: dict[tuple[str, str], object] = {}
 
     for err in simple:
         fix = propose_simple_fix(err)
         if fix is not None:
-            proposals[err.field] = fix
+            proposals[(err.field, err.fix_kind)] = fix
 
     if cross and num_replicas is not None and config is not None:
         base = {
@@ -2553,13 +2557,13 @@ def _build_suggestion_block(errors: list[ValidationError], num_replicas: int | N
         if solution is not None:
             for f_name in _CROSS_PARAM_FIELDS + ("train_val_split",):
                 if solution[f_name] != base[f_name]:
-                    proposals[f"training.{f_name}"] = solution[f_name]
+                    proposals[(f"training.{f_name}", "cross_param")] = solution[f_name]
 
     if not proposals:
         return ""
 
     flag_lines: list[str] = []
-    for f_name, value in proposals.items():
+    for (f_name, _fix_kind), value in proposals.items():
         # Drop the config-section prefix and switch underscores to hyphens.
         short = f_name.split(".", 1)[-1]
         flag = "--" + short.replace("_", "-")

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -476,6 +476,19 @@ class Config:
             "AETHERSCAN_OUTPUT_PATH", "/datax/scratch/zachy/outputs/aetherscan"
         )
 
+        # Coupled-defaults guard: inference.stamp_width and data.width_bin are independent
+        # dataclass fields that must agree — energy-detection stamps are cut at stamp_width
+        # while every loader/model surface is sized off width_bin. A divergent source-level
+        # default edit would otherwise surface only at load time (load_inference_data fails
+        # safe, but late and per-file); fail here, at config init. CLI overrides are
+        # validated separately in cli.collect_validation_errors.
+        if self.inference.stamp_width != self.data.width_bin:
+            raise ValueError(
+                f"Config defaults diverged: inference.stamp_width "
+                f"({self.inference.stamp_width}) must equal data.width_bin "
+                f"({self.data.width_bin})"
+            )
+
     @classmethod
     def _reset(cls):
         """

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -376,10 +376,14 @@ def _infer_cadence(
     # Umbrella stage span for this cadence's inference phase — the load_lognorm /
     # encode / rf / db_write sub-stages inside nest under it via thread-local naming
     with stage_timer(f"inference.infer_cadence_{unit.index:03d}"):
-        # copy=False: the loader already returns float32; don't duplicate GBs of stamps
+        # copy=False: the loader already returns float32; don't duplicate GBs of stamps.
+        # parallel=False: this loads exactly one already-downsampled cadence .npy whose
+        # per-cadence work is a cheap vectorized log-norm, while the prefetch thread is
+        # driving the persistent energy-detection pool at full n_processes width — forking
+        # a second n_processes chunk pool here would double-subscribe the CPU.
         with stage_timer("load_lognorm"):
             cadence_data = preprocessor.load_inference_data(
-                override_filepaths=[cadence_result.npy_path]
+                override_filepaths=[cadence_result.npy_path], parallel=False
             ).astype(np.float32, copy=False)
 
         # Step 1: retire any partial rows from a dead attempt before fresh ones land

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -1536,9 +1536,14 @@ class DataPreprocessor:
         # representation for a 5-observation cadence.
         rank_problems: list[str] = []
         short_problems: list[str] = []
-        for obs_h5 in group.h5_paths:
-            with h5py.File(obs_h5, "r") as hf:
-                obs_shape = hf["data"].shape
+        for idx, obs_h5 in enumerate(group.h5_paths):
+            if idx == 0:
+                # group.h5_paths[0] == primary_h5, already opened above for header/data_shape —
+                # reuse it instead of a redundant second h5py.File open.
+                obs_shape = data_shape
+            else:
+                with h5py.File(obs_h5, "r") as hf:
+                    obs_shape = hf["data"].shape
             if len(obs_shape) != 3:
                 rank_problems.append(
                     f"{obs_h5} has 'data' of rank {len(obs_shape)} (shape {obs_shape})"

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -984,7 +984,9 @@ class DataPreprocessor:
 
     # NOTE: shared resources currently created & destroyed within function itself. think about abstractions once preprocessing.py is complete
     # NOTE: calculate intensity statistics to overlay with training distributions (C' vs C)?
-    def load_inference_data(self, override_filepaths: list[str] | None = None) -> np.ndarray:
+    def load_inference_data(
+        self, override_filepaths: list[str] | None = None, parallel: bool = True
+    ) -> np.ndarray:
         """
         Load and preprocess inference data into an array of shape
         (n, 6, 16, width_bin_downsampled). Uses a multiprocessing pool over shared memory to
@@ -1000,6 +1002,13 @@ class DataPreprocessor:
         resolving config.data.test_files via get_test_file_path — used by the inference command
         to chain per-cadence .npy outputs from preprocessing into inference without
         monkey-patching paths.
+
+        parallel=False routes every chunk through the sequential in-process branch (no chunk
+        pool, no shared memory) regardless of manager.n_processes. The streaming per-cadence
+        path (main._infer_cadence) uses this: it loads exactly one already-downsampled cadence
+        .npy whose per-cadence work is a cheap vectorized log-norm, while the prefetch thread
+        is already driving the persistent energy-detection pool at full n_processes width —
+        forking a second n_processes pool for that would double-subscribe the CPU.
         """
         logger.info(f"Loading backgrounds from {self.config.data_path} for inference")
 
@@ -1126,7 +1135,7 @@ class DataPreprocessor:
                     args_list = [(i, downsample_factor, final_width) for i in range(n_cadences)]
 
                 # NOTE: do we need to create & destroy the pool every chunk? or just the shared memory & pass new references in? is there a differenc?
-                if n_processes > 1:
+                if parallel and n_processes > 1:
                     # Create shared memory block for chunk data
                     chunk_shm = self.manager.create_shared_memory(
                         size=chunk_data.nbytes,
@@ -1161,7 +1170,10 @@ class DataPreprocessor:
 
                 else:
                     # Sequential processing
-                    logger.info("DataPreprocessor running in sequential mode (n_processes=1)")
+                    logger.info(
+                        f"DataPreprocessor running in sequential mode "
+                        f"(parallel={parallel}, n_processes={n_processes})"
+                    )
 
                     chunk_shm = None
                     chunk_pool = None
@@ -1508,31 +1520,50 @@ class DataPreprocessor:
             header = {k: hf["data"].attrs[k] for k in hf["data"].attrs}
             data_shape = hf["data"].shape
 
-        # Energy detection and stamp extraction index the dataset as [time, polarization,
-        # frequency] (see _energy_detect_channel_worker / _extract_stamps_worker), so a 'data'
-        # dataset that isn't rank-3 would otherwise blow up deep inside a worker with a cryptic
-        # IndexError. Reject it up front with the file path and expected-vs-actual rank; the
-        # caller (process_pending_cadence) turns this ValueError into a logged skip, so the
-        # skip-and-continue policy across a large catalog is preserved.
-        if len(data_shape) != 3:
+        # Up-front geometry validation of ALL 6 observation files, not just the primary.
+        # Energy detection and stamp extraction index every dataset as [time, polarization,
+        # frequency] and read exactly the first time_bins rows (see
+        # _energy_detect_channel_worker / _extract_stamps_worker — extra rows beyond
+        # time_bins are simply ignored), so a malformed file anywhere in the cadence would
+        # otherwise fail deep inside a worker: a wrong-rank dataset mis-slices cryptically,
+        # and a short row count in ANY of the 6 files (ON or OFF) raises a broadcast
+        # ValueError mid-extraction when the short stamp is assigned into its fixed
+        # (n_stamps, 6, time_bins, stored_width) memmap slot — a short ON file additionally
+        # degrades the k2 statistic silently first, since _sliding_normality_k2 derives its
+        # sample count from the rows it receives. The whole cadence is skipped rather than
+        # just the offending file: the 6-observation stamp tensor and the num_observations
+        # contract downstream (encoder reshape, RF features, ABACAD viz) have no
+        # representation for a 5-observation cadence.
+        rank_problems: list[str] = []
+        short_problems: list[str] = []
+        for obs_h5 in group.h5_paths:
+            with h5py.File(obs_h5, "r") as hf:
+                obs_shape = hf["data"].shape
+            if len(obs_shape) != 3:
+                rank_problems.append(
+                    f"{obs_h5} has 'data' of rank {len(obs_shape)} (shape {obs_shape})"
+                )
+            elif int(obs_shape[0]) < time_bins:
+                short_problems.append(f"{obs_h5} has only {int(obs_shape[0])} time bins")
+        if rank_problems:
+            # The caller (process_pending_cadence) turns this ValueError into a logged skip,
+            # so the skip-and-continue policy across a large catalog is preserved.
             raise ValueError(
-                f"Cadence {group.key}: primary ON-source file {primary_h5} has 'data' of rank "
-                f"{len(data_shape)} (shape {data_shape}), expected rank 3 "
-                f"(time, polarization, frequency)"
+                f"Cadence {group.key}: expected rank 3 (time, polarization, frequency) "
+                f"'data' in every observation file; offending file(s): "
+                f"{'; '.join(rank_problems)}"
             )
+        if short_problems:
+            logger.warning(
+                f"Cadence {group.key}: every observation file needs >= {time_bins} time "
+                f"bins; skipping whole cadence — offending file(s): "
+                f"{'; '.join(short_problems)}"
+            )
+            return None
 
         n_chans = int(header.get("nchans", data_shape[-1]))
         foff = float(header["foff"])
         fch1 = float(header["fch1"])
-        n_time_avail = int(data_shape[0])
-
-        # NOTE: come back to this later (why do we only check if n_time_avail < time_bins? what happens if n_time_avail > time_bins?)
-        if n_time_avail < time_bins:
-            logger.warning(
-                f"Cadence {group.key}: primary file has only {n_time_avail} time bins, "
-                f"expected >= {time_bins}; skipping"
-            )
-            return None
 
         # NOTE: every complete coarse channel is processed. The historical block-based path
         # floored to a multiple of the old parallel_coarse_chans knob, silently dropping up to

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -13,6 +13,7 @@ import pytest
 from aetherscan import cli
 from aetherscan.cli import (
     _TAG_PATTERN,
+    _build_suggestion_block,
     _check_cross_constraints,
     _solve_cross_param_constraints,
     apply_args_to_config,
@@ -320,6 +321,22 @@ class TestSemanticChecks:
         ]
         errors = collect_validation_errors(_parse(argv), None)
         assert any("divisible by" in e.message and "downsample-factor" in e.message for e in errors)
+
+    def test_colliding_stamp_width_fixes_both_survive_in_suggestions(self, make_inference_csv):
+        # --stamp-width 2047 violates BOTH stamp_width checks (equality with the default
+        # width_bin 4096 and divisibility by the default downsample_factor 8) on the same
+        # field. The suggestion block keys proposals on (field, fix_kind), so both proposed
+        # fixes must appear — 4096 from the equality fix, 2048 from the divisibility fix —
+        # instead of one silently overwriting the other.
+        csv_path = make_inference_csv("subset.csv")
+        argv = ["inference", "--inference-files", csv_path.name, "--stamp-width", "2047"]
+        errors = collect_validation_errors(_parse(argv), None)
+        stamp_errors = [e for e in errors if e.field == "inference.stamp_width"]
+        assert len(stamp_errors) == 2
+
+        block = _build_suggestion_block(errors, None)
+        assert "--stamp-width 4096" in block
+        assert "--stamp-width 2048" in block
 
     def test_bandpass_method_enum(self):
         errors = collect_validation_errors(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,6 +1,7 @@
 # NOTE: come back to this later
 
-"""Unit tests for aetherscan.config: singleton semantics and to_dict() field coverage."""
+"""Unit tests for aetherscan.config: singleton semantics, to_dict() field coverage, and the
+coupled-defaults guard (inference.stamp_width == data.width_bin)."""
 
 from __future__ import annotations
 
@@ -8,7 +9,10 @@ import dataclasses
 import json
 import os
 
-from aetherscan.config import Config, get_config, init_config
+import pytest
+
+import aetherscan.config as config_module
+from aetherscan.config import Config, InferenceConfig, get_config, init_config
 
 # Keys to_dict() emits that are not sub-dataclass sections (derived/grouped scalars).
 _NON_SECTION_KEYS = frozenset({"paths"})
@@ -114,3 +118,26 @@ class TestToDict:
     def test_json_serializable(self):
         # Saved run configs are json.dump'ed — the dict must be JSON-native throughout.
         json.dumps(get_config().to_dict())
+
+
+class TestCoupledDefaultsGuard:
+    """Config init must fail fast when the coupled defaults inference.stamp_width and
+    data.width_bin diverge (a source-level edit to one but not the other), instead of
+    surfacing only at load time deep inside load_inference_data."""
+
+    def test_equal_defaults_initialize_cleanly(self):
+        # The autouse fixture already ran init_config() without raising; pin the invariant.
+        config = get_config()
+        assert config.inference.stamp_width == config.data.width_bin
+
+    def test_diverged_defaults_raise_at_init(self, monkeypatch):
+        # Simulate a source-level default edit: Config.__init__ resolves InferenceConfig
+        # through the module global, so patch it to construct a diverged instance.
+        monkeypatch.setattr(
+            config_module, "InferenceConfig", lambda: InferenceConfig(stamp_width=2048)
+        )
+        Config._reset()
+        with pytest.raises(ValueError, match=r"stamp_width \(2048\) must equal data.width_bin"):
+            Config()
+        # Don't leave the half-built diverged singleton behind for the fixture teardown.
+        Config._reset()

--- a/tests/unit/test_inference.py
+++ b/tests/unit/test_inference.py
@@ -1,7 +1,7 @@
 """Unit tests for aetherscan.inference: the tail-padding fix in
 prepare_distributed_inf_dataset (regression for the silent partial-batch drop), the
-InfDataHolder clear semantics, and the confidence-summary math backing the
-inference_cadences manifest."""
+encoded-padding-row truncation in run_inference, the InfDataHolder clear semantics, and the
+confidence-summary math backing the inference_cadences manifest."""
 
 from __future__ import annotations
 
@@ -9,8 +9,10 @@ import numpy as np
 import pytest
 import tensorflow as tf
 
+from aetherscan.config import get_config
 from aetherscan.inference import (
     InfDataHolder,
+    InferencePipeline,
     prepare_distributed_inf_dataset,
     summarize_confidences,
 )
@@ -109,6 +111,93 @@ class TestPrepareDistributedInfDataset:
         )
         out = _collect_batches(result)
         np.testing.assert_array_equal(out[:7, 0, 0, 0], np.arange(7, dtype=np.float32))
+
+    @pytest.mark.parametrize("num_replicas", [1, 2])
+    def test_multi_replica_global_batch_geometry(self, strategy, num_replicas):
+        """global_batch = per_replica x num_replicas — the production geometry the tail-drop
+        fix targets. num_replicas is a plain argument to the padding/step math (independent
+        of the CPU default strategy used here); true cross-replica distribution is only
+        exercised by the gpu-marked integration smoke."""
+        data = _make_data(5)
+        result = prepare_distributed_inf_dataset(
+            data=data,
+            n_samples=5,
+            per_replica_inf_batch_size=2,
+            num_replicas=num_replicas,
+            strategy=strategy,
+        )
+        global_batch = 2 * num_replicas
+        expected_padded = -(-5 // global_batch) * global_batch  # 6 for 1 replica, 8 for 2
+        assert result["n_padded"] == expected_padded
+        assert result["inf_steps"] == expected_padded // global_batch
+
+        out = _collect_batches(result)
+        assert out.shape[0] == expected_padded
+        np.testing.assert_array_equal(out[:5], data)
+        # Padding rows cycle deterministically from the front, whatever the replica count
+        np.testing.assert_array_equal(out[5:], data[np.arange(expected_padded - 5) % 5])
+
+
+class _StubEncoder:
+    """Keras-encoder stand-in usable inside the tf.function encode step: one latent
+    dimension per observation carrying the observation's mean power. _make_data gives
+    sample i the constant value i, so every latent row is traceable to its snippet."""
+
+    def __call__(self, reshaped, training=False):
+        z = tf.reduce_mean(reshaped, axis=[1, 2])  # (batch * 6, 4, 8, 1) -> (batch * 6, 1)
+        return z, z, z
+
+
+class _RecordingRF:
+    """predict_proba stub recording how many latent rows reached the classifier."""
+
+    def __init__(self):
+        self.n_rows_seen: int | None = None
+
+    def predict_proba(self, latents):
+        self.n_rows_seen = latents.shape[0]
+        return np.full((latents.shape[0], 2), [0.7, 0.3])  # P(true)=0.3: never a candidate
+
+
+class TestLatentPaddingRowTruncation:
+    """run_inference must drop the encoded padding rows before the RF sees them
+    (inference.py: latents = latents[: n_samples * self.num_observations]) — the
+    encoder-side half of the tail-drop fix, complementing the dataset-padding tests above."""
+
+    def test_encoded_padding_rows_are_dropped(self):
+        config = get_config()
+        config.data.time_bins = 4
+        config.data.width_bin = 64
+        config.data.downsample_factor = 8  # encode reshape width: 64 // 8 = 8
+
+        # Bypass __init__ (which loads real models); wire only what run_inference touches.
+        pipeline = InferencePipeline.__new__(InferencePipeline)
+        pipeline.config = config
+        pipeline.strategy = tf.distribute.get_strategy()
+        pipeline.num_replicas = 1
+        pipeline.encoder = _StubEncoder()
+        pipeline.rf_model = _RecordingRF()
+        pipeline.latent_dim = 1
+        pipeline.num_observations = 6
+        pipeline.per_replica_inf_batch_size = 2  # global batch 2: n=5 pads to 6
+        pipeline.threshold = 0.99
+        pipeline._encode_step = None
+        # DB writes are covered elsewhere; keep this test on the truncation seam.
+        pipeline._write_inference_results = lambda **kwargs: 0
+
+        data = _make_data(5)
+        results = pipeline.run_inference(data=data, npy_path="/fake/cadence.npy")
+
+        # 5 samples pad to 6 -> 36 latent rows encoded; only the 30 real ones may survive.
+        assert pipeline.rf_model.n_rows_seen == 5 * 6
+        assert results["latents"].shape == (5 * 6, 1)
+        assert results["n_cadence_snippets"] == 5
+        assert results["n_processed"] == 5
+        # Row signatures prove the survivors are the real snippets in snippet-major order
+        # (the dropped tail re-encoded sample 0 and would have carried signature 0.0).
+        np.testing.assert_allclose(
+            results["latents"][:, 0], np.repeat(np.arange(5, dtype=np.float32), 6)
+        )
 
 
 class TestInfDataHolder:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -94,6 +94,7 @@ class _StubPreprocessor:
         self.units = [self._make_unit(key) for key in keys]
         self.processed_keys: list[tuple] = []
         self.loaded_paths: list[str] = []
+        self.load_parallel_flags: list[bool] = []
 
     def _make_unit(self, key):
         group = CadenceGroup(
@@ -130,12 +131,13 @@ class _StubPreprocessor:
             metadata_path=metadata_path,
         )
 
-    def load_inference_data(self, override_filepaths=None):
+    def load_inference_data(self, override_filepaths=None, parallel=True):
         # override_filepaths=None mirrors the legacy --test-files call shape, which loads
         # the configured test_files with no arguments
         if override_filepaths is None:
             override_filepaths = [get_config().data.test_files[0]]
         self.loaded_paths.extend(override_filepaths)
+        self.load_parallel_flags.append(parallel)
         return np.load(override_filepaths[0])
 
 
@@ -204,6 +206,9 @@ class TestStreamingResumeStateMachine:
         assert totals["n_cadences"] == 2
         assert totals["n_skipped"] == 0
         assert totals["n_cadence_snippets"] == 8
+        # The streaming loader must run sequentially (parallel=False): the prefetch thread
+        # already saturates the CPU with the persistent energy-detection pool.
+        assert preprocessor.load_parallel_flags == [False, False]
         assert db.flush(timeout=10) is True
         rows = db.query_inference_cadences(tag="test_v1", status="inferred")
         assert len(rows) == 2

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -580,9 +580,9 @@ class TestProcessCadenceEndToEnd:
             DataPreprocessor()._process_cadence(group, npy_path)
 
     @staticmethod
-    def _rewrite_primary_rank(h5_path, shape):
-        """Replace the primary file's 'data' with an array of the given (wrong) shape, keeping
-        the original header attrs so only the rank is invalid."""
+    def _rewrite_rank(h5_path, shape):
+        """Replace one observation file's 'data' with an array of the given (wrong) shape,
+        keeping the original header attrs so only the rank is invalid."""
         import h5py  # noqa: PLC0415
 
         with h5py.File(h5_path, "r+") as hf:
@@ -601,7 +601,7 @@ class TestProcessCadenceEndToEnd:
 
         self._configure()
         h5_paths = self._make_cadence(tmp_path)
-        self._rewrite_primary_rank(h5_paths[0], bad_shape)
+        self._rewrite_rank(h5_paths[0], bad_shape)
         group = CadenceGroup(
             key=("T4", "S1", "L", "10", "2251"),
             h5_paths=h5_paths,
@@ -615,6 +615,72 @@ class TestProcessCadenceEndToEnd:
         with pytest.raises(ValueError, match=r"expected rank 3"):
             DataPreprocessor()._process_cadence(group, npy_path)
 
+    def test_wrong_rank_in_non_primary_file_rejected_up_front(self, tmp_path, initialized_runtime):
+        """The rank check covers all 6 observation files, not just the primary: a wrong-rank
+        OFF file (index 3) is rejected with the same up-front ValueError naming the file."""
+        from aetherscan.preprocessing import CadenceGroup  # noqa: PLC0415
+
+        self._configure()
+        h5_paths = self._make_cadence(tmp_path)
+        self._rewrite_rank(h5_paths[3], (16, 2048))
+        group = CadenceGroup(
+            key=("T7", "S1", "L", "13", "2251"),
+            h5_paths=h5_paths,
+            csv_path="unused.csv",
+            expected_obs=6,
+            is_valid=True,
+        )
+        npy_path = str(tmp_path / "out" / "cad_bad_rank_off.npy")
+        os.makedirs(os.path.dirname(npy_path), exist_ok=True)
+
+        with pytest.raises(ValueError, match=r"expected rank 3") as exc_info:
+            DataPreprocessor()._process_cadence(group, npy_path)
+        assert h5_paths[3] in str(exc_info.value)
+
+    @pytest.mark.parametrize("short_obs_idx", [1, 2])
+    def test_short_time_bins_in_any_file_skips_whole_cadence(
+        self, tmp_path, initialized_runtime, caplog, short_obs_idx
+    ):
+        """One observation file with fewer than time_bins rows — an OFF file (index 1) or a
+        non-primary ON file (index 2) — skips the whole cadence up front with a warning
+        naming the file, instead of failing mid-extraction with a broadcast ValueError (and,
+        for a short ON file, silently degrading the k2 statistic first). The cadence is
+        dropped whole because the (n, 6, time_bins, width) stamp tensor and the downstream
+        num_observations=6 contract have no representation for a 5-observation cadence."""
+        import h5py  # noqa: PLC0415
+
+        from aetherscan.preprocessing import CadenceGroup  # noqa: PLC0415
+
+        config = self._configure()
+        h5_paths = self._make_cadence(tmp_path)
+        short_path = h5_paths[short_obs_idx]
+        with h5py.File(short_path, "r+") as hf:
+            attrs = dict(hf["data"].attrs)
+            short_data = hf["data"][: config.data.time_bins - 4]
+            del hf["data"]
+            dset = hf.create_dataset("data", data=short_data)
+            for k, v in attrs.items():
+                dset.attrs[k] = v
+        group = CadenceGroup(
+            key=("T6", "S1", "L", "12", "2251"),
+            h5_paths=h5_paths,
+            csv_path="unused.csv",
+            expected_obs=6,
+            is_valid=True,
+        )
+        npy_path = str(tmp_path / "out" / "cad_short.npy")
+        os.makedirs(os.path.dirname(npy_path), exist_ok=True)
+
+        with caplog.at_level(logging.WARNING, logger="aetherscan.preprocessing"):
+            result = DataPreprocessor().process_pending_cadence(PendingCadence(group, npy_path))
+
+        assert result is None
+        assert not os.path.exists(npy_path)
+        # The skip happens before extraction, so no partial .tmp.npy is ever created
+        assert not os.path.exists(os.path.splitext(npy_path)[0] + ".tmp.npy")
+        warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(short_path in m and "time bins" in m for m in warnings)
+
     def test_wrong_rank_data_is_skipped_not_fatal(self, tmp_path, initialized_runtime):
         """process_pending_cadence swallows the rank ValueError into a logged skip (returns
         None, no .npy written), so one malformed cadence can't abort a large-catalog run."""
@@ -622,7 +688,7 @@ class TestProcessCadenceEndToEnd:
 
         self._configure()
         h5_paths = self._make_cadence(tmp_path)
-        self._rewrite_primary_rank(h5_paths[0], (16, 2048))
+        self._rewrite_rank(h5_paths[0], (16, 2048))
         group = CadenceGroup(
             key=("T5", "S1", "L", "11", "2251"),
             h5_paths=h5_paths,
@@ -1054,6 +1120,36 @@ class TestLoadInferenceDataPaths:
         assert loaded.shape == (2, 6, 16, final_width)
         for i in range(2):
             np.testing.assert_allclose(loaded[i], log_norm(good[i]), rtol=1e-6)
+
+    def test_parallel_false_uses_no_pool_or_shared_memory(
+        self, tmp_path, initialized_runtime, monkeypatch
+    ):
+        """parallel=False (the streaming per-cadence path in main._infer_cadence) must route
+        through the sequential in-process branch even when n_processes > 1 — no chunk pool,
+        no shared memory — so the loader can't double-subscribe the CPU against the
+        persistent energy-detection pool. The output is pinned to the same log-norm oracle
+        the parallel-path tests above use, so both paths provably agree."""
+        config = self._configure()
+        config.manager.n_processes = 4  # would fork a chunk pool on the parallel path
+        final_width = config.data.width_bin // config.data.downsample_factor
+        rng = np.random.default_rng(71)
+        arr = rng.chisquare(df=4, size=(3, 6, 16, final_width)).astype(np.float32)
+        path = tmp_path / "streaming_cadence.npy"
+        np.save(path, arr)
+
+        preprocessor = DataPreprocessor()
+
+        def _fail(*args, **kwargs):
+            raise AssertionError("no pool/shared memory may be created when parallel=False")
+
+        monkeypatch.setattr(preprocessor.manager, "create_pool", _fail)
+        monkeypatch.setattr(preprocessor.manager, "create_shared_memory", _fail)
+
+        loaded = preprocessor.load_inference_data(override_filepaths=[str(path)], parallel=False)
+
+        assert loaded.shape == (3, 6, 16, final_width)
+        for i in range(3):
+            np.testing.assert_allclose(loaded[i], log_norm(arr[i]), rtol=1e-6)
 
     def test_mixed_legacy_and_downsampled_files(self, tmp_path, initialized_runtime):
         config = self._configure()


### PR DESCRIPTION
Closes #151

Implements all six follow-ups deferred out of the #120 code review.

## Robustness

**(1) All 6 observation files validated up front in `_process_cadence`** (`preprocessing.py`). Previously only the primary ON file's rank and time-bin count were checked. Triage found the issue's cited failure mode had drifted: `_sliding_normality_k2` now derives its sample count from the rows it receives, so a short non-primary ON file no longer raises an `IndexError` — it silently degrades the k2 statistic, and the hard failure moved downstream to `_extract_stamps_worker`, where a short row count in ANY of the 6 files (ON *or* OFF — broader than the issue stated) raises a broadcast `ValueError` against the fixed `(n_stamps, 6, time_bins, stored_width)` memmap slot, swallowed as a whole-cadence skip mid-extraction. The new up-front loop checks rank-3 and `n_time >= time_bins` for every file, and skips the cadence with a warning naming the offending file(s) before any ED work or `.tmp.npy` creation. Comments/tests reflect the drifted reality.

The cadence is deliberately dropped whole rather than salvaging 5 observations: the `(n, 6, time_bins, width)` stamp tensor and the `num_observations=6` contract downstream (encoder reshape, RF features, ABACAD viz) have no representation for a 5-observation cadence — documented in the code comment.

**(2) Sequential per-cadence load on the streaming path** (`preprocessing.py`, `main.py`). `load_inference_data` grows `parallel: bool = True`; `_infer_cadence` passes `parallel=False`. The streaming path loads exactly one already-downsampled cadence `.npy` whose per-cadence work is a cheap vectorized log-norm, so forking a fresh `n_processes` chunk pool mid-loop — while the prefetch thread drives the persistent energy-detection pool — double-subscribed the CPU (~2x `n_processes` workers) for no gain. Docs (`PREPROCESSING.md`, `INFERENCE_PIPELINE.md`) updated to match.

## Code quality

**(3) Suggestion-block collision** (`cli.py`). `_build_suggestion_block` keyed proposals by `err.field`, so the two `inference.stamp_width` errors (equality with `width_bin`, divisibility by `downsample_factor`) silently overwrote each other's fix. Proposals are now keyed on `(field, fix_kind)` — one flag line per violation, honest even when a flag repeats with different candidate values.

**(4) Config-level coupling assertion** (`config.py`). `Config.__init__` now raises if `inference.stamp_width != data.width_bin`, surfacing a divergent source-level default edit at config-init time instead of deep inside `load_inference_data`. CLI overrides remain validated in `collect_validation_errors`.

## Test coverage

**(5) Latent padding-row truncation** (`tests/unit/test_inference.py`). A stubbed encoder/RF `InferencePipeline` (via `__new__`) pins `inference.py`'s `latents = latents[: n_samples * self.num_observations]`: the RF sees exactly `n_samples * num_observations` rows, `n_processed` reports the real snippet count, and row signatures prove the survivors are the real snippets in snippet-major order.

**(6) Multi-replica sharding geometry** (`tests/unit/test_inference.py`). `prepare_distributed_inf_dataset` is now exercised with `num_replicas` in (1, 2), covering `global_batch = per_replica x num_replicas > per_replica` — the production case the tail-drop fix targets. Docstring notes that true cross-replica distribution still needs the gpu-marked smoke.

Also shipped: tests for (1)–(4) (short/wrong-rank files at ON position 2 and OFF positions, no-`.tmp.npy` assertion, no-pool/no-SHM assertion for `parallel=False` with output pinned to the same log-norm oracle as the parallel-path tests, both stamp-width fixes surviving in the suggestion block, config guard raise), plus the `_StubPreprocessor` in `test_main.py` now asserts the streaming loop passes `parallel=False`.

## Verification

- `tests/unit/test_config.py` + `tests/unit/test_cli_validation.py`: 113 passed
- `tests/unit/test_inference.py`: 14 passed
- `tests/unit/test_preprocessing.py` + `tests/unit/test_main.py`: 126 passed

All run locally in the TF venv with `-m "not gpu and not cluster"`; full suite deferred to CI. `ruff check` + `ruff format` clean via pre-commit on all changed files. No `cli.py` flag/help changes, so no README CLI Reference regeneration needed.

## Maintainer decisions applied

- **Whole-cadence skip for a short file** (per the issue's "or" branch and the triage gameplan): did NOT implement "clamp/skip only the short file" — a 5-obs cadence has no downstream representation. Veto would mean redesigning the stamp-tensor contract.
- **Rank problems raise `ValueError` (logged skip via `process_pending_cadence`), short-time-bin problems warn + return `None`** — preserving the two pre-existing failure styles rather than unifying them.
- **Config guard placed at the end of `Config.__init__`** (the singleton isn't a dataclass, so no literal `__post_init__` exists). It catches divergent source-level defaults only; post-init CLI mutation stays covered by `collect_validation_errors`.
- **Duplicate `--stamp-width` lines in the suggestion block are allowed** (the gameplan's "honest" option) instead of post-filtering to a single all-constraints-satisfying proposal.
- Renamed the test helper `_rewrite_primary_rank` -> `_rewrite_rank` in `test_preprocessing.py` since it is now also used on a non-primary file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
