### PR TITLE
Seed all sources of training randomness behind an opt-in root --seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ options:
                         generation, dataset split/shuffles, TF weight init,
                         and the VAE sampling layer (the random forest is
                         seeded separately via --rf-seed). Omit for OS-entropy
-                        (non-reproducible) behavior. Must be >= 0
+                        (non-reproducible) behavior. Must be >= 0.
   --tf-deterministic-ops, --no-tf-deterministic-ops
                         Force deterministic TensorFlow/cuDNN op
                         implementations

--- a/README.md
+++ b/README.md
@@ -416,7 +416,8 @@ usage: train [-h] [--data-path DATA_PATH] [--model-path MODEL_PATH]
              [--num-target-backgrounds NUM_TARGET_BACKGROUNDS]
              [--background-load-chunk-size BACKGROUND_LOAD_CHUNK_SIZE]
              [--max-chunks-per-file MAX_CHUNKS_PER_FILE]
-             [--train-files TRAIN_FILES [TRAIN_FILES ...]]
+             [--train-files TRAIN_FILES [TRAIN_FILES ...]] [--seed SEED]
+             [--tf-deterministic-ops | --no-tf-deterministic-ops]
              [--num-training-rounds NUM_TRAINING_ROUNDS]
              [--epochs-per-round EPOCHS_PER_ROUND]
              [--num-samples-beta-vae NUM_SAMPLES_BETA_VAE]
@@ -555,6 +556,18 @@ options:
   --train-files TRAIN_FILES [TRAIN_FILES ...]
                         Space-separated list of training data file names
                         (e.g., real_filtered_LARGE_HIP110750.npy)
+  --seed SEED           Root random seed for reproducible runs: seeds data
+                        generation, dataset split/shuffles, TF weight init,
+                        and the VAE sampling layer (the random forest is
+                        seeded separately via --rf-seed). Omit for OS-entropy
+                        (non-reproducible) behavior. Must be >= 0
+  --tf-deterministic-ops, --no-tf-deterministic-ops
+                        Force deterministic TensorFlow/cuDNN op
+                        implementations
+                        (tf.config.experimental.enable_op_determinism) for
+                        bit-exact GPU reproducibility at some training-speed
+                        cost. Only meaningful together with --seed (default:
+                        disabled)
   --num-training-rounds NUM_TRAINING_ROUNDS
                         Total number of training rounds in curriculum learning
                         schedule

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -41,6 +41,7 @@ tests/
 │   ├── test_data_generation.py      # log_norm, create_* shapes/labels, intersection checks,
 │   │                                #   chunk segments / batched task partitioning
 │   ├── test_round_data.py           # paths/manifest protocol, reuse/delete semantics, producer
+│   ├── test_seeding.py              # root-seed stream derivation (reproducible runs)
 │   ├── test_run_state.py            # manifest round-trip, stage machine transitions
 │   ├── test_train_utils.py          # get_latest_tag ladder, curriculum schedules, archiving
 │   ├── test_train_datasets.py       # batched generators: coverage, stratification, alignment
@@ -102,8 +103,10 @@ indirectly today; a direct test would only harden against future refactors):
   path. A CPU-strategy test that drives a deliberately mismatched geometry would pin it.
 - **Per-task RNG determinism** in `data_generation._run_memmap_task` — that the same
   `(task, seed)` produces byte-identical output regardless of worker scheduling or prior global
-  RNG state — is relied on but not asserted anywhere. A small same-seed-twice equality test
-  would catch a future refactor that drops the per-task reseed or adds in-process threads.
+  RNG state — is asserted by `test_round_data.py`'s same-seed-twice test
+  (`test_same_seed_regenerates_byte_identical_data`, which perturbs the global RNGs between
+  runs), but only through the sequential in-process path; worker-scheduling independence under
+  a real pool is still only exercised implicitly.
 - **Round-data manifest corruption cases**: `test_round_data.py` covers missing/mismatched
   manifests, shape mismatch, and whole-array value corruption, but truncation and array-swap
   are only caught *implicitly* (via the broad `except` and the sampled checksum). The checksum

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -393,6 +393,18 @@ def _add_train_flags_to(parser):
 
     # Training configuration
     parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Root random seed for reproducible runs: seeds data generation, dataset split/shuffles, TF weight init, and the VAE sampling layer (the random forest is seeded separately via --rf-seed). Omit for OS-entropy (non-reproducible) behavior. Must be >= 0",
