### PR TITLE
test: coverage hardening — CI marker leak-guard, #221/#217/#203/#207 regression tests, smoke model-tag override

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,4 +59,4 @@ jobs:
       # GPU- and cluster-marked tests need physical GPUs / cluster-resident data;
       # everything else (including slow CPU TF graph tests) runs here
       - name: Run test suite
-        run: pytest -m "not gpu and not cluster" -q
+        run: pytest -m "not gpu and not cluster and not integration" -q

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -138,6 +138,17 @@ ever observed on real training runs. Gate 2 — the SNR→confidence monotonicit
 training pipeline's own injection code and scores them in-process against the persisted
 VAE+RF, so it is `gpu`+`cluster`-only by nature (it can never run in CI).
 
+Two further gaps are accepted as-is (neither affects pipeline correctness):
+
+- **`slack_handler.py`** carries no unit tests — it is observability-only (a `logging.Handler`
+  that posts records to Slack), so its absence never affects pipeline results. Its network-free
+  helpers — the consecutive-failure cooldown, exponential backoff, and level-to-color coding —
+  would be cheap to unit-test in isolation if the module is ever hardened.
+- **End-to-end training-loop resume and clean SIGTERM/SIGINT shutdown mid-run** are exercised
+  only by real cluster runs: nothing today asserts that a mid-run interrupt tears down resources
+  cleanly and resumes from the persisted checkpoint/manifest. This promotes the standing
+  [`tests/conftest.py`](../tests/conftest.py) TODO into the visible gaps list.
+
 ## Markers
 
 | Marker | Meaning | In default selection? |

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -30,6 +30,14 @@ def cluster_paths():
     )
 
 
+@pytest.fixture
+def smoke_model_tag():
+    """The persisted model tag the consumer smokes (inference + model-behavior) score against,
+    overridable via AETHERSCAN_SMOKE_MODEL_TAG. Defaults to the blpc3 dummy model (test_v17);
+    point it at whatever tag test_train_smoke just produced on a fresh cluster."""
+    return os.environ.get("AETHERSCAN_SMOKE_MODEL_TAG", "test_v17")
+
+
 # NOTE: come back to this later
 @pytest.fixture
 def run_pipeline():

--- a/tests/integration/test_inference_smoke.py
+++ b/tests/integration/test_inference_smoke.py
@@ -28,22 +28,21 @@ import pytest
 pytestmark = [pytest.mark.integration, pytest.mark.gpu, pytest.mark.cluster]
 
 # NOTE: this smoke is coupled to a specific dummy model that must exist on the cluster; the
-# skip guard below handles its absence gracefully. Future improvement for a contributor who
-# wants to decouple it: make the tag configurable via an env var (e.g.
-# AETHERSCAN_SMOKE_MODEL_TAG) or a pytest option/marker so the smoke isn't wired to one artifact.
-_MODEL_TAG = "test_v17"  # persisted dummy model on blpc3
+# skip guard below handles its absence gracefully. The tag is overridable via the shared
+# smoke_model_tag fixture (AETHERSCAN_SMOKE_MODEL_TAG, default test_v17) so this smoke can point
+# at whatever tag test_train_smoke just produced instead of being wired to one fixed artifact.
 _CSV_NAME = "subset_test.csv"  # 2 complete 6-observation cadences
 
 
-def test_inference_smoke(cluster_paths, run_pipeline):
+def test_inference_smoke(cluster_paths, run_pipeline, smoke_model_tag):
     if shutil.which("nvidia-smi") is None:
         pytest.skip("requires a GPU host (nvidia-smi not found)")
 
     data_path, model_path, output_path = cluster_paths
 
-    encoder = os.path.join(model_path, f"vae_encoder_{_MODEL_TAG}.keras")
-    rf = os.path.join(model_path, f"random_forest_{_MODEL_TAG}.joblib")
-    saved_config = os.path.join(model_path, f"config_{_MODEL_TAG}.json")
+    encoder = os.path.join(model_path, f"vae_encoder_{smoke_model_tag}.keras")
+    rf = os.path.join(model_path, f"random_forest_{smoke_model_tag}.joblib")
+    saved_config = os.path.join(model_path, f"config_{smoke_model_tag}.json")
     csv_path = os.path.join(data_path, "inference", _CSV_NAME)
     for required in (encoder, rf, saved_config, csv_path):
         if not os.path.exists(required):
