### PR TITLE
Model-behavior gates: val ROC-AUC quality floor + SNR->confidence monotonicity test

### DIFF
--- a/docs/CONFIG_AND_CLI.md
+++ b/docs/CONFIG_AND_CLI.md
@@ -93,6 +93,13 @@ Two important consequences:
    own subsection. There is no runtime gating that prevents a developer from typing
    `config.inference.X` inside `train.py` — that's a code-review concern.
 
+Not every config field has a matching CLI flag — most tuning knobs are config-only and
+are changed by editing their default in `config.py`. One worth knowing:
+`training.min_val_auc` (default `0.0` = disabled) is an opt-in quality floor on the
+Random Forest's validation ROC-AUC. When set and unmet after the RF fit, training logs a
+loud WARNING (which reaches the Slack summary) rather than failing the run, so a run
+that "completes" but learned nothing is caught before its model is promoted.
+
 ## The CLI surface
 
 `setup_argument_parser()` registers two subparsers (`train`, `inference`) via

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -119,6 +119,13 @@ indirectly today; a direct test would only harden against future refactors):
   `test_round_data.py`'s timing test, which drives the real drainer-to-`record_stage` path
   with a real span name.
 
+**Model-behavior gates** (issue #139): validation gates on model *quality*, as opposed to
+function-level correctness, need a trained model and therefore live outside the CI selection.
+Gate 1 — the opt-in `training.min_val_auc` floor on the RF's validation ROC-AUC (a loud
+WARNING at train time when unmet; see [`CONFIG_AND_CLI.md`](CONFIG_AND_CLI.md)) — has its
+guard logic unit-tested in `test_train_utils.py`, but whether a given run *clears* it is only
+ever observed on real training runs.
+
 ## Markers
 
 | Marker | Meaning | In default selection? |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -58,10 +58,11 @@ tests/
 │   ├── test_dashboard.py            # dashboard pure data layer (DB-driven plot data)
 │   ├── test_dashboard_launcher.py   # dashboard launcher argv builder + guard paths
 │   └── test_logger.py               # StreamToLogger redirect probes: isatty/writable/readable/fileno
-└── integration/                 # marked integration+gpu+cluster: real subprocess runs
+└── integration/                 # marked integration+gpu+cluster: needs real GPUs + cluster data
     ├── conftest.py                  # repo-root launcher + cluster path resolution
     ├── test_train_smoke.py          # known-good training smoke config, end to end
-    └── test_inference_smoke.py     # subset CSV inference against cluster-resident .h5 data
+    ├── test_inference_smoke.py      # subset CSV inference against cluster-resident .h5 data
+    └── test_model_behavior.py       # SNR→confidence monotonicity gate vs the persisted VAE+RF
 ```
 
 ## Coverage and deliberate gaps
@@ -124,7 +125,10 @@ function-level correctness, need a trained model and therefore live outside the 
 Gate 1 — the opt-in `training.min_val_auc` floor on the RF's validation ROC-AUC (a loud
 WARNING at train time when unmet; see [`CONFIG_AND_CLI.md`](CONFIG_AND_CLI.md)) — has its
 guard logic unit-tested in `test_train_utils.py`, but whether a given run *clears* it is only
-ever observed on real training runs.
+ever observed on real training runs. Gate 2 — the SNR→confidence monotonicity check in
+`tests/integration/test_model_behavior.py` — generates cadences at controlled SNRs with the
+training pipeline's own injection code and scores them in-process against the persisted
+VAE+RF, so it is `gpu`+`cluster`-only by nature (it can never run in CI).
 
 ## Markers
 
@@ -205,10 +209,12 @@ workflow feeds the weekly flaky-test tracker.
 
 ## Running the cluster smokes
 
-The two integration tests launch `python -m aetherscan.main ...` as a subprocess from the
+The two end-to-end smokes launch `python -m aetherscan.main ...` as a subprocess from the
 repo root (their conftest prepends `<repo>/src` to `PYTHONPATH`) with the known-good smoke
-configs, and assert on return codes and produced artifacts. They need real GPUs, the
-cluster-resident data/models, and hours of wall time (subprocess timeout: 2 h each):
+configs, and assert on return codes and produced artifacts; `test_model_behavior.py` instead
+generates and scores synthetic cadences in-process against the persisted VAE+RF (minutes,
+not hours). The suite needs real GPUs, the cluster-resident data/models, and hours of wall
+time for the smokes (subprocess timeout: 2 h each):
 
 ```bash
 # On the cluster, inside the container:

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -284,6 +284,9 @@ class TrainingConfig:
         5000  # Subsample val points for decision boundary plot legibility
     )
 
