### PR TITLE
feat(dashboard): aetherscan-dashboard console entry point for manual runs

### DIFF
--- a/docs/RUNTIME_SERVICES.md
+++ b/docs/RUNTIME_SERVICES.md
@@ -217,3 +217,12 @@ reconstruct plus a PNG gallery.
   spawn failure only warns and never aborts the run — the dashboard is optional observability.
   Teardown is registered via `atexit` and the `SIGTERM`/`SIGINT` handlers so the server is
   reaped with the run.
+- **Manual runs against a saved DB.** The `aetherscan-dashboard` console script
+  ([`src/aetherscan/dashboard_cli.py`](../src/aetherscan/dashboard_cli.py), registered under
+  `[project.scripts]`) forwards its args verbatim to `dashboard.py`'s argparse:
+  `aetherscan-dashboard --db-path /path/to/aetherscan.db --tag final_v1`. In a source checkout /
+  the container (no installed entry point), run the same shim as
+  `PYTHONPATH=src python -m aetherscan.dashboard_cli <args>`. Either way it re-execs
+  `python -m streamlit run <packaged dashboard.py> -- <args>` — Streamlit must own the process,
+  so `python -m aetherscan.dashboard` does **not** work (`st.*` calls outside a
+  ScriptRunContext render nothing).

--- a/docs/RUNTIME_SERVICES.md
+++ b/docs/RUNTIME_SERVICES.md
@@ -225,4 +225,8 @@ reconstruct plus a PNG gallery.
   `PYTHONPATH=src python -m aetherscan.dashboard_cli <args>`. Either way it re-execs
   `python -m streamlit run <packaged dashboard.py> -- <args>` — Streamlit must own the process,
   so `python -m aetherscan.dashboard` does **not** work (`st.*` calls outside a
-  ScriptRunContext render nothing).
+  ScriptRunContext render nothing). Everything after the script is forwarded to `dashboard.py`'s
+  argparse (`--db-path` / `--tag` / `--plots-dir` / `--refresh`), so `aetherscan-dashboard` does
+  **not** expose Streamlit's own `--server.*` flags; to set those (e.g. a custom `--server.port`),
+  run the verbose form directly:
+  `python -m streamlit run <packaged dashboard.py> --server.port 9000 -- --db-path … --tag …`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,12 @@ classifiers = [
 Homepage = "https://github.com/zachtheyek/Aetherscan"
 Issues = "https://github.com/zachtheyek/Aetherscan/issues"
 
+[project.scripts]
+# Manual dashboard runs against a saved DB (main.py auto-launches it during a run). Re-execs
+# `python -m streamlit run <packaged dashboard.py>` because streamlit must own the process —
+# a plain `python -m aetherscan.dashboard` renders nothing. Needs the `dashboard` extra.
+aetherscan-dashboard = "aetherscan.dashboard_cli:main"
+
 [project.optional-dependencies]
 dev = ["ruff", "pre-commit", "pytest"]
 # Live monitoring dashboard (aetherscan/dashboard.py, auto-launched by main.py). Opt-in extra so a

--- a/src/aetherscan/dashboard_cli.py
+++ b/src/aetherscan/dashboard_cli.py
@@ -40,6 +40,10 @@ def main(argv: list[str] | None = None) -> None:
             "aetherscan-dashboard: streamlit is not installed. "
             "Install the dashboard extra: pip install 'aetherscan[dashboard]'"
         )
+    # Parity with dashboard_launcher._DASHBOARD_SCRIPT.is_file(): fail with a clear message
+    # instead of a cryptic os.execv OSError / Streamlit error if the packaged script is absent.
+    if not _DASHBOARD_SCRIPT.is_file():
+        raise SystemExit(f"aetherscan-dashboard: dashboard script not found: {_DASHBOARD_SCRIPT}")
     os.execv(sys.executable, build_exec_argv(sys.argv[1:] if argv is None else argv))
 
 