@@ -83,3 +82,7 @@ def test_inference_smoke(cluster_paths, run_pipeline):
     assert proc.returncode == 0, f"inference smoke run failed (tag={tag}); last output:\n{tail}"
     assert "Inference completed successfully!" in proc.stdout
     assert os.path.exists(os.path.join(output_path, f"config_{tag}.json"))
+
+    # End-of-run benchmark report: pins the #203 _post_benchmark_report hook's real
+    # db.flush -> render path end-to-end (output_path/plots/benchmark_report_{tag}.png).
+    assert os.path.exists(os.path.join(output_path, "plots", f"benchmark_report_{tag}.png"))

--- a/tests/integration/test_model_behavior.py
+++ b/tests/integration/test_model_behavior.py
@@ -33,9 +33,8 @@ import pytest
 
 pytestmark = [pytest.mark.integration, pytest.mark.gpu, pytest.mark.cluster]
 
-# NOTE: coupled to the same persisted dummy model as the smokes (see test_inference_smoke.py
-# for the decoupling suggestion).
-_MODEL_TAG = "test_v17"  # persisted dummy model on blpc3
+# NOTE: coupled to the same persisted dummy model as the smokes, resolved through the shared
+# smoke_model_tag fixture (AETHERSCAN_SMOKE_MODEL_TAG, default test_v17).
 _BACKGROUND_FILE = "real_filtered_LARGE_HIP110750.npy"  # first default train file
 # Pinned to DataConfig's current defaults (config.py) rather than read live: test_v17 was
 # trained against these values, so a future default change must not silently alter what this
@@ -52,13 +51,13 @@ _TOLERANCE = 0.05
 _SEED = 139
 
 
-def test_snr_confidence_monotonicity(cluster_paths):
+def test_snr_confidence_monotonicity(cluster_paths, smoke_model_tag):
     if shutil.which("nvidia-smi") is None:
         pytest.skip("requires a GPU host (nvidia-smi not found)")
 
     data_path, model_path, _ = cluster_paths
-    encoder_path = os.path.join(model_path, f"vae_encoder_{_MODEL_TAG}.keras")
-    rf_path = os.path.join(model_path, f"random_forest_{_MODEL_TAG}.joblib")
+    encoder_path = os.path.join(model_path, f"vae_encoder_{smoke_model_tag}.keras")
+    rf_path = os.path.join(model_path, f"random_forest_{smoke_model_tag}.joblib")
     background_path = os.path.join(data_path, "training", _BACKGROUND_FILE)
     for required in (encoder_path, rf_path, background_path):
         if not os.path.exists(required):

