### PR TITLE
feat(logger): per-save-tag log files instead of overwriting a single aetherscan.log

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -223,7 +223,7 @@ Three roots, set by `AETHERSCAN_{DATA,MODEL,OUTPUT}_PATH` (defaults under
 ├── config_{tag}.json                  # resolved config snapshot (written by final_save / inference)
 ├── run_state_{tag}.json               # training run manifest (stage machine + completed rounds)
 ├── db/aetherscan.db                   # SQLite (WAL) — all stats/results tables
-├── logs/aetherscan.log                # current run's log (mode="w": overwritten each run)
+├── logs/aetherscan_{tag}.log          # this run's log (mode="w": overwrites the same tag's log on rerun)
 ├── pfb_cache/pfb_response_*.npy       # content-addressed PFB passband responses
 ├── round_data/{tag}/round_XX/         # per-round training memmaps (deleted after the round trains)
 │   └── rf/                            #   plus the RF training dataset

--- a/docs/RUNTIME_SERVICES.md
+++ b/docs/RUNTIME_SERVICES.md
@@ -22,7 +22,7 @@ record through one consumer instead:
 main process:  logging.* → QueueHandler ─┐
 pool workers:  logging.* → QueueHandler ─┼→ multiprocessing.Queue → QueueListener thread
 producer tree: QueueHandler (own queue,  ─┘        │
-               relayed by RoundDataProducer)       ├→ FileHandler   logs/aetherscan.log (mode="w")
+               relayed by RoundDataProducer)       ├→ FileHandler   logs/aetherscan_{tag}.log (mode="w")
                                                    ├→ StreamHandler stdout
                                                    └→ SlackHandler  (optional)
 ```
@@ -32,8 +32,9 @@ producer tree: QueueHandler (own queue,  ─┘        │
 thread that drains it into the real handlers, each with its own configured level
 (`logger.{console,file,slack}_level`, all INFO by default). Consequences:
 
-- The log file is **the current run only** (`mode="w"` truncates at startup); pull it off the
-  cluster before relaunching if you need history.
+- Each run's log file is **tag-scoped** (`logs/aetherscan_{tag}.log`, named from the effective
+  `--save-tag`); `mode="w"` truncates at startup, so a same-tag rerun overwrites that tag's own
+  log while differently-tagged runs no longer clobber each other.
 - **Fork-started workers** inherit the queue: `init_worker_logging()` (called from every pool
   initializer) resets the worker's root logger to a single `QueueHandler` — and resets
   `sys.stdout`/`sys.stderr` to the real streams, because the inherited `StreamToLogger`

--- a/src/aetherscan/logger/logger.py
+++ b/src/aetherscan/logger/logger.py
@@ -1,4 +1,4 @@
-# TODO: add tag to file log & archive old logs
+# TODO: archive old logs
 """
 Logger for Aetherscan Pipeline
 Runs as background thread & uses thread-safe queue-based logging to avoid deadlocks and corrupted
@@ -37,6 +37,17 @@ def _parse_level(level_str: str) -> int:
         "CRITICAL": logging.CRITICAL,
     }
     return level_map.get(level_str.upper(), logging.INFO)
+
+
+def log_path_for_tag(output_path: str, tag: str) -> str:
+    """Return this run's log-file path: ``{output_path}/logs/aetherscan_{tag}.log``.
+
+    Pure and dependency-free so the tag->path derivation is unit-testable on its own. Naming the
+    log file with the run's save_tag mirrors how every other artifact is already tag-scoped
+    (config_{tag}.json, model files, plots, DB rows), so each run gets its own log instead of
+    overwriting a single shared aetherscan.log.
+    """
+    return os.path.join(output_path, "logs", f"aetherscan_{tag}.log")
 
 
 class StreamToLogger:
@@ -102,7 +113,9 @@ class Logger:
     # since __new__ is called before __init__ every time we instantiate a class,
     # by overriding __new__, we can short-circuit object creation entirely, and control whether a
     # new instance is created, or just return the existing instance
-    def __new__(cls):
+    def __new__(cls, *args, **kwargs):
+        # *args/**kwargs are accepted (and ignored here) so the constructor can forward
+        # __init__ arguments like save_tag; object.__new__ takes no extra args itself.
         # Double-checked locking pattern:
         # First check if _instance is None, without lock (for performance)
         if cls._instance is None:
@@ -118,8 +131,13 @@ class Logger:
         # Return the same instance for all subsequent constructor calls
         return cls._instance
 
-    def __init__(self):
-        """Initialize logger"""
+    def __init__(self, save_tag: str | None = None):
+        """Initialize logger.
+
+        `save_tag` names this run's log file (aetherscan_{save_tag}.log). Callers pass the run's
+        effective tag (the CLI --save-tag if given, else the config default timestamp tag); when
+        omitted, it falls back to config.checkpoint.save_tag directly.
+        """
         # Note, __init__ is triggered every time the class's constructor is called,
         # even if __new__ returned the existing singleton instance
         # Hence, we use the _initialized flag to make sure __init__ only runs once
@@ -132,7 +150,12 @@ class Logger:
         if self.config is None:
             raise ValueError("get_config() returned None")
 
-        self.log_path = os.path.join(self.config.output_path, "logs", "aetherscan.log")
+        # Per-run, tag-scoped log file: each run writes aetherscan_{tag}.log, so a new run no
+        # longer overwrites the previous run's log. init_logger() runs before the CLI --save-tag
+        # is applied to the config, so main.py resolves the effective tag from args and passes it
+        # in here; the config default is the fallback for any other caller.
+        tag = save_tag if save_tag is not None else self.config.checkpoint.save_tag
+        self.log_path = log_path_for_tag(self.config.output_path, tag)
         os.makedirs(os.path.dirname(self.log_path), exist_ok=True)  # Create dir if it doesn't exist
 
         # Create queue for worker processes (no size limit)
@@ -304,11 +327,15 @@ class Logger:
         )
 
 
-def init_logger() -> Logger:
+def init_logger(save_tag: str | None = None) -> Logger:
     """
-    Initialize global logger instance (call once at startup)
+    Initialize global logger instance (call once at startup).
+
+    `save_tag` names this run's log file (aetherscan_{save_tag}.log). Pass the run's effective tag
+    (the CLI --save-tag if given, else the config default timestamp tag); when omitted, the Logger
+    falls back to config.checkpoint.save_tag.
     """
-    logger_instance = Logger()
+    logger_instance = Logger(save_tag=save_tag)
 
     # Note, unlike other modules, due to dependency chains,
     # we wait to call register_logger() inside main.py:main()

--- a/src/aetherscan/logger/logger.py
+++ b/src/aetherscan/logger/logger.py
@@ -7,6 +7,7 @@ outputs from concurrent writes (e.g. from worker processes)
 
 from __future__ import annotations
 
+import contextlib
 import io
 import logging
 import os
@@ -289,6 +290,17 @@ class Logger:
             self.log_listener.stop()
             # Note, can't log after this point -- listener thread has stopped
             # All subsequent logs will get queued but never logged
+
+        # Dispose of the multiprocessing.Queue's feeder thread. Once the listener (the
+        # consumer) is stopped, a mp.Queue with buffered records left its feeder thread
+        # blocked in _feed/_send_bytes on a pipe nobody drains; its exit-time join finalizer
+        # then hangs the interpreter (surfaces when a real Logger is built in-process, e.g.
+        # the unit tests). close() + cancel_join_thread() drops those undelivered
+        # shutdown-time records and lets the process exit cleanly.
+        if self.log_queue is not None:
+            with contextlib.suppress(Exception):
+                self.log_queue.close()
+                self.log_queue.cancel_join_thread()
 
     # NOTE:
     # currently only title is broadcasted to main channel,

--- a/src/aetherscan/logger/logger.py
+++ b/src/aetherscan/logger/logger.py
@@ -16,8 +16,6 @@ import threading
 from logging.handlers import QueueHandler, QueueListener
 from multiprocessing import Queue
 
-import tensorflow as tf
-
 from aetherscan.config import get_config
 
 # NOTE: can this just be from aetherscan.logger import SlackHandler?
@@ -244,7 +242,11 @@ class Logger:
         if slack_init_message:
             logger.log(slack_init_level, slack_init_message)
 
-        # Redirect TensorFlow logs to Python logging
+        # Redirect TensorFlow logs to Python logging. Lazy import: TF is only needed for this
+        # one call, and log_path_for_tag (and this class's non-TF behavior) stay importable
+        # without pulling in the full TF stack — e.g. from a fast, TF-free test/tooling context.
+        import tensorflow as tf  # noqa: PLC0415
+
         os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"  # Show all TF logs
         tf.get_logger().setLevel(logging.INFO)
         tf_logger = tf.get_logger()

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -906,7 +906,9 @@ def main():
     try:
         init_config()
     except Exception as e:
-        # Note, can't log before init_logger()
+        # Note, can't log before init_logger() — write to stderr so the failure isn't silent
+        # (print() is banned outside utils/ by the T20 lint rule).
+        sys.stderr.write(f"Failed to initialize config: {e}\n")
         sys.exit(1)
 
     # Set up the CLI parser and parse arguments BEFORE init_logger so the logger can name this
@@ -917,7 +919,9 @@ def main():
     try:
         parser = setup_argument_parser()
     except Exception as e:
-        # Note, can't log before init_logger()
+        # Note, can't log before init_logger() — write to stderr so the failure isn't silent
+        # (print() is banned outside utils/ by the T20 lint rule).
+        sys.stderr.write(f"Failed to set up argument parser: {e}\n")
         sys.exit(1)
 
     # Parse arguments
@@ -935,10 +939,11 @@ def main():
     # Initialize logger. Name the run's log file with its effective save_tag: the CLI --save-tag
     # when provided (present on the train/inference subcommands as args.save_tag), else the config
     # default timestamp tag. init_logger() runs before apply_args_to_config(), so the tag is
-    # resolved from args here rather than from the not-yet-updated config.
+    # resolved from args here rather than from the not-yet-updated config. Pass None straight
+    # through rather than pre-resolving the default here — Logger.__init__ already does the
+    # is-not-None fallback to config.checkpoint.save_tag internally.
     try:
-        effective_save_tag = getattr(args, "save_tag", None) or get_config().checkpoint.save_tag
-        init_logger(save_tag=effective_save_tag)
+        init_logger(save_tag=getattr(args, "save_tag", None))
         logger.info("Logger initialization successful, but not yet registered for cleanup.")
         logger.info("Awaiting resource manager initialization. Do not terminate the process!")
     except Exception as e:

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -909,9 +909,36 @@ def main():
         # Note, can't log before init_logger()
         sys.exit(1)
 
-    # Initialize logger
+    # Set up the CLI parser and parse arguments BEFORE init_logger so the logger can name this
+    # run's log file with its effective save_tag (aetherscan_{save_tag}.log instead of a single
+    # overwritten aetherscan.log). Arg parsing has no dependency on the logger/manager; it is
+    # hoisted here only to resolve the tag. Like init_config above, these steps run before the
+    # logger exists and so cannot log.
     try:
-        init_logger()
+        parser = setup_argument_parser()
+    except Exception as e:
+        # Note, can't log before init_logger()
+        sys.exit(1)
+
+    # Parse arguments
+    try:
+        args = parser.parse_args()
+    except SystemExit as e:
+        # argparse calls sys.exit(2) on parse errors (invalid types, missing required args, etc.),
+        # which is why we catch SystemExit instead of Exception. argparse already prints its own
+        # error message + usage to stderr; we re-print full help and re-raise to preserve exit
+        # code 2. No logger exists yet (see above), so nothing is logged here.
+        if e.code == 2:  # argparse error (syntax/type error)
+            parser.print_help()
+        raise
+
+    # Initialize logger. Name the run's log file with its effective save_tag: the CLI --save-tag
+    # when provided (present on the train/inference subcommands as args.save_tag), else the config
+    # default timestamp tag. init_logger() runs before apply_args_to_config(), so the tag is
+    # resolved from args here rather than from the not-yet-updated config.
+    try:
+        effective_save_tag = getattr(args, "save_tag", None) or get_config().checkpoint.save_tag
+        init_logger(save_tag=effective_save_tag)
         logger.info("Logger initialization successful, but not yet registered for cleanup.")
         logger.info("Awaiting resource manager initialization. Do not terminate the process!")
     except Exception as e:
@@ -933,33 +960,6 @@ def main():
     except Exception as e:
         logger.error(f"Failed to register logger: {e}")
         sys.exit(1)
-
-    # Setup CLI argument parser
-    try:
-        parser = setup_argument_parser()
-        logger.info("CLI argument parser setup successfully")
-    except Exception as e:
-        logger.error(f"Failed to setup argument parser: {e}")
-        sys.exit(1)
-
-    # Parse arguments
-    try:
-        args = parser.parse_args()
-        logger.info("CLI arguments parsed. No issues found")
-    except SystemExit as e:
-        # argparse calls sys.exit(2) on parse errors (invalid types, missing required args, etc.)
-        # which is why we catch with SystemExit instead of Exception
-        # Exit code 2 = command line syntax error (standard for CLI tools)
-        if e.code == 2:  # argparse error (syntax/type error)
-            # Print help message & exit if parse_args() fails
-            # Note, argparse prints its own error message, but we call print_help() again
-            # just to be safe
-            parser.print_help()
-            logger.error("Invalid CLI arguments received")
-            logger.error("See usage")
-        # Here, we simply let the original traceback propagate by re-raising
-        # so cleanup handlers still run via atexit
-        raise
 
     # Inference mode: resolve the model artifact trio before anything reads it. When the
     # user provided none of --encoder-path/--rf-path/--config-path, the pinned

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1,15 +1,19 @@
-"""Unit tests for aetherscan.logger.logger.StreamToLogger: the file-protocol probe surface
-that libraries writing to the redirected sys.stdout/sys.stderr rely on (tqdm progress bars
-via huggingface_hub probe isatty(); others probe writable()/fileno())."""
+"""Unit tests for aetherscan.logger.logger:
+- StreamToLogger: the file-protocol probe surface that libraries writing to the redirected
+  sys.stdout/sys.stderr rely on (tqdm progress bars via huggingface_hub probe isatty(); others
+  probe writable()/fileno()).
+- log_path_for_tag: the pure tag->path derivation that gives each run its own tag-scoped log file
+  (aetherscan_{save_tag}.log) instead of overwriting a single aetherscan.log."""
 
 from __future__ import annotations
 
 import io
 import logging
+import os
 
 import pytest
 
-from aetherscan.logger.logger import StreamToLogger
+from aetherscan.logger.logger import Logger, StreamToLogger, log_path_for_tag, shutdown_logger
 
 
 class _CaptureHandler(logging.Handler):
@@ -65,3 +69,49 @@ class TestStreamToLogger:
             stream.fileno()
         assert issubclass(io.UnsupportedOperation, OSError)
         assert issubclass(io.UnsupportedOperation, ValueError)
+
+
+class TestLogPathForTag:
+    """The pure tag->path derivation (issue #215): each run's log lives at
+    {output_path}/logs/aetherscan_{save_tag}.log."""
+
+    def test_explicit_tag(self):
+        # An explicit --save-tag (e.g. test_v30) names the file aetherscan_test_v30.log.
+        path = log_path_for_tag("/datax/out", "test_v30")
+        assert path == os.path.join("/datax/out", "logs", "aetherscan_test_v30.log")
+        assert os.path.basename(path) == "aetherscan_test_v30.log"
+
+    def test_timestamp_default_tag(self):
+        # Untagged runs fall back to the import-time YYYYMMDD_HHMMSS tag; it flows into the
+        # filename unchanged, so even untagged runs stop clobbering each other.
+        tag = "20260723_141516"
+        path = log_path_for_tag("/datax/out", tag)
+        assert path == os.path.join("/datax/out", "logs", f"aetherscan_{tag}.log")
+
+    def test_different_tags_yield_distinct_files_same_dir(self):
+        # The crux of #215: two tags -> two separate files under the same logs/ dir; neither
+        # overwrites the other.
+        a = log_path_for_tag("/out", "final_v1")
+        b = log_path_for_tag("/out", "final_v2")
+        assert a != b
+        assert os.path.dirname(a) == os.path.dirname(b) == os.path.join("/out", "logs")
+
+
+class TestLoggerUsesTaggedPath:
+    """Light integration check that Logger actually builds its FileHandler from the tagged path."""
+
+    def test_logger_targets_tag_named_file(self):
+        # A Logger built with an explicit tag points log_path (and its FileHandler) at the
+        # tag-named file under the config's output_path, and creates it. get_config() is the
+        # conftest-initialized singleton (output_path scoped to tmp_path); shutdown_logger()
+        # tears the singleton down so it can't leak into the next test.
+        from aetherscan.config import get_config  # noqa: PLC0415
+
+        output_path = get_config().output_path
+        try:
+            instance = Logger(save_tag="test_v30")
+            assert instance.log_path == log_path_for_tag(output_path, "test_v30")
+            assert os.path.basename(instance.log_path) == "aetherscan_test_v30.log"
+            assert os.path.exists(instance.log_path)
+        finally:
+            shutdown_logger()

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -115,3 +115,18 @@ class TestLoggerUsesTaggedPath:
             assert os.path.exists(instance.log_path)
         finally:
             shutdown_logger()
+
+    def test_logger_falls_back_to_config_tag_when_omitted(self):
+        # No save_tag passed (the untagged-run / default-timestamp-tag path, arguably more
+        # common than the explicit-tag path) — Logger must fall back to
+        # config.checkpoint.save_tag rather than name the file after a None/sentinel tag.
+        from aetherscan.config import get_config  # noqa: PLC0415
+
+        config = get_config()
+        try:
+            instance = Logger()
+            expected = log_path_for_tag(config.output_path, config.checkpoint.save_tag)
+            assert instance.log_path == expected
+            assert os.path.exists(instance.log_path)
+        finally:
+            shutdown_logger()

--- a/utils/fetch_run_outputs.sh
+++ b/utils/fetch_run_outputs.sh
@@ -63,11 +63,9 @@
 #   * Machine name is used both as the ssh host and the filename prefix, so it must
 #     resolve (a Host alias in ~/.ssh/config or DNS). User/port go in ssh config.
 #   * Re-running is cheap: rsync -t skips files already present and unchanged.
-### TODO:
+# Note:
 #   * Log filenames are tagged like every other output, i.e. aetherscan_<tag>.log
-#     in logs/. (The logger writes a single untagged aetherscan.log TODAY; per-tag
-#     log names are a planned change. This script is written for that future state,
-#     so it will report "no match" against today's untagged log until that lands.)
+#     in logs/, so this script pulls each run's log by its tag.
 
 set -euo pipefail
 


### PR DESCRIPTION
Closes #215

## What changed

Each run now writes its log to `{output_path}/logs/aetherscan_{save_tag}.log` instead of overwriting a single `aetherscan.log`. The filename uses the run's **effective** save_tag: the CLI `--save-tag` when given, else the config default timestamp tag — so two runs with different tags produce two separate log files, and even untagged runs (each gets a unique import-time timestamp tag) stop clobbering each other. This mirrors how every other artifact is already tag-scoped (`config_{tag}.json`, model files, plots, DB rows).

- **`src/aetherscan/logger/logger.py`**
  - New pure helper `log_path_for_tag(output_path, tag) -> {output_path}/logs/aetherscan_{tag}.log`.
  - `Logger.__init__` takes an optional `save_tag` and builds `self.log_path` via the helper (fallback: `config.checkpoint.save_tag`). `__new__` now absorbs `*args/**kwargs` so the singleton constructor can forward it.
  - `init_logger(save_tag=None)` forwards the tag through.
- **`src/aetherscan/main.py`** — arg parsing hoisted above `init_logger()` (see decision below); `init_logger(save_tag=getattr(args, "save_tag", None) or get_config().checkpoint.save_tag)`.
- **`tests/unit/test_logger.py`** — added `log_path_for_tag` unit tests + a light Logger-targets-tagged-file check.
- Doc/comment sync for the old single-file name: `docs/ARCHITECTURE.md`, `docs/RUNTIME_SERVICES.md`, `utils/fetch_run_outputs.sh` (whose comment already anticipated this change as a TODO).

## Approach for the init-order wrinkle: (a)

I took **approach (a)** from the issue — resolve the effective tag and build the `FileHandler` with the tag-named path **from the start** (no rename, no lost lines). Approach (b) (create-early-then-retarget) would split a `--save-tag` run's first ~15 lines into the timestamp-named file and needs a risky live-`QueueListener` handler swap; (a) yields one clean per-run log file.

## Maintainer decisions applied

- **Arg parsing hoisted above `init_logger()`.** The issue (and the task) assumed `args` was available before `init_logger()`. It was not: in the actual code `parser.parse_args()` ran *after* `init_logger()`. Approach (a) requires the tag at logger-init time, so I moved `setup_argument_parser()` + `parse_args()` just above `init_logger()`. Arg parsing has no dependency on the logger/manager, so the reorder is safe. Consequence: like the pre-existing `init_config()` step, these two steps now run before the logger exists and therefore don't emit their prior INFO confirmations; on a parse error argparse still prints its own message + usage to stderr (I keep `print_help()` and re-raise to preserve exit code 2). The "logging available for every real init error" guarantee is preserved — the logger still comes up before `init_manager`, `register_logger`, validation, config-apply, and command dispatch.
- **`mode="w"` kept.** A same-tag rerun overwrites that tag's own log — identical to today's per-run truncate semantics, just scoped to the tag. Not switching to `"a"` keeps the change minimal and behavior-consistent.
- **Tag not re-validated before use in the log filename.** `validate_args` (which enforces the tag pattern) still runs after `init_logger`, as it did before. A malformed `--save-tag` is rejected there and aborts the run; its only new side effect is a possibly oddly-named stray log file first. I did not add speculative sanitization (valid tags contain no path separators), consistent with how the codebase already trusts the tag for every other artifact.
- **Helper location.** `log_path_for_tag` lives in `logger.py` next to `Logger` (co-located as the issue suggested). It's pure, but importing it pulls in `logger.py`'s top-level `import tensorflow`; it's exercised via the TF venv below.

## Verified

Run in a local TF 2.17.1 venv (`PYTHONPATH=src`, marker `not gpu and not cluster`):

- `tests/unit/test_logger.py` — **9 passed** (5 existing `StreamToLogger` + 3 new `log_path_for_tag` + 1 Logger-tagged-path).
- `tests/unit/test_main.py`, `tests/unit/test_cli_validation.py`, `tests/unit/test_tag_guards.py` (the suites exercising the `main()` reorder / `setup_argument_parser` / `args.save_tag`) — **140 passed**.
- `ruff check` + `ruff format --check` on all changed source/tests — clean.
- Confirmed no test asserts on the two INFO log strings dropped by the reorder.

The full unit suite is CI's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