+    # Model-quality gate params (issue #139 Gate 1)
+    min_val_auc: float = 0.0  # Opt-in floor on the RF's validation ROC-AUC; 0.0 disables the check. When set and unmet after the RF fit, training logs a loud WARNING (reaches the Slack summary) rather than failing the run
+
     # Curriculum learning params
     snr_base: int = 10
     initial_snr_range: int = 40
@@ -651,6 +654,7 @@ class Config:
                 "shap_top_k_features_dependence": self.training.shap_top_k_features_dependence,
                 "rf_decision_boundary_grid_size": self.training.rf_decision_boundary_grid_size,
                 "rf_decision_boundary_max_points": self.training.rf_decision_boundary_max_points,
+                "min_val_auc": self.training.min_val_auc,
                 "snr_base": self.training.snr_base,
                 "initial_snr_range": self.training.initial_snr_range,
                 "final_snr_range": self.training.final_snr_range,

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -39,6 +39,7 @@ from sklearn.metrics import (
     brier_score_loss,
     confusion_matrix,
     precision_recall_curve,
+    roc_auc_score,
     roc_curve,
 )
 from tensorflow.keras.initializers import GlorotNormal, HeNormal
@@ -406,6 +407,36 @@ def check_encoder_trained(encoder, threshold=0.2):
     else:
         logger.info("Encoder appears untrained (all layers close to initializer).")
         return False