--- a/tests/integration/test_seeding_determinism.py
+++ b/tests/integration/test_seeding_determinism.py
@@ -1,0 +1,97 @@
+# NOTE: come back to this later
+
+"""GPU-path seeding determinism smoke (cluster-only; issue #207's --tf-deterministic-ops).
+
+Pins the promise behind --seed + --tf-deterministic-ops: with the TF global RNG seeded and op
+determinism enabled, a run is bit-exact reproducible on GPU. Building the beta-VAE and taking
+one optimizer step over identical inputs *twice* must yield byte-identical encoder weights.
+This is the only automated coverage that the deterministic-kernel path actually delivers
+reproducibility — weight init (HeNormal/GlorotNormal) and the VAE Sampling layer's epsilon both
+draw from the seeded global RNG, so a regression in the seeding wiring would desynchronize them.
+
+Like test_model_behavior.py this drives the real seams in-process (not a subprocess of
+`aetherscan.main`): it uses the pipeline's own `create_beta_vae_model()` construction path and a
+train step mirroring `TrainingPipeline._distributed_train_step` + `_apply_gradients`
+(GradientTape -> `compute_total_loss` -> `clip_by_global_norm` -> `optimizer.apply_gradients`).
+The inputs are fixed synthetic snippets, so no cluster-resident data is read; the gpu/cluster
+markers keep it in the same GPU-host-only selection as the other smokes (deterministic cuDNN
+kernels are only meaningful on real GPUs). All TF/aetherscan imports are deferred into the test
+body so collecting this module never pulls TensorFlow into the pytest parent process.
+
+    ./utils/run_container.sh python -m pytest tests/integration -m "gpu or cluster" -q
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import numpy as np
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.gpu, pytest.mark.cluster]
+
+_SEED = 207
+# Two cadences (12 observations) exercise reconstruction + KL + both clustering heads; the shape
+# matches the VAE's expected cadence form (batch, 6, 16, 512) — see BetaVAE.call in models/vae.py.
+_BATCH = 2
+_CADENCE_SHAPE = (_BATCH, 6, 16, 512)
+
+
+def test_seeding_yields_byte_identical_encoder_weights():
+    if shutil.which("nvidia-smi") is None:
+        pytest.skip("requires a GPU host (nvidia-smi not found)")
+
+    import tensorflow as tf  # noqa: PLC0415
+
+    from aetherscan.config import get_config, init_config  # noqa: PLC0415
+    from aetherscan.models import create_beta_vae_model  # noqa: PLC0415
+
+    # Integration tests skip the autouse config-init fixture, so bootstrap the singleton here,
+    # then pin the seed the construction path reads (create_beta_vae_model -> get_config). Single
+    # -threaded test, so the mutate-config-post-init caveat does not apply.
+    if get_config() is None:
+        init_config()
+    get_config().training.seed = _SEED
+    seed = get_config().training.seed
+
+    # Deterministic cuDNN/reduction kernels (the --tf-deterministic-ops promise). Process-global
+    # and only meaningful on a real GPU, hence the gpu/cluster markers + nvidia-smi guard above.
+    tf.config.experimental.enable_op_determinism()
+
+    # Fixed synthetic snippets, generated once and reused across both runs so the two builds see
+    # byte-identical inputs. Values in [0, 1) match the sigmoid-bounded reconstruction target of
+    # the binary-cross-entropy loss; target_data = main_data, as in the real reconstruction path.
+    rng = np.random.default_rng(_SEED)
+    main_data = tf.constant(rng.random(size=_CADENCE_SHAPE, dtype=np.float32))
+    true_data = tf.constant(rng.random(size=_CADENCE_SHAPE, dtype=np.float32))
+    false_data = tf.constant(rng.random(size=_CADENCE_SHAPE, dtype=np.float32))
+    target_data = main_data
+
+    strategy = tf.distribute.get_strategy()
+
+    def _build_and_train_once() -> list[np.ndarray]:
+        # Seed the TF global RNG before any variable creation so weight init and the Sampling
+        # layer's epsilon draw the same stream each run — exactly the ordering TrainingPipeline
+        # uses (tf.random.set_seed before create_beta_vae_model, inside strategy.scope()).
+        tf.random.set_seed(seed)
+        with strategy.scope():
+            vae = create_beta_vae_model()
+            # One real train step: mirrors _distributed_train_step's per-replica body and
+            # _apply_gradients (global-norm gradient clipping at 1.0, then Adam apply).
+            with tf.GradientTape() as tape:
+                losses = vae.compute_total_loss(
+                    main_data, true_data, false_data, target_data, training=True
+                )
+            gradients = tape.gradient(losses["total_loss"], vae.trainable_variables)
+            clipped_gradients, _ = tf.clip_by_global_norm(gradients, 1.0)
+            vae.optimizer.apply_gradients(
+                zip(clipped_gradients, vae.trainable_variables, strict=False)
+            )
+            return vae.encoder.get_weights()
+
+    weights_first = _build_and_train_once()
+    weights_second = _build_and_train_once()
+
+    assert len(weights_first) == len(weights_second)
+    for w_first, w_second in zip(weights_first, weights_second, strict=True):
+        np.testing.assert_array_equal(w_first, w_second)

--- a/tests/integration/test_seeding_determinism.py
+++ b/tests/integration/test_seeding_determinism.py
@@ -18,6 +18,13 @@ markers keep it in the same GPU-host-only selection as the other smokes (determi
 kernels are only meaningful on real GPUs). All TF/aetherscan imports are deferred into the test
 body so collecting this module never pulls TensorFlow into the pytest parent process.
 
+NOTE: `tf.config.experimental.enable_op_determinism()` is a process-global toggle with no
+"disable" counterpart, so once this test runs the deterministic-kernel mode persists for the
+rest of the pytest invocation. Alphabetical collection puts this module before
+`test_train_smoke.py`, so the train smoke inherits deterministic kernels (a mild train-speed
+cost only — no correctness impact). Left as-is; splitting it into its own pytest process to
+isolate the toggle would cost more than the speed hit it saves.
+
     ./utils/run_container.sh python -m pytest tests/integration -m "gpu or cluster" -q
 """
 