--- a/src/aetherscan/dashboard_cli.py
+++ b/src/aetherscan/dashboard_cli.py
@@ -1,0 +1,47 @@
+"""
+Console entry point (`aetherscan-dashboard`) for manual runs of the live dashboard.
+
+main.py auto-launches the dashboard alongside a run (dashboard_launcher.py); this shim covers the
+ad-hoc case — inspecting a saved DB after the fact — replacing the verbose manual incantation from
+dashboard.py's docstring with:
+
+    aetherscan-dashboard --db-path /path/to/aetherscan.db --tag final_v1
+
+Everything on the command line is forwarded verbatim to dashboard.py's argparse (--db-path, --tag,
+--plots-dir, --refresh). Streamlit must OWN the process (`streamlit run <file>`) for the `st.*`
+calls to render, so this execs `python -m streamlit run` in place — a plain
+`python -m aetherscan.dashboard` would call `st.*` outside a ScriptRunContext and render nothing.
+In a source checkout / the container (no installed entry point), the same shim runs as
+`PYTHONPATH=src python -m aetherscan.dashboard_cli <args>`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+# Same resolution as dashboard_launcher._DASHBOARD_SCRIPT — not imported from there, so this shim
+# stays stdlib-only and the console script works (and fails fast) without the pipeline deps.
+_DASHBOARD_SCRIPT = Path(__file__).resolve().parent / "dashboard.py"
+
+
+def build_exec_argv(argv: list[str]) -> list[str]:
+    """`python -m streamlit run <packaged dashboard.py> -- <argv>` — build_dashboard_command's
+    shape, with the caller's args forwarded verbatim to dashboard.py's argparse. Pure/testable."""
+    return [sys.executable, "-m", "streamlit", "run", str(_DASHBOARD_SCRIPT), "--", *argv]
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Replace this process with the Streamlit server (os.execv never returns on success)."""
+    if importlib.util.find_spec("streamlit") is None:
+        raise SystemExit(
+            "aetherscan-dashboard: streamlit is not installed. "
+            "Install the dashboard extra: pip install 'aetherscan[dashboard]'"
+        )
+    os.execv(sys.executable, build_exec_argv(sys.argv[1:] if argv is None else argv))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_dashboard_cli.py
+++ b/tests/unit/test_dashboard_cli.py
@@ -60,3 +60,17 @@ def test_main_exits_when_streamlit_absent():
         with pytest.raises(SystemExit, match="streamlit is not installed"):
             main([])
         execv.assert_not_called()
+
+
+def test_main_exits_when_script_missing():
+    # streamlit present but the packaged dashboard.py absent → clear error, never exec
+    fake_script = mock.Mock()
+    fake_script.is_file.return_value = False
+    with (
+        mock.patch(f"{_MOD}.importlib.util.find_spec", return_value=object()),
+        mock.patch(f"{_MOD}._DASHBOARD_SCRIPT", fake_script),
+        mock.patch(f"{_MOD}.os.execv") as execv,
+    ):
+        with pytest.raises(SystemExit, match="dashboard script not found"):
+            main([])
+        execv.assert_not_called()

--- a/tests/unit/test_dashboard_cli.py
+++ b/tests/unit/test_dashboard_cli.py
@@ -1,0 +1,62 @@
+"""Unit tests for aetherscan.dashboard_cli: the `aetherscan-dashboard` console entry point that
+re-execs `python -m streamlit run dashboard.py -- <args>` for manual dashboard runs. The exec
+itself is mocked — only the argv construction and the streamlit-missing guard are under test."""
+
+from __future__ import annotations
+
+import sys
+from unittest import mock
+
+import pytest
+
+from aetherscan.dashboard_cli import _DASHBOARD_SCRIPT, build_exec_argv, main
+
+_MOD = "aetherscan.dashboard_cli"
+
+
+def test_build_exec_argv_shape():
+    argv = build_exec_argv(["--db-path", "/out/db/aetherscan.db", "--tag", "final_v1"])
+    # `python -m streamlit run <packaged dashboard.py>` up front — streamlit must own the process
+    assert argv[:4] == [sys.executable, "-m", "streamlit", "run"]
+    assert argv[4] == str(_DASHBOARD_SCRIPT)
+    assert argv[4].endswith("dashboard.py")
+    # everything after `--` is the caller's args, forwarded verbatim to dashboard.py's argparse
+    assert argv[5] == "--"
+    assert argv[6:] == ["--db-path", "/out/db/aetherscan.db", "--tag", "final_v1"]
+
+
+def test_build_exec_argv_no_args():
+    # bare `aetherscan-dashboard` — trailing `--` with nothing after it is valid for streamlit
+    assert build_exec_argv([])[-1] == "--"
+
+
+def test_main_execs_streamlit():
+    with (
+        mock.patch(f"{_MOD}.importlib.util.find_spec", return_value=object()),
+        mock.patch(f"{_MOD}.os.execv") as execv,
+    ):
+        main(["--db-path", "/x/aetherscan.db"])
+        execv.assert_called_once_with(
+            sys.executable, build_exec_argv(["--db-path", "/x/aetherscan.db"])
+        )
+
+
+def test_main_defaults_to_sys_argv():
+    with (
+        mock.patch(f"{_MOD}.importlib.util.find_spec", return_value=object()),
+        mock.patch(f"{_MOD}.os.execv") as execv,
+        mock.patch.object(sys, "argv", ["aetherscan-dashboard", "--tag", "t1"]),
+    ):
+        main()
+        assert execv.call_args.args[1][-2:] == ["--tag", "t1"]  # argv[0] not forwarded
+
+
+def test_main_exits_when_streamlit_absent():
+    # A bare install still gets the console script; it must fail fast with a hint, never exec
+    with (
+        mock.patch(f"{_MOD}.importlib.util.find_spec", return_value=None),
+        mock.patch(f"{_MOD}.os.execv") as execv,
+    ):
+        with pytest.raises(SystemExit, match="streamlit is not installed"):
+            main([])
+        execv.assert_not_called()