+
+
+def check_val_auc_floor(
+    val_binary_labels: np.ndarray, val_probas: np.ndarray, min_val_auc: float, tag: str
+) -> float | None:
+    """
+    Opt-in quality floor on the RF's validation ROC-AUC (issue #139 Gate 1). Returns None
+    without computing anything when the gate is disabled (min_val_auc <= 0.0, the default);
+    otherwise returns the computed AUC. When the floor is set and unmet, emits a loud WARNING
+    (which reaches the Slack summary) rather than failing the run — so a run that "completes"
+    but learned nothing (bad data, collapsed latent, mislabeled classes) is flagged before
+    its model is promoted.
+    """
+    if min_val_auc <= 0.0:
+        return None
+
+    val_auc = float(roc_auc_score(val_binary_labels, val_probas))
+    if val_auc < min_val_auc:
+        logger.warning(
+            f"MODEL QUALITY GATE UNMET: validation ROC-AUC {val_auc:.4f} is below the "
+            f"configured floor training.min_val_auc={min_val_auc} for tag '{tag}'. The "
+            f"trained model may be degenerate — inspect rf_eval_artifacts_{tag}.joblib "
+            f"before promoting this model."
+        )
+    else:
+        logger.info(
+            f"Model quality gate passed: validation ROC-AUC {val_auc:.4f} >= "
+            f"training.min_val_auc={min_val_auc}"
+        )
+    return val_auc
 
 
 def build_traversal_latents(
@@ -2500,6 +2531,15 @@ class TrainingPipeline:
             os.makedirs(os.path.dirname(artifact_path), exist_ok=True)
             joblib.dump(artifacts, artifact_path)
             logger.info(f"Saved RF eval artifacts to {artifact_path}")
+
+            # Opt-in model-quality gate on the val ROC-AUC (issue #139 Gate 1) — a loud
+            # WARNING when unmet, not a failure
+            check_val_auc_floor(
+                val_binary_labels=val_binary_labels,
+                val_probas=val_probas,
+                min_val_auc=self.config.training.min_val_auc,
+                tag=tag,
+            )
 
             # Persist the trained RF immediately (final_save re-saves it later): a retry that
             # resumes into rf_plots/final_save can then reload the model without regenerating

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -414,13 +414,23 @@ def check_val_auc_floor(
 ) -> float | None:
     """
     Opt-in quality floor on the RF's validation ROC-AUC (issue #139 Gate 1). Returns None
-    without computing anything when the gate is disabled (min_val_auc <= 0.0, the default);
-    otherwise returns the computed AUC. When the floor is set and unmet, emits a loud WARNING
-    (which reaches the Slack summary) rather than failing the run — so a run that "completes"
-    but learned nothing (bad data, collapsed latent, mislabeled classes) is flagged before
-    its model is promoted.
+    without computing anything when the gate is disabled (min_val_auc <= 0.0, the default) or
+    when val_binary_labels is single-class (roc_auc_score is undefined there; guaranteed not
+    to happen by the data pipeline, but guarded per the gate's warn-don't-abort philosophy —
+    mirrors compute_rf_eval_metrics' identical guard in rf_metrics.py); otherwise returns the
+    computed AUC. When the floor is set and unmet, emits a loud WARNING (which reaches the
+    Slack summary) rather than failing the run — so a run that "completes" but learned nothing
+    (bad data, collapsed latent, mislabeled classes) is flagged before its model is promoted.
     """
     if min_val_auc <= 0.0:
+        return None
+
+    if np.unique(val_binary_labels).size < 2:
+        logger.warning(
+            f"Model quality gate cannot be evaluated: validation labels for tag '{tag}' are "
+            f"single-class, so ROC-AUC is undefined (training.min_val_auc={min_val_auc} was "
+            f"configured). This should not happen — data generation guarantees both classes."
+        )
         return None
 
     val_auc = float(roc_auc_score(val_binary_labels, val_probas))

--- a/tests/integration/test_model_behavior.py
+++ b/tests/integration/test_model_behavior.py
@@ -37,6 +37,11 @@ pytestmark = [pytest.mark.integration, pytest.mark.gpu, pytest.mark.cluster]
 # for the decoupling suggestion).
 _MODEL_TAG = "test_v17"  # persisted dummy model on blpc3
 _BACKGROUND_FILE = "real_filtered_LARGE_HIP110750.npy"  # first default train file
+# Pinned to DataConfig's current defaults (config.py) rather than read live: test_v17 was
+# trained against these values, so a future default change must not silently alter what this
+# behavioral gate exercises.
+_FREQ_RESOLUTION = 2.7939677238464355  # Hz
+_TIME_RESOLUTION = 18.25361108  # seconds
 # Controlled SNRs spanning the training curriculum (snr_base=10, initial range 40 → the
 # model saw SNR 10-50 during training).
 _SNRS = (10.0, 20.0, 35.0, 50.0)
@@ -62,7 +67,6 @@ def test_snr_confidence_monotonicity(cluster_paths):
     import joblib  # noqa: PLC0415
     import tensorflow as tf  # noqa: PLC0415
 
-    from aetherscan.config import DataConfig  # noqa: PLC0415
     from aetherscan.data_generation import create_true_single  # noqa: PLC0415
     from aetherscan.models import prepare_latent_features  # noqa: PLC0415
 
@@ -78,7 +82,6 @@ def test_snr_confidence_monotonicity(cluster_paths):
     # background per cadence.
     plate = np.load(background_path, mmap_mode="r")
     _, num_observations, time_bins, width_bin = plate.shape
-    data_defaults = DataConfig()
 
     # Load the persisted models the same way inference does (encoder inside strategy scope).
     strategy = tf.distribute.get_strategy()
@@ -97,8 +100,8 @@ def test_snr_confidence_monotonicity(cluster_paths):
                     snr_base=snr,
                     snr_range=0.0,
                     width_bin=width_bin,
-                    freq_resolution=data_defaults.freq_resolution,
-                    time_resolution=data_defaults.time_resolution,
+                    freq_resolution=_FREQ_RESOLUTION,
+                    time_resolution=_TIME_RESOLUTION,
                 )[0]
                 for _ in range(_CADENCES_PER_SNR)
             ]