+    )
+    parser.add_argument(
+        "--tf-deterministic-ops",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Force deterministic TensorFlow/cuDNN op implementations (tf.config.experimental.enable_op_determinism) for bit-exact GPU reproducibility at some training-speed cost. Only meaningful together with --seed (default: disabled)",
+    )
+    parser.add_argument(
         "--num-training-rounds",
         type=int,
         default=None,
@@ -1110,6 +1122,13 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
         config.data.inference_files = args.inference_files
 
     # Training configuration
+    if hasattr(args, "seed") and args.seed is not None:
+        config.training.seed = args.seed
+    # tf_deterministic_ops uses argparse.BooleanOptionalAction with default=None so the CLI
+    # can express "leave the config default" (omit), "force on", and "force off" — same
+    # pattern as async_allocator above
+    if hasattr(args, "tf_deterministic_ops") and args.tf_deterministic_ops is not None:
+        config.training.tf_deterministic_ops = args.tf_deterministic_ops
     if hasattr(args, "num_training_rounds") and args.num_training_rounds is not None:
         config.training.num_training_rounds = args.num_training_rounds
     if hasattr(args, "epochs_per_round") and args.epochs_per_round is not None:
@@ -1484,6 +1503,20 @@ def collect_validation_errors(
             config.training.latent_viz_num_cadences_per_type,
         )
         cs = _resolve(args, "curriculum_schedule", config.training.curriculum_schedule)
+
+        # Root seed must be non-negative (np.random.SeedSequence and tf.random.set_seed both
+        # reject negatives at runtime)
+        seed = _resolve(args, "seed", config.training.seed)
+        if seed is not None and seed < 0:
+            errors.append(
+                ValidationError(
+                    field="training.seed",
+                    current=seed,
+                    message=f"--seed must be a non-negative integer, got {seed}",
+                    fix_kind="clamp_low",
+                    min_val=0,
+                )
+            )
 
         # NOTE: come back to this later (should we parametrize num_signal_types = 4 in config.py?)
         # num_samples_beta_vae divisible by 4 (balanced class generation)

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -396,7 +396,7 @@ def _add_train_flags_to(parser):
         "--seed",
         type=int,
         default=None,
-        help="Root random seed for reproducible runs: seeds data generation, dataset split/shuffles, TF weight init, and the VAE sampling layer (the random forest is seeded separately via --rf-seed). Omit for OS-entropy (non-reproducible) behavior. Must be >= 0",
+        help="Root random seed for reproducible runs: seeds data generation, dataset split/shuffles, TF weight init, and the VAE sampling layer (the random forest is seeded separately via --rf-seed). Omit for OS-entropy (non-reproducible) behavior. Must be >= 0.",
     )
     parser.add_argument(
         "--tf-deterministic-ops",

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -178,6 +178,18 @@ class DataConfig:
 
 @dataclass
 class TrainingConfig:
+    # Reproducibility params
+    # Root seed for the pipeline's random streams: synthetic data generation, dataset
+    # split/shuffles, TF weight init, and the VAE sampling layer (each consumer derives an
+    # independent stream — see aetherscan.seeding). None = OS entropy, i.e. non-reproducible
+    # runs (the historical behavior). The Random Forest stage is seeded independently via
+    # rf.seed. Bit-exact GPU reproducibility additionally needs tf_deterministic_ops and
+    # identical hardware/software (GPU count, TF version).
+    seed: int | None = None
+    # Force deterministic TF/cuDNN op implementations (tf.config.experimental
+    # .enable_op_determinism) at some training-speed cost. Only meaningful alongside `seed`.
+    tf_deterministic_ops: bool = False
+
     num_training_rounds: int = 20
     epochs_per_round: int = 100
 
@@ -624,6 +636,8 @@ class Config:
                 "inference_files": self.data.inference_files,
             },
             "training": {
+                "seed": self.training.seed,
+                "tf_deterministic_ops": self.training.tf_deterministic_ops,
                 "num_training_rounds": self.training.num_training_rounds,
                 "epochs_per_round": self.training.epochs_per_round,
                 "num_samples_beta_vae": self.training.num_samples_beta_vae,

--- a/src/aetherscan/data_generation.py
+++ b/src/aetherscan/data_generation.py
@@ -33,6 +33,7 @@ from aetherscan.db import get_db
 from aetherscan.logger import init_worker_logging
 from aetherscan.manager import get_manager
 from aetherscan.round_data import RoundDataPaths, build_manifest, write_done_manifest
+from aetherscan.seeding import STREAM_DATA_GEN, derive_rng
 
 logger = logging.getLogger(__name__)
 
@@ -787,9 +788,10 @@ def _run_memmap_task(args: tuple, backgrounds: np.ndarray) -> tuple[float, list[
     # are single-threaded processes, and the only in-process (pool=None) generation is the RF
     # dataset, which runs after the training datasets/iterators are torn down (train_round's
     # finally: holder.clear() -> del datasets -> clear_session -> gc), so no tf.data generator
-    # thread is alive mutating global RNG state during it. Note per-task seeds come from OS
-    # entropy (round_data seed_rng) and are not persisted, so runs are not reproducible anyway;
-    # what this guarantees is independence of results from worker scheduling within a run.
+    # thread is alive mutating global RNG state during it. Per-task seeds are drawn from the
+    # per-round seed_rng in generate_round_to_memmap — derived from config.training.seed
+    # when set (making generation reproducible across runs), OS entropy otherwise; either
+    # way this reseed keeps results independent of worker scheduling within a run.
     random.seed(seed)
     np.random.seed(seed % (2**32))
 
@@ -972,6 +974,7 @@ def generate_round_to_memmap(
     pool: Pool | None = None,
     backgrounds: np.ndarray | None = None,
     round_num: int | None = None,
+    seed: int | None = None,
     stats_cb=None,
     progress_cb=None,
 ) -> dict:
@@ -993,6 +996,10 @@ def generate_round_to_memmap(
 
     stats_cb(segment_dict) fires once per class-segment per chunk; progress_cb(chunk,
     n_chunks) once per chunk. Returns the manifest dict.
+
+    `seed` is the pipeline root seed (config.training.seed): when set, per-task seeds derive
+    deterministically from (seed, round_num) and the same call regenerates byte-identical
+    data; None keeps the OS-entropy behavior.
     """
     if n_samples % 4 != 0:
         raise ValueError(f"n_samples must be divisible by 4, got {n_samples}")
@@ -1027,7 +1034,12 @@ def generate_round_to_memmap(
     labels = np.empty(n_samples, dtype="U20")
 
     n_chunks = max(1, (n_samples + chunk_size - 1) // chunk_size)
-    seed_rng = np.random.default_rng()  # OS entropy; per-task seeds are drawn from this
+    # Per-task seeds are drawn from this stream. With a root `seed` it derives
+    # deterministically from (seed, round), so the same seed regenerates identical data;
+    # with seed=None it falls back to OS entropy (non-reproducible, the historical
+    # behavior). The RF dataset passes round_num=None and maps onto the round-0 key —
+    # beta-VAE rounds are 1-based, so the streams never collide.
+    seed_rng = derive_rng(seed, STREAM_DATA_GEN, round_num if round_num is not None else 0)
 
     logger.info(
         f"Generating {n_samples} samples into {paths.round_dir} "
@@ -1313,5 +1325,6 @@ class DataGenerator:
             pool=self.pool,
             backgrounds=self.backgrounds if self.pool is None else None,
             round_num=round_num,
+            seed=self.config.training.seed,
             stats_cb=_stats_cb,
         )

--- a/src/aetherscan/round_data.py
+++ b/src/aetherscan/round_data.py
@@ -393,6 +393,7 @@ def _default_generate(paths, round_idx, snr_base, snr_range, pool, params, stats
         time_resolution=params["time_resolution"],
         pool=pool,
         round_num=round_idx,
+        seed=params["seed"],
         stats_cb=stats_cb,
         progress_cb=progress_cb,
     )
@@ -598,6 +599,7 @@ class RoundDataProducer:
         time_resolution: float,
         db,
         tag: str,
+        seed: int | None = None,
     ):
         self._params = {
             "base_dir": base_dir,
@@ -613,6 +615,10 @@ class RoundDataProducer:
             "task_size": task_size,
             "freq_resolution": freq_resolution,
             "time_resolution": time_resolution,
+            # Pipeline root seed (config.training.seed) — crosses the spawn boundary with the
+            # rest of the params so producer-generated rounds derive the same per-round
+            # streams as in-process generation. None = OS entropy
+            "seed": seed,
         }
         self._db = db
         self._tag = tag

--- a/src/aetherscan/seeding.py
+++ b/src/aetherscan/seeding.py
@@ -1,0 +1,40 @@
+"""
+Root-seed stream derivation for reproducible pipeline runs (issue #49).
+
+A single root seed (config.training.seed, --seed) makes every random stream in the training
+pipeline deterministic. Rather than seeding numpy's global RNG once (streams would collide and
+any consumer could perturb every other), each consumer derives its own independent Generator
+here via np.random.SeedSequence keyed on (root_seed, stream id, ...extras) — the same key always
+reproduces the same stream, and distinct keys are statistically independent.
+
+TensorFlow's global RNG (weight init + the VAE Sampling layer) is seeded separately with
+tf.random.set_seed(root_seed) in TrainingPipeline.__init__, and the Random Forest stage keeps
+its own long-standing config.rf.seed.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# Stream ids: the leading component of every derived stream key. Each consumer of the root seed
+# owns one id (extra key components — e.g. the round index — subdivide it further), so no two
+# consumers can ever end up sharing a stream. Add a new id here for any new consumer.
+STREAM_DATA_GEN = 0  # per-round worker-task seeds (data_generation.generate_round_to_memmap)
+STREAM_DATASET = 1  # stratified split / trim / epoch shuffles (prepare_distributed_train_dataset)
+STREAM_VIZ = 2  # latent-viz batch selection + padding (train.TrainingPipeline)
+STREAM_PLOT = 3  # plot subsampling (train.TrainingPipeline plot helpers)
+
+
+def derive_rng(root_seed: int | None, *stream_key: int) -> np.random.Generator:
+    """
+    Build the numpy Generator for one consumer stream of the pipeline root seed.
+
+    With root_seed None (the config default) this returns a fresh OS-entropy Generator —
+    the historical non-reproducible behavior. Otherwise the Generator is seeded from
+    SeedSequence([root_seed, *stream_key]), so the same (root_seed, stream_key) always yields
+    an identical stream and different keys yield independent ones. `stream_key` must start
+    with one of the STREAM_* ids above.
+    """
+    if root_seed is None:
+        return np.random.default_rng()
+    return np.random.default_rng(np.random.SeedSequence([root_seed, *stream_key]))

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -78,6 +78,7 @@ from aetherscan.run_state import (
     run_state_path,
     save_run_state,
 )
+from aetherscan.seeding import STREAM_DATASET, STREAM_PLOT, STREAM_VIZ, derive_rng
 
 logger = logging.getLogger(__name__)
 
@@ -593,11 +594,16 @@ def prepare_distributed_train_dataset(
     num_replicas: int,
     strategy: tf.distribute.Strategy,
     shuffle: bool = True,
+    rng: np.random.Generator | None = None,
 ) -> dict:
     """
     Build distributed training and validation datasets from the `data` dict, returning a dict
     with the two tf.data datasets, sample/step counts, the shared TrainDataHolder, and the
     stratified train/val indices into the original arrays.
+
+    `rng` supplies all randomness (stratified split, trim subsampling, per-epoch shuffles):
+    callers pass a Generator derived from the pipeline root seed for reproducible runs (see
+    aetherscan.seeding.derive_rng); None falls back to OS entropy (the historical behavior).
 
     `data` must contain 'concatenated', 'true', 'false', and 'labels' — typically the read-only
     memmaps returned by round_data.load_round_arrays(), though plain in-RAM ndarrays work too.
@@ -638,6 +644,12 @@ def prepare_distributed_train_dataset(
             f"per_replica_batch_size * num_replicas ({global_train_batch_size})"
         )
 
+    # The train generator below closes over this rng, so epoch k's shuffle consumes the
+    # stream's k-th state — deterministic given a seeded Generator, different every epoch
+    if rng is None:
+        rng = np.random.default_rng()
+
+
     # Stratified train/val split to ensure both sets contain proportional representation
     # of all 4 signal types (false_no_signal, false_with_rfi, true_only_eti, true_eti_rfi).
     # This is necessary because generation arranges labels sequentially within
@@ -650,7 +662,7 @@ def prepare_distributed_train_dataset(
 
     for label in unique_labels:
         label_indices = np.where(labels == label)[0]
-        np.random.shuffle(label_indices)
+        rng.shuffle(label_indices)
         n_label_train = int(len(label_indices) * train_val_split)
         train_indices.append(label_indices[:n_label_train])
         val_indices.append(label_indices[n_label_train:])
@@ -673,9 +685,9 @@ def prepare_distributed_train_dataset(
 
     # Randomly subsample to trimmed size (avoids positional bias from slicing the tail)
     if n_train_trimmed < n_train:
-        train_indices = np.random.choice(train_indices, size=n_train_trimmed, replace=False)
+        train_indices = rng.choice(train_indices, size=n_train_trimmed, replace=False)
     if n_val_trimmed < n_val:
-        val_indices = np.random.choice(val_indices, size=n_val_trimmed, replace=False)
+        val_indices = rng.choice(val_indices, size=n_val_trimmed, replace=False)
 
     # Sort both index sets ascending. For shuffle=False this pins the generators' yield order
     # to the returned train_indices/val_indices arrays (the alignment contract
@@ -709,11 +721,11 @@ def prepare_distributed_train_dataset(
                 false = train_holder.false
 
             # Work with local references (safe from clearing, no per-batch lock needed)
-            # Copy train_indices because np.random.shuffle mutates in-place
+            # Copy train_indices because rng.shuffle mutates in-place
             indices = train_indices.copy()
             if shuffle:
                 # Perform global shuffle on each epoch so each pass through the data is unique
-                np.random.shuffle(indices)
+                rng.shuffle(indices)
             for start in range(0, len(indices), global_train_batch_size):
                 batch_indices = indices[start : start + global_train_batch_size]
                 if shuffle:
@@ -821,6 +833,7 @@ def prepare_distributed_viz_dataset(
     per_replica_inf_batch_size: int,
     num_replicas: int,
     strategy: tf.distribute.Strategy,
+    rng: np.random.Generator | None = None,
 ) -> dict:
     """
     Build a distributed dataset for latent-space visualization from `concat_data` (shape
@@ -830,10 +843,14 @@ def prepare_distributed_viz_dataset(
     The dataset yields cadences in original order (no shuffle) — plot_latent_space_gif() depends
     on this ordering. If n_samples isn't divisible by the global batch size, the input is padded
     with random duplicates to keep all replicas evenly fed; downstream code can use n_samples vs.
-    n_padded to drop the padded tail when needed.
+    n_padded to drop the padded tail when needed. `rng` seeds the padding choice (a Generator
+    derived from the pipeline root seed, or None for OS entropy).
     """
     global_viz_batch_size = per_replica_inf_batch_size * num_replicas
     n_samples = concat_data.shape[0]
+
+    if rng is None:
+        rng = np.random.default_rng()
 
     # NOTE: does padding/divisibility matter for inference?
     # Pad datasets to fit batch sizes (prevents uneven batches on final step)
@@ -845,7 +862,7 @@ def prepare_distributed_viz_dataset(
 
     if n_padded > n_samples:
         pad_count = n_padded - n_samples
-        pad_indices = np.random.choice(n_samples, size=pad_count, replace=True)
+        pad_indices = rng.choice(n_samples, size=pad_count, replace=True)
         padded_data = np.concatenate([concat_data, concat_data[pad_indices]], axis=0)
         logger.info(f"Data alignment: Viz {n_samples}→{n_padded} (padded {pad_count})")
     else:
@@ -995,6 +1012,20 @@ class TrainingPipeline:
         self.db = get_db()
         if self.db is None:
             raise ValueError("get_db() returned None")
+
+        # Reproducibility: seed TF's global RNG before any model/variable creation so weight
+        # initialization (HeNormal/GlorotNormal) and the VAE Sampling layer draw
+        # deterministic streams. numpy/python randomness is NOT globally seeded here — each
+        # consumer derives its own independent stream from the same root seed (see
+        # aetherscan.seeding.derive_rng and its call sites). No-op when seed is None
+        if self.config.training.seed is not None:
+            tf.random.set_seed(self.config.training.seed)
+            logger.info(f"Seeded TF global RNG from root seed {self.config.training.seed}")
+        if self.config.training.tf_deterministic_ops:
+            # Deterministic cuDNN/reduction kernels for bit-exact GPU reproducibility, at
+            # some training-speed cost. Only useful alongside a root seed
+            tf.config.experimental.enable_op_determinism()
+            logger.info("TF op determinism enabled (deterministic GPU kernels)")
 
         # Load (or create) the persisted run manifest for this tag. This resolves
         # self.start_time (wall clock of attempt 1 — used by every DB query/plot, so retries
@@ -1343,6 +1374,7 @@ class TrainingPipeline:
                     time_resolution=self.data_generator.time_resolution,
                     db=self.db,
                     tag=self.config.checkpoint.save_tag,
+                    seed=self.config.training.seed,
                 )
                 self._round_producer.start()
                 # Kick off the first round's data right away (nothing to overlap with yet —
@@ -1450,7 +1482,8 @@ class TrainingPipeline:
         train_labels = train_data.get("labels")
         train_lognorm = train_data.get("lognorm")
 
-        # Distribute training data
+        # Distribute training data (rng keyed on the round so each round's split/epoch
+        # shuffles are an independent — but seed-reproducible — stream)
         data = prepare_distributed_train_dataset(
             data=train_data,
             train_val_split=self.config.training.train_val_split,
@@ -1460,6 +1493,7 @@ class TrainingPipeline:
             num_replicas=self.strategy.num_replicas_in_sync,
             strategy=self.strategy,
             shuffle=True,
+            rng=derive_rng(self.config.training.seed, STREAM_DATASET, round_number),
         )
 
         # Free the dict shell (original arrays stay alive via the shared train_holder)
@@ -2422,6 +2456,9 @@ class TrainingPipeline:
             num_replicas=self.strategy.num_replicas_in_sync,
             strategy=self.strategy,
             shuffle=False,
+            # RF dataset uses the round-0 stream key, mirroring its data generation
+            # (beta-VAE rounds are 1-based, so no collision)
+            rng=derive_rng(self.config.training.seed, STREAM_DATASET, 0),
         )
 
         # NOTE: come back to this later
@@ -2485,7 +2522,7 @@ class TrainingPipeline:
             #
             # Disjointness contract: the train and val passes below read from the same
             # TrainDataHolder backing arrays via train_indices / val_indices, which are
-            # built by stratified per-label split + np.random.choice subsampling — disjoint
+            # built by stratified per-label split + rng.choice subsampling — disjoint
             # by construction. The .repeat()-ed datasets cannot leak across splits because
             # each generator only yields rows from its own index subset.
             train_encode_steps = train_steps * accumulation_steps
@@ -4140,6 +4177,7 @@ class TrainingPipeline:
 
         max_points = self.config.training.plot_injection_subsampling_count
         outlier_pct = self.config.training.plot_injection_outlier_percentile
+        rng = derive_rng(self.config.training.seed, STREAM_PLOT)
 
         fig, axes = plt.subplots(2, 3, figsize=(15, 10))
         fig.suptitle(
@@ -4176,7 +4214,7 @@ class TrainingPipeline:
                         # Subsample normal points to fill remaining budget
                         remaining = max(0, max_points - len(outlier_indices))
                         if remaining < len(normal_indices):
-                            sampled_normal = np.random.choice(
+                            sampled_normal = rng.choice(
                                 normal_indices, size=remaining, replace=False
                             )
                             keep_indices = np.concatenate([outlier_indices, sampled_normal])
@@ -6442,6 +6480,7 @@ class TrainingPipeline:
         """
         n_per_type = self.config.training.latent_viz_num_cadences_per_type
         signal_types = ["false_no_signal", "false_with_rfi", "true_only_eti", "true_eti_rfi"]
+        rng = derive_rng(self.config.training.seed, STREAM_VIZ, 0)
 
         # Restrict to candidate subset if provided (avoids copying the entire partition)
         if candidate_indices is not None:
@@ -6466,7 +6505,7 @@ class TrainingPipeline:
                 )
                 sampled = type_global_indices
             else:
-                sampled = np.random.choice(type_global_indices, size=n_per_type, replace=False)
+                sampled = rng.choice(type_global_indices, size=n_per_type, replace=False)
             selected_indices.append(sampled)
             selected_labels.extend([stype] * len(sampled))
 
@@ -6507,6 +6546,7 @@ class TrainingPipeline:
             per_replica_inf_batch_size=self.config.training.per_replica_val_batch_size,
             num_replicas=self.strategy.num_replicas_in_sync,
             strategy=self.strategy,
+            rng=derive_rng(self.config.training.seed, STREAM_VIZ, 1),
         )
 
         self._latent_viz_dataset = viz_results["viz_dataset"]

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -649,7 +649,6 @@ def prepare_distributed_train_dataset(
     if rng is None:
         rng = np.random.default_rng()
 
-
     # Stratified train/val split to ensure both sets contain proportional representation
     # of all 4 signal types (false_no_signal, false_with_rfi, true_only_eti, true_eti_rfi).
     # This is necessary because generation arranges labels sequentially within
@@ -1026,6 +1025,14 @@ class TrainingPipeline:
             # some training-speed cost. Only useful alongside a root seed
             tf.config.experimental.enable_op_determinism()
             logger.info("TF op determinism enabled (deterministic GPU kernels)")
+            if self.config.training.seed is None:
+                # Without a seed the deterministic kernels cost speed but buy no
+                # reproducibility (TF's global RNG stays unseeded) — warn so it isn't silent.
+                logger.warning(
+                    "tf_deterministic_ops is enabled but --seed is not set: deterministic "
+                    "kernels incur a speed cost without making the run reproducible. Pass "
+                    "--seed to seed the RNG streams."
+                )
 
         # Load (or create) the persisted run manifest for this tag. This resolves
         # self.start_time (wall clock of attempt 1 — used by every DB query/plot, so retries

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -151,6 +151,15 @@ class TestSemanticChecks:
         errors = collect_validation_errors(_parse(["train", "--num-samples-beta-vae", "202"]), None)
         assert any(e.field == "training.num_samples_beta_vae" and e.divisor == 4 for e in errors)
 
+    def test_negative_seed_rejected(self):
+        errors = collect_validation_errors(_parse(["train", "--seed", "-1"]), None)
+        assert any(e.field == "training.seed" and e.fix_kind == "clamp_low" for e in errors)
+
+    @pytest.mark.parametrize("seed", ["0", "42"])
+    def test_non_negative_seed_passes(self, seed):
+        errors = collect_validation_errors(_parse(["train", "--seed", seed]), None)
+        assert not any(e.field == "training.seed" for e in errors)
+
     def test_curriculum_schedule_enum(self):
         errors = collect_validation_errors(
             _parse(["train", "--curriculum-schedule", "sigmoid"]), None
@@ -558,6 +567,20 @@ class TestApplyArgsToConfig:
         config = get_config()
         apply_args_to_config(_parse(["train", "--load-tag", "round_03"]))
         assert config.checkpoint.start_round == 4
+
+    def test_seed_flags_apply_to_training_config(self):
+        config = get_config()
+        assert config.training.seed is None  # default: OS entropy
+        assert config.training.tf_deterministic_ops is False
+        apply_args_to_config(_parse(["train", "--seed", "123", "--tf-deterministic-ops"]))
+        assert config.training.seed == 123
+        assert config.training.tf_deterministic_ops is True
+        # Omitting both flags leaves the applied values untouched (None-guarded application)
+        apply_args_to_config(_parse(["train"]))
+        assert config.training.seed == 123
+        assert config.training.tf_deterministic_ops is True
+        apply_args_to_config(_parse(["train", "--no-tf-deterministic-ops"]))
+        assert config.training.tf_deterministic_ops is False
 
     def test_bandpass_flags_apply_to_inference_config(self):
         config = get_config()

--- a/tests/unit/test_round_data.py
+++ b/tests/unit/test_round_data.py
@@ -31,6 +31,7 @@ from aetherscan.round_data import (
     validate_done_manifest,
     write_done_manifest,
 )
+from aetherscan.seeding import STREAM_DATA_GEN, derive_rng
 
 # Keep injection fast: small frequency axis, real-ish resolutions (mirrors
 # tests/unit/test_data_generation.py).
@@ -283,6 +284,29 @@ class TestChunkSegmentsAndTasks:
                 np.random.default_rng(0),
             )
 
+    def test_task_seeds_stable_for_root_seed_and_round(self):
+        """Seed-derivation stability: the same (root seed, round) always yields the same
+        per-task seed sequence (the invariant reproducible generation rests on), and a
+        different round yields a different one."""
+        segment = build_chunk_segments(0, 8)[0]
+
+        def _task_seeds(round_idx):
+            tasks = build_segment_tasks(
+                segment,
+                "arr.npy",
+                2,
+                10.0,
+                40.0,
+                _WIDTH_BIN,
+                _FREQ_RES,
+                _TIME_RES,
+                derive_rng(42, STREAM_DATA_GEN, round_idx),
+            )
+            return [task[11] for task in tasks]  # per-task seed slot
+
+        assert _task_seeds(1) == _task_seeds(1)
+        assert _task_seeds(1) != _task_seeds(2)
+
 
 class TestGenerateRoundToMemmap:
     @pytest.fixture
@@ -365,6 +389,48 @@ class TestGenerateRoundToMemmap:
         assert any(k.startswith("rfi_") for k in double_keys)
 
         assert progress == [(1, 2), (2, 2)]
+
+    def test_same_seed_regenerates_byte_identical_data(self, tmp_path, plate):
+        """The same-seed-twice test docs/TESTING.md calls for: with a root seed, two
+        generations of the same round are byte-identical regardless of ambient global RNG
+        state (the per-task reseed in _run_memmap_task must fully determine the output)."""
+        common = {
+            "n_samples": 8,
+            "snr_base": 10.0,
+            "snr_range": 5.0,
+            "width_bin": _WIDTH_BIN,
+            "num_observations": 6,
+            "time_bins": 16,
+            "chunk_size": 4,
+            "task_size": 3,
+            "freq_resolution": _FREQ_RES,
+            "time_resolution": _TIME_RES,
+            "backgrounds": plate,
+            "round_num": 1,
+        }
+        paths_a = RoundDataPaths.for_round(str(tmp_path / "a"), 1)
+        paths_b = RoundDataPaths.for_round(str(tmp_path / "b"), 1)
+        paths_c = RoundDataPaths.for_round(str(tmp_path / "c"), 1)
+
+        generate_round_to_memmap(paths_a, seed=123, **common)
+        # Perturb the legacy global RNGs between runs — per-task reseeding must make the
+        # second run independent of ambient state
+        random.seed(999)
+        np.random.seed(999)
+        generate_round_to_memmap(paths_b, seed=123, **common)
+        generate_round_to_memmap(paths_c, seed=124, **common)
+
+        data_a = load_round_arrays(paths_a)
+        data_b = load_round_arrays(paths_b)
+        data_c = load_round_arrays(paths_c)
+        for key in ("concatenated", "true", "false"):
+            np.testing.assert_array_equal(np.asarray(data_a[key]), np.asarray(data_b[key]))
+        np.testing.assert_array_equal(data_a["labels"], data_b["labels"])
+        np.testing.assert_array_equal(data_a["lognorm"], data_b["lognorm"])
+        # A different root seed must produce different data
+        assert not np.array_equal(
+            np.asarray(data_a["concatenated"]), np.asarray(data_c["concatenated"])
+        )
 
     def test_regeneration_clears_stale_dir(self, tmp_path, plate):
         paths = RoundDataPaths.for_round(str(tmp_path), 1)

--- a/tests/unit/test_seeding.py
+++ b/tests/unit/test_seeding.py
@@ -1,0 +1,47 @@
+"""Unit tests for aetherscan.seeding: root-seed stream derivation (issue #49)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from aetherscan.seeding import (
+    STREAM_DATA_GEN,
+    STREAM_DATASET,
+    STREAM_PLOT,
+    STREAM_VIZ,
+    derive_rng,
+)
+
+
+def _draws(rng: np.random.Generator, n: int = 16) -> list[int]:
+    return rng.integers(0, 2**63, size=n).tolist()
+
+
+class TestDeriveRng:
+    def test_same_key_reproduces_stream(self):
+        assert _draws(derive_rng(42, STREAM_DATA_GEN, 1)) == _draws(
+            derive_rng(42, STREAM_DATA_GEN, 1)
+        )
+
+    def test_round_index_changes_stream(self):
+        assert _draws(derive_rng(42, STREAM_DATA_GEN, 1)) != _draws(
+            derive_rng(42, STREAM_DATA_GEN, 2)
+        )
+
+    def test_root_seed_changes_stream(self):
+        assert _draws(derive_rng(42, STREAM_DATA_GEN, 1)) != _draws(
+            derive_rng(43, STREAM_DATA_GEN, 1)
+        )
+
+    def test_stream_ids_are_distinct_and_independent(self):
+        ids = [STREAM_DATA_GEN, STREAM_DATASET, STREAM_VIZ, STREAM_PLOT]
+        assert len(set(ids)) == len(ids)
+        streams = [tuple(_draws(derive_rng(42, stream_id, 1))) for stream_id in ids]
+        assert len(set(streams)) == len(streams)
+
+    def test_none_root_seed_falls_back_to_entropy(self):
+        # None = the historical OS-entropy behavior: still a Generator, but two derivations
+        # of the same key are (overwhelmingly likely) different streams
+        rng = derive_rng(None, STREAM_DATA_GEN, 1)
+        assert isinstance(rng, np.random.Generator)
+        assert _draws(rng) != _draws(derive_rng(None, STREAM_DATA_GEN, 1))

--- a/tests/unit/test_train_datasets.py
+++ b/tests/unit/test_train_datasets.py
@@ -35,7 +35,7 @@ def _make_data(n_samples=40):
     }
 
 
-def _build(data, shuffle, train_val_split=0.8, prb=4, eb=8, prvb=4):
+def _build(data, shuffle, train_val_split=0.8, prb=4, eb=8, prvb=4, rng=None):
     return prepare_distributed_train_dataset(
         data=data,
         train_val_split=train_val_split,
@@ -45,6 +45,7 @@ def _build(data, shuffle, train_val_split=0.8, prb=4, eb=8, prvb=4):
         num_replicas=1,
         strategy=tf.distribute.get_strategy(),
         shuffle=shuffle,
+        rng=rng,
     )
 
 
@@ -141,6 +142,28 @@ class TestPrepareDistributedTrainDataset:
             assert int(np.sum(labels[val_indices] == signal_type)) == 2
         results["_train_holder"].clear()
 
+    def test_seeded_rng_reproduces_split_and_epoch_order(self):
+        """Reproducibility contract (issue #49): the same seeded Generator reproduces the
+        stratified split AND every epoch's shuffled batch order; successive epochs still
+        differ from each other (the rng advances, randomness is not removed)."""
+
+        def _run():
+            results = _build(_make_data(), shuffle=True, rng=np.random.default_rng(11))
+            n_batches = results["train_steps"] * results["accumulation_steps"]
+            iterator = iter(results["train_dataset"])
+            epochs = [
+                [_batch_row_ids(next(iterator)).tolist() for _ in range(n_batches)]
+                for _ in range(2)
+            ]
+            out = (results["train_indices"].tolist(), results["val_indices"].tolist(), epochs)
+            results["_train_holder"].clear()
+            return out
+
+        first, second = _run(), _run()
+        assert first == second
+        # Epoch-level randomness survives seeding: epoch 2's batch membership differs
+        assert first[2][0] != first[2][1]
+
     def test_memmap_inputs_supported(self, tmp_path):
         """Round data arrives as np.load(mmap_mode='r') memmaps — gathers must produce plain
         in-RAM batches from them."""
@@ -165,12 +188,13 @@ class TestPrepareDistributedTrainDataset:
 
 
 class TestPrepareDistributedVizDataset:
-    def _build_viz(self, concat, prib=4):
+    def _build_viz(self, concat, prib=4, rng=None):
         return prepare_distributed_viz_dataset(
             concat_data=concat,
             per_replica_inf_batch_size=prib,
             num_replicas=1,
             strategy=tf.distribute.get_strategy(),
+            rng=rng,
         )
 
     def test_order_preserved_with_padding(self):
@@ -202,3 +226,19 @@ class TestPrepareDistributedVizDataset:
         assert results["n_padded"] == n
         assert results["viz_steps"] == 2
         results["_viz_holder"].clear()
+
+    def test_seeded_rng_reproduces_padding(self):
+        n = 10
+        base = np.arange(n, dtype=np.float32)[:, None, None, None]
+        concat = base * np.ones((n, *_SAMPLE_SHAPE), dtype=np.float32)
+
+        def _padded_tail():
+            results = self._build_viz(concat, rng=np.random.default_rng(7))
+            iterator = iter(results["viz_dataset"])
+            seen = []
+            for _ in range(results["viz_steps"]):
+                seen.extend(next(iterator).numpy()[:, 0, 0, 0].astype(np.int64).tolist())
+            results["_viz_holder"].clear()
+            return seen[n:]
+
+        assert _padded_tail() == _padded_tail()


### PR DESCRIPTION
Closes #49

## What

Adds an opt-in root seed that makes training runs reproducible end to end, per the restated plan in the triage of #49 (the issue body's worker-id mechanics predate the #117 per-task-seed architecture; the owner's comments flagged it as unverified). **Default is `None` = today's OS-entropy behavior, so this is zero-risk when the flag is omitted.**

- **Config + CLI** — `TrainingConfig.seed: int | None = None` with a `--seed` train flag (mirrors the `--rf-seed` plumbing; validated non-negative), plus `tf_deterministic_ops: bool = False` / `--tf-deterministic-ops`. Both serialize in `to_dict()` and therefore in the run-manifest config fingerprint (a changed seed under a reused save tag correctly forces a fresh run). README CLI Reference regenerated with `utils/print_cli_help.py`.
- **New `aetherscan.seeding` module** — `derive_rng(root_seed, *stream_key)` derives per-consumer `np.random.Generator`s via `SeedSequence([root_seed, stream_id, ...])`, with a registry of stream ids (data-gen / dataset / viz / plot) so no two consumers ever share or correlate a stream, and none pollutes global state.
- **Data generation** — `generate_round_to_memmap`'s task-seed `seed_rng` (previously always OS entropy) now derives from `(root seed, round index)`; the existing per-task reseed in `_run_memmap_task` then makes generation byte-identical across runs. Threaded through both paths: in-process `DataGenerator.generate_round` and the spawn-started `RoundDataProducer` (root seed rides in the producer params). The RF dataset maps onto the round-0 key (beta-VAE rounds are 1-based — no collision).
- **train.py** — `tf.random.set_seed(seed)` in `TrainingPipeline.__init__` before model construction (covers `HeNormal`/`GlorotNormal` init and the VAE `Sampling` layer), `enable_op_determinism()` behind the config flag; the unseeded global `np.random` calls (stratified split, trim subsampling, per-epoch train shuffle, viz padding, viz batch selection, injection-bias plot subsampling) move onto derived Generators. `prepare_distributed_train_dataset` / `prepare_distributed_viz_dataset` take an `rng` parameter; the infinite train generator closes over its rng, so epoch k's shuffle consumes the stream's k-th state — deterministic given the seed, still different every epoch.

Randomness is never removed — every shuffle/injection/sampling call remains, only made reproducible given the same seed. Already-seeded surfaces (RF via `rf.seed`, UMAP/KMeans, most plot subsampling) are untouched.

## Tests

- `tests/unit/test_seeding.py` (new): derivation stability, stream independence, `None` fallback.
- `tests/unit/test_round_data.py`: task-seed stability for `(root, round)`, plus the same-seed-twice byte-identical generation test `docs/TESTING.md` explicitly called for (global RNGs perturbed between runs; different seed produces different data).
- `tests/unit/test_train_datasets.py`: same seeded rng reproduces the stratified split and both epochs' batch order while epochs still differ from each other; seeded viz padding reproduces its padded tail.
- `tests/unit/test_cli_validation.py`: negative `--seed` rejected, non-negative passes, config round-trip for both flags (incl. `--no-tf-deterministic-ops`).
- `docs/TESTING.md` updated (layout + the per-task RNG coverage-gap bullet is now asserted).

## Verification

Ran locally on this branch in a TF venv (`-m "not gpu and not cluster"`): `test_seeding.py`, `test_config.py`, `test_cli_validation.py` (119 passed), `test_round_data.py` (35 passed), `test_train_datasets.py` + `test_data_generation.py` (38 passed), `test_cli_help_sync.py` + `test_run_state.py` + `test_train_utils.py` (97 passed), `test_main.py` (14 passed) — 303 passed, 0 failed. `ruff check` + `ruff format --check` clean; all pre-commit hooks passed on every commit. Full suite deferred to CI; GPU-path behavior (`tf.random.set_seed` / op determinism under `MirroredStrategy`) is not exercisable here and needs a cluster smoke.

## Maintainer decisions applied

- **Stream-key scheme**: derivation is namespaced as `SeedSequence([root_seed, STREAM_ID, ...extras])` (registry in `seeding.py`) rather than the triage's bare `[root_seed, round_idx]` example, so dataset/viz/plot streams can never collide with data-gen round streams.
- **Op determinism is config-gated and CLI-exposed** (`--tf-deterministic-ops`, default off): config fields in this repo are only reachable via CLI flags, so a config-only knob would have been dead. Seeding alone gives approximate GPU reproducibility; the flag buys bit-exactness at some speed cost.
- **RF dataset stream key = round 0** for both its generation and its dataset split (beta-VAE rounds are 1-based).
- **Fingerprint impact**: adding `seed`/`tf_deterministic_ops` to the training `to_dict()` section changes config fingerprints, so a run started before this PR cannot resume across it under the same save tag (it downgrades to a fresh run with a loud warning — the existing guard's designed behavior). Flagging since it affects in-flight tags at upgrade time.
- **Scope**: training pipeline only, per the issue. The inference pipeline sets no TF seed (its randomness surface is the already-deterministic model forward pass); `rf.seed` remains the RF stage's independent knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
