### PR TITLE
feat: auto-post the benchmark report to Slack at end of train/inference runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ The Aetherscan training pipeline exposes the following CLI flags to the user. Re
 usage: train [-h] [--data-path DATA_PATH] [--model-path MODEL_PATH]
              [--output-path OUTPUT_PATH] [--dashboard | --no-dashboard]
              [--dashboard-port DASHBOARD_PORT]
+             [--benchmark-report | --no-benchmark-report]
              [--vae-latent-dim VAE_LATENT_DIM]
              [--vae-dense-layer-size VAE_DENSE_LAYER_SIZE]
              [--vae-kernel-size VAE_KERNEL_SIZE VAE_KERNEL_SIZE]
@@ -476,6 +477,10 @@ options:
   --dashboard-port DASHBOARD_PORT
                         Port for the auto-launched live dashboard (default:
                         8501)
+  --benchmark-report, --no-benchmark-report
+                        Render the end-of-run benchmark report (stage timeline
+                        + bottleneck suggestions) and post it to Slack
+                        (default: on). Use --no-benchmark-report to disable
   --vae-latent-dim VAE_LATENT_DIM
                         Dimensionality of the VAE latent space (bottleneck
                         size)
@@ -721,6 +726,7 @@ The Aetherscan inference pipeline exposes the following CLI flags to the user. R
 usage: inference [-h] [--data-path DATA_PATH] [--model-path MODEL_PATH]
                  [--output-path OUTPUT_PATH] [--dashboard | --no-dashboard]
                  [--dashboard-port DASHBOARD_PORT]
+                 [--benchmark-report | --no-benchmark-report]
                  [--num-replicas NUM_REPLICAS]
                  [--gpu-memory-limit-mb GPU_MEMORY_LIMIT_MB]
                  [--async-allocator | --no-async-allocator]
@@ -771,6 +777,10 @@ options:
   --dashboard-port DASHBOARD_PORT
                         Port for the auto-launched live dashboard (default:
                         8501)
+  --benchmark-report, --no-benchmark-report
+                        Render the end-of-run benchmark report (stage timeline
+                        + bottleneck suggestions) and post it to Slack
+                        (default: on). Use --no-benchmark-report to disable
   --num-replicas NUM_REPLICAS
                         Number of GPUs to use for the distributed strategy. If
                         omitted, the strategy uses every GPU visible to TF;

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -19,7 +19,8 @@ numbers and how to read the annotated resource plot.
   opened without name plumbing.
 - `python utils/benchmark_report.py --save-tag <tag>` prints the stage tree, writes a
   flame-style timeline PNG, and flags likely bottlenecks from `pipeline_stages` joined with
-  `system_resources`.
+  `system_resources`. The report PNG is also rendered and posted to Slack automatically at
+  the end of every `train`/`inference` run (`--no-benchmark-report` opts out).
 - The 1 Hz resource plot overlays the top-level stages as labeled bands
   (`monitor.annotate_stages`), so a CPU plateau reads as "round 3 data generation" at a
   glance.
@@ -118,6 +119,15 @@ python utils/benchmark_report.py --save-tag final_v1
 # Explicit db (e.g. a copy pulled off the cluster)
 python utils/benchmark_report.py --save-tag test_v18 --db-path /path/to/aetherscan.db
 ```
+
+The same report is also generated **automatically at the tail of every `train`/`inference`
+run** (`_post_benchmark_report` in [`main.py`](../src/aetherscan/main.py)): the hook flushes
+the DB write queue (stage spans land through it asynchronously), loads this tool by file path
+(preserving its no-`aetherscan`-imports contract), renders
+`{output_path}/plots/benchmark_report_{tag}.png`, and uploads it to Slack with the
+suggestions as the image comment. It is gated by `monitor.benchmark_report_enabled`
+(`--no-benchmark-report` to opt out) and fully guarded — any failure logs an error and never
+fails the run.
 
 It produces three things for one `--save-tag`:
 

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -230,6 +230,12 @@ def _add_train_flags_to(parser):
         default=None,
         help="Port for the auto-launched live dashboard (default: 8501)",
     )
+    parser.add_argument(
+        "--benchmark-report",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Render the end-of-run benchmark report (stage timeline + bottleneck suggestions) and post it to Slack (default: on). Use --no-benchmark-report to disable",
+    )
 
     # BetaVAE model configuration
     parser.add_argument(
@@ -719,6 +725,12 @@ def _add_inference_flags_to(parser):
         default=None,
         help="Port for the auto-launched live dashboard (default: 8501)",
     )
+    parser.add_argument(
+        "--benchmark-report",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Render the end-of-run benchmark report (stage timeline + bottleneck suggestions) and post it to Slack (default: on). Use --no-benchmark-report to disable",
+    )
 
     # GPU configuration
     parser.add_argument(
@@ -1030,6 +1042,8 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
         config.monitor.dashboard_enabled = args.dashboard
     if hasattr(args, "dashboard_port") and args.dashboard_port is not None:
         config.monitor.dashboard_port = args.dashboard_port
+    if hasattr(args, "benchmark_report") and args.benchmark_report is not None:
+        config.monitor.benchmark_report_enabled = args.benchmark_report
 
     # BetaVAE configuration
     if hasattr(args, "vae_latent_dim") and args.vae_latent_dim is not None:

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -53,6 +53,9 @@ class MonitorConfig:
     # --no-dashboard opts out. Served headless on dashboard_port (SSH-forward to reach it).
     dashboard_enabled: bool = True
     dashboard_port: int = 8501
+    # End-of-run benchmark report (utils/benchmark_report.py) rendered at the tail of
+    # train/inference and posted to Slack; --no-benchmark-report opts out.
+    benchmark_report_enabled: bool = True
 
 
 @dataclass
@@ -567,6 +570,7 @@ class Config:
                 "annotate_stages": self.monitor.annotate_stages,
                 "dashboard_enabled": self.monitor.dashboard_enabled,
                 "dashboard_port": self.monitor.dashboard_port,
+                "benchmark_report_enabled": self.monitor.benchmark_report_enabled,
             },
             "logger": {
                 "console_level": self.logger.console_level,

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -7,12 +7,14 @@ Entry point for Aetherscan Pipeline
 from __future__ import annotations
 
 import gc
+import importlib.util
 import json
 import logging
 import os
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 
 import numpy as np
 import tensorflow as tf
@@ -31,7 +33,7 @@ from aetherscan.db import get_db, init_db
 from aetherscan.hf_hub import resolve_inference_artifacts
 from aetherscan.inference import InferencePipeline, run_inference_pipeline, summarize_confidences
 from aetherscan.inference_viz import InferenceVizCollector, render_inference_visualizations
-from aetherscan.logger import init_logger
+from aetherscan.logger import get_logger, init_logger
 from aetherscan.manager import get_manager, init_manager, register_logger
 from aetherscan.monitor import init_monitor
 from aetherscan.preprocessing import (
@@ -221,6 +223,76 @@ def _report_final_training_status(pipeline) -> None:
     logger.info("=" * 60)
 
 
+def _post_benchmark_report(tag: str) -> None:
+    """
+    Render the end-of-run benchmark report (utils/benchmark_report.py) and post it to Slack.
+
+    Runs at the tail of train_command/inference_command rather than after monitor shutdown:
+    the monitor never writes pipeline_stages rows (stage spans land via the async DB write
+    queue), and by the time main()'s finally block stops the monitor the Slack handler is
+    being torn down too. An explicit db.flush() is what guarantees every span row is on disk
+    before the report reads them. Fully guarded: any failure (including the report tool's
+    SystemExit) logs an error and never fails the run.
+    """
+    try:
+        config = get_config()
+        if config is None:
+            raise ValueError("get_config() returned None")
+        if not config.monitor.benchmark_report_enabled:
+            logger.info("Benchmark report disabled (--no-benchmark-report)")
+            return
+
+        db = get_db()
+        if db is None:
+            raise ValueError("get_db() returned None")
+        # Stage spans reach the DB through the async write queue — drain it so the report
+        # sees every row of this run
+        db.flush(timeout=config.db.flush_timeout)
+
+        # utils/benchmark_report.py is deliberately import-free of aetherscan (stdlib
+        # sqlite3 + numpy + matplotlib) so it stays cluster-portable — load it by file path
+        # instead of importing, same pattern as tests/unit/test_benchmark.py. The
+        # sys.modules registration must precede exec_module: the module's @dataclass
+        # resolves its own module by name at class-creation time (PEP 563 string
+        # annotations).
+        report_path = Path(__file__).resolve().parents[2] / "utils" / "benchmark_report.py"
+        if not report_path.exists():
+            # e.g. a pip-installed package without the repo checkout alongside
+            logger.warning(f"Benchmark report skipped: {report_path} does not exist")
+            return
+        spec = importlib.util.spec_from_file_location("benchmark_report", report_path)
+        benchmark_report = importlib.util.module_from_spec(spec)
+        sys.modules["benchmark_report"] = benchmark_report
+        spec.loader.exec_module(benchmark_report)
+
+        rows = benchmark_report.load_rows(db.db_path, tag)
+        if not rows:
+            logger.warning(f"Benchmark report skipped: no pipeline_stages rows for tag {tag!r}")
+            return
+        root = benchmark_report.build_stage_tree(rows)
+        png_path = os.path.join(config.output_path, "plots", f"benchmark_report_{tag}.png")
+        benchmark_report.render_report_png(root, rows, tag, png_path)
+        logger.info(f"Benchmark report saved to {png_path}")
+
+        # Bottleneck suggestions ride along as the upload's comment, landing in the run
+        # thread right next to the figure
+        suggestions = benchmark_report.build_suggestions(root, db.db_path, tag)
+        message = "\n".join(f"- {s}" for s in suggestions) if suggestions else None
+
+        logger_instance = get_logger()
+        if logger_instance is None:
+            raise ValueError("get_logger() returned None")
+        if not logger_instance.upload_image_to_slack(
+            png_path, title=f"Benchmark Report - {tag}", message=message
+        ):
+            logger.warning("Benchmark report rendered but Slack upload was skipped or failed")
+
+    except (Exception, SystemExit) as e:
+        # SystemExit included: load_rows raises it on a pre-benchmarking-schema DB.
+        # Observability must never fail an otherwise-finished run.
+        logger.error(f"Benchmark report generation failed: {e}")
+
+
 def train_command():
     """Execute training pipeline with distributed strategy & fault tolerance"""
     logger.info("=" * 60)
@@ -309,6 +381,11 @@ def train_command():
                 logger.error(f"Training attempts exceeded maximum retries ({max_retries})")
                 logger.error(f"Final error: {e}")
                 sys.exit(1)
+
+    # Post the end-of-run benchmark report before the terminal status report: the latter
+    # sys.exit(1)s when any non-critical stage permanently failed, and the timing data is
+    # exactly as valuable on those runs
+    _post_benchmark_report(config.checkpoint.save_tag)
 
     # Note, the training configuration JSON is saved by the pipeline's final_save stage
     # (so it's covered by the retry machinery), not here
@@ -805,6 +882,8 @@ def inference_command():
     logger.info(f"    Processed: {results['n_processed']}")
     logger.info(f"    Candidates found: {results['n_candidates']}")
     logger.info("=" * 60)
+
+    _post_benchmark_report(config.checkpoint.save_tag)
 
 
 def main():

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -289,7 +289,12 @@ def _post_benchmark_report(tag: str) -> None:
 
     except (Exception, SystemExit) as e:
         # SystemExit included: load_rows raises it on a pre-benchmarking-schema DB.
-        # Observability must never fail an otherwise-finished run.
+        # Observability must never fail an otherwise-finished run. Runs at the very tail
+        # of the command (after all real work is done), so this also swallowing a
+        # KeyboardInterrupt-adjacent exit here has minimal blast radius — a Ctrl-C during
+        # report generation still leaves the run's actual results intact.
+        # TODO: if utils/benchmark_report.py's load_rows ever stops raising SystemExit for
+        # a pre-benchmarking-schema DB, narrow this back to `except Exception`.
         logger.error(f"Benchmark report generation failed: {e}")
 
 

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -609,6 +609,17 @@ class TestApplyArgsToConfig:
         apply_args_to_config(_parse(["inference"]))
         assert config.checkpoint.force_tag is True
 
+    def test_benchmark_report_flag_routes_to_monitor_section(self):
+        config = get_config()
+        assert config.monitor.benchmark_report_enabled is True  # default: on
+        apply_args_to_config(_parse(["train", "--no-benchmark-report"]))
+        assert config.monitor.benchmark_report_enabled is False
+        # Omitting the flag leaves the config value untouched (tri-state BooleanOptionalAction)
+        apply_args_to_config(_parse(["inference"]))
+        assert config.monitor.benchmark_report_enabled is False
+        apply_args_to_config(_parse(["inference", "--benchmark-report"]))
+        assert config.monitor.benchmark_report_enabled is True
+
 
 class TestLatentTraversalFlags:
     """Flags and validation for the latent-dimension traversal plot (PLAN PR-05)."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,19 +1,23 @@
 """Unit tests for main.py glue that isn't reachable through the higher-level commands: the
 terminal training-status / exit-code contract (_report_final_training_status), non-retryable
-streaming-inference failures, and the stage-aware inference retry state machine (manifest-driven
+streaming-inference failures, the stage-aware inference retry state machine (manifest-driven
 skip, per-cadence failure containment, supersede-on-retry) with the GPU pipeline and
-preprocessing stubbed out."""
+preprocessing stubbed out, and the end-of-run benchmark-report Slack hook
+(_post_benchmark_report)."""
 
 from __future__ import annotations
 
 import json
 import logging
+import os
+import sqlite3
 import types
 
 import numpy as np
 import pytest
 
 from aetherscan import main
+from aetherscan.benchmark import stage_timer
 from aetherscan.config import get_config
 from aetherscan.db import get_db
 from aetherscan.main import NonRetryableInferenceError, _run_streaming_csv_inference
@@ -413,3 +417,73 @@ class TestLegacyTestFilesSupersede:
         monkeypatch.setattr(_StubPreprocessor, "process_pending_cadence", lambda self, unit: None)
         with pytest.raises(NonRetryableInferenceError, match="No cadence results"):
             _run_streaming_csv_inference(preprocessor, strategy=None)
+
+
+class TestPostBenchmarkReport:
+    """End-of-run benchmark-report hook: flush -> render PNG -> Slack upload, fully guarded."""
+
+    @pytest.fixture
+    def slack_upload(self, monkeypatch):
+        """Stub main.get_logger with a recording uploader; returns the recorded calls."""
+        calls = []
+
+        def upload(png_path, title=None, message=None, **kwargs):
+            calls.append({"png_path": png_path, "title": title, "message": message})
+            return True
+
+        fake_logger = types.SimpleNamespace(upload_image_to_slack=upload)
+        monkeypatch.setattr(main, "get_logger", lambda: fake_logger)
+        return calls
+
+    def _png_path(self, tag):
+        return os.path.join(get_config().output_path, "plots", f"benchmark_report_{tag}.png")
+
+    def test_renders_png_and_uploads(self, initialized_runtime, slack_upload):
+        # The span is still sitting in the async DB write queue when the hook runs — the
+        # hook's own db.flush() must drain it before the report tool reads the DB
+        with stage_timer("train.load_backgrounds", tag="test_v1"):
+            pass
+
+        main._post_benchmark_report("test_v1")
+
+        png_path = self._png_path("test_v1")
+        assert os.path.exists(png_path)
+        assert len(slack_upload) == 1
+        assert slack_upload[0]["png_path"] == png_path
+        assert "test_v1" in slack_upload[0]["title"]
+
+    def test_disabled_by_config_skips_everything(self, initialized_runtime, slack_upload):
+        get_config().monitor.benchmark_report_enabled = False
+        with stage_timer("train.load_backgrounds", tag="test_v1"):
+            pass
+
+        main._post_benchmark_report("test_v1")
+
+        assert slack_upload == []
+        assert not os.path.exists(self._png_path("test_v1"))
+
+    def test_no_stage_rows_skips_upload(self, initialized_runtime, slack_upload):
+        main._post_benchmark_report("test_v1")
+        assert slack_upload == []
+        assert not os.path.exists(self._png_path("test_v1"))
+
+    def test_exception_inside_hook_is_swallowed(self, initialized_runtime, monkeypatch):
+        # Any blow-up inside the hook (here: resolving the Slack logger) must never
+        # escape and fail an otherwise-finished run
+        def boom():
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(main, "get_logger", boom)
+        with stage_timer("train.load_backgrounds", tag="test_v1"):
+            pass
+        main._post_benchmark_report("test_v1")  # must not raise
+
+    def test_system_exit_from_report_tool_is_swallowed(self, monkeypatch, tmp_path):
+        # A DB file predating the benchmarking schema (no pipeline_stages table) makes the
+        # report tool's load_rows raise SystemExit — which is NOT an Exception subclass,
+        # so the hook must swallow it explicitly rather than kill the run
+        legacy_db = tmp_path / "legacy.db"
+        sqlite3.connect(str(legacy_db)).close()
+        fake_db = types.SimpleNamespace(db_path=str(legacy_db), flush=lambda timeout=None: True)
+        monkeypatch.setattr(main, "get_db", lambda: fake_db)
+        main._post_benchmark_report("test_v1")  # must not raise

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -487,3 +487,15 @@ class TestPostBenchmarkReport:
         fake_db = types.SimpleNamespace(db_path=str(legacy_db), flush=lambda timeout=None: True)
         monkeypatch.setattr(main, "get_db", lambda: fake_db)
         main._post_benchmark_report("test_v1")  # must not raise
+
+    def test_missing_report_script_skips_without_raising(
+        self, initialized_runtime, slack_upload, monkeypatch
+    ):
+        # A pip-installed package without the repo checkout alongside has no utils/
+        # directory next to src/aetherscan — the report_path.exists() guard must skip
+        # gracefully (warn + return) rather than blow up on the missing file.
+        monkeypatch.setattr(main.Path, "exists", lambda self: False)
+        with stage_timer("train.load_backgrounds", tag="test_v1"):
+            pass
+        main._post_benchmark_report("test_v1")  # must not raise
+        assert slack_upload == []


### PR DESCRIPTION
Closes #168

## What

Auto-generates the benchmark report (`utils/benchmark_report.py`'s stage timeline + top-10-slowest table PNG, plus the bottleneck suggestions) at the end of every `train`/`inference` run and posts it to Slack, like the other end-of-run plots.

- **`src/aetherscan/main.py`**: new `_post_benchmark_report(tag)` called at the tail of both `train_command` and `inference_command`. It flushes the async DB write queue (`db.flush(timeout=config.db.flush_timeout)`) so every `pipeline_stages` span is on disk, importlib-loads `utils/benchmark_report.py` by file path (same pattern as `tests/unit/test_benchmark.py`, preserving the tool's no-`aetherscan`-imports/cluster-portable contract), renders `{output_path}/plots/benchmark_report_{tag}.png` (same path as the manual tool), and uploads it via `get_logger().upload_image_to_slack(...)` — verified to exist (`logger/logger.py` -> `SlackHandler.upload_file` -> `files_upload_v2`) — with the suggestions text riding along as the upload's `initial_comment`. The whole hook is wrapped in `except (Exception, SystemExit)` (the report tool's `load_rows` raises `SystemExit` on a pre-benchmarking-schema DB, which a bare `except Exception` would not catch), so it can never fail the run. A missing repo checkout (pip-installed package) degrades to a warning and skips.
- **`src/aetherscan/config.py`**: `MonitorConfig.benchmark_report_enabled: bool = True` + `to_dict` entry (also picked up generically by `apply_saved_config`).
- **`src/aetherscan/cli.py`**: `--benchmark-report`/`--no-benchmark-report` (`BooleanOptionalAction`, tri-state, mirrors `--dashboard`) on both subcommands + `apply_args_to_config` mapping.
- **`README.md`**: CLI Reference regenerated via `utils/print_cli_help.py` (guarded by `tests/unit/test_cli_help_sync.py`, which passes).
- **`docs/BENCHMARKING.md`**: TL;DR bullet + a paragraph in the report-tool section documenting the automatic hook.
- **Tests**: `tests/unit/test_main.py` gains `TestPostBenchmarkReport` — render + mocked-upload against a seeded tmp-path SQLite DB (span left un-flushed so the hook's own flush is exercised), config-gate off, no-rows skip, exception swallow, and `SystemExit` swallow (DB file without the `pipeline_stages` table); `tests/unit/test_cli_validation.py` gains the flag->`config.monitor` routing test.

## Maintainer decisions applied

- **Hook placement: tail-of-command with an explicit `db.flush()`** — the issue proposed "after the monitor has stopped (so all spans are flushed)", but the monitor never writes `pipeline_stages` rows (spans land via the async DB write queue), and monitor shutdown only happens in `main()`'s `finally` via `manager.cleanup_all()`, after the commands return and while the Slack handler is being torn down. The explicit flush is the mechanism that actually guarantees span visibility.
- **In `train_command`, the hook runs just before `_report_final_training_status`** (not after): that reporter `sys.exit(1)`s when any non-critical stage permanently failed, and the timing report is exactly as valuable on those runs.
- **Config-gate home: `MonitorConfig`** (vs a new benchmark section) — it already owns the sibling observability knobs (`annotate_stages`, `dashboard_*`).
- **Suggestions delivery: Slack image comment** (`initial_comment` on the upload), not a separate text post; the full text tree stays report-tool-only.
- **Missing `utils/benchmark_report.py` (pip-installed, no repo checkout): guarded degradation** — warn and skip, rather than relocating the report core into the package.
- **End-of-run only**, per the issue's proposal — no per-round posting.

## Verification

- `pytest tests/unit/test_main.py tests/unit/test_cli_validation.py tests/unit/test_cli_help_sync.py tests/unit/test_config.py tests/unit/test_benchmark.py -m "not gpu and not cluster" -q` in a local TF venv: **161 passed**. Full suite deferred to CI.
- `pre-commit run ruff`/`ruff-format` on all changed files: passed (plus the full hook set on commit).
- Not exercised against a live cluster run/Slack workspace — the upload path is unit-tested via the stubbed logger only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