--- a/tests/integration/test_train_smoke.py
+++ b/tests/integration/test_train_smoke.py
@@ -88,6 +88,10 @@ def test_train_smoke(cluster_paths, run_pipeline):
         assert os.path.exists(os.path.join(model_path, artifact)), f"missing {artifact}"
     assert os.path.exists(os.path.join(output_path, f"config_{tag}.json"))
 
+    # End-of-run benchmark report: pins the #203 _post_benchmark_report hook's real
+    # db.flush -> render path end-to-end (output_path/plots/benchmark_report_{tag}.png).
+    assert os.path.exists(os.path.join(output_path, "plots", f"benchmark_report_{tag}.png"))
+
     # Per-round checkpoints for both rounds.
     checkpoints = os.path.join(model_path, "checkpoints")
     for round_tag in ("round_01", "round_02"):

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -7,9 +7,11 @@
 
 from __future__ import annotations
 
+import contextlib
 import io
 import logging
 import os
+from unittest.mock import patch
 
 import pytest
 
@@ -130,3 +132,34 @@ class TestLoggerUsesTaggedPath:
             assert os.path.exists(instance.log_path)
         finally:
             shutdown_logger()
+
+
+class TestLoggerStop:
+    """Regression guard for the #221 interpreter-hang fix in Logger.stop()."""
+
+    def test_stop_disposes_log_queue_feeder_thread(self):
+        # stop() must call BOTH log_queue.close() AND log_queue.cancel_join_thread(): once the
+        # QueueListener (consumer) is stopped, an mp.Queue with a live feeder thread hangs the
+        # interpreter's exit-time join unless both are called (issue #221, logger.py stop()).
+        # Dropping either call currently only surfaces as a >90s suite timeout — this converts
+        # it into a fast, localized failure. Build a real Logger (the conftest-initialized
+        # config singleton scopes output_path to tmp_path) and spy on the queue's disposal calls.
+        instance = Logger(save_tag="test_v31")
+        try:
+            with (
+                patch.object(instance.log_queue, "close") as mock_close,
+                patch.object(instance.log_queue, "cancel_join_thread") as mock_cancel,
+            ):
+                instance.stop()
+            mock_close.assert_called_once()
+            mock_cancel.assert_called_once()
+        finally:
+            # stop() ran with close()/cancel_join_thread() mocked out, so the real queue was
+            # never disposed — do it for real now so its feeder thread can't outlive the test
+            # (the very hang #221 fixed). Then drop the singleton via _reset() rather than
+            # shutdown_logger(): stop() is not idempotent (QueueListener.stop() raises on a
+            # second call), so shutdown_logger()'s stop() would crash after the explicit one above.
+            with contextlib.suppress(Exception):
+                instance.log_queue.close()
+                instance.log_queue.cancel_join_thread()
+            Logger._reset()

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -14,9 +14,14 @@ from types import SimpleNamespace
 import matplotlib.pyplot as plt
 import psutil
 import pytest
+from matplotlib.lines import Line2D
 
 from aetherscan.monitor import get_process_tree_stats
-from aetherscan.monitor.monitor import _draw_stage_boundaries, _sanitize_gpu_display_name
+from aetherscan.monitor.monitor import (
+    _draw_stage_boundaries,
+    _grouped_legend_entries,
+    _sanitize_gpu_display_name,
+)
 
 
 class FakeProcess:
@@ -270,3 +275,59 @@ class TestDrawStageBoundaries:
             assert axes[0].lines[0].get_xdata()[0] == pytest.approx(30.0)
         finally:
             plt.close(fig)