--- a/tests/integration/test_model_behavior.py
+++ b/tests/integration/test_model_behavior.py
@@ -1,0 +1,124 @@
+# NOTE: come back to this later
+
+"""SNR→confidence monotonicity behavioral gate (cluster-only; issue #139 Gate 2).
+
+The core scientific expectation for the trained VAE+RF: higher injected-signal SNR ⇒ higher
+P(true). Aggregate metrics (ROC-AUC on a mixed-SNR val set) can miss a model that ignores
+signal strength, so this test generates synthetic cadences at a few controlled SNRs with the
+same injection code the training pipeline uses (`data_generation.create_true_single` with
+`snr_range=0` pins the drawn SNR to `snr_base`), scores them in-process with the persisted
+VAE encoder + Random Forest, and asserts the mean P(true) is non-decreasing in SNR within a
+tolerance.
+
+Unlike the two end-to-end smokes this does not subprocess `aetherscan.main` — it drives the
+generation and scoring seams directly (no config singleton, no DB). All TF/aetherscan imports
+are deferred into the test body so collecting this module never pulls TensorFlow into the
+pytest parent process.
+
+The tolerance is sized for the persisted smoke-trained dummy model (weakly trained, and the
+encoder samples z stochastically); tighten it when gating a production model. Runs only on
+the cluster inside the NGC container:
+
+    ./utils/run_container.sh python -m pytest tests/integration -m "gpu or cluster" -q
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import shutil
+
+import numpy as np
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.gpu, pytest.mark.cluster]
+
+# NOTE: coupled to the same persisted dummy model as the smokes (see test_inference_smoke.py
+# for the decoupling suggestion).
+_MODEL_TAG = "test_v17"  # persisted dummy model on blpc3
+_BACKGROUND_FILE = "real_filtered_LARGE_HIP110750.npy"  # first default train file
+# Controlled SNRs spanning the training curriculum (snr_base=10, initial range 40 → the
+# model saw SNR 10-50 during training).
+_SNRS = (10.0, 20.0, 35.0, 50.0)
+_CADENCES_PER_SNR = 32
+# Allowed decrease in mean P(true) between consecutive SNR levels; absorbs sampling noise
+# from the stochastic encoder z and the finite cadence count.
+_TOLERANCE = 0.05
+_SEED = 139
+
+
+def test_snr_confidence_monotonicity(cluster_paths):
+    if shutil.which("nvidia-smi") is None:
+        pytest.skip("requires a GPU host (nvidia-smi not found)")
+
+    data_path, model_path, _ = cluster_paths
+    encoder_path = os.path.join(model_path, f"vae_encoder_{_MODEL_TAG}.keras")
+    rf_path = os.path.join(model_path, f"random_forest_{_MODEL_TAG}.joblib")
+    background_path = os.path.join(data_path, "training", _BACKGROUND_FILE)
+    for required in (encoder_path, rf_path, background_path):
+        if not os.path.exists(required):
+            pytest.skip(f"required cluster artifact missing: {required}")
+
+    import joblib  # noqa: PLC0415
+    import tensorflow as tf  # noqa: PLC0415
+
+    from aetherscan.config import DataConfig  # noqa: PLC0415
+    from aetherscan.data_generation import create_true_single  # noqa: PLC0415
+    from aetherscan.models import prepare_latent_features  # noqa: PLC0415
+
+    # create_true_single/new_cadence draw from the global legacy RNGs (mirroring
+    # data_generation._run_memmap_task's per-task seeding); tf seed pins the encoder's
+    # z sampling.
+    random.seed(_SEED)
+    np.random.seed(_SEED)
+    tf.random.set_seed(_SEED)
+
+    # Background plates shaped (n, 6, 16, width_bin_downsampled), same as training. mmap
+    # keeps the (potentially multi-GB) file on disk; create_true_single reads one
+    # background per cadence.
+    plate = np.load(background_path, mmap_mode="r")
+    _, num_observations, time_bins, width_bin = plate.shape
+    data_defaults = DataConfig()
+
+    # Load the persisted models the same way inference does (encoder inside strategy scope).
+    strategy = tf.distribute.get_strategy()
+    with strategy.scope():
+        encoder = tf.keras.models.load_model(encoder_path)
+    rf = joblib.load(rf_path)
+
+    mean_proba_true = []
+    for snr in _SNRS:
+        # snr_range=0.0 pins the per-cadence drawn SNR exactly to `snr` (the draw is
+        # random.random() * snr_range + snr_base).
+        cadences = np.stack(
+            [
+                create_true_single(
+                    plate,
+                    snr_base=snr,
+                    snr_range=0.0,
+                    width_bin=width_bin,
+                    freq_resolution=data_defaults.freq_resolution,
+                    time_resolution=data_defaults.time_resolution,
+                )[0]
+                for _ in range(_CADENCES_PER_SNR)
+            ]
+        ).astype(np.float32)
+
+        # Score exactly like the inference pipeline: (n, 6, 16, W) -> (n*6, 16, W, 1)
+        # snippets, sampled z from the encoder, 6 latents concatenated per cadence, RF
+        # P(class=1).
+        snippets = cadences.reshape(-1, time_bins, width_bin, 1)
+        _, _, z = encoder(snippets, training=False)
+        features = prepare_latent_features(z.numpy(), num_observations)
+        proba_true = rf.predict_proba(features)[:, 1]
+        mean_proba_true.append(float(proba_true.mean()))
+
+    curve = ", ".join(
+        f"SNR {snr:g} -> {mean:.4f}" for snr, mean in zip(_SNRS, mean_proba_true, strict=True)
+    )
+    for i in range(1, len(_SNRS)):
+        assert mean_proba_true[i] >= mean_proba_true[i - 1] - _TOLERANCE, (
+            f"mean P(true) decreased with SNR beyond tolerance {_TOLERANCE}: "
+            f"SNR {_SNRS[i - 1]:g} -> {mean_proba_true[i - 1]:.4f} vs "
+            f"SNR {_SNRS[i]:g} -> {mean_proba_true[i]:.4f} (full curve: {curve})"
+        )

--- a/tests/unit/test_train_utils.py
+++ b/tests/unit/test_train_utils.py
@@ -395,6 +395,20 @@ class TestCheckValAucFloor:
         assert "min_val_auc" in warnings[0].message
         assert "rf_eval_artifacts_test_v1.joblib" in warnings[0].message
 
+    def test_single_class_labels_with_gate_enabled_warns_instead_of_raising(self, caplog):
+        # roc_auc_score raises ValueError on single-class labels; with the gate enabled the
+        # guard must warn and return None rather than let that escape (mirrors
+        # compute_rf_eval_metrics' identical guard in rf_metrics.py).
+        labels = np.ones(4, dtype=np.int64)
+        probas = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32)
+        with caplog.at_level(logging.WARNING, logger="aetherscan.train"):
+            result = check_val_auc_floor(labels, probas, min_val_auc=0.9, tag="test_v1")
+        assert result is None
+        assert any(
+            "single-class" in r.message and "cannot be evaluated" in r.message
+            for r in caplog.records
+        )
+
 
 class TestSelectPositiveClassShap:
     N, F = 5, 8

--- a/tests/unit/test_train_utils.py
+++ b/tests/unit/test_train_utils.py
@@ -1,8 +1,9 @@
 # NOTE: come back to this later
 
 """Unit tests for aetherscan.train pure-logic helpers: checkpoint tag resolution, curriculum
