### PR TITLE
feat(data-gen): cap create_true_double intersection retries + deliberate ON-band boundary check

### DIFF
--- a/src/aetherscan/data_generation.py
+++ b/src/aetherscan/data_generation.py
@@ -476,6 +476,12 @@ def create_true_single(
     return final, sample_info
 
 
+# Defensive cap on create_true_double's intersection-retry loop (#118). Acceptance is i.i.d.
+# geometric with p~=0.42, so P(a single sample needs >100 attempts) ~ 1e-24 — the cap exists so
+# one pathological draw can never stall a batched task, not because it is expected to fire.
+MAX_INTERSECTION_RETRIES = 100
+
+
 def create_true_double(
     plate: np.ndarray,
     snr_base: float,
@@ -490,8 +496,9 @@ def create_true_double(
     Create a true-double-class cadence (non-intersecting ETI and RFI signals injected into
     ON-only and ON-OFF respectively) and return (final, sample_info). final has shape
     (6, 16, width_bin); sample_info carries background_index, per-stage intensity_stats (A/B/C),
-    signal_info with both eti_* and rfi_* keys, slope_was_clamped, and per-observation
-    lognorm_params (shape (6, 2)).
+    signal_info with both eti_* and rfi_* keys, slope_was_clamped, intersection_retries /
+    intersection_retry_capped (retry-cap telemetry, #118), and per-observation lognorm_params
+    (shape (6, 2)).
     """
     # Select random background from plate
     background_index = int(plate.shape[0] * random.random())
@@ -515,13 +522,17 @@ def create_true_double(
     # Select a random SNR from the given range
     snr = random.random() * snr_range + snr_base
 
-    # Note, small but nonzero probability for "infinite" (long-running) loops
     # NOTE: quantified in #118 — acceptance is i.i.d. geometric with p~=0.42, so the worst
     # sample over a full 499200-round is ~25 retries (~3s); a >100-retry sample is effectively
     # impossible (P~1e-24). This loop is therefore NOT the ~10-min single-worker stall seen in
-    # the #117 smoke (that is gc/IO/scheduling, see #118). #118 tracks a defensive retry cap.
-    # Retry signal injection until we get valid non-intersecting signals
+    # the #117 smoke (that is gc/IO/scheduling, see #118). MAX_INTERSECTION_RETRIES is the
+    # defensive cap #118 called for: on exhaustion keep the last drawn pair and flag the sample
+    # (clamp-and-flag, mirroring slope_was_clamped) rather than raise and kill a whole round.
+    # Retry signal injection until we get valid non-intersecting signals (or the cap is hit)
+    intersection_retries = 0
+    intersection_retry_capped = False
     while True:
+        intersection_retries += 1
         # Inject RFI
         cadence_1, rfi_signal_info, rfi_slope_clamped = new_cadence(
             data, snr, width_bin, freq_resolution, time_resolution
@@ -540,6 +551,14 @@ def create_true_double(
         if slope_1 != slope_2 and check_valid_intersection(
             slope_1, slope_2, intercept_1, intercept_2
         ):
+            break
+
+        if intersection_retries >= MAX_INTERSECTION_RETRIES:
+            intersection_retry_capped = True
+            logger.warning(
+                f"create_true_double: intersection retry cap ({MAX_INTERSECTION_RETRIES}) "
+                f"exhausted; keeping last drawn signal pair and flagging the sample"
+            )
             break
 
     # Track if any slope was clamped (either RFI or ETI)
@@ -576,6 +595,8 @@ def create_true_double(
         "intensity_stats": {"A": stats_a, "B": stats_b, "C": stats_c},
         "signal_info": signal_info,  # Both eti_* and rfi_* signal characteristics
         "slope_was_clamped": slope_was_clamped,
+        "intersection_retries": intersection_retries,
+        "intersection_retry_capped": intersection_retry_capped,
         "lognorm_params": lognorm_params,
     }
 
@@ -799,7 +820,8 @@ def write_segment_stats(db, tag: str, segment: dict) -> None:
     generate_round_to_memmap's stats_cb.
 
     Per-sample writes: 6 intensity stats x 3 stages = 18 rows, plus 0-12 signal-characteristic
-    rows depending on signal_type. Segment-level writes: 4 metadata rows.
+    rows depending on signal_type, plus 2 intersection-retry rows for true-double samples
+    (#118). Segment-level writes: 4 metadata rows.
     """
     if db is None:
         raise RuntimeError("No database instance detected - cannot write injection stats")
@@ -861,6 +883,30 @@ def write_segment_stats(db, tag: str, segment: dict) -> None:
                 tag=tag,
                 timestamp=timestamp,
             )
+
+        # Straggler observability (#118): true-double samples record how many injection
+        # attempts the intersection-retry loop took and whether it exhausted the cap.
+        # injection_stage=None since these describe the injection itself
+        if "intersection_retries" in sample_info:
+            retry_stats = [
+                ("intersection_retries", float(sample_info["intersection_retries"])),
+                ("intersection_retry_capped", float(sample_info["intersection_retry_capped"])),
+            ]
+            for stat_name, value in retry_stats:
+                db.write_injection_stat(
+                    stat_name=stat_name,
+                    value=value,
+                    round_number=round_number,
+                    chunk_number=chunk_number,
+                    sample_index=sample_idx,
+                    background_index=background_index,
+                    signal_class=signal_class,
+                    signal_type=signal_type,
+                    injection_stage=None,
+                    slope_clamped=slope_was_clamped,
+                    tag=tag,
+                    timestamp=timestamp,
+                )
 
     # Segment-level metadata stats (once per segment, not per sample)
     metadata_stats = [

--- a/src/aetherscan/data_generation.py
+++ b/src/aetherscan/data_generation.py
@@ -256,9 +256,25 @@ def new_cadence(
     return modified_data, signal_info, slope_was_clamped
 
 
+# Float-rounding pad for the ON-band boundary comparison in check_valid_intersection (#118).
+# Same-sign trajectory pairs intersect exactly ON a band edge (y* = 0 in exact arithmetic:
+# positive-drift lines all pass through (0, 0) and negative-drift lines through (width_bin, 0),
+# see new_cadence's y_intercept construction), but the float intersection lands at y* ~ -1e-14,
+# so a bare inclusive comparison used to accept ~4.8% of them by rounding luck. 1e-9 is several
+# orders of magnitude above the observed rounding noise yet negligible against the pixel-scale
+# band geometry (an extra ~2e-9-wide rejection sliver per boundary).
+_ON_BAND_BOUNDARY_EPS = 1e-9
+
+
 def check_valid_intersection(slope_1, slope_2, intercept_1, intercept_2):
     """
-    Check if 2 drifting signals intersect in the ON regions
+    Check if 2 drifting signals intersect in the ON regions.
+
+    ON-band boundaries are deliberately INCLUSIVE: an intersection lying exactly on a band edge
+    counts as inside the ON region and invalidates the pair (returns False) — a boundary
+    crossing still overlaps ON-region pixels once the signals' finite width is considered. The
+    comparison is padded by _ON_BAND_BOUNDARY_EPS so float rounding cannot flip an
+    exact-boundary case to "valid".
     """
     if slope_1 == slope_2:
         return True  # Parallel lines never intersect. Avoids division by 0
@@ -267,7 +283,10 @@ def check_valid_intersection(slope_1, slope_2, intercept_1, intercept_2):
     y_intersect = slope_1 * x_intersect + intercept_1
 
     on_y_coords = [(0, 16), (32, 48), (64, 80)]
-    return all(not y_lower <= y_intersect <= y_upper for y_lower, y_upper in on_y_coords)
+    return all(
+        not (y_lower - _ON_BAND_BOUNDARY_EPS <= y_intersect <= y_upper + _ON_BAND_BOUNDARY_EPS)
+        for y_lower, y_upper in on_y_coords
+    )
 
 
 # TODO: add more sophisticated statistics for data leakage analysis

--- a/src/aetherscan/data_generation.py
+++ b/src/aetherscan/data_generation.py
@@ -574,9 +574,14 @@ def create_true_double(
 
         if intersection_retries >= MAX_INTERSECTION_RETRIES:
             intersection_retry_capped = True
+            # "Last drawn pair" is the pair the acceptance check just rejected above (the cap
+            # is only reached after check_valid_intersection fails) — NOT an unconditionally
+            # accepted 100th draw. At this probability (~1e-24) the sample is already a
+            # statistical non-event; keeping a known-intersecting pair rather than drawing
+            # (and not testing) a 101st is the simpler contract to reason about.
             logger.warning(
                 f"create_true_double: intersection retry cap ({MAX_INTERSECTION_RETRIES}) "
-                f"exhausted; keeping last drawn signal pair and flagging the sample"
+                f"exhausted; keeping last drawn (rejected) signal pair and flagging the sample"
             )
             break
 

--- a/tests/unit/test_data_generation.py
+++ b/tests/unit/test_data_generation.py
@@ -138,6 +138,32 @@ class TestCheckValidIntersection:
         # y = x and y = -x + 2*y_target intersect at (y_target, y_target).
         assert check_valid_intersection(1.0, -1.0, 0.0, 2 * y_target) is False
 
+    @pytest.mark.parametrize(
+        "b1, b2, positive_drift",
+        [
+            # Pairs whose float intersection lands at y* ~ -1e-14 instead of the exact 0:
+            # the un-padded inclusive comparison accepted all of these by rounding luck (#118).
+            (1, 187, True),
+            (173, 434, True),
+            (383, 511, True),
+            (1, 75, False),
+            (102, 500, False),
+            (239, 511, False),
+        ],
+    )
+    def test_boundary_intersections_rejected_despite_float_noise(self, b1, b2, positive_drift):
+        # Production geometry (new_cadence): positive-drift trajectories all pass through
+        # (0, 0) and negative-drift ones through (width_bin, 0), so same-sign pairs intersect
+        # exactly ON the first ON-band edge (y* = 0) and must be rejected (boundaries are
+        # inclusive) regardless of float rounding in slope/intercept/intersection arithmetic.
+        total_time, width_bin = 96, 512
+        slopes_intercepts = []
+        for b in (b1, b2):
+            slope = total_time / b if positive_drift else total_time / (b - width_bin)
+            slopes_intercepts.append((slope, total_time - slope * b))
+        (s1, e1), (s2, e2) = slopes_intercepts
+        assert check_valid_intersection(s1, s2, e1, e2) is False
+
 
 class TestNewCadence:
     def _background(self, rng=None):

--- a/tests/unit/test_data_generation.py
+++ b/tests/unit/test_data_generation.py
@@ -5,13 +5,16 @@ create_* cadence generators, and intensity statistics."""
 
 from __future__ import annotations
 
+import itertools
 import math
 import random
 
 import numpy as np
 import pytest
 
+from aetherscan import data_generation
 from aetherscan.data_generation import (
+    MAX_INTERSECTION_RETRIES,
     _compute_intensity_stats,
     check_valid_intersection,
     create_false,
@@ -19,6 +22,7 @@ from aetherscan.data_generation import (
     create_true_single,
     log_norm,
     new_cadence,
+    write_segment_stats,
 )
 
 # Keep injection fast: small frequency axis, real-ish resolutions.
@@ -273,6 +277,45 @@ class TestCreateCadences:
             sample_info["signal_info"]["rfi_y_intercept"],
             sample_info["signal_info"]["eti_y_intercept"],
         )
+        # Retry-cap telemetry (#118): real geometry accepts well before the cap.
+        assert sample_info["intersection_retries"] >= 1
+        assert sample_info["intersection_retry_capped"] is False
+
+    def _stub_injections(self, monkeypatch):
+        # Replace the expensive setigen injection with a shape-preserving stub whose slope
+        # differs on every call, so the slope_1 != slope_2 guard never causes a retry and
+        # the retry count is driven purely by the (patched) intersection check.
+        calls = itertools.count(1)
+
+        def fake_new_cadence(data, snr, width_bin, freq_resolution, time_resolution):
+            signal_info = {
+                "snr": float(snr),
+                "drift_rate": 1.0,
+                "signal_width": 1.0,
+                "starting_bin": 1.0,
+                "slope_pixel": float(next(calls)),
+                "y_intercept": 0.0,
+            }
+            return data, signal_info, False
+
+        monkeypatch.setattr(data_generation, "new_cadence", fake_new_cadence)
+
+    def test_true_double_retry_cap_clamps_and_flags(self, plate, monkeypatch):
+        # Always-rejecting geometry must terminate at the cap, keep the last drawn pair,
+        # and flag the sample — not raise and not spin forever (#118).
+        self._stub_injections(monkeypatch)
+        monkeypatch.setattr(data_generation, "check_valid_intersection", lambda *a: False)
+        final, sample_info = create_true_double(plate, **self._kwargs())
+        assert final.shape == (6, 16, _WIDTH_BIN)
+        assert sample_info["intersection_retries"] == MAX_INTERSECTION_RETRIES
+        assert sample_info["intersection_retry_capped"] is True
+
+    def test_true_double_first_attempt_accept_records_one_retry(self, plate, monkeypatch):
+        self._stub_injections(monkeypatch)
+        monkeypatch.setattr(data_generation, "check_valid_intersection", lambda *a: True)
+        _, sample_info = create_true_double(plate, **self._kwargs())
+        assert sample_info["intersection_retries"] == 1
+        assert sample_info["intersection_retry_capped"] is False
 
 
 class TestComputeIntensityStats:
@@ -302,3 +345,58 @@ class TestComputeIntensityStats:
         # is_finite=0 rather than rejecting the write.
         assert math.isnan(stats["global_skew"])
         assert math.isnan(stats["global_kurtosis"])
+
+
+class _RecordingDB:
+    """Minimal stand-in for the DB singleton: records write_injection_stat calls."""
+
+    def __init__(self):
+        self.calls = []
+
+    def write_injection_stat(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+class TestWriteSegmentStats:
+    def _sample_info(self, **extra):
+        info = {
+            "background_index": 0,
+            "intensity_stats": {s: dict.fromkeys(_STAT_KEYS, 0.0) for s in ("A", "B", "C")},
+            "signal_info": {},
+            "slope_was_clamped": False,
+        }
+        info.update(extra)
+        return info
+
+    def _segment(self, stats_list):
+        return {
+            "round_number": 0,
+            "chunk_number": 0,
+            "signal_class": "true",
+            "signal_type": "true_eti_rfi",
+            "timestamp": 123.0,
+            "stats_list": stats_list,
+            "snr_range_floor": 10.0,
+            "snr_range_ceil": 15.0,
+            "num_samples": len(stats_list),
+            "inject_duration": 1.0,
+        }
+
+    def test_emits_intersection_retry_rows_for_true_double_samples(self):
+        db = _RecordingDB()
+        sample = self._sample_info(intersection_retries=7, intersection_retry_capped=True)
+        write_segment_stats(db, "test_tag", self._segment([sample]))
+        rows = {c["stat_name"]: c for c in db.calls if c["stat_name"].startswith("intersection_")}
+        assert set(rows) == {"intersection_retries", "intersection_retry_capped"}
+        assert rows["intersection_retries"]["value"] == 7.0
+        assert rows["intersection_retry_capped"]["value"] == 1.0
+        for row in rows.values():
+            assert row["sample_index"] == 0
+            assert row["injection_stage"] is None
+            assert row["signal_type"] == "true_eti_rfi"
+
+    def test_no_retry_rows_for_samples_without_retry_keys(self):
+        # create_false / create_true_single samples carry no retry telemetry — no rows.
+        db = _RecordingDB()
+        write_segment_stats(db, "test_tag", self._segment([self._sample_info()]))
+        assert not [c for c in db.calls if c["stat_name"].startswith("intersection_")]


### PR DESCRIPTION
Closes #118

## What changed

**Commit 1 — retry cap + observability (the #118 core):**
- `MAX_INTERSECTION_RETRIES = 100` module constant in `src/aetherscan/data_generation.py`; `create_true_double`'s previously unbounded `while True` intersection-retry loop now counts attempts and, on exhaustion, keeps the last drawn signal pair and flags the sample (clamp-and-flag, mirroring `slope_was_clamped`) instead of raising — per the issue's 2026-07-17 analysis comment, a raise would kill a whole round for a ~1e-24-per-sample event. A `logger.warning` fires when the cap is hit.
- `sample_info` gains `intersection_retries` (int, 1 = accepted on first attempt) and `intersection_retry_capped` (bool).
- `write_segment_stats` emits both as per-sample `injection_stats` rows (`stat_name` is free-form per `db.write_injection_stat` — **no schema change**), only for samples carrying the keys (i.e. true-double).

**Commit 2 — deliberate ON-band boundary comparison (the analysis comment's correctness footnote):**
- `check_valid_intersection` now documents the boundary decision explicitly: ON-band edges are **inclusive** (an exact-edge intersection counts as inside the ON region and rejects the pair — consistent with the pre-existing unit test `test_on_region_boundaries_are_inclusive`), and the comparison is padded by `_ON_BAND_BOUNDARY_EPS = 1e-9` so float rounding can no longer decide.
- Why: same-sign trajectory pairs intersect exactly ON a band edge (y* = 0 in exact arithmetic — positive-drift lines all pass through (0, 0), negative-drift through (width_bin, 0)), but the float intersection lands at y* ~ -1e-14. I re-verified by exact enumeration at width 512: 8,656 of 130,305 positive-positive pairs and 2,196 negative-negative pairs were accepted purely by rounding luck (~4.8% of accepted pairs, matching the issue comment). These now reject deterministically.

## Deliberately deferred

The analysis comment's follow-up (a) — pre-draw the (bin, sign) geometry, loop only the cheap arithmetic acceptance check, and run the two expensive injections exactly once (~halves true-double cost) — is **not** included. It is perf-only and reorders RNG draws relative to master; left for a separate PR under #118's umbrella if wanted.

## Maintainer decisions applied

- **Cap as a module constant (100), not a config field** — the issue offered "or config-tunable"; the constant matches the triage gameplan and avoids a config knob for a never-event. Veto = say the word and it moves to `TrainingConfig`.
- **Clamp-and-flag fallback** (keep last drawn pair + flag) rather than redrawing a fresh background plate or raising — the analysis comment's stated preference.
- **Telemetry rows only for true-double samples**; false/single samples carry no retry keys and get no rows (vs. writing 0/`NULL` rows for every sample).
- **`intersection_retry_capped` stored as a 1.0/0.0 stat value** in `injection_stats` (like other stats; also mirrored into the row's `slope_clamped`-style semantics via `stat_name`, no schema change).
- **Boundary convention: inclusive + epsilon (1e-9)** — chosen to match the existing documented test behavior; the alternative (exclusive edges) would have changed that test. Side effect worth knowing: the ~4.8% float-luck same-sign pairs are no longer accepted, so p(accept) drops ~0.423 → ~0.402 (E[attempts] ~2.37 → ~2.49) and true-double training data no longer contains same-sign exact-boundary-crossing pairs — an intended distribution correction, but a distribution change nonetheless.

## Verification

- `tests/unit/test_data_generation.py`: **37 passed** locally in the TF venv (`-m "not gpu and not cluster"`), including 4 new retry-cap/telemetry tests (monkeypatched always-reject geometry terminates at the cap with `capped=True`; first-attempt accept records `retries==1`/`capped False`; `write_segment_stats` emits/omits the rows correctly) and 6 new parametrized boundary-regression tests built from the exact production slope/intercept formulas (all previously accepted by the un-padded check).
- `tests/unit/test_round_data.py`: **33 passed** locally in the TF venv (exercises `generate_round_to_memmap` end-to-end over the changed create path).
- `ruff check` + `ruff format` via pre-commit hooks: clean.
- Full suite deferred to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)