+
+
+class TestGroupedLegendEntries:
+    """The column-major legend grid helper (issue #217): two GPU-metric groups (usage + memory)
+    each occupy their own column block, padded with invisible handles so the second group always
+    starts a fresh column, and a group grows a second column only once it exceeds `max_rows`.
+    Pure helper — handles pass straight through, so plain sentinels stand in for Line2D artists."""
+
+    @pytest.mark.parametrize(
+        ("n_usage", "n_memory", "max_rows", "expected_ncol", "expected_slots"),
+        [
+            # No wrap (n <= max_rows -> cols_per_group=1, ncol=2): the two groups sit in one
+            # column each, and the memory group starts at the column boundary (slots).
+            pytest.param(3, 3, 5, 2, 3, id="no_wrap_equal"),
+            # No wrap with a shorter memory group: it is padded up to a whole column (slots).
+            pytest.param(3, 2, 5, 2, 3, id="no_wrap_padded"),
+            # The docstring's worked example: 5 GPUs at max_rows>=5 -> columns of 5 | 5.
+            pytest.param(5, 5, 5, 2, 5, id="docstring_5x5"),
+            # Wrap (n > max_rows -> cols_per_group=2, ncol=4): each group spans two columns.
+            pytest.param(6, 6, 5, 4, 6, id="wrap_equal"),
+            # Wrap with a shorter memory group: padded up to two whole columns (slots).
+            pytest.param(6, 4, 5, 4, 6, id="wrap_padded"),
+        ],
+    )
+    def test_grid_shape_and_column_major_padding(
+        self, n_usage, n_memory, max_rows, expected_ncol, expected_slots
+    ):
+        # Unique sentinels so real entries are identifiable by identity and padding entries
+        # (Line2D with alpha=0) are unambiguously distinguishable from them.
+        usage_handles = [object() for _ in range(n_usage)]
+        usage_labels = [f"usage{i}" for i in range(n_usage)]
+        memory_handles = [object() for _ in range(n_memory)]
+        memory_labels = [f"mem{i}" for i in range(n_memory)]
+
+        handles, labels, ncol = _grouped_legend_entries(
+            usage_handles, usage_labels, memory_handles, memory_labels, max_rows=max_rows
+        )
+
+        assert ncol == expected_ncol
+        # Both groups are padded to `slots`, so the output is exactly two column blocks.
+        assert len(handles) == len(labels) == 2 * expected_slots
+
+        def _assert_group(offset, real_handles, real_labels):
+            # Real entries land first, unchanged and in order...
+            assert handles[offset : offset + len(real_handles)] == real_handles
+            assert labels[offset : offset + len(real_labels)] == real_labels
+            # ...then invisible Line2D handles + "" labels pad the block up to `slots`.
+            for i in range(offset + len(real_handles), offset + expected_slots):
+                assert isinstance(handles[i], Line2D)
+                assert handles[i].get_alpha() == 0
+                assert labels[i] == ""
+
+        # Group 1 (usage) fills the first block; group 2 (memory) starts a fresh column block
+        # at index `slots` — the column-major invariant.
+        _assert_group(0, usage_handles, usage_labels)
+        _assert_group(expected_slots, memory_handles, memory_labels)


### PR DESCRIPTION
Closes #248

Test-coverage hardening: the cheap, high-value improvements from the suite audit. No behavior changes to `src/` — this is tests, CI config, and docs only.

## What changed

- **CI marker leak-guard** (`.github/workflows/tests.yml`): the run selection is now `pytest -m "not gpu and not cluster and not integration" -q`, so a test marked only `integration` (which skips the singleton-isolation fixture) can never leak into CI regardless of co-marking.
- **`Logger.stop()` regression test** (`tests/unit/test_logger.py`): builds a real `Logger`, spies on its `log_queue` via `patch.object`, calls `stop()`, and asserts **both** `log_queue.close()` and `log_queue.cancel_join_thread()` fire — converting the #221 interpreter-hang from a >90s suite timeout into a fast, localized failure.
- **`_grouped_legend_entries` unit test** (`tests/unit/test_monitor.py`): parametrized over GPU count vs `max_rows`, asserting `ncol` and the column-major group padding (invisible `Line2D` handles + empty labels) for no-wrap, no-wrap-padded, the docstring's 5|5 example, wrap, and wrap-padded cases (#217).
- **Benchmark-report smoke assertions** (`tests/integration/test_train_smoke.py`, `test_inference_smoke.py`): after the config-snapshot assert, `assert os.path.exists(.../plots/benchmark_report_{tag}.png)`. Verified both the train path (`main.py:393`) and the inference path (`main.py:891`) call `_post_benchmark_report`, and that the render target is `output_path/plots/benchmark_report_{tag}.png` (`main.py:273`).
- **`smoke_model_tag` fixture** (`tests/integration/conftest.py`): `os.environ.get("AETHERSCAN_SMOKE_MODEL_TAG", "test_v17")`, consumed by `test_inference_smoke.py` and `test_model_behavior.py` in place of the hardcoded `_MODEL_TAG`.
- **Seeding-determinism cluster smoke** (`tests/integration/test_seeding_determinism.py`, marked `integration,gpu,cluster`): under a fixed seed + `enable_op_determinism()`, builds the beta-VAE twice via `create_beta_vae_model()` and takes one real train step over identical synthetic snippets, asserting byte-identical encoder `get_weights()` — the only coverage of #207's `--tf-deterministic-ops` promise.
- **`docs/TESTING.md`**: two accepted-gap bullets (slack_handler.py observability-only; mid-run resume + clean SIGTERM/SIGINT shutdown cluster-smoke-only).

## Verified locally (TF 2.17 venv, Python 3.12)

- `pytest tests/unit/test_logger.py tests/unit/test_monitor.py -m "not gpu and not cluster" -q` → **32 passed in ~5s** (6 new: 1 logger + 5 parametrized monitor). No hang.
- All touched files AST-parse; `pytest tests/integration --collect-only` collects all 4 tests; running the integration dir yields **4 clean skips** at the `nvidia-smi` guard (not fixture errors), confirming the `smoke_model_tag` fixture wiring resolves for both consumers and the new seeding test.
- The new CI expression correctly **deselects all 4 integration tests** (`no tests collected (4 deselected)`).
- `pre-commit run --files <changed>` → all hooks pass (ruff lint + format, whitespace/eof, gitleaks).

## Deferred to CI / cluster (NOT run here)

- The three `gpu`+`cluster` integration tests cannot run without physical GPUs and cluster-resident data/models — they were **import-/collect-checked and skip-verified only**, not executed.

## Notes for the reviewer

- **`test_logger` teardown**: the new test calls `stop()` once and then `Logger._reset()` in the `finally` (not `shutdown_logger()`), because `stop()` is **not idempotent** — `QueueListener.stop()` raises `AttributeError` on a second call (verified empirically), so `shutdown_logger()` after an explicit `stop()` would crash the teardown. Same isolation guarantee, avoids the double-stop. It also disposes the real queue in the `finally` so the mocked-out disposal can't leave a live feeder thread (the very hang #221 fixed).
- **Seeding smoke — API names verified against source**, but flagged for a human with cluster access to double-check by actually running it:
  - `create_beta_vae_model()` (`aetherscan.models`), `BetaVAE.compute_total_loss(main_data, true_data, false_data, target_data, training=True)`, `vae.trainable_variables`, `vae.optimizer.apply_gradients(...)`, `vae.encoder.get_weights()`, `tf.clip_by_global_norm(grads, 1.0)` — all mirror `train.py`'s `_distributed_train_step` + `_apply_gradients`.
  - Seed/determinism setup mirrors `train.py` (`tf.random.set_seed(seed)` before construction, inside `strategy.scope()`; `tf.config.experimental.enable_op_determinism()`).
  - The test bootstraps the config singleton with `init_config()` (integration tests skip the autouse config-init fixture) and pins `get_config().training.seed`, since `create_beta_vae_model()` reads `get_config()`.
  - **The core assertion — that byte-identical weights actually hold on real GPU hardware — is unverifiable locally by nature; that is the behavior the test exists to pin.**
  - Deliberate minimal choice: the test generates fixed synthetic snippets in-process and therefore does **not** take `cluster_paths` (no cluster data is read). It keeps the `gpu`+`cluster` markers so it only runs alongside the other GPU-host smokes. Add `cluster_paths` if you prefer an exact structural mirror.
- **`docs/TESTING.md` overlaps with open PR #247** (which edits the test-tree and logger bullets). These edits live only in the deliberate-gaps prose to avoid conflict, but a trivial rebase may be needed depending on merge order. No existing seeding-determinism gap bullet existed to remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
