### PR TITLE
fix: give RF-generation injection_stats rows a real round_number (not NULL)

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -592,8 +592,8 @@ After an `rf_train` retry that regenerates the RF dataset, stale RF-generation `
 
 ### Status
 
-**Open.** No fix implemented yet. A fix would need either a NULL-aware supersede variant for the RF phase or a sentinel round number on RF-generation rows.
+**Closed.** Fixed in [PR #211](https://github.com/zachtheyek/Aetherscan/pull/211): RF-generation rows now carry a sentinel round number (`num_training_rounds + 1`, one past the last beta-VAE round) instead of `NULL`, making them reachable by the existing `round_ge` supersede call — no NULL-aware special case needed.
 
 ### Related Code
 
-`src/aetherscan/db/db.py` (`mark_superseded`), `src/aetherscan/train.py` (RF dataset generation), `src/aetherscan/data_generation.py` (writes the `round_number=NULL` rows)
+`src/aetherscan/db/db.py` (`mark_superseded`), `src/aetherscan/train.py` (RF dataset generation), `src/aetherscan/data_generation.py` (writes the `round_number` rows)

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -2384,8 +2384,27 @@ class TrainingPipeline:
         else:
             # RF data is always generated in-process (no background producer for the RF phase);
             # tag source to match the per-round data_generation spans (producer / in-process)
+            #
+            # round_num: a sentinel one past the last beta-VAE round, NOT the literal RF phase
+            # (there is no "RF round" numbering). Passing it (instead of the default None) gives
+            # every injection_stats row from this call a real round_number, so a stale row from a
+            # crashed rf_train attempt is reachable by _init_run_state's round_ge supersede on the
+            # next retry. That call marks (tag, round_number >= self._start_round); SQL NULLs never
+            # satisfy ">=", so a NULL round_number (the previous default) permanently escaped it.
+            # resume_round (run_state.py) is max(completed_rounds) + 1, and completed_rounds only
+            # ever holds values <= num_training_rounds, so _start_round <= num_training_rounds + 1
+            # always — and rf_train only (re)starts once vae_rounds is fully done, i.e. exactly
+            # when _start_round == num_training_rounds + 1. round_number has no other consumer
+            # (plot_injection_stats/query_injection_stat don't filter or group by it), so this is
+            # safe to change without touching mark_superseded or the DB schema.
             with stage_timer("data_generation", metadata={"source": "in-process"}):
-                self.data_generator.generate_round(rf_paths, n_samples, snr_base, snr_range)
+                self.data_generator.generate_round(
+                    rf_paths,
+                    n_samples,
+                    snr_base,
+                    snr_range,
+                    round_num=self.config.training.num_training_rounds + 1,
+                )
         rf_data = load_round_arrays(rf_paths)
 
         # Prepare distributed train+val datasets (stratified split). shuffle=False so the

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -295,6 +295,37 @@ class TestMarkSuperseded:
         assert [r["npy_path"] for r in live] == ["/b.npy"]
         assert len(db.query_inference_result(tag=tag, include_superseded=True)) == 2
 
+    def test_null_round_number_escapes_round_ge(self, db):
+        """Documents the mechanism behind #210 / KNOWN_ISSUES entry 17: SQL comparisons against
+        NULL never match, so a row written without a round_number (the RF-generation call's old
+        default) is invisible to round_ge no matter the threshold — it stays live forever."""
+        tag = "test_v_null_round"
+        db.write_injection_stat("eti_snr", 12.5, round_number=None, tag=tag)
+        assert db.mark_superseded("injection_stats", tag, round_ge=1) is True
+
+        live = db.query_injection_stat(tag=tag)
+        assert len(live) == 1
+        assert live[0]["superseded"] == 0
+
+    def test_sentinel_round_number_is_supersedable(self, db):
+        """The fix for #210: giving RF-generation rows a real round_number (num_training_rounds
+        + 1, instead of the None default) makes them reachable by the exact same round_ge
+        supersede call _init_run_state already issues on every retry -- no NULL-aware special
+        case needed. A stale row from a crashed rf_train attempt (sentinel=21) is marked
+        superseded once the resumed attempt's round_ge reaches that sentinel; a live row from a
+        completed VAE round below it survives."""
+        tag = "test_v_sentinel_round"
+        sentinel = 21  # num_training_rounds=20 + 1, as train_random_forest computes it
+        db.write_injection_stat("eti_snr", 1.0, round_number=20, tag=tag)  # completed VAE round
+        db.write_injection_stat("eti_snr", 2.0, round_number=sentinel, tag=tag)  # stale RF attempt
+        assert db.mark_superseded("injection_stats", tag, round_ge=sentinel) is True
+
+        live = db.query_injection_stat(tag=tag)
+        assert [r["round_number"] for r in live] == [20]
+
+        everything = db.query_injection_stat(tag=tag, include_superseded=True)
+        assert {r["round_number"]: r["superseded"] for r in everything} == {20: 0, sentinel: 1}
+
     def test_stability_aggregation_excludes_superseded(self, db):
         tag = "test_v7"
         db.write_injection_stat("global_skew", 1.0, round_number=1, tag=tag)


### PR DESCRIPTION
Closes #210

## What this fixes

KNOWN_ISSUES.md entry 17 (landed via #149) documents a limitation surfaced during that PR's review: rows written to `injection_stats` during the RF phase's data generation carry `round_number=NULL`, which is invisible to `mark_superseded`'s `round_ge` filter (SQL comparisons against NULL never match). On a crashed-and-retried `rf_train` attempt, the failed attempt's stale rows never get marked superseded, and the retry's fresh generation writes a second overlapping set under the same tag — doubling the sample `plot_injection_stats()`'s bias/leakage figures draw from.

## The fix

`train_random_forest()`'s `generate_round()` call now passes `round_num=self.config.training.num_training_rounds + 1` — a sentinel one past the last beta-VAE round (there's no real "RF round" numbering) — instead of leaving it at the default `None`.

This is deliberately the minimal fix, reusing existing machinery rather than adding a NULL-aware special case:
- `resume_round` (`run_state.py`) is `max(completed_rounds) + 1`, and `completed_rounds` only ever holds values `<= num_training_rounds`, so `_start_round <= num_training_rounds + 1` always.
- The RF phase only (re)starts once the `vae_rounds` stage is fully done, so on any `rf_train` retry, `_start_round` is exactly `num_training_rounds + 1` — the same sentinel.
- That means `_init_run_state`'s **existing** `mark_superseded(table, tag, round_ge=self._start_round)` loop (already run on every retry, for `training_stats`/`injection_stats`/`latent_snapshots`) now covers RF rows automatically. No schema change, no new `mark_superseded` filter, no other call sites touched.
- Verified `round_number` has no other consumer that would care about the value changing from NULL to a real int: `plot_injection_stats()` and `query_injection_stat()` never filter or group by it (only `training_stats`' round_number is used for plotting, a separate table/code path this PR doesn't touch).

## Tests

Two new tests in `tests/unit/test_db.py`'s `TestMarkSuperseded`, run locally (48/48 passed in a TF venv, `PYTHONPATH=src pytest tests/unit/test_db.py -m "not gpu and not cluster"`):
- `test_null_round_number_escapes_round_ge` — documents the bug mechanism: a NULL-round_number row survives `mark_superseded(round_ge=1)` untouched.
- `test_sentinel_round_number_is_supersedable` — proves the fix: a row at the sentinel round number IS marked superseded by the same `round_ge` call, while a live row from a completed VAE round below it survives.

`ruff check` clean; pre-commit hooks passed on every commit.

## KNOWN_ISSUES.md

Entry 17's Status flips Open → Closed, referencing this PR (`3972613`). This branch is based on master **after** #149 merged, so entry 17 was already present at the fork point — no rebase needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)