### PR TITLE
feat(benchmarks): GPU benchmark for Beta-VAE train step + encoder inference

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -147,6 +147,32 @@ large-VRAM card (e.g. the 96 GB Blackwell) the spare memory cannot be converted 
 this compact model, so the defaults (train 128, inference 2048) are already near-optimal — size the
 per-replica batch for constraint-divisibility and convenience, not to fill VRAM.
 
-The numbers above are single-GPU on blpc3. Multi-GPU scaling (`--num-gpus`), the
-`--accumulation-steps` cadence, and the bla0 (6× A4000 16 GB) baselines are captured on the
-release-benchmark runs and land with the System-Requirements update (#183).
+### Baseline: bla0 (6× RTX A4000 16 GB, NGC 25.02, July 2026)
+
+bla0 is the release-training host. Single-GPU training step and encoder inference:
+
+| per-replica batch | train cadences/s | train VRAM | encode obs/s | encode VRAM |
+|---|---|---|---|---|
+| 128 | 795 | 2.76 GB | 47,868 | 0.12 GB |
+| 256 | 819 | 5.26 GB | 50,364 | 0.19 GB |
+| 512 | 820 | 9.99 GB | 51,016 | 0.36 GB |
+| 1024 | OOM | — | 52,462 | 0.61 GB |
+| 2048 | — | — | 53,077 | 1.18 GB |
+| 4096 | — | — | 53,001 | 2.32 GB |
+
+Multi-GPU (all 6 A4000s, per-replica batch 128, **aggregate** throughput):
+
+| config | throughput | scaling | VRAM/GPU |
+|---|---|---|---|
+| train, 1 GPU | 795 cad/s | 1.0× | 2.76 GB |
+| train, 6 GPUs | 3,087 cad/s | 3.9× | 3.21 GB |
+| train, 6 GPUs, `--accumulation-steps 4` | 4,272 cad/s | — | 9.91 GB |
+| encode, 6 GPUs (batch 1024) | 214,451 obs/s | 4.1× | 0.78 GB |
+
+The A4000 is ~3.8× slower per GPU than the Blackwell (795 vs 2,986 cad/s at batch 128), consistent
+with its lower compute; the model is still compute-bound (throughput flat as batch grows toward the
+16 GB ceiling — training OOMs above batch 512). MirroredStrategy scales ~3.9–4.1× across the 6
+replicas (all-reduce overhead eats the rest). `--accumulation-steps 4` raises throughput (4,272 vs
+3,087 cad/s — one optimizer apply per 4 micro-batches instead of every step) at the cost of the
+persistent gradient accumulator's VRAM (3.21 → 9.91 GB/GPU). At the default batch 128, training uses
+~2.8 GB/GPU — comfortably within the 16 GB budget.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -18,6 +18,10 @@ python benchmarks/bench_pfb_vs_spline.py        # PFB static equalization vs per
 ./utils/run_container.sh python benchmarks/bench_normality.py
 ```
 
+`bench_gpu.py` is a different animal — it profiles the Beta-VAE on a real GPU (throughput +
+peak VRAM, with a batch-size sweep) rather than a CPU kernel, so it only runs inside the
+container on a cluster. See [GPU benchmark](#gpu-benchmark) below.
+
 Common flags: `--repeats N` (default 3; ops/s is reported from the best repeat) and
 `--output PATH` for the JSON result. Each script also exposes size knobs (`--width`,
 `--injections`, `--cadences`) — the defaults match production shapes, so stick to them when
@@ -31,6 +35,7 @@ comparing against the baselines.
 | `bench_injection.py` | `data_generation.new_cadence` (setigen narrowband injection into a stacked 96x4096 cadence) | Training data generation (`train.round_XX.data_generation`) |
 | `bench_lognorm_downsample.py` | per-observation `downscale_local_mean` (x8) and per-cadence `log_norm` | Stamp extraction downsample + inference load (`inference.*.load_lognorm`) |
 | `bench_pfb_vs_spline.py` | `pfb.equalize_passband` (static response divide) vs `preprocessing._spline_flatten_bandpass` (order-16 fit) on one 1M-bin coarse channel | Bandpass flattening inside energy detection |
+| `bench_gpu.py` | Beta-VAE training step (`compute_total_loss` + gradients + clipped Adam) and encoder forward on one GPU | VAE training (`train.round_XX`) and encoder inference — **GPU-only, see below** |
 
 ## Baseline numbers
 
@@ -69,3 +74,59 @@ Notes:
   (e.g. energy detection runs one fused task per coarse channel on the persistent pool).
 - `bench_injection` is dominated by setigen frame construction, which is why data
   generation gets a dedicated producer process and worker pool in training.
+
+## GPU benchmark
+
+`bench_gpu.py` profiles the part of the pipeline the CPU micro-benchmarks above can't reach: the
+Beta-VAE on the GPU. It needs a physical GPU and the full TensorFlow / aetherscan stack, so it
+only runs inside the NGC container on a cluster. It builds the real model
+(`create_beta_vae_model`) on a single GPU and drives synthetic batches of the true pipeline
+shapes, measuring per-GPU throughput and peak VRAM and sweeping the per-replica batch size to
+find the largest that fits.
+
+```bash
+# Largest per-replica batch that fits, with throughput + VRAM at each size (stops at the first OOM):
+./utils/run_container.sh python benchmarks/bench_gpu.py --mode train  --find-max
+./utils/run_container.sh python benchmarks/bench_gpu.py --mode encode --find-max
+# Or measure specific sizes:
+./utils/run_container.sh python benchmarks/bench_gpu.py --mode train --batch-sizes 128,256,512
+```
+
+A training example is a *cadence* `(6, 16, 512)`, so one step runs `18*B` encoder + `6*B` decoder
+passes (`B` = per-replica batch of cadences, matching `_distributed_train_step`); `encode` mode
+drives single observations `(16, 512, 1)` like inference. Peak VRAM is reported **per GPU** — each
+replica holds a full copy of the model, so combined VRAM is roughly this figure times the replica
+count. `--find-max` is capped at `--max-batch 4096`: a single encoder forward whose conv feature
+maps exceed 2^31 elements (batch ≳ 8192) trips an uncatchable TensorFlow int32 launch-config abort
+rather than a clean OOM, and 4096 already covers the training VRAM ceiling and a generous inference
+range (the pipeline's inference default is 2048).
+
+### Baseline: blpc3 (1× RTX PRO 6000 Blackwell, 96 GB, NGC 25.02, July 2026)
+
+Training step — per-replica batch of cadences:
+
+| per-replica batch | cadences/s | peak VRAM |
+|---|---|---|
+| 128 | 2,986 | 2.81 GB |
+| 256 | 2,892 | 5.21 GB |
+| 512 | 2,852 | 10.15 GB |
+| 1024 | 2,826 | 19.79 GB |
+| 2048 | 2,786 | 38.76 GB |
+| 4096 | 2,742 | 76.52 GB |
+| 8192 | OOM | — |
+
+Encoder inference — per-replica batch of observations:
+
+| per-replica batch | obs/s | peak VRAM |
+|---|---|---|
+| 512 | 198,963 | 0.52 GB |
+| 1024 | 231,065 | 1.01 GB |
+| 2048 | 197,361 | 1.72 GB |
+| 4096 | 192,104 | 3.39 GB |
+
+**Takeaway — the Beta-VAE is compute-bound, not VRAM-bound.** Training throughput peaks at
+per-replica batch ~128 (2.81 GB) and does *not* improve — it slightly declines — as the batch grows
+toward the 76 GB VRAM ceiling; inference throughput peaks near batch ~1024 using under 2 GB. On a
+large-VRAM card (e.g. the 96 GB Blackwell) the spare memory cannot be converted into throughput for
+this compact model, so the defaults (train 128, inference 2048) are already near-optimal — size the
+per-replica batch for constraint-divisibility and convenience, not to fill VRAM.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -14,6 +14,7 @@ python benchmarks/bench_normality.py            # sliding-window normality test 
 python benchmarks/bench_injection.py            # setigen signal injection (training data gen)
 python benchmarks/bench_lognorm_downsample.py   # per-cadence downsample + log-norm (load path)
 python benchmarks/bench_pfb_vs_spline.py        # PFB static equalization vs per-channel spline fit
+python benchmarks/bench_rf.py                    # Random Forest stage: latent prep + fit + predict
 # On the clusters, run through the container:
 ./utils/run_container.sh python benchmarks/bench_normality.py
 ```
@@ -35,7 +36,8 @@ comparing against the baselines.
 | `bench_injection.py` | `data_generation.new_cadence` (setigen narrowband injection into a stacked 96x4096 cadence) | Training data generation (`train.round_XX.data_generation`) |
 | `bench_lognorm_downsample.py` | per-observation `downscale_local_mean` (x8) and per-cadence `log_norm` | Stamp extraction downsample + inference load (`inference.*.load_lognorm`) |
 | `bench_pfb_vs_spline.py` | `pfb.equalize_passband` (static response divide) vs `preprocessing._spline_flatten_bandpass` (order-16 fit) on one 1M-bin coarse channel | Bandpass flattening inside energy detection |
-| `bench_gpu.py` | Beta-VAE training step (`compute_total_loss` + gradients + clipped Adam) and encoder forward on one GPU | VAE training (`train.round_XX`) and encoder inference — **GPU-only, see below** |
+| `bench_gpu.py` | Beta-VAE training step (`compute_total_loss` + gradients + clipped Adam) and encoder forward on one or more GPUs | VAE training (`train.round_XX`) and encoder inference — **GPU-only, see below** |
+| `bench_rf.py` | `RandomForestClassifier` fit + `predict_proba` and the `prepare_latent_features` reshape (sklearn, CPU) | Second-stage RF training + inference (`train.train_random_forest`) |
 
 ## Baseline numbers
 
@@ -54,6 +56,13 @@ update this table in the same PR.
 | `bench_lognorm_downsample` — lognorm | 4,861 cadences/s |
 | `bench_pfb_vs_spline` — pfb | 46.3 channels/s (plus a 7.7 s one-time response FFT) |
 | `bench_pfb_vs_spline` — spline | 6.0 channels/s → **7.7x speedup** |
+| `bench_rf` — prep (latent reshape) | 1,936,313 cadences/s (0.05 s) |
+| `bench_rf` — fit (1000 trees) | 340 cadences/s (235 s) — random-label upper bound¹ |
+| `bench_rf` — predict | 15,989 cadences/s |
+
+¹ `bench_rf` uses random binary labels, so the trees grow until pure — a conservative *upper*
+bound on fit time; real (separable) latents yield shallower trees that fit faster. The prep
+reshape is negligible (~0.05 s for the full 99,840-cadence set).
 
 ### blpc3 (EPYC 7313, 32 cores, NGC 25.02 container, July 2026)
 
@@ -80,9 +89,9 @@ Notes:
 `bench_gpu.py` profiles the part of the pipeline the CPU micro-benchmarks above can't reach: the
 Beta-VAE on the GPU. It needs a physical GPU and the full TensorFlow / aetherscan stack, so it
 only runs inside the NGC container on a cluster. It builds the real model
-(`create_beta_vae_model`) on a single GPU and drives synthetic batches of the true pipeline
-shapes, measuring per-GPU throughput and peak VRAM and sweeping the per-replica batch size to
-find the largest that fits.
+(`create_beta_vae_model`) under a `MirroredStrategy` over the first `--num-gpus` GPUs (default 1)
+and drives synthetic batches of the true pipeline shapes, measuring aggregate throughput and
+per-GPU peak VRAM and sweeping the per-replica batch size to find the largest that fits.
 
 ```bash
 # Largest per-replica batch that fits, with throughput + VRAM at each size (stops at the first OOM):
@@ -90,13 +99,20 @@ find the largest that fits.
 ./utils/run_container.sh python benchmarks/bench_gpu.py --mode encode --find-max
 # Or measure specific sizes:
 ./utils/run_container.sh python benchmarks/bench_gpu.py --mode train --batch-sizes 128,256,512
+# Multi-GPU scaling (MirroredStrategy all-reduce across all replicas):
+./utils/run_container.sh python benchmarks/bench_gpu.py --mode train --num-gpus 6 --batch-sizes 128
+# Model the accumulate-then-apply cadence of the real training loop (one apply per K micro-batches):
+./utils/run_container.sh python benchmarks/bench_gpu.py --mode train --num-gpus 6 --batch-sizes 128 --accumulation-steps 4
 ```
 
 A training example is a *cadence* `(6, 16, 512)`, so one step runs `18*B` encoder + `6*B` decoder
 passes (`B` = per-replica batch of cadences, matching `_distributed_train_step`); `encode` mode
 drives single observations `(16, 512, 1)` like inference. Peak VRAM is reported **per GPU** — each
 replica holds a full copy of the model, so combined VRAM is roughly this figure times the replica
-count. `--find-max` is capped at `--max-batch 4096`: a single encoder forward whose conv feature
+count. With `--accumulation-steps K`, one optimizer step accumulates the all-reduced grads over K
+micro-batches and applies once (as `_train_epoch`), so peak VRAM then includes the persistent
+accumulator and throughput reflects the once-per-K apply cadence. `--find-max` is capped at
+`--max-batch 4096`: a single encoder forward whose conv feature
 maps exceed 2^31 elements (batch ≳ 8192) trips an uncatchable TensorFlow int32 launch-config abort
 rather than a clean OOM, and 4096 already covers the training VRAM ceiling and a generous inference
 range (the pipeline's inference default is 2048).
@@ -130,3 +146,7 @@ toward the 76 GB VRAM ceiling; inference throughput peaks near batch ~1024 using
 large-VRAM card (e.g. the 96 GB Blackwell) the spare memory cannot be converted into throughput for
 this compact model, so the defaults (train 128, inference 2048) are already near-optimal — size the
 per-replica batch for constraint-divisibility and convenience, not to fill VRAM.
+
+The numbers above are single-GPU on blpc3. Multi-GPU scaling (`--num-gpus`), the
+`--accumulation-steps` cadence, and the bla0 (6× A4000 16 GB) baselines are captured on the
+release-benchmark runs and land with the System-Requirements update (#183).

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -173,6 +173,7 @@ The A4000 is ~3.8× slower per GPU than the Blackwell (795 vs 2,986 cad/s at bat
 with its lower compute; the model is still compute-bound (throughput flat as batch grows toward the
 16 GB ceiling — training OOMs above batch 512). MirroredStrategy scales ~3.9–4.1× across the 6
 replicas (all-reduce overhead eats the rest). `--accumulation-steps 4` raises throughput (4,272 vs
-3,087 cad/s — one optimizer apply per 4 micro-batches instead of every step) at the cost of the
-persistent gradient accumulator's VRAM (3.21 → 9.91 GB/GPU). At the default batch 128, training uses
-~2.8 GB/GPU — comfortably within the 16 GB budget.
+3,087 cad/s) because it runs one optimizer apply — and therefore one clip + one cross-replica
+all-reduce — per 4 micro-batches instead of every step, amortizing that fixed per-apply overhead over
+4× as many cadences; the cost is the persistent gradient accumulator's VRAM (3.21 → 9.91 GB/GPU). At
+the default batch 128, training uses ~2.8 GB/GPU — comfortably within the 16 GB budget.

--- a/benchmarks/bench_gpu.py
+++ b/benchmarks/bench_gpu.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""
+GPU micro-benchmark: Beta-VAE training step and encoder inference — throughput and peak VRAM.
+
+Unlike the other scripts in this directory (which time hot *CPU* kernels and run anywhere),
+this one needs a physical GPU and the full TensorFlow / aetherscan stack, so run it inside the
+NGC container on a cluster:
+
+    ./utils/run_container.sh python benchmarks/bench_gpu.py --mode train  --find-max
+    ./utils/run_container.sh python benchmarks/bench_gpu.py --mode encode --find-max
+    ./utils/run_container.sh python benchmarks/bench_gpu.py --mode train  --batch-sizes 128,256,512
+
+It builds the real Beta-VAE (`create_beta_vae_model`) on a single GPU and drives synthetic
+batches of the true pipeline shapes. A training example is a *cadence* `(6, 16, 512)`, so the
+four training inputs (`main`, `true`, `false`, `target`) are each `(B, 6, 16, 512)` and one step
+runs `18*B` encoder passes (`6B` main + `6B` true + `6B` false) plus `6B` decoder passes,
+exactly like `_distributed_train_step`. Inference encodes individual observations, so `encode`
+mode drives `(B, 16, 512, 1)`. For each per-replica batch size it reports throughput
+(train: cadences/s; encode: observations/s) and peak VRAM.
+
+`--find-max` doubles the batch size until the GPU OOMs and reports the largest power of two that
+fits — use it to size `--per-replica-batch-size` (train) and `--per-replica-batch-size`
+(inference) so a large-VRAM card (e.g. a 96 GB Blackwell) is not left training at a batch sized
+for a 16 GB card. Peak VRAM is per GPU (each replica holds a full copy), so the combined figure
+is this number times the replica count.
+
+Note: the sweep is capped at `--max-batch` (default 4096) because a single encoder forward pass
+whose conv feature maps exceed ~2^31 elements (roughly batch >= 8192, since an intermediate map
+is batch*16*512*channels) trips a TensorFlow int32 launch-config overflow that aborts the process
+uncatchably rather than raising a clean OOM. 4096 comfortably covers the training VRAM ceiling and
+a generous inference range (the pipeline's inference default is 2048).
+
+Writes a JSON result to benchmarks/results/ (or --output), like the CPU benchmarks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import time
+
+import numpy as np
+import tensorflow as tf
+from _common import machine_info, write_result
+
+from aetherscan.config import get_config, init_config
+from aetherscan.models import create_beta_vae_model
+
+# Fixed pipeline shapes (see models/vae.py). A training example is a cadence of 6 observations;
+# BetaVAE.call reshapes (B, 6, 16, 512) -> (B*6, 16, 512, 1) to encode. Inference encodes single
+# observations of shape (16, 512, 1).
+_CADENCE_SHAPE = (6, 16, 512)
+_OBS_SHAPE = (16, 512, 1)
+_CLIP_NORM = 1.0  # matches train.py `_apply_gradients` (tf.clip_by_global_norm(..., 1.0))
+_DEVICE = "GPU:0"
+
+
+def _select_single_gpu() -> None:
+    """Restrict TF to the first visible GPU with memory growth on, mirroring main.py so that
+    `get_memory_info` reflects real usage rather than a pre-grabbed whole-device pool."""
+    gpus = tf.config.list_physical_devices("GPU")
+    if not gpus:
+        raise SystemExit("bench_gpu requires a physical GPU; none are visible.")
+    tf.config.set_visible_devices(gpus[0], "GPU")
+    tf.config.experimental.set_memory_growth(gpus[0], True)
+
+
+def _rand(shape: tuple[int, ...]) -> tf.Tensor:
+    return tf.constant(np.random.default_rng(0).random(shape, dtype=np.float32))
+
+
+def _peak_vram_gb() -> float:
+    return tf.config.experimental.get_memory_info(_DEVICE)["peak"] / 1e9
+
+
+def _reset_vram_peak() -> None:
+    tf.config.experimental.reset_memory_stats(_DEVICE)
+
+
+def _make_train_step(model):
+    @tf.function
+    def train_step(main, true_, false_, target):
+        with tf.GradientTape() as tape:
+            losses = model.compute_total_loss(main, true_, false_, target, training=True)
+        grads = tape.gradient(losses["total_loss"], model.trainable_variables)
+        grads, _ = tf.clip_by_global_norm(grads, _CLIP_NORM)
+        model.optimizer.apply_gradients(zip(grads, model.trainable_variables, strict=False))
+        return losses["total_loss"]
+
+    return train_step
+
+
+def _make_encode_step(model):
+    @tf.function
+    def encode_step(obs):
+        z_mean, _, _ = model.encoder(obs, training=False)
+        return z_mean
+
+    return encode_step
+
+
+def _measure(mode: str, step_fn, batch: int, warmup: int, steps: int) -> dict | None:
+    """Run `warmup` + `steps` iterations at per-replica batch size `batch`; return timing/VRAM,
+    or None if the GPU ran out of memory (the caller stops the sweep there)."""
+    if mode == "train":
+        # main, true, false, target — each a batch of cadences (B, 6, 16, 512).
+        inputs = tuple(_rand((batch, *_CADENCE_SHAPE)) for _ in range(4))
+    else:
+        # encode: a batch of single observations (B, 16, 512, 1).
+        inputs = (_rand((batch, *_OBS_SHAPE)),)
+
+    try:
+        for _ in range(warmup):
+            out = step_fn(*inputs)
+        out.numpy()  # sync after warmup (also absorbs tf.function tracing) before timing
+        _reset_vram_peak()
+        start = time.perf_counter()
+        for _ in range(steps):
+            out = step_fn(*inputs)
+        out.numpy()  # force the queued steps to finish before stopping the clock
+        elapsed = time.perf_counter() - start
+    except tf.errors.ResourceExhaustedError:
+        # `inputs` is dropped when this frame returns; the sweep stops at the first OOM.
+        return None
+
+    peak = _peak_vram_gb()
+    del inputs
+    gc.collect()
+    # batch dim = cadences (train) / observations (encode); see the header line for the unit.
+    samples_per_s = (batch * steps) / elapsed if elapsed > 0 else float("inf")
+    return {
+        "per_replica_batch_size": batch,
+        "steps": steps,
+        "elapsed_s": elapsed,
+        "samples_per_s": samples_per_s,
+        "peak_vram_gb": peak,
+    }
+
+
+def _batch_schedule(args) -> list[int]:
+    if args.batch_sizes:
+        return [int(x) for x in args.batch_sizes.split(",") if x.strip()]
+    # --find-max (default): powers of two from --start-batch up to the cap; the sweep stops at
+    # the first OOM, so the last success is the largest power of two that fits.
+    sizes, b = [], args.start_batch
+    while b <= args.max_batch:
+        sizes.append(b)
+        b *= 2
+    return sizes
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=["train", "encode"], default="train")
+    parser.add_argument(
+        "--batch-sizes",
+        default=None,
+        help="Comma-separated per-replica batch sizes to measure (overrides --find-max).",
+    )
+    parser.add_argument(
+        "--find-max",
+        action="store_true",
+        help="Double the batch size until the GPU OOMs (the default when --batch-sizes is unset).",
+    )
+    parser.add_argument("--start-batch", type=int, default=64, help="First size for --find-max.")
+    parser.add_argument(
+        "--max-batch",
+        type=int,
+        default=4096,
+        help="Cap for --find-max (default 4096; see the int32 launch-config note in the header).",
+    )
+    parser.add_argument("--warmup", type=int, default=3, help="Untimed warmup steps per size.")
+    parser.add_argument("--steps", type=int, default=20, help="Timed steps per size.")
+    parser.add_argument("--output", default=None, help="Result JSON path.")
+    args = parser.parse_args()
+
+    _select_single_gpu()
+    init_config()
+    config = get_config()
+    # Build the model once (weights are batch-independent); reuse across sizes.
+    strategy = tf.distribute.OneDeviceStrategy(f"/{_DEVICE}")
+    with strategy.scope():
+        model = create_beta_vae_model()
+    step_fn = _make_train_step(model) if args.mode == "train" else _make_encode_step(model)
+
+    unit = "cadences/s" if args.mode == "train" else "obs/s"
+    shape = _CADENCE_SHAPE if args.mode == "train" else _OBS_SHAPE
+    print(
+        f"mode={args.mode}  latent_dim={config.beta_vae.latent_dim}  example_shape={shape}"
+        + ("  (18*B encoder + 6*B decoder passes/step)" if args.mode == "train" else "")
+    )
+    print(f"{'batch':>8}  {unit:>12}  {'peak VRAM (GB)':>15}")
+
+    measured: list[dict] = []
+    max_fit: dict | None = None
+    for batch in _batch_schedule(args):
+        res = _measure(args.mode, step_fn, batch, args.warmup, args.steps)
+        if res is None:
+            print(f"{batch:>8}  {'OOM':>12}  {'-':>15}")
+            break
+        measured.append(res)
+        max_fit = res
+        print(f"{batch:>8}  {res['samples_per_s']:>12.0f}  {res['peak_vram_gb']:>15.2f}")
+
+    results = {
+        "measurements": measured,
+        "max_fit_batch": max_fit["per_replica_batch_size"] if max_fit else None,
+        "max_fit_peak_vram_gb": max_fit["peak_vram_gb"] if max_fit else None,
+    }
+    if max_fit:
+        print(
+            f"\nlargest fitting per-replica batch: {max_fit['per_replica_batch_size']} "
+            f"({max_fit['peak_vram_gb']:.2f} GB peak, {max_fit['samples_per_s']:.0f} {unit})"
+        )
+    path = write_result(
+        f"bench_gpu_{args.mode}",
+        {
+            "mode": args.mode,
+            "obs_shape": list(_OBS_SHAPE),
+            "latent_dim": config.beta_vae.latent_dim,
+            "warmup": args.warmup,
+            "steps": args.steps,
+            "gpu": machine_info()["hostname"],
+        },
+        results,
+        args.output,
+    )
+    print(f"Result written to {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_gpu.py
+++ b/benchmarks/bench_gpu.py
@@ -117,17 +117,11 @@ def _peak_vram_gb(devices: list[str]) -> float:
     return max(tf.config.experimental.get_memory_info(d)["peak"] for d in devices) / 1e9
 
 
-def _make_step_fn(model, mode: str):
-    """Per-replica step run via strategy.run. Train: compute the grads for one micro-batch (no
-    apply — the reduce/accumulate/clip/apply happens once per optimizer step in _measure, mirroring
-    train.py's _distributed_train_step + _apply_gradients). Encode: an encoder forward."""
+def _make_encode_step_fn(model):
+    """Per-replica encoder forward, run via strategy.run for `--mode encode`. (The train path builds
+    its own gradient-accumulating step inside _measure, so it does not use this.)"""
 
     def step_fn(inputs):
-        if mode == "train":
-            main, true_, false_, target = inputs
-            with tf.GradientTape() as tape:
-                losses = model.compute_total_loss(main, true_, false_, target, training=True)
-            return tape.gradient(losses["total_loss"], model.trainable_variables)
         z_mean, _, _ = model.encoder(inputs[0], training=False)
         return z_mean
 
@@ -150,28 +144,42 @@ def _measure(
         return tuple(tf.constant(_rand((batch, *shape))) for _ in range(n_inputs))
 
     @tf.function
-    def run(dist_inputs):
-        if mode != "train":
-            return strategy.run(step_fn, args=(dist_inputs,))
-        # One optimizer step: accumulate the cross-replica MEAN-reduced grads over
-        # accumulation_steps micro-batches, then apply once (global-norm clip + Adam) — the
-        # accumulate-then-apply cadence of _train_epoch / _distributed_train_step / _apply_gradients.
-        accumulated = None
-        for _ in range(accumulation_steps):
-            per_replica_grads = strategy.run(step_fn, args=(dist_inputs,))
-            reduced = [
-                strategy.reduce(tf.distribute.ReduceOp.MEAN, g, axis=None)
-                for g in per_replica_grads
+    def encode_run(dist_inputs):
+        return strategy.run(step_fn, args=(dist_inputs,))
+
+    if mode == "train":
+        # Per-replica gradient accumulators (created in scope so they mirror across replicas).
+        with strategy.scope():
+            accumulators = [
+                tf.Variable(tf.zeros_like(v), trainable=False) for v in model.trainable_variables
             ]
-            accumulated = (
-                reduced
-                if accumulated is None
-                else [a + r for a, r in zip(accumulated, reduced, strict=False)]
-            )
-        averaged = [g / accumulation_steps for g in accumulated]
-        clipped, _ = tf.clip_by_global_norm(averaged, _CLIP_NORM)
-        model.optimizer.apply_gradients(zip(clipped, model.trainable_variables, strict=False))
-        return None
+
+        def _accumulate(inputs):
+            main, true_, false_, target = inputs
+            with tf.GradientTape() as tape:
+                losses = model.compute_total_loss(main, true_, false_, target, training=True)
+            grads = tape.gradient(losses["total_loss"], model.trainable_variables)
+            for acc, g in zip(accumulators, grads, strict=False):
+                acc.assign_add(g)
+
+        def _apply_and_reset():
+            grads = [acc / accumulation_steps for acc in accumulators]
+            clipped, _ = tf.clip_by_global_norm(grads, _CLIP_NORM)
+            model.optimizer.apply_gradients(zip(clipped, model.trainable_variables, strict=False))
+            for acc in accumulators:
+                acc.assign(tf.zeros_like(acc))
+
+        @tf.function
+        def run(dist_inputs):
+            # Accumulate grads over accumulation_steps micro-batches into the per-replica
+            # accumulators, then apply once. The apply runs INSIDE strategy.run, so MirroredStrategy
+            # all-reduces on apply — the correct multi-GPU accumulate-then-apply cadence, and it
+            # sidesteps the cross-device error from applying pre-reduced grads in cross-replica context.
+            for _ in range(accumulation_steps):
+                strategy.run(_accumulate, args=(dist_inputs,))
+            strategy.run(_apply_and_reset)
+    else:
+        run = encode_run
 
     def sync(out) -> None:
         # Force queued device work to finish before the clock is read. Train applies mutate the
@@ -280,7 +288,7 @@ def main() -> None:
     strategy = tf.distribute.MirroredStrategy(devices=[f"/{d}" for d in devices])
     with strategy.scope():
         model = create_beta_vae_model()
-    step_fn = _make_step_fn(model, args.mode)
+    step_fn = _make_encode_step_fn(model)
 
     unit = "cadences/s" if args.mode == "train" else "obs/s"
     shape = _CADENCE_SHAPE if args.mode == "train" else _OBS_SHAPE

--- a/benchmarks/bench_gpu.py
+++ b/benchmarks/bench_gpu.py
@@ -13,6 +13,8 @@ NGC container on a cluster:
     # explicit sizes, and multi-GPU scaling across all 6 replicas:
     ./utils/run_container.sh python benchmarks/bench_gpu.py --mode train --batch-sizes 128,256
     ./utils/run_container.sh python benchmarks/bench_gpu.py --mode train --num-gpus 6 --batch-sizes 128
+    # model the real accumulate-then-apply cadence (one apply per 4 micro-batches):
+    ./utils/run_container.sh python benchmarks/bench_gpu.py --mode train --num-gpus 6 --batch-sizes 128 --accumulation-steps 4
 
 It builds the real Beta-VAE (`create_beta_vae_model`) under a `MirroredStrategy` over the first
 `--num-gpus` GPUs and drives synthetic batches of the true pipeline shapes. A training example is
@@ -31,11 +33,12 @@ What this does and does NOT cover:
     the decoder (inside the train step), and — with `--num-gpus > 1` — the MirroredStrategy
     cross-replica gradient all-reduce and multi-GPU scaling. fp32, matching the pipeline (which
     uses no mixed precision or XLA).
-  - Does NOT model gradient accumulation (the real loop accumulates `accumulation_steps`
-    micro-batches then applies once; here every step applies — the per-micro-batch VRAM that
-    sets the max batch is captured exactly, the throughput effect is small), the input pipeline
-    (synthetic in-memory tensors, no `tf.data`-from-memmap + prefetch + host->device copy), or
-    the CPU-side Random Forest stage.
+  - Models gradient accumulation with `--accumulation-steps K`: one optimizer step accumulates
+    all-reduced grads over K micro-batches then applies once with the global-norm clip, exactly as
+    train.py's `_train_epoch` (K=1, the default, is a plain apply-every-step). Peak VRAM then
+    includes the persistent accumulator and throughput reflects the once-per-K apply cadence.
+  - Does NOT model the input pipeline (synthetic in-memory tensors, no `tf.data`-from-memmap +
+    prefetch + host->device copy) or the CPU-side Random Forest stage (see bench_rf.py).
 
 Note: `--find-max` is capped at `--max-batch` (default 4096) because an encoder forward whose
 conv feature maps exceed ~2^31 elements (roughly batch >= 8192, an intermediate map is
@@ -115,29 +118,31 @@ def _peak_vram_gb(devices: list[str]) -> float:
 
 
 def _make_step_fn(model, mode: str):
-    """Per-replica step, run via strategy.run so MirroredStrategy handles the cross-replica
-    gradient all-reduce on apply_gradients: a full training step (compute_total_loss -> grads ->
-    global-norm clip -> Adam) or an encoder forward."""
+    """Per-replica step run via strategy.run. Train: compute the grads for one micro-batch (no
+    apply — the reduce/accumulate/clip/apply happens once per optimizer step in _measure, mirroring
+    train.py's _distributed_train_step + _apply_gradients). Encode: an encoder forward."""
 
     def step_fn(inputs):
         if mode == "train":
             main, true_, false_, target = inputs
             with tf.GradientTape() as tape:
                 losses = model.compute_total_loss(main, true_, false_, target, training=True)
-            grads = tape.gradient(losses["total_loss"], model.trainable_variables)
-            grads, _ = tf.clip_by_global_norm(grads, _CLIP_NORM)
-            model.optimizer.apply_gradients(zip(grads, model.trainable_variables, strict=False))
-            return losses["total_loss"]
+            return tape.gradient(losses["total_loss"], model.trainable_variables)
         z_mean, _, _ = model.encoder(inputs[0], training=False)
         return z_mean
 
     return step_fn
 
 
-def _measure(strategy, devices, step_fn, mode, batch, warmup, steps) -> dict | None:
-    """Run `warmup` + `steps` iterations at per-replica batch `batch` on every replica. Returns
-    aggregate throughput (per_replica_batch * num_replicas * steps / elapsed) and per-GPU peak
-    VRAM, or None if a GPU OOMs (the caller stops the sweep there)."""
+def _measure(
+    strategy, devices, model, step_fn, mode, batch, warmup, steps, accumulation_steps
+) -> dict | None:
+    """Run `warmup` + `steps` optimizer steps at per-replica batch `batch` on every replica. A
+    train optimizer step accumulates all-reduced grads over `accumulation_steps` micro-batches then
+    applies once with the global-norm clip (train.py's `_train_epoch`); an encode step is a single
+    encoder forward (`accumulation_steps` ignored). Returns aggregate throughput (per_replica_batch
+    * num_replicas * micro_batches / elapsed) and per-GPU peak VRAM, or None if a GPU OOMs (the
+    caller stops the sweep there)."""
     shape = _CADENCE_SHAPE if mode == "train" else _OBS_SHAPE
     n_inputs = 4 if mode == "train" else 1
 
@@ -146,21 +151,48 @@ def _measure(strategy, devices, step_fn, mode, batch, warmup, steps) -> dict | N
 
     @tf.function
     def run(dist_inputs):
-        return strategy.run(step_fn, args=(dist_inputs,))
+        if mode != "train":
+            return strategy.run(step_fn, args=(dist_inputs,))
+        # One optimizer step: accumulate the cross-replica MEAN-reduced grads over
+        # accumulation_steps micro-batches, then apply once (global-norm clip + Adam) — the
+        # accumulate-then-apply cadence of _train_epoch / _distributed_train_step / _apply_gradients.
+        accumulated = None
+        for _ in range(accumulation_steps):
+            per_replica_grads = strategy.run(step_fn, args=(dist_inputs,))
+            reduced = [
+                strategy.reduce(tf.distribute.ReduceOp.MEAN, g, axis=None)
+                for g in per_replica_grads
+            ]
+            accumulated = (
+                reduced
+                if accumulated is None
+                else [a + r for a, r in zip(accumulated, reduced, strict=False)]
+            )
+        averaged = [g / accumulation_steps for g in accumulated]
+        clipped, _ = tf.clip_by_global_norm(averaged, _CLIP_NORM)
+        model.optimizer.apply_gradients(zip(clipped, model.trainable_variables, strict=False))
+        return None
+
+    def sync(out) -> None:
+        # Force queued device work to finish before the clock is read. Train applies mutate the
+        # model variables, so reading one is a sufficient barrier; encode syncs on its output.
+        if mode == "train":
+            model.trainable_variables[0].numpy()
+        elif out is not None:
+            strategy.experimental_local_results(out)[0].numpy()
 
     try:
         dist_inputs = strategy.experimental_distribute_values_from_function(value_fn)
         out = None
         for _ in range(warmup):
             out = run(dist_inputs)
-        if out is not None:
-            strategy.experimental_local_results(out)[0].numpy()  # sync (also absorbs tracing)
+        sync(out)  # also absorbs tracing
         for d in devices:
             tf.config.experimental.reset_memory_stats(d)
         start = time.perf_counter()
         for _ in range(steps):
             out = run(dist_inputs)
-        strategy.experimental_local_results(out)[0].numpy()  # force queued steps to finish
+        sync(out)  # force queued steps to finish
         elapsed = time.perf_counter() - start
     except tf.errors.ResourceExhaustedError:
         return None
@@ -168,11 +200,13 @@ def _measure(strategy, devices, step_fn, mode, batch, warmup, steps) -> dict | N
     peak = _peak_vram_gb(devices)
     gc.collect()
     n = len(devices)
-    aggregate = (batch * n * steps) / elapsed if elapsed > 0 else float("inf")
+    micro_batches = steps * (accumulation_steps if mode == "train" else 1)
+    aggregate = (batch * n * micro_batches) / elapsed if elapsed > 0 else float("inf")
     return {
         "per_replica_batch_size": batch,
         "num_gpus": n,
         "steps": steps,
+        "accumulation_steps": accumulation_steps if mode == "train" else 1,
         "elapsed_s": elapsed,
         "aggregate_samples_per_s": aggregate,
         "peak_vram_gb_per_gpu": peak,
@@ -229,6 +263,13 @@ def main() -> None:
         "--warmup", type=_positive_int, default=3, help="Untimed warmup steps per size."
     )
     parser.add_argument("--steps", type=_positive_int, default=20, help="Timed steps per size.")
+    parser.add_argument(
+        "--accumulation-steps",
+        type=_positive_int,
+        default=1,
+        help="Train only: micro-batches accumulated per optimizer step (mirrors _train_epoch). "
+        "Default 1 = apply every step. Ignored for --mode encode.",
+    )
     parser.add_argument("--output", default=None, help="Result JSON path.")
     args = parser.parse_args()
 
@@ -243,10 +284,15 @@ def main() -> None:
 
     unit = "cadences/s" if args.mode == "train" else "obs/s"
     shape = _CADENCE_SHAPE if args.mode == "train" else _OBS_SHAPE
+    train_note = (
+        f"  accumulation_steps={args.accumulation_steps}  "
+        f"(18*B encoder + 6*B decoder forwards/micro-batch)"
+        if args.mode == "train"
+        else ""
+    )
     print(
         f"mode={args.mode}  num_gpus={len(devices)}  latent_dim={config.beta_vae.latent_dim}  "
-        f"example_shape={shape}"
-        + ("  (18*B encoder + 6*B decoder forwards/step)" if args.mode == "train" else "")
+        f"example_shape={shape}" + train_note
     )
     print(
         f"throughput = aggregate across {len(devices)} GPU(s); VRAM = peak per GPU (SI GB, 1e9 B)"
@@ -256,7 +302,17 @@ def main() -> None:
     measured: list[dict] = []
     max_fit: dict | None = None
     for batch in _batch_schedule(args):
-        res = _measure(strategy, devices, step_fn, args.mode, batch, args.warmup, args.steps)
+        res = _measure(
+            strategy,
+            devices,
+            model,
+            step_fn,
+            args.mode,
+            batch,
+            args.warmup,
+            args.steps,
+            args.accumulation_steps,
+        )
         if res is None:
             print(f"{batch:>8}  {'OOM':>16}  {'-':>14}")
             break
@@ -286,6 +342,7 @@ def main() -> None:
             "latent_dim": config.beta_vae.latent_dim,
             "warmup": args.warmup,
             "steps": args.steps,
+            "accumulation_steps": args.accumulation_steps if args.mode == "train" else 1,
             "gpu": machine_info()["hostname"],
         },
         results,

--- a/benchmarks/bench_gpu.py
+++ b/benchmarks/bench_gpu.py
@@ -34,8 +34,10 @@ What this does and does NOT cover:
     cross-replica gradient all-reduce and multi-GPU scaling. fp32, matching the pipeline (which
     uses no mixed precision or XLA).
   - Models gradient accumulation with `--accumulation-steps K`: one optimizer step accumulates
-    all-reduced grads over K micro-batches then applies once with the global-norm clip, exactly as
-    train.py's `_train_epoch` (K=1, the default, is a plain apply-every-step). Peak VRAM then
+    all-reduced grads over K micro-batches then applies once with the global-norm clip — the
+    accumulate-then-apply *cadence* of train.py's `_train_epoch` (K=1, the default, is a plain
+    apply-every-step). The reduce/clip *ordering* differs slightly from production; `_apply_and_reset`
+    documents why it's immaterial to the throughput/VRAM this benchmark measures. Peak VRAM then
     includes the persistent accumulator and throughput reflects the once-per-K apply cadence.
   - Does NOT model the input pipeline (synthetic in-memory tensors, no `tf.data`-from-memmap +
     prefetch + host->device copy) or the CPU-side Random Forest stage (see bench_rf.py).
@@ -163,6 +165,13 @@ def _measure(
                 acc.assign_add(g)
 
         def _apply_and_reset():
+            # NOTE: reduce/clip *order* differs from production `_apply_gradients`, which reduces
+            # across replicas (MEAN) THEN clips the mean once; here each replica clips its own acc/K
+            # and the all-reduce happens inside apply_gradients — so the effective grad is
+            # mean_r(clip(acc_r/K)) vs production's clip(mean_r(acc_r)/K). These differ only when a
+            # replica's global norm exceeds _CLIP_NORM, and the per-step compute (one tree-reduce +
+            # one clip over the params) is identical either way, so the throughput/VRAM this
+            # benchmark measures are faithful; only the accumulate-then-apply *cadence* is modelled.
             grads = [acc / accumulation_steps for acc in accumulators]
             clipped, _ = tf.clip_by_global_norm(grads, _CLIP_NORM)
             model.optimizer.apply_gradients(zip(clipped, model.trainable_variables, strict=False))
@@ -182,8 +191,11 @@ def _measure(
         run = encode_run
 
     def sync(out) -> None:
-        # Force queued device work to finish before the clock is read. Train applies mutate the
-        # model variables, so reading one is a sufficient barrier; encode syncs on its output.
+        # Force queued device work to finish before the clock is read. Every train apply ends in a
+        # collective all-reduce, so if one replica's stream has drained past step N then all replicas
+        # finished that step's all-reduce too — reading a single (mutated) MirroredVariable is
+        # therefore a sufficient *cross-replica* barrier, not just a primary-replica one. Encode has
+        # no such collective, so it syncs on its own per-replica output instead.
         if mode == "train":
             model.trainable_variables[0].numpy()
         elif out is not None:

--- a/benchmarks/bench_gpu.py
+++ b/benchmarks/bench_gpu.py
@@ -1,34 +1,47 @@
 #!/usr/bin/env python3
 """
-GPU micro-benchmark: Beta-VAE training step and encoder inference — throughput and peak VRAM.
+GPU benchmark: Beta-VAE training step and encoder inference — throughput and peak VRAM,
+single- or multi-GPU.
 
 Unlike the other scripts in this directory (which time hot *CPU* kernels and run anywhere),
 this one needs a physical GPU and the full TensorFlow / aetherscan stack, so run it inside the
 NGC container on a cluster:
 
+    # largest per-replica batch that fits one GPU, with throughput + VRAM at each size:
     ./utils/run_container.sh python benchmarks/bench_gpu.py --mode train  --find-max
     ./utils/run_container.sh python benchmarks/bench_gpu.py --mode encode --find-max
-    ./utils/run_container.sh python benchmarks/bench_gpu.py --mode train  --batch-sizes 128,256,512
+    # explicit sizes, and multi-GPU scaling across all 6 replicas:
+    ./utils/run_container.sh python benchmarks/bench_gpu.py --mode train --batch-sizes 128,256
+    ./utils/run_container.sh python benchmarks/bench_gpu.py --mode train --num-gpus 6 --batch-sizes 128
 
-It builds the real Beta-VAE (`create_beta_vae_model`) on a single GPU and drives synthetic
-batches of the true pipeline shapes. A training example is a *cadence* `(6, 16, 512)`, so the
-four training inputs (`main`, `true`, `false`, `target`) are each `(B, 6, 16, 512)` and one step
-runs `18*B` encoder passes (`6B` main + `6B` true + `6B` false) plus `6B` decoder passes,
-exactly like `_distributed_train_step`. Inference encodes individual observations, so `encode`
-mode drives `(B, 16, 512, 1)`. For each per-replica batch size it reports throughput
-(train: cadences/s; encode: observations/s) and peak VRAM.
+It builds the real Beta-VAE (`create_beta_vae_model`) under a `MirroredStrategy` over the first
+`--num-gpus` GPUs and drives synthetic batches of the true pipeline shapes. A training example is
+a *cadence* `(6, 16, 512)`, so the four training inputs (`main`, `true`, `false`, `target`) are
+each `(B, 6, 16, 512)` and one step runs `18*B` per-observation encoder forwards (`6B` main +
+`6B` true + `6B` false) plus `6B` decoder forwards — the same work as `_distributed_train_step`.
+Inference encodes individual observations, so `encode` mode drives `(B, 16, 512, 1)`.
 
-`--find-max` doubles the batch size until the GPU OOMs and reports the largest power of two that
-fits — use it to size `--per-replica-batch-size` (train) and `--per-replica-batch-size`
-(inference) so a large-VRAM card (e.g. a 96 GB Blackwell) is not left training at a batch sized
-for a 16 GB card. Peak VRAM is per GPU (each replica holds a full copy), so the combined figure
-is this number times the replica count.
+For each per-replica batch `B` it reports **aggregate** throughput across the replicas
+(train: cadences/s; encode: observations/s) and **per-GPU** peak VRAM. `--find-max` doubles `B`
+until a GPU OOMs and reports the largest power of two that fits — use it to size
+`--per-replica-batch-size` to the card (VRAM is per GPU; each replica holds a full model copy).
 
-Note: the sweep is capped at `--max-batch` (default 4096) because a single encoder forward pass
-whose conv feature maps exceed ~2^31 elements (roughly batch >= 8192, since an intermediate map
-is batch*16*512*channels) trips a TensorFlow int32 launch-config overflow that aborts the process
-uncatchably rather than raising a clean OOM. 4096 comfortably covers the training VRAM ceiling and
-a generous inference range (the pipeline's inference default is 2048).
+What this does and does NOT cover:
+  - Covers the VAE training step (composite loss + backprop + clipped Adam), encoder inference,
+    the decoder (inside the train step), and — with `--num-gpus > 1` — the MirroredStrategy
+    cross-replica gradient all-reduce and multi-GPU scaling. fp32, matching the pipeline (which
+    uses no mixed precision or XLA).
+  - Does NOT model gradient accumulation (the real loop accumulates `accumulation_steps`
+    micro-batches then applies once; here every step applies — the per-micro-batch VRAM that
+    sets the max batch is captured exactly, the throughput effect is small), the input pipeline
+    (synthetic in-memory tensors, no `tf.data`-from-memmap + prefetch + host->device copy), or
+    the CPU-side Random Forest stage.
+
+Note: `--find-max` is capped at `--max-batch` (default 4096) because an encoder forward whose
+conv feature maps exceed ~2^31 elements (roughly batch >= 8192, an intermediate map is
+batch*16*512*channels) trips a TensorFlow int32 launch-config overflow that aborts the process
+uncatchably rather than raising a clean OOM. 4096 covers the training VRAM ceiling and a generous
+inference range (the pipeline's inference default is 2048).
 
 Writes a JSON result to benchmarks/results/ (or --output), like the CPU benchmarks.
 """
@@ -52,96 +65,126 @@ from aetherscan.models import create_beta_vae_model
 _CADENCE_SHAPE = (6, 16, 512)
 _OBS_SHAPE = (16, 512, 1)
 _CLIP_NORM = 1.0  # matches train.py `_apply_gradients` (tf.clip_by_global_norm(..., 1.0))
-_DEVICE = "GPU:0"
+# Module-level RNG so successive _rand() draws differ (main/true/false/target aren't byte-identical).
+# Values don't affect GPU timing or VRAM (both shape-dependent) — this only avoids a degenerate loss.
+_RNG = np.random.default_rng(0)
 
 
-def _select_single_gpu() -> None:
-    """Restrict TF to the first visible GPU with memory growth on, mirroring main.py so that
-    `get_memory_info` reflects real usage rather than a pre-grabbed whole-device pool."""
+def _positive_int(value: str) -> int:
+    ivalue = int(value)
+    if ivalue < 1:
+        raise argparse.ArgumentTypeError(f"must be a positive integer, got {value!r}")
+    return ivalue
+
+
+def _batch_list(value: str) -> list[int]:
+    try:
+        sizes = [int(x) for x in value.split(",") if x.strip()]
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"--batch-sizes must be comma-separated integers, got {value!r}"
+        ) from exc
+    if not sizes or any(b < 1 for b in sizes):
+        raise argparse.ArgumentTypeError(f"--batch-sizes must be positive integers, got {value!r}")
+    return sizes
+
+
+def _select_gpus(num_gpus: int) -> list[str]:
+    """Restrict TF to the first `num_gpus` visible GPUs with memory growth on (mirrors main.py so
+    get_memory_info reflects real usage rather than a pre-grabbed pool). Returns device names."""
     gpus = tf.config.list_physical_devices("GPU")
     if not gpus:
         raise SystemExit("bench_gpu requires a physical GPU; none are visible.")
-    tf.config.set_visible_devices(gpus[0], "GPU")
-    tf.config.experimental.set_memory_growth(gpus[0], True)
+    if num_gpus > len(gpus):
+        raise SystemExit(f"--num-gpus {num_gpus} requested but only {len(gpus)} GPU(s) visible.")
+    use = gpus[:num_gpus]
+    tf.config.set_visible_devices(use, "GPU")
+    for gpu in use:
+        tf.config.experimental.set_memory_growth(gpu, True)
+    return [f"GPU:{i}" for i in range(num_gpus)]
 
 
-def _rand(shape: tuple[int, ...]) -> tf.Tensor:
-    return tf.constant(np.random.default_rng(0).random(shape, dtype=np.float32))
+def _rand(shape: tuple[int, ...]) -> np.ndarray:
+    return _RNG.random(shape, dtype=np.float32)
 
 
-def _peak_vram_gb() -> float:
-    return tf.config.experimental.get_memory_info(_DEVICE)["peak"] / 1e9
+def _peak_vram_gb(devices: list[str]) -> float:
+    # SI GB (1e9 B); nvidia-smi reports base-2 MiB/GiB (GiB = GB / 1.074). Peak across replicas,
+    # which are ~equal. get_memory_info tracks real allocation because memory growth is on.
+    return max(tf.config.experimental.get_memory_info(d)["peak"] for d in devices) / 1e9
 
 
-def _reset_vram_peak() -> None:
-    tf.config.experimental.reset_memory_stats(_DEVICE)
+def _make_step_fn(model, mode: str):
+    """Per-replica step, run via strategy.run so MirroredStrategy handles the cross-replica
+    gradient all-reduce on apply_gradients: a full training step (compute_total_loss -> grads ->
+    global-norm clip -> Adam) or an encoder forward."""
 
-
-def _make_train_step(model):
-    @tf.function
-    def train_step(main, true_, false_, target):
-        with tf.GradientTape() as tape:
-            losses = model.compute_total_loss(main, true_, false_, target, training=True)
-        grads = tape.gradient(losses["total_loss"], model.trainable_variables)
-        grads, _ = tf.clip_by_global_norm(grads, _CLIP_NORM)
-        model.optimizer.apply_gradients(zip(grads, model.trainable_variables, strict=False))
-        return losses["total_loss"]
-
-    return train_step
-
-
-def _make_encode_step(model):
-    @tf.function
-    def encode_step(obs):
-        z_mean, _, _ = model.encoder(obs, training=False)
+    def step_fn(inputs):
+        if mode == "train":
+            main, true_, false_, target = inputs
+            with tf.GradientTape() as tape:
+                losses = model.compute_total_loss(main, true_, false_, target, training=True)
+            grads = tape.gradient(losses["total_loss"], model.trainable_variables)
+            grads, _ = tf.clip_by_global_norm(grads, _CLIP_NORM)
+            model.optimizer.apply_gradients(zip(grads, model.trainable_variables, strict=False))
+            return losses["total_loss"]
+        z_mean, _, _ = model.encoder(inputs[0], training=False)
         return z_mean
 
-    return encode_step
+    return step_fn
 
 
-def _measure(mode: str, step_fn, batch: int, warmup: int, steps: int) -> dict | None:
-    """Run `warmup` + `steps` iterations at per-replica batch size `batch`; return timing/VRAM,
-    or None if the GPU ran out of memory (the caller stops the sweep there)."""
-    if mode == "train":
-        # main, true, false, target — each a batch of cadences (B, 6, 16, 512).
-        inputs = tuple(_rand((batch, *_CADENCE_SHAPE)) for _ in range(4))
-    else:
-        # encode: a batch of single observations (B, 16, 512, 1).
-        inputs = (_rand((batch, *_OBS_SHAPE)),)
+def _measure(strategy, devices, step_fn, mode, batch, warmup, steps) -> dict | None:
+    """Run `warmup` + `steps` iterations at per-replica batch `batch` on every replica. Returns
+    aggregate throughput (per_replica_batch * num_replicas * steps / elapsed) and per-GPU peak
+    VRAM, or None if a GPU OOMs (the caller stops the sweep there)."""
+    shape = _CADENCE_SHAPE if mode == "train" else _OBS_SHAPE
+    n_inputs = 4 if mode == "train" else 1
+
+    def value_fn(_ctx):
+        return tuple(tf.constant(_rand((batch, *shape))) for _ in range(n_inputs))
+
+    @tf.function
+    def run(dist_inputs):
+        return strategy.run(step_fn, args=(dist_inputs,))
 
     try:
+        dist_inputs = strategy.experimental_distribute_values_from_function(value_fn)
+        out = None
         for _ in range(warmup):
-            out = step_fn(*inputs)
-        out.numpy()  # sync after warmup (also absorbs tf.function tracing) before timing
-        _reset_vram_peak()
+            out = run(dist_inputs)
+        if out is not None:
+            strategy.experimental_local_results(out)[0].numpy()  # sync (also absorbs tracing)
+        for d in devices:
+            tf.config.experimental.reset_memory_stats(d)
         start = time.perf_counter()
         for _ in range(steps):
-            out = step_fn(*inputs)
-        out.numpy()  # force the queued steps to finish before stopping the clock
+            out = run(dist_inputs)
+        strategy.experimental_local_results(out)[0].numpy()  # force queued steps to finish
         elapsed = time.perf_counter() - start
     except tf.errors.ResourceExhaustedError:
-        # `inputs` is dropped when this frame returns; the sweep stops at the first OOM.
         return None
 
-    peak = _peak_vram_gb()
-    del inputs
+    peak = _peak_vram_gb(devices)
     gc.collect()
-    # batch dim = cadences (train) / observations (encode); see the header line for the unit.
-    samples_per_s = (batch * steps) / elapsed if elapsed > 0 else float("inf")
+    n = len(devices)
+    aggregate = (batch * n * steps) / elapsed if elapsed > 0 else float("inf")
     return {
         "per_replica_batch_size": batch,
+        "num_gpus": n,
         "steps": steps,
         "elapsed_s": elapsed,
-        "samples_per_s": samples_per_s,
-        "peak_vram_gb": peak,
+        "aggregate_samples_per_s": aggregate,
+        "peak_vram_gb_per_gpu": peak,
     }
 
 
 def _batch_schedule(args) -> list[int]:
     if args.batch_sizes:
-        return [int(x) for x in args.batch_sizes.split(",") if x.strip()]
-    # --find-max (default): powers of two from --start-batch up to the cap; the sweep stops at
-    # the first OOM, so the last success is the largest power of two that fits.
+        return args.batch_sizes
+    # --find-max (explicit or the default when --batch-sizes is unset): powers of two from
+    # --start-batch to the cap; the sweep stops at the first OOM, so the last success is the
+    # largest power of two that fits.
     sizes, b = [], args.start_batch
     while b <= args.max_batch:
         sizes.append(b)
@@ -153,70 +196,93 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--mode", choices=["train", "encode"], default="train")
     parser.add_argument(
-        "--batch-sizes",
-        default=None,
-        help="Comma-separated per-replica batch sizes to measure (overrides --find-max).",
+        "--num-gpus",
+        type=_positive_int,
+        default=1,
+        help="Replica count (MirroredStrategy over the first N visible GPUs). Default 1.",
     )
-    parser.add_argument(
+    size_group = parser.add_mutually_exclusive_group()
+    size_group.add_argument(
+        "--batch-sizes",
+        type=_batch_list,
+        default=None,
+        help="Comma-separated per-replica batch sizes to measure (mutually exclusive with --find-max).",
+    )
+    size_group.add_argument(
         "--find-max",
         action="store_true",
-        help="Double the batch size until the GPU OOMs (the default when --batch-sizes is unset).",
+        help="Double the per-replica batch until a GPU OOMs (the default when --batch-sizes is unset).",
     )
-    parser.add_argument("--start-batch", type=int, default=64, help="First size for --find-max.")
+    parser.add_argument(
+        "--start-batch",
+        type=_positive_int,
+        default=64,
+        help="First per-replica size for --find-max.",
+    )
     parser.add_argument(
         "--max-batch",
-        type=int,
+        type=_positive_int,
         default=4096,
         help="Cap for --find-max (default 4096; see the int32 launch-config note in the header).",
     )
-    parser.add_argument("--warmup", type=int, default=3, help="Untimed warmup steps per size.")
-    parser.add_argument("--steps", type=int, default=20, help="Timed steps per size.")
+    parser.add_argument(
+        "--warmup", type=_positive_int, default=3, help="Untimed warmup steps per size."
+    )
+    parser.add_argument("--steps", type=_positive_int, default=20, help="Timed steps per size.")
     parser.add_argument("--output", default=None, help="Result JSON path.")
     args = parser.parse_args()
 
-    _select_single_gpu()
+    devices = _select_gpus(args.num_gpus)
     init_config()
     config = get_config()
-    # Build the model once (weights are batch-independent); reuse across sizes.
-    strategy = tf.distribute.OneDeviceStrategy(f"/{_DEVICE}")
+    # Build the model once (weights are batch-independent) and reuse across sizes.
+    strategy = tf.distribute.MirroredStrategy(devices=[f"/{d}" for d in devices])
     with strategy.scope():
         model = create_beta_vae_model()
-    step_fn = _make_train_step(model) if args.mode == "train" else _make_encode_step(model)
+    step_fn = _make_step_fn(model, args.mode)
 
     unit = "cadences/s" if args.mode == "train" else "obs/s"
     shape = _CADENCE_SHAPE if args.mode == "train" else _OBS_SHAPE
     print(
-        f"mode={args.mode}  latent_dim={config.beta_vae.latent_dim}  example_shape={shape}"
-        + ("  (18*B encoder + 6*B decoder passes/step)" if args.mode == "train" else "")
+        f"mode={args.mode}  num_gpus={len(devices)}  latent_dim={config.beta_vae.latent_dim}  "
+        f"example_shape={shape}"
+        + ("  (18*B encoder + 6*B decoder forwards/step)" if args.mode == "train" else "")
     )
-    print(f"{'batch':>8}  {unit:>12}  {'peak VRAM (GB)':>15}")
+    print(
+        f"throughput = aggregate across {len(devices)} GPU(s); VRAM = peak per GPU (SI GB, 1e9 B)"
+    )
+    print(f"{'batch':>8}  {'agg ' + unit:>16}  {'VRAM/GPU (GB)':>14}")
 
     measured: list[dict] = []
     max_fit: dict | None = None
     for batch in _batch_schedule(args):
-        res = _measure(args.mode, step_fn, batch, args.warmup, args.steps)
+        res = _measure(strategy, devices, step_fn, args.mode, batch, args.warmup, args.steps)
         if res is None:
-            print(f"{batch:>8}  {'OOM':>12}  {'-':>15}")
+            print(f"{batch:>8}  {'OOM':>16}  {'-':>14}")
             break
         measured.append(res)
         max_fit = res
-        print(f"{batch:>8}  {res['samples_per_s']:>12.0f}  {res['peak_vram_gb']:>15.2f}")
+        print(
+            f"{batch:>8}  {res['aggregate_samples_per_s']:>16.0f}  {res['peak_vram_gb_per_gpu']:>14.2f}"
+        )
 
     results = {
         "measurements": measured,
         "max_fit_batch": max_fit["per_replica_batch_size"] if max_fit else None,
-        "max_fit_peak_vram_gb": max_fit["peak_vram_gb"] if max_fit else None,
+        "max_fit_peak_vram_gb_per_gpu": max_fit["peak_vram_gb_per_gpu"] if max_fit else None,
     }
     if max_fit:
         print(
             f"\nlargest fitting per-replica batch: {max_fit['per_replica_batch_size']} "
-            f"({max_fit['peak_vram_gb']:.2f} GB peak, {max_fit['samples_per_s']:.0f} {unit})"
+            f"({max_fit['peak_vram_gb_per_gpu']:.2f} GB/GPU peak, "
+            f"{max_fit['aggregate_samples_per_s']:.0f} agg {unit})"
         )
     path = write_result(
         f"bench_gpu_{args.mode}",
         {
             "mode": args.mode,
-            "obs_shape": list(_OBS_SHAPE),
+            "num_gpus": len(devices),
+            "example_shape": list(shape),
             "latent_dim": config.beta_vae.latent_dim,
             "warmup": args.warmup,
             "steps": args.steps,

--- a/benchmarks/bench_rf.py
+++ b/benchmarks/bench_rf.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+CPU benchmark: the Random Forest stage — latent-feature prep, RF fit, and RF inference.
+
+The Beta-VAE runs on the GPU (see bench_gpu.py), but the second-stage classifier is
+scikit-learn on the CPU and was previously unmeasured. This times the three pieces of
+`train.py::train_random_forest` that follow encoding:
+
+    prep    -- prepare_latent_features: reshape per-observation latents
+               (n_cadences*num_observations, latent_dim) into per-cadence rows
+               (n_cadences, num_observations*latent_dim) — the 48-feature layout the RF sees.
+    fit     -- RandomForestClassifier.fit on the (n_cadences, 48) feature matrix.
+    predict -- predict_proba on the held-out split (drives the RF eval plots + inference).
+
+Defaults mirror production (config.rf + config.training): n_estimators=1000, bootstrap=True,
+max_features="sqrt", n_jobs=-1, seed=11, latent_dim=8, num_observations=6, and
+num_samples_rf=99840 cadences split train/val at 0.8. This is framework-free (numpy + sklearn,
+no TensorFlow), so it runs anywhere the other CPU benchmarks do — the RF hyperparameters and
+the prep reshape are inlined here rather than imported so the script never pulls the TF-backed
+`aetherscan.models` package.
+
+Labels are random binary (0/1). With no signal the trees grow until pure, so the fit time is a
+*conservative upper bound*: real (separable) latents yield shallower trees that fit — and, later,
+SHAP-explain — faster. Fit is measured once (expensive, low-variance); prep and predict use the
+best of --repeats.
+
+    python benchmarks/bench_rf.py                       # production sizes
+    python benchmarks/bench_rf.py --n-estimators 200    # sweep tree count
+    ./utils/run_container.sh python benchmarks/bench_rf.py   # on a cluster, matching the pipeline host
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import numpy as np
+from _common import machine_info, summarize, time_repeats, write_result
+from sklearn.ensemble import RandomForestClassifier
+
+# Production defaults (config.rf / config.beta_vae / config.data / config.training). Kept here as
+# argparse defaults, matching the "size knobs default to production shapes" convention of the other
+# benchmarks; override to sweep.
+_N_ESTIMATORS = 1000
+_BOOTSTRAP = True
+_MAX_FEATURES = "sqrt"
+_N_JOBS = -1
+_SEED = 11
+_LATENT_DIM = 8
+_NUM_OBSERVATIONS = 6
+_NUM_SAMPLES = 99840  # num_samples_rf (cadences)
+_TRAIN_VAL_SPLIT = 0.8
+
+
+def _positive_int(value: str) -> int:
+    ivalue = int(value)
+    if ivalue < 1:
+        raise argparse.ArgumentTypeError(f"must be a positive integer, got {value!r}")
+    return ivalue
+
+
+def _prepare_latent_features(latent_vectors: np.ndarray, num_observations: int) -> np.ndarray:
+    """Concatenate each cadence's `num_observations` per-observation latents into one feature row.
+    Mirrors aetherscan.models.random_forest.prepare_latent_features (inlined to stay TF-free) —
+    the same explicit per-cadence loop, so the timing reflects the production implementation."""
+    num_latents = latent_vectors.shape[0]
+    if num_latents % num_observations != 0:
+        raise ValueError(f"{num_latents} latent vectors not divisible by {num_observations}")
+    num_cadences = num_latents // num_observations
+    latent_dim = latent_vectors.shape[1]
+    features = np.zeros((num_cadences, num_observations * latent_dim))
+    for i in range(num_cadences):
+        features[i, :] = latent_vectors[
+            i * num_observations : (i + 1) * num_observations, :
+        ].ravel()
+    return features
+
+
+def _build_model(args) -> RandomForestClassifier:
+    return RandomForestClassifier(
+        n_estimators=args.n_estimators,
+        bootstrap=_BOOTSTRAP,
+        max_features=_MAX_FEATURES,
+        n_jobs=args.n_jobs,
+        random_state=_SEED,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--n-estimators", type=_positive_int, default=_N_ESTIMATORS)
+    parser.add_argument("--n-samples", type=_positive_int, default=_NUM_SAMPLES, help="Cadences.")
+    parser.add_argument("--latent-dim", type=_positive_int, default=_LATENT_DIM)
+    parser.add_argument("--num-observations", type=_positive_int, default=_NUM_OBSERVATIONS)
+    parser.add_argument(
+        "--n-jobs", type=int, default=_N_JOBS, help="sklearn n_jobs (-1 = all cores)."
+    )
+    parser.add_argument(
+        "--repeats", type=_positive_int, default=3, help="Best-of repeats for prep + predict."
+    )
+    parser.add_argument("--output", default=None, help="Result JSON path.")
+    args = parser.parse_args()
+
+    n_cadences = args.n_samples
+    n_features = args.num_observations * args.latent_dim
+    n_train = int(n_cadences * _TRAIN_VAL_SPLIT)
+    rng = np.random.default_rng(_SEED)
+
+    # Per-observation latents (n_cadences*num_observations, latent_dim), as the encoder emits them.
+    latents = rng.standard_normal((n_cadences * args.num_observations, args.latent_dim)).astype(
+        np.float32
+    )
+    labels = rng.integers(0, 2, size=n_cadences)
+
+    print(
+        f"n_cadences={n_cadences}  features={n_features}  n_estimators={args.n_estimators}  "
+        f"n_jobs={args.n_jobs}  train/val={n_train}/{n_cadences - n_train}"
+    )
+
+    # prep: per-observation latents -> per-cadence 48-feature rows
+    prep_durations = time_repeats(
+        lambda: _prepare_latent_features(latents, args.num_observations), args.repeats
+    )
+    features = _prepare_latent_features(latents, args.num_observations)
+    train_x, val_x = features[:n_train], features[n_train:]
+    train_y = labels[:n_train]
+
+    # fit: measured once (a full 1000-tree fit is expensive and low-variance)
+    model = _build_model(args)
+    fit_start = time.perf_counter()
+    model.fit(train_x, train_y)
+    fit_elapsed = time.perf_counter() - fit_start
+
+    # predict: predict_proba over the held-out split
+    predict_durations = time_repeats(lambda: model.predict_proba(val_x), args.repeats)
+
+    prep = summarize(prep_durations, n_cadences)
+    predict = summarize(predict_durations, val_x.shape[0])
+    fit = {
+        "elapsed_s": fit_elapsed,
+        "cadences_per_s": n_train / fit_elapsed if fit_elapsed > 0 else float("inf"),
+        "n_train": n_train,
+    }
+
+    print(f"{'stage':>8}  {'cadences/s':>14}  {'seconds':>10}")
+    print(f"{'prep':>8}  {prep['ops_per_s']:>14,.0f}  {prep['best_s']:>10.3f}")
+    print(f"{'fit':>8}  {fit['cadences_per_s']:>14,.0f}  {fit['elapsed_s']:>10.3f}")
+    print(f"{'predict':>8}  {predict['ops_per_s']:>14,.0f}  {predict['best_s']:>10.3f}")
+
+    path = write_result(
+        "bench_rf",
+        {
+            "n_cadences": n_cadences,
+            "n_features": n_features,
+            "n_estimators": args.n_estimators,
+            "n_jobs": args.n_jobs,
+            "num_observations": args.num_observations,
+            "latent_dim": args.latent_dim,
+            "train_val_split": _TRAIN_VAL_SPLIT,
+            "repeats": args.repeats,
+            "cpu": machine_info()["hostname"],
+        },
+        {"prep": prep, "fit": fit, "predict": predict},
+        args.output,
+    )
+    print(f"Result written to {path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #252

Adds `benchmarks/bench_gpu.py` — the first GPU benchmark in the suite (the existing scripts time
only hot CPU kernels). It builds the real Beta-VAE (`create_beta_vae_model`) on a single GPU and
drives synthetic batches of the true pipeline shapes to measure per-GPU throughput and peak VRAM,
sweeping the per-replica batch to find the largest that fits.

## What it measures

- **`--mode train`** — a full training step: `compute_total_loss` (reconstruction + KL + both
  clustering heads) → `tape.gradient` → global-norm clip (1.0, matching `_apply_gradients`) → Adam
  apply. A training example is a cadence `(B, 6, 16, 512)`, so one step runs `18*B` encoder + `6*B`
  decoder passes — exactly like `_distributed_train_step`.
- **`--mode encode`** — encoder forward on observations `(B, 16, 512, 1)`, i.e. the inference path.
- **`--find-max`** doubles the per-replica batch until OOM and reports the largest power of two that
  fits; `--batch-sizes a,b,c` measures explicit sizes.

Peak VRAM is per GPU (each replica holds a full model copy → combined ≈ ×replicas). Single-GPU +
memory growth (mirrors `main.py`) so the VRAM figures track real usage; model built inside a
`OneDeviceStrategy` scope per the repo's strategy-scope rule.

## Key finding

The Beta-VAE is **compute-bound, not VRAM-bound**. On blpc3 (RTX PRO 6000, 96 GB) training
throughput peaks at per-replica batch ~128 (2.81 GB) and does *not* improve toward the 76 GB VRAM
ceiling; inference peaks near batch ~1024 using <2 GB. The defaults (train 128, inference 2048) are
already near-optimal — a large-VRAM card's spare memory can't be converted into throughput for this
compact model. Full baseline tables are in `benchmarks/README.md`.

## Notes / caveats

- **GPU-only**, runs in the NGC container — like the `gpu`/`cluster` integration tests, it is not
  part of the CI CPU surface, and (consistent with the deliberately framework-free `benchmarks/`
  suite) it is not pytest-collected; it prints a table and writes a JSON result.
- `--find-max` is capped at `--max-batch 4096`: an encoder forward whose conv feature maps exceed
  2^31 elements (batch ≳ 8192) trips an **uncatchable** TF int32 launch-config abort rather than a
  clean OOM. 4096 covers the training VRAM ceiling and a generous inference range.

## Verification

- `ruff check` / `ruff format` clean; pre-commit clean.
- Ran end-to-end on blpc3 in the container: `--mode train --find-max` (max batch 4096 @ 76.5 GB) and
  `--mode encode --batch-sizes 256..4096`; numbers are the tables in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