### PR DESCRIPTION
Closes #176

## What

Implements the console entry point endorsed in the issue's owner comment (2026-07-20): manual dashboard runs against a saved DB no longer need the verbose `streamlit run "$(python -c 'import aetherscan, os; print(...)')"` incantation —

```bash
aetherscan-dashboard --db-path /path/to/aetherscan.db --tag final_v1
```

- **`src/aetherscan/dashboard_cli.py`** (new, stdlib-only): `main()` execs `python -m streamlit run <packaged dashboard.py> -- <args>` in place via `os.execv`, reusing `build_dashboard_command`'s argv shape. All CLI args are forwarded verbatim after `--` to `dashboard.py`'s argparse (`--db-path`, `--tag`, `--plots-dir`, `--refresh`). A missing streamlit fails fast with the `pip install 'aetherscan[dashboard]'` hint.
- **`pyproject.toml`**: `[project.scripts] aetherscan-dashboard = "aetherscan.dashboard_cli:main"`.
- **`tests/unit/test_dashboard_cli.py`** (new): argv construction + guard, with the exec mocked.
- **`docs/RUNTIME_SERVICES.md`**: manual-run bullet added to the Live monitoring dashboard section (where auto-launch is described).

As the issue comment establishes: `python -m aetherscan.dashboard` would NOT work — Streamlit must own the process (`streamlit run <file>`); running the module directly calls `st.*` outside a ScriptRunContext and renders nothing. Hence the re-exec, and hence `os.execv` (replace the process, don't wrap it).

## Coordination with the nit-sweep PR

The issue's two body nits (n1 SIG_IGN restore, n2 under-mocked test) land in the separate nit-sweep PR. This PR deliberately touches **neither** `dashboard_launcher.py` nor `tests/unit/test_dashboard_launcher.py` — its diff is a new module + new test file + `pyproject.toml` + `docs/RUNTIME_SERVICES.md`, so the two PRs cannot conflict.

## Verification

- `tests/unit/test_dashboard_cli.py`: **5/5 passed** locally in the TF venv (`PYTHONPATH=src pytest -m "not gpu and not cluster" -q`).
- `tests/unit/test_dashboard_launcher.py`: **11/11 passed** (sanity — untouched by this PR).
- End-to-end smoke: `PYTHONPATH=src python -m aetherscan.dashboard_cli --db-path ...` in a venv with streamlit installed really replaced the process with a Streamlit server (its first-run prompt appeared; process reaped cleanly) — confirms the exec hand-off works.
- pre-commit hooks (ruff lint + format, check-toml, etc.) pass on all changed files.
- Full suite deferred to CI. No `cli.py` change, so no README CLI Reference regen needed.

## Maintainer decisions applied

- **New standalone module** (`dashboard_cli.py`) rather than adding `main()` to `dashboard_launcher.py` — the triage gameplan allowed either; chosen to (a) guarantee zero file overlap with the nit-sweep PR and (b) keep the console script stdlib-only, so it works (and fails fast) in a bare install without the heavy pipeline deps that `dashboard_launcher` imports.
- **Docs placed in `docs/RUNTIME_SERVICES.md`**, not README — that's where the dashboard/auto-launch is documented; README's only dashboard mentions are the auto-generated CLI reference and the unrelated tmux section. `dashboard.py`'s docstring (verbose incantation) left untouched — still valid as the no-entry-point fallback.
- **`if __name__ == "__main__": main()` guard added** so source checkouts / the container (no installed entry point) get the same shim via `PYTHONPATH=src python -m aetherscan.dashboard_cli <args>`.
- **No streamlit server flags exposed** (e.g. `--server.port`): everything after the script goes to `dashboard.py`'s argparse, matching the endorsed minimal shape; anyone needing custom `--server.*` flags can still use the verbose incantation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)