### PR TITLE
feat: persist RF eval metrics to the DB + live RF dashboard tab

### DIFF
--- a/src/aetherscan/dashboard.py
+++ b/src/aetherscan/dashboard.py
@@ -3,10 +3,11 @@
 Live dashboard for an Aetherscan pipeline run, read straight from its SQLite DB.
 
 Renders, in one auto-refreshing page, every run metric that is reconstructable from the DB —
-resource utilization (CPU/RAM/GPU), beta-VAE loss + stability curves, the signal-injection
-stats suite, a live latent-space scatter, the stage timeline (PR #134), and inference candidate
-stats — plus a gallery of every saved plot PNG (RF diagnostics, latent traversals, inference
-figures) as it appears on disk.
+resource utilization (CPU/RAM/GPU), beta-VAE loss + stability curves, RF eval metrics
+(accuracy/AUC/AP/Brier tiles, confusion heatmaps, ensemble curve, confidence quantiles), the
+signal-injection stats suite, a live latent-space scatter, the stage timeline (PR #134), and
+inference candidate stats — plus a gallery of every saved plot PNG (RF diagnostics, latent
+traversals, inference figures) as it appears on disk.
 
 It is STANDALONE — no `aetherscan` imports (like utils/benchmark_report.py), only stdlib sqlite3 +
 numpy + pandas + plotly + streamlit — so streamlit can execute it directly and it runs against a
@@ -114,6 +115,58 @@ def load_training_stats(conn: sqlite3.Connection, tag: str, stats: list[str]) ->
         params=(tag, *wanted),
     )
     return df
+
+
+def load_rf_stats(conn: sqlite3.Connection, tag: str) -> pd.DataFrame:
+    """Non-superseded model_name='rf' training_stats for `tag` (timestamp, stat_name, value,
+    round_number, epoch_number). Duplicate (stat_name, epoch_number) rows — an rf_plots retry
+    re-writing the ensemble curve, or a reused tag's stale scalars — collapse last-write-wins
+    (rows are ordered by timestamp; scalar rows share a NULL epoch_number, which pandas
+    treats as equal when de-duplicating)."""
+    df = pd.read_sql_query(
+        "SELECT timestamp, stat_name, value, round_number, epoch_number "
+        f"FROM training_stats WHERE tag = ? AND model_name = 'rf' AND {_ALIVE} "
+        "ORDER BY timestamp",
+        conn,
+        params=(tag,),
+    )
+    if not df.empty:
+        df = df.drop_duplicates(subset=["stat_name", "epoch_number"], keep="last").reset_index(
+            drop=True
+        )
+    return df
+
+
+def rf_confusion_matrices(rf: pd.DataFrame) -> tuple[pd.DataFrame | None, pd.DataFrame | None]:
+    """Shape load_rf_stats rows into the RF tab's two confusion matrices: the binary 2x2
+    (actual x predicted, from confusion_{tn,fp,fn,tp}) and the sub-type x predicted-class
+    counts (from confusion_{subtype}_pred_{false,true}). Either is None when its cell rows
+    are absent."""
+    if rf.empty:
+        return None, None
+    scalars = dict(zip(rf["stat_name"], rf["value"], strict=False))
+
+    cells = [scalars.get(f"confusion_{c}") for c in ("tn", "fp", "fn", "tp")]
+    binary = None
+    if None not in cells:
+        binary = pd.DataFrame(
+            [[cells[0], cells[1]], [cells[2], cells[3]]],
+            index=["actual false", "actual true"],
+            columns=["pred false", "pred true"],
+        )
+
+    subtype = None
+    sub = rf[rf["stat_name"].str.match(r"^confusion_.+_pred_(true|false)$")].copy()
+    if not sub.empty:
+        parts = sub["stat_name"].str.extract(r"^confusion_(.+)_pred_(true|false)$")
+        sub["subtype"] = parts[0]
+        sub["pred"] = "pred " + parts[1]
+        subtype = (
+            sub.pivot_table(index="subtype", columns="pred", values="value", aggfunc="last")
+            .reindex(columns=["pred false", "pred true"])
+            .sort_index()
+        )
+    return binary, subtype
 
 
 def load_injection_stats(conn: sqlite3.Connection, tag: str) -> pd.DataFrame:
@@ -372,6 +425,7 @@ def render(args: argparse.Namespace) -> None:  # pragma: no cover - requires Str
         tabs = st.tabs(
             [
                 "Training",
+                "RF",
                 "Injection",
                 "Latent",
                 "Resources",
@@ -401,8 +455,96 @@ def render(args: argparse.Namespace) -> None:  # pragma: no cover - requires Str
                     fig.update_layout(height=240, margin={"l": 10, "r": 10, "t": 40, "b": 10})
                     st.plotly_chart(fig, use_container_width=True)
 
-        # --- Injection stats ---------------------------------------------------
+        # --- RF eval metrics ---------------------------------------------------
         with tabs[1]:
+            rf = load_rf_stats(conn, tag)
+            if rf.empty:
+                st.caption("No rf training_stats yet (written when the RF stage completes).")
+            else:
+                scalars = dict(zip(rf["stat_name"], rf["value"], strict=False))
+                tiles = [
+                    ("Val accuracy", "val_accuracy"),
+                    ("ROC-AUC", "val_roc_auc"),
+                    ("Avg precision", "val_average_precision"),
+                    ("Brier score", "val_brier_score"),
+                ]
+                cols = st.columns(len(tiles))
+                for col, (label, name) in zip(cols, tiles, strict=False):
+                    v = scalars.get(name)
+                    col.metric(label, f"{v:.4f}" if v is not None else "—")
+                thr = scalars.get("classification_threshold")
+                if thr is not None:
+                    st.caption(
+                        f"Accuracy + confusion cells at deployment threshold {thr:g}; "
+                        "the ensemble curve thresholds at 0.5."
+                    )
+
+                binary_cm, subtype_cm = rf_confusion_matrices(rf)
+                left, right = st.columns(2)
+                for col, cm, title in (
+                    (left, binary_cm, "Binary confusion (val)"),
+                    (right, subtype_cm, "Sub-type × prediction (val)"),
+                ):
+                    if cm is None:
+                        continue
+                    with col:
+                        st.subheader(title)
+                        fig = px.imshow(
+                            cm.to_numpy(),
+                            x=list(cm.columns),
+                            y=list(cm.index),
+                            text_auto=".0f",
+                            color_continuous_scale="Blues",
+                        )
+                        fig.update_layout(
+                            height=300,
+                            margin={"l": 10, "r": 10, "t": 10, "b": 10},
+                            coloraxis_showscale=False,
+                        )
+                        st.plotly_chart(fig, use_container_width=True)
+
+                acc = rf[rf["stat_name"].str.startswith("val_accuracy_")].copy()
+                if not acc.empty:
+                    acc["subtype"] = acc["stat_name"].str.replace("val_accuracy_", "", regex=False)
+                    fig = px.bar(acc, x="subtype", y="value", title="Per-sub-type val accuracy")
+                    fig.update_layout(height=260, margin={"l": 10, "r": 10, "t": 40, "b": 10})
+                    st.plotly_chart(fig, use_container_width=True)
+
+                curve = rf[rf["stat_name"] == "ensemble_val_accuracy"].sort_values("epoch_number")
+                if curve.empty:
+                    st.caption("No ensemble_val_accuracy series yet (written by rf_plots).")
+                else:
+                    fig = px.line(
+                        curve, x="epoch_number", y="value", title="Ensemble accuracy vs tree count"
+                    )
+                    fig.update_layout(
+                        height=280,
+                        margin={"l": 10, "r": 10, "t": 40, "b": 10},
+                        xaxis_title="number of trees",
+                        yaxis_title="val accuracy",
+                    )
+                    st.plotly_chart(fig, use_container_width=True)
+
+                quant = rf[rf["stat_name"].str.startswith("val_proba_q")].copy()
+                if not quant.empty:
+                    quant["quantile"] = quant["stat_name"].str.replace(
+                        "val_proba_q", "p", regex=False
+                    )
+                    fig = px.bar(
+                        quant.sort_values("quantile"),
+                        x="quantile",
+                        y="value",
+                        title="Val P(true) quantiles",
+                    )
+                    fig.update_layout(height=260, margin={"l": 10, "r": 10, "t": 40, "b": 10})
+                    st.plotly_chart(fig, use_container_width=True)
+                st.caption(
+                    "Richer RF figures (SHAP suite, decision boundary, calibration) live under "
+                    "All plots (PNG)."
+                )
+
+        # --- Injection stats ---------------------------------------------------
+        with tabs[2]:
             inj = load_injection_stats(conn, tag)
             if inj.empty:
                 st.caption("No injection_stats yet.")
@@ -435,7 +577,7 @@ def render(args: argparse.Namespace) -> None:  # pragma: no cover - requires Str
                 st.plotly_chart(fig, use_container_width=True)
 
         # --- Latent scatter (live PCA of the latest snapshot) ------------------
-        with tabs[2]:
+        with tabs[3]:
             snaps = load_latent_snapshots_latest(conn, tag)
             mat, labels = parse_latent_matrix(snaps)
             if mat.shape[0] == 0:
@@ -454,7 +596,7 @@ def render(args: argparse.Namespace) -> None:  # pragma: no cover - requires Str
                 )
 
         # --- Resource utilization ---------------------------------------------
-        with tabs[3]:
+        with tabs[4]:
             if resources.empty:
                 st.caption("No system_resources yet.")
             else:
@@ -475,7 +617,7 @@ def render(args: argparse.Namespace) -> None:  # pragma: no cover - requires Str
                     st.plotly_chart(fig, use_container_width=True)
 
         # --- Stage timeline ----------------------------------------------------
-        with tabs[4]:
+        with tabs[5]:
             if stages.empty:
                 st.caption("No pipeline_stages yet (needs PR #134's benchmarking layer).")
             else:
@@ -508,7 +650,7 @@ def render(args: argparse.Namespace) -> None:  # pragma: no cover - requires Str
                 st.plotly_chart(fig, use_container_width=True)
 
         # --- Inference candidates ---------------------------------------------
-        with tabs[5]:
+        with tabs[6]:
             results = load_inference_results(conn, tag)
             cadences = load_inference_cadences(conn, tag)
             if results.empty and cadences.empty:
@@ -536,7 +678,7 @@ def render(args: argparse.Namespace) -> None:  # pragma: no cover - requires Str
                 st.dataframe(cadences, use_container_width=True)
 
         # --- All plots (PNG gallery) ------------------------------------------
-        with tabs[6]:
+        with tabs[7]:
             pngs = list_png_artifacts(plots_dir)
             if not pngs:
                 st.caption(f"No plot PNGs under {plots_dir} yet.")

--- a/src/aetherscan/rf_metrics.py
+++ b/src/aetherscan/rf_metrics.py
@@ -1,0 +1,85 @@
+"""
+Pure Random Forest eval-metric computation for Aetherscan Pipeline.
+
+Deliberately TF-free (numpy + sklearn.metrics only; no aetherscan.models import — that
+package's __init__ pulls in TensorFlow via vae.py) so the helper stays unit-testable
+without the GPU stack. train.py calls compute_rf_eval_metrics() at the tail of
+train_random_forest() and persists each returned scalar to training_stats via
+db.write_training_stat(model_name="rf", ...) for the live dashboard's RF tab.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+from sklearn.metrics import (
+    average_precision_score,
+    brier_score_loss,
+    confusion_matrix,
+    roc_auc_score,
+)
+
+logger = logging.getLogger(__name__)
+
+# Persisted quantiles of the val P(true) distribution (stat_name val_proba_q{QQ})
+_CONFIDENCE_QUANTILES = (5, 25, 50, 75, 95)
+
+
+def compute_rf_eval_metrics(
+    val_binary_labels: np.ndarray,
+    val_subtype_labels: np.ndarray,
+    val_probas: np.ndarray,
+    val_preds: np.ndarray,
+) -> dict[str, float]:
+    """
+    Compute the scalar RF validation metrics persisted to training_stats (model_name='rf').
+
+    Inputs are the aligned per-cadence arrays already built by train_random_forest():
+    binary ground truth (0/1), sub-type ground truth (false_no_signal / false_with_rfi /
+    true_only_eti / true_eti_rfi), ensemble P(true), and thresholded predictions (at
+    inference.classification_threshold). Returns a flat {stat_name: float} dict:
+
+      val_accuracy / val_roc_auc / val_average_precision / val_brier_score
+      val_accuracy_{subtype}                  binary correctness within each sub-type
+      confusion_{tn,fp,fn,tp}                 binary 2x2 confusion cell counts
+      confusion_{subtype}_pred_{false,true}   sub-type x predicted-class cell counts
+      val_proba_q{05,...,95}                  confidence-distribution quantiles
+
+    The ranking metrics (ROC-AUC / average precision) are threshold-free; accuracy and the
+    confusion cells reflect val_preds' operating point (the deployment threshold).
+    """
+    val_binary_labels = np.asarray(val_binary_labels)
+    val_subtype_labels = np.asarray(val_subtype_labels)
+    val_probas = np.asarray(val_probas, dtype=np.float64)
+    val_preds = np.asarray(val_preds)
+
+    metrics: dict[str, float] = {
+        "val_accuracy": float(np.mean(val_preds == val_binary_labels)),
+        "val_roc_auc": float(roc_auc_score(val_binary_labels, val_probas)),
+        "val_average_precision": float(average_precision_score(val_binary_labels, val_probas)),
+        "val_brier_score": float(brier_score_loss(val_binary_labels, val_probas)),
+    }
+
+    # Binary 2x2 cells (explicit label order keeps the cell layout stable regardless of
+    # which classes appear in the val split)
+    tn, fp, fn, tp = confusion_matrix(val_binary_labels, val_preds, labels=[0, 1]).ravel()
+    metrics["confusion_tn"] = float(tn)
+    metrics["confusion_fp"] = float(fp)
+    metrics["confusion_fn"] = float(fn)
+    metrics["confusion_tp"] = float(tp)
+
+    # Per-sub-type binary accuracy + sub-type x predicted-class cell counts
+    correct = val_preds == val_binary_labels
+    for subtype in np.unique(val_subtype_labels):
+        mask = val_subtype_labels == subtype
+        metrics[f"val_accuracy_{subtype}"] = float(np.mean(correct[mask]))
+        n_pred_true = int(np.sum(val_preds[mask] == 1))
+        metrics[f"confusion_{subtype}_pred_true"] = float(n_pred_true)
+        metrics[f"confusion_{subtype}_pred_false"] = float(int(np.sum(mask)) - n_pred_true)
+
+    # Confidence-distribution quantiles of val P(true)
+    for q in _CONFIDENCE_QUANTILES:
+        metrics[f"val_proba_q{q:02d}"] = float(np.quantile(val_probas, q / 100))
+
+    return metrics

--- a/src/aetherscan/rf_metrics.py
+++ b/src/aetherscan/rf_metrics.py
@@ -47,7 +47,10 @@ def compute_rf_eval_metrics(
       val_proba_q{05,...,95}                  confidence-distribution quantiles
 
     The ranking metrics (ROC-AUC / average precision) are threshold-free; accuracy and the
-    confusion cells reflect val_preds' operating point (the deployment threshold).
+    confusion cells reflect val_preds' operating point (the deployment threshold). On a
+    degenerate single-class val split the ranking metrics are undefined, so their two keys
+    are omitted (the dashboard renders absent tiles as an em dash) and everything else
+    still lands.
     """
     val_binary_labels = np.asarray(val_binary_labels)
     val_subtype_labels = np.asarray(val_subtype_labels)
@@ -56,10 +59,22 @@ def compute_rf_eval_metrics(
 
     metrics: dict[str, float] = {
         "val_accuracy": float(np.mean(val_preds == val_binary_labels)),
-        "val_roc_auc": float(roc_auc_score(val_binary_labels, val_probas)),
-        "val_average_precision": float(average_precision_score(val_binary_labels, val_probas)),
         "val_brier_score": float(brier_score_loss(val_binary_labels, val_probas)),
     }
+
+    # Ranking metrics are undefined when only one class is present: roc_auc_score raises
+    # ValueError and average_precision_score silently degenerates (all-negative labels
+    # -> -0.0 with a warning). Omit both keys in that case rather than letting the raise
+    # reach the caller's blanket best-effort guard and lose the whole dict.
+    if np.unique(val_binary_labels).size > 1:
+        metrics["val_roc_auc"] = float(roc_auc_score(val_binary_labels, val_probas))
+        metrics["val_average_precision"] = float(
+            average_precision_score(val_binary_labels, val_probas)
+        )
+    else:
+        logger.warning(
+            "Single-class val split: omitting undefined val_roc_auc / val_average_precision"
+        )
 
     # Binary 2x2 cells (explicit label order keeps the cell layout stable regardless of
     # which classes appear in the val split)

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -55,6 +55,7 @@ from aetherscan.models import (
     create_beta_vae_model,
     prepare_latent_features,
 )
+from aetherscan.rf_metrics import compute_rf_eval_metrics
 from aetherscan.round_data import (
     RoundDataPaths,
     RoundDataProducer,
@@ -2508,6 +2509,35 @@ class TrainingPipeline:
             logger.info(f"Saved Random Forest to {rf_model_path}")
 
             rf_trained = True
+
+            # Persist scalar eval metrics to training_stats (model_name='rf') so the RF is
+            # first-class on the live dashboard (issue #171). Written only after both
+            # joblibs above landed: any later retry then resumes via try_load_rf_for_resume()
+            # and skips retraining, so these rows are never duplicated (a reused tag's stale
+            # rows are handled by the dashboard's last-write-wins read). Best-effort:
+            # metric persistence must never fail the training run.
+            try:
+                rf_metrics = compute_rf_eval_metrics(
+                    val_binary_labels=val_binary_labels,
+                    val_subtype_labels=val_subtype_labels,
+                    val_probas=val_probas,
+                    val_preds=val_preds,
+                )
+                rf_metrics["classification_threshold"] = float(classification_threshold)
+                metrics_timestamp = time.time()
+                for stat_name, value in rf_metrics.items():
+                    self.db.write_training_stat(
+                        model_name="rf",
+                        stat_name=stat_name,
+                        value=value,
+                        tag=tag,
+                        timestamp=metrics_timestamp,
+                    )
+                logger.info(
+                    f"Wrote {len(rf_metrics)} RF eval metrics to training_stats (tag={tag})"
+                )
+            except Exception as e:
+                logger.warning(f"Failed to write RF eval metrics to db: {e}")
 
             # NOTE: come back to this later (are we dereferencing the correct things? can we instead write things to db instead of storing in memory?)
             del (
@@ -6057,6 +6087,24 @@ class TrainingPipeline:
         final_val_acc = val_acc[-1]
         near_final = np.where(val_acc >= final_val_acc - 0.01)[0]
         elbow_idx = int(near_final[0]) if near_final.size else n_trees - 1
+
+        # Persist the per-tree series to training_stats (model_name='rf', epoch_number =
+        # tree count) for the dashboard's live ensemble curve (issue #171). Written here —
+        # not in train_random_forest() — to reuse the O(n_trees) per-tree predict_proba
+        # loop above, so these rows only land when the rf_plots stage runs and this plot
+        # succeeds; an rf_plots retry re-writes them (the dashboard reads last-write-wins).
+        # NOTE: this series thresholds the running ensemble mean at the hard-coded 0.5
+        # above, unlike the scalar val_accuracy stat (deployment classification_threshold).
+        series_timestamp = time.time()
+        for t in range(n_trees):
+            self.db.write_training_stat(
+                model_name="rf",
+                stat_name="ensemble_val_accuracy",
+                value=float(val_acc[t]),
+                epoch_number=t + 1,
+                tag=tag,
+                timestamp=series_timestamp,
+            )
 
         fig, ax = plt.subplots(1, 1, figsize=(11, 6))
         fig.suptitle(

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -84,6 +84,32 @@ def _build_db(path):
         " VALUES (?,?,?,?,?,?,?,?)",
         (105.0, "rf", "total_loss", 7.0, 1, 1, "t1", 0),
     )
+    # rf eval metrics: scalars (epoch NULL) incl a stale duplicate (300.0, re-written at 400.0)
+    # + a superseded row, and an ensemble series (epoch = tree count) whose tree-2 row is
+    # re-written by an rf_plots retry (420.0)
+    for ts, name, v, ep, sup in [
+        (300.0, "val_accuracy", 0.90, None, 0),
+        (400.0, "val_accuracy", 0.95, None, 0),
+        (400.0, "val_roc_auc", 0.99, None, 0),
+        (400.0, "confusion_tn", 40.0, None, 0),
+        (400.0, "confusion_fp", 2.0, None, 0),
+        (400.0, "confusion_fn", 3.0, None, 0),
+        (400.0, "confusion_tp", 55.0, None, 0),
+        (400.0, "confusion_true_only_eti_pred_true", 28.0, None, 0),
+        (400.0, "confusion_true_only_eti_pred_false", 1.0, None, 0),
+        (400.0, "confusion_false_no_signal_pred_true", 1.0, None, 0),
+        (400.0, "confusion_false_no_signal_pred_false", 20.0, None, 0),
+        (500.0, "val_accuracy", 0.10, None, 1),
+        (410.0, "ensemble_val_accuracy", 0.80, 1, 0),
+        (410.0, "ensemble_val_accuracy", 0.90, 2, 0),
+        (420.0, "ensemble_val_accuracy", 0.92, 2, 0),
+    ]:
+        conn.execute(
+            "INSERT INTO training_stats"
+            " (timestamp,model_name,stat_name,value,round_number,epoch_number,tag,superseded)"
+            " VALUES (?,?,?,?,?,?,?,?)",
+            (ts, "rf", name, v, None, ep, "t1", sup),
+        )
     # injection_stats
     for i, (sig, fin, clamp) in enumerate([("eti", 1, 0), ("rfi", 0, 1), ("eti", 1, 0)]):
         conn.execute(
@@ -186,6 +212,38 @@ def test_load_training_stats_filters_model_superseded_and_statset(conn):
     assert list(df["value"]) == [1.0, 0.5, 0.2]
     # a stat not in the requested set is not returned
     assert dashboard.load_training_stats(conn, "t1", ["clipping_rate"]).empty
+
+
+def test_load_rf_stats_filters_and_dedupes(conn):
+    rf = dashboard.load_rf_stats(conn, "t1")
+    # beta_vae rows excluded: the only total_loss row is the rf-model seed (7.0)
+    assert list(rf.loc[rf["stat_name"] == "total_loss", "value"]) == [7.0]
+    # superseded (0.10) excluded; the stale duplicate (0.90) collapses last-write-wins to 0.95
+    assert list(rf.loc[rf["stat_name"] == "val_accuracy", "value"]) == [0.95]
+    # ensemble series: per-tree dedup keeps the rf_plots-retry value for tree 2
+    curve = rf[rf["stat_name"] == "ensemble_val_accuracy"].sort_values("epoch_number")
+    assert list(curve["epoch_number"]) == [1, 2]
+    assert list(curve["value"]) == [0.80, 0.92]
+
+
+def test_load_rf_stats_empty_for_unknown_tag(conn):
+    assert dashboard.load_rf_stats(conn, "nope").empty
+
+
+def test_rf_confusion_matrices(conn):
+    rf = dashboard.load_rf_stats(conn, "t1")
+    binary, subtype = dashboard.rf_confusion_matrices(rf)
+    # binary 2x2: rows actual false/true, cols pred false/true
+    assert binary.to_numpy().tolist() == [[40.0, 2.0], [3.0, 55.0]]
+    assert list(binary.columns) == ["pred false", "pred true"]
+    # sub-type x prediction counts, one row per seeded sub-type
+    assert list(subtype.index) == ["false_no_signal", "true_only_eti"]
+    assert subtype.loc["true_only_eti"].tolist() == [1.0, 28.0]
+    assert subtype.loc["false_no_signal"].tolist() == [20.0, 1.0]
+
+
+def test_rf_confusion_matrices_absent_cells(conn):
+    assert dashboard.rf_confusion_matrices(dashboard.load_rf_stats(conn, "nope")) == (None, None)
 
 
 def test_load_injection_stats_excludes_superseded(conn):

--- a/tests/unit/test_rf_metrics.py
+++ b/tests/unit/test_rf_metrics.py
@@ -69,6 +69,25 @@ def test_all_values_are_floats_and_key_count():
     assert len(metrics) == 25
 
 
+def test_single_class_split_omits_ranking_metrics():
+    """A degenerate all-one-class val split must still yield the non-ranking metrics
+    (ranking metrics are undefined there: roc_auc_score raises, AP degenerates)."""
+    val_binary = np.array([0, 0, 0], dtype=np.int64)
+    val_subtype = np.array(["false_no_signal", "false_with_rfi", "false_no_signal"], dtype="U20")
+    val_probas = np.array([0.1, 0.8, 0.3], dtype=np.float32)
+    val_preds = (val_probas >= 0.7).astype(np.int64)  # -> [0, 1, 0]
+    metrics = compute_rf_eval_metrics(val_binary, val_subtype, val_probas, val_preds)
+    assert "val_roc_auc" not in metrics
+    assert "val_average_precision" not in metrics
+    assert metrics["val_accuracy"] == pytest.approx(2 / 3)
+    # mean((p - y)^2) = (0.01 + 0.64 + 0.09) / 3
+    assert metrics["val_brier_score"] == pytest.approx(0.74 / 3, abs=1e-6)
+    assert (metrics["confusion_tn"], metrics["confusion_fp"]) == (2.0, 1.0)
+    assert metrics["confusion_fn"] == 0.0 and metrics["confusion_tp"] == 0.0
+    assert metrics["val_proba_q50"] == pytest.approx(0.3, abs=1e-6)
+    assert all(isinstance(v, float) for v in metrics.values())
+
+
 def test_perfect_predictions():
     val_binary = np.array([0, 0, 1, 1], dtype=np.int64)
     val_subtype = np.array(

--- a/tests/unit/test_rf_metrics.py
+++ b/tests/unit/test_rf_metrics.py
@@ -1,0 +1,86 @@
+"""Unit tests for aetherscan/rf_metrics.py — the pure (TF-free) RF eval-metric helper whose
+output train.py persists to training_stats (model_name='rf') for the dashboard's RF tab."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from aetherscan.rf_metrics import compute_rf_eval_metrics
+
+
+def _tiny_eval_arrays():
+    """One cadence per sub-type, with one binary error in each class (threshold 0.7)."""
+    val_binary = np.array([0, 0, 1, 1], dtype=np.int64)
+    val_subtype = np.array(
+        ["false_no_signal", "false_with_rfi", "true_only_eti", "true_eti_rfi"], dtype="U20"
+    )
+    val_probas = np.array([0.1, 0.8, 0.9, 0.4], dtype=np.float32)
+    val_preds = (val_probas >= 0.7).astype(np.int64)  # -> [0, 1, 1, 0]
+    return val_binary, val_subtype, val_probas, val_preds
+
+
+def test_scalar_metrics_hand_computed():
+    metrics = compute_rf_eval_metrics(*_tiny_eval_arrays())
+    assert metrics["val_accuracy"] == pytest.approx(0.5)
+    # AUC = fraction of (neg, pos) pairs ranked correctly = 3/4
+    assert metrics["val_roc_auc"] == pytest.approx(0.75)
+    # ranked desc: 0.9(1), 0.8(0), 0.4(1), 0.1(0) -> AP = 0.5*1 + 0.5*(2/3)
+    assert metrics["val_average_precision"] == pytest.approx(5 / 6, abs=1e-6)
+    # mean((p - y)^2) = (0.01 + 0.64 + 0.01 + 0.36) / 4
+    assert metrics["val_brier_score"] == pytest.approx(0.255, abs=1e-6)
+
+
+def test_confusion_cells():
+    metrics = compute_rf_eval_metrics(*_tiny_eval_arrays())
+    assert (
+        metrics["confusion_tn"],
+        metrics["confusion_fp"],
+        metrics["confusion_fn"],
+        metrics["confusion_tp"],
+    ) == (1.0, 1.0, 1.0, 1.0)
+    # sub-type x predicted-class cells: preds are [0, 1, 1, 0] in sub-type order
+    assert metrics["confusion_false_no_signal_pred_false"] == 1.0
+    assert metrics["confusion_false_no_signal_pred_true"] == 0.0
+    assert metrics["confusion_false_with_rfi_pred_true"] == 1.0
+    assert metrics["confusion_true_only_eti_pred_true"] == 1.0
+    assert metrics["confusion_true_eti_rfi_pred_false"] == 1.0
+
+
+def test_subtype_accuracies():
+    metrics = compute_rf_eval_metrics(*_tiny_eval_arrays())
+    assert metrics["val_accuracy_false_no_signal"] == pytest.approx(1.0)
+    assert metrics["val_accuracy_false_with_rfi"] == pytest.approx(0.0)
+    assert metrics["val_accuracy_true_only_eti"] == pytest.approx(1.0)
+    assert metrics["val_accuracy_true_eti_rfi"] == pytest.approx(0.0)
+
+
+def test_confidence_quantiles_monotonic():
+    metrics = compute_rf_eval_metrics(*_tiny_eval_arrays())
+    quantiles = [metrics[f"val_proba_q{q:02d}"] for q in (5, 25, 50, 75, 95)]
+    assert metrics["val_proba_q50"] == pytest.approx(0.6, abs=1e-6)
+    assert quantiles == sorted(quantiles)
+
+
+def test_all_values_are_floats_and_key_count():
+    metrics = compute_rf_eval_metrics(*_tiny_eval_arrays())
+    assert all(isinstance(v, float) for v in metrics.values())
+    # 4 scalars + 4 binary cells + 4 sub-type accuracies + 8 sub-type cells + 5 quantiles
+    assert len(metrics) == 25
+
+
+def test_perfect_predictions():
+    val_binary = np.array([0, 0, 1, 1], dtype=np.int64)
+    val_subtype = np.array(
+        ["false_no_signal", "false_with_rfi", "true_only_eti", "true_eti_rfi"], dtype="U20"
+    )
+    val_probas = np.array([0.1, 0.2, 0.8, 0.9], dtype=np.float32)
+    val_preds = (val_probas >= 0.5).astype(np.int64)
+    metrics = compute_rf_eval_metrics(val_binary, val_subtype, val_probas, val_preds)
+    assert metrics["val_accuracy"] == pytest.approx(1.0)
+    assert metrics["val_roc_auc"] == pytest.approx(1.0)
+    assert metrics["val_average_precision"] == pytest.approx(1.0)
+    assert metrics["confusion_fp"] == 0.0
+    assert metrics["confusion_fn"] == 0.0
+    assert metrics["confusion_tn"] == 2.0
+    assert metrics["confusion_tp"] == 2.0


### PR DESCRIPTION
Closes #171

## What changed

The Random Forest was the one model family with no DB backing — every RF diagnostic was sourced from the on-disk `rf_eval_artifacts_{tag}.joblib` and appeared on the dashboard only via the PNG gallery. This PR persists RF eval metrics to `training_stats` and gives the dashboard a first-class RF tab.

- **`src/aetherscan/rf_metrics.py` (new)** — `compute_rf_eval_metrics()`, a pure helper (arrays in → `{stat_name: float}` out) computing val accuracy / ROC-AUC / average precision / Brier score, per-sub-type accuracies, binary 2×2 + sub-type × prediction confusion cell counts, and confidence quantiles of val P(true). Deliberately a top-level TF-free module (the `models` package `__init__` pulls TensorFlow via `vae.py`), so it is unit-testable without the GPU stack.
- **`train.py` `train_random_forest()` tail** — calls the helper on the already-in-memory val arrays and writes each scalar via `db.write_training_stat(model_name="rf", ...)`, plus a `classification_threshold` row. Writes happen only after both RF joblibs land, so any later retry resumes via `try_load_rf_for_resume()` and skips retraining — the rows are never duplicated by the resume path. The block is best-effort: a metrics failure logs a warning and never fails the training run.
- **`train.py` `plot_rf_ensemble_accuracy_curve()`** — writes the per-tree `ensemble_val_accuracy` series (`epoch_number` = tree count) from inside the plot function where the O(n_trees) per-tree `predict_proba` loop already runs, rather than duplicating that cost at train time. A comment notes the resulting dependency: the series only lands when the `rf_plots` stage runs and this plot succeeds, and it still thresholds at the pre-existing hard-coded 0.5 (unlike the scalar `val_accuracy`, which uses the deployment threshold — the stat names + an in-tab caption disambiguate).
- **`dashboard.py`** — `load_rf_stats()` (alive `model_name='rf'` rows with last-write-wins dedup on `(stat_name, epoch_number)`, which absorbs rf_plots-retry re-writes and reused-tag stale scalars), `rf_confusion_matrices()` pure shaping helper, and an **RF** tab: metric tiles (accuracy/AUC/AP/Brier), binary + sub-type confusion heatmaps, per-sub-type accuracy bars, the ensemble-accuracy-vs-tree-count curve, and confidence quantiles. SHAP / decision-boundary / calibration figures stay in the PNG gallery as planned. The dashboard stays standalone (stdlib + numpy/pandas/plotly/streamlit only).
- **Tests** — `tests/unit/test_rf_metrics.py` (hand-computed AUC/AP/Brier/confusion/quantile values, perfect-prediction case, float-purity + key-count) and new `test_dashboard.py` cases (seeded-sqlite `load_rf_stats` model/superseded filtering + dedup semantics, `rf_confusion_matrices` shaping, empty-tag behavior).

Note: the issue body says `utils/dashboard.py`; the actual dashboard is `src/aetherscan/dashboard.py` (there is no utils dashboard), which is what this PR edits.

## Verification

- `tests/unit/test_rf_metrics.py` + `tests/unit/test_dashboard.py`: **27 passed** locally in the TF venv (`-m "not gpu and not cluster"`).
- Adjacent suites `test_dashboard_launcher.py`, `test_train_utils.py`, `test_train_datasets.py`: **65 passed** locally.
- `import aetherscan.train` verified in the TF venv (new import wiring).
- `ruff check` + `ruff format` clean on all changed files (pre-commit hooks passed).
- Full suite deferred to CI. The train-side write paths (train_random_forest tail, plot fn) are not exercised by unit tests — they need a GPU/cluster run, matching the existing coverage posture for `train.py`'s beta-VAE DB writes.

## Maintainer decisions applied

- **Reuse `training_stats` (no schema v5)** — rows go in with `model_name='rf'`, which `write_training_stat`'s docstring already anticipated; the ensemble curve's x-value is carried in `epoch_number` (= tree count). A dedicated typed `rf_metrics` table would need a v5 bump + writer/query plumbing; veto if you prefer that.
- **Split computation: scalars at train time, ensemble curve at plot time** — the curve series reuses the expensive per-tree loop inside `plot_rf_ensemble_accuracy_curve`, so those rows depend on the `rf_plots` stage succeeding (scalars do not).
- **Duplicate handling is read-side** — `load_rf_stats` dedupes last-write-wins instead of adding a model/stat-scoped `mark_superseded` variant (the existing supersede mark is `round_ge`-based and RF rows carry no round number; a write-side mark would have superseded beta-VAE rows too).
- **Threshold disambiguation via naming + caption, not code change** — the scalar `val_accuracy` uses the deployment `inference.classification_threshold` (persisted as its own row); `ensemble_val_accuracy` keeps the plot's pre-existing hard-coded 0.5 (flagged by the existing NOTE there, unchanged here).
- **Feature importances / mean-|SHAP| left out** — the issue marked them optional; the SHAP figures remain in the PNG gallery.
- **Metric persistence is best-effort** — wrapped in try/except with a warning so an sklearn edge case (e.g. degenerate single-class val split) can't fail a multi-hour training run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