-schedules, directory archiving, encoder-trained heuristics, SHAP output normalization, and the
-training stage machine (skip-if-done / record-failure semantics against a stub pipeline)."""
+schedules, directory archiving, encoder-trained heuristics, the val-AUC quality floor, SHAP
+output normalization, and the training stage machine (skip-if-done / record-failure semantics
+against a stub pipeline)."""
 
 from __future__ import annotations
 
@@ -31,6 +32,7 @@ from aetherscan.train import (
     _select_positive_class_shap,
     archive_directory,
     check_encoder_trained,
+    check_val_auc_floor,
     compute_expected_std,
     get_latest_tag,
 )
@@ -358,6 +360,40 @@ class TestEncoderTrainedHeuristics:
         kernel, bias = layer.get_weights()
         layer.set_weights([kernel * 3.0, bias])  # 200% deviation from expected std
         assert check_encoder_trained(model) is True
+
+
+class TestCheckValAucFloor:
+    """check_val_auc_floor: the opt-in RF val-ROC-AUC quality gate (issue #139 Gate 1)."""
+
+    def test_disabled_by_default_computes_nothing(self, caplog):
+        # Single-class labels would make roc_auc_score raise — proving the disabled gate
+        # (min_val_auc=0.0) returns early without computing any metric.
+        labels = np.ones(4, dtype=np.int64)
+        probas = np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float32)
+        with caplog.at_level(logging.INFO, logger="aetherscan.train"):
+            result = check_val_auc_floor(labels, probas, min_val_auc=0.0, tag="test_v1")
+        assert result is None
+        assert not caplog.records
+
+    def test_floor_met_returns_auc_without_warning(self, caplog):
+        labels = np.array([0, 0, 1, 1], dtype=np.int64)
+        probas = np.array([0.1, 0.2, 0.8, 0.9], dtype=np.float32)  # perfect separation
+        with caplog.at_level(logging.INFO, logger="aetherscan.train"):
+            result = check_val_auc_floor(labels, probas, min_val_auc=0.9, tag="test_v1")
+        assert result == pytest.approx(1.0)
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("Model quality gate passed" in r.message for r in caplog.records)
+
+    def test_floor_unmet_warns_loudly(self, caplog):
+        labels = np.array([0, 0, 1, 1], dtype=np.int64)
+        probas = np.array([0.9, 0.8, 0.2, 0.1], dtype=np.float32)  # inverted separation
+        with caplog.at_level(logging.WARNING, logger="aetherscan.train"):
+            result = check_val_auc_floor(labels, probas, min_val_auc=0.9, tag="test_v1")
+        assert result == pytest.approx(0.0)
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert "min_val_auc" in warnings[0].message
+        assert "rf_eval_artifacts_test_v1.joblib" in warnings[0].message
 
 
 class TestSelectPositiveClassShap:


### PR DESCRIPTION
Closes #139

## What changed

Two commits, one per gate from the issue:

**Gate 1 — val-metric quality floor (`training.min_val_auc`)**

- New `TrainingConfig.min_val_auc: float = 0.0` (opt-in; `0.0` disables the check), serialized via `Config.to_dict` so it lands in config snapshots.
- New module-level helper `check_val_auc_floor` in `train.py`, called in `train_random_forest` right after the `rf_eval_artifacts_{tag}.joblib` dump: it computes the validation ROC-AUC from the same val probas/labels the artifacts persist and, when the floor is set and unmet, logs a loud **WARNING** (which reaches the Slack summary) pointing at the eval artifact — so a run that "completes" but learned nothing (bad data, collapsed latent, mislabeled classes) is flagged before its model is promoted. When the gate is disabled it returns early without computing anything.
- Documented in `docs/CONFIG_AND_CLI.md` (as a config-only knob) and in `docs/TESTING.md`'s coverage section.
- Guard logic unit-tested in `tests/unit/test_train_utils.py::TestCheckValAucFloor` (disabled-by-default computes no metric — proven with single-class labels that would make `roc_auc_score` raise; floor met → AUC returned, no warning; floor unmet → exactly one WARNING naming `min_val_auc` and the artifact).

**Gate 2 — SNR→confidence monotonicity behavioral test**

- New `tests/integration/test_model_behavior.py`, marked `integration`+`gpu`+`cluster` and reusing the integration `cluster_paths` fixture. It generates 32 cadences at each of four controlled SNRs spanning the training curriculum (10/20/35/50; `create_true_single` with `snr_range=0` pins the drawn SNR exactly), scores them in-process with the persisted VAE encoder + RF exactly like the inference pipeline (sampled `z`, 6 concatenated latents per cadence, `predict_proba`), and asserts mean P(true) is non-decreasing in SNR within a 0.05 tolerance.
- **This test can never run locally or in CI** — per the issue's own scoping it needs the cluster-resident background plates and the persisted `test_v17` dummy model (same skip-guard coupling as the existing smokes), so it runs only via `./utils/run_container.sh python -m pytest tests/integration -m "gpu or cluster" -q` on the cluster. All TF/aetherscan imports are deferred into the test body so collection never pulls TensorFlow into the pytest parent process.
- `docs/TESTING.md` updated: layout tree, the Gate 2 coverage note, and the cluster-smokes section (this test is in-process and takes minutes, unlike the 2 h subprocess smokes).

No `cli.py` changes → README CLI Reference untouched.

## Verification

- `tests/unit/test_train_utils.py` + `tests/unit/test_config.py`: **58 passed** locally in a TF venv (`pytest -m "not gpu and not cluster" -q`). Full suite deferred to CI.
- Gate 2 collection verified locally: the module collects cleanly without importing TF and is deselected by the CI marker expression (`1 deselected`). The generation/scoring geometry (pinned SNR via `snr_range=0`, cadence/snippet/feature shapes) was direct-driven against a synthetic plate in the venv; **the assertion itself has not been executed against the persisted cluster model** — it needs a cluster run, which I could not do from here.
- `ruff check` + `ruff format` (pre-commit) pass on all changed files.

## Maintainer decisions applied

- **WARNING, not raise, for Gate 1** (per the issue's "fail the run (or emit a loud WARNING)" option): the floor being unmet logs a loud WARNING and lets the run finish, so artifacts/plots still land for post-mortem. Escalating to a hard failure later is a two-line change in `check_val_auc_floor`.
- **Config-only knob, no `--min-val-auc` CLI flag**: opting in currently means editing the default in `config.py`, like the other training tuning knobs. Say the word and I'll add the flag (plus README CLI Reference regeneration) on this PR.
- **Gate 2 tolerance/SNR grid** (0.05 slack, SNRs 10/20/35/50, 32 cadences/SNR, fixed seed): sized for the smoke-trained `test_v17` dummy model and the stochastic encoder `z`; tighten when gating a production model.
- Gate 1's integration-side sibling from the issue (a cluster test asserting a smoke-trained model's metrics clear a low threshold) was **not** added: the runtime guard + unit tests cover the mechanism, and the issue framed (a)/(b) as alternatives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
