### PR TITLE
feat(config): defaults valid on 4/5/6 GPUs + robust find_optimal_configs solver

### DIFF
--- a/docs/CONFIG_AND_CLI.md
+++ b/docs/CONFIG_AND_CLI.md
@@ -350,8 +350,8 @@ Examples (from the script's docstring):
 # Check default config against a 4-GPU setup
 python utils/find_optimal_configs.py --num-gpus 4 train
 
-# Override --effective-batch-size and search for a fix valid on both 4 and 6 GPUs
-python utils/find_optimal_configs.py --num-gpus 4,6 train --effective-batch-size 3072
+# An override that's invalid for 5 GPUs — the solver proposes the nearest valid combination
+python utils/find_optimal_configs.py --num-gpus 5 train --effective-batch-size 3072
 
 # Check inference defaults with an invalid --overlap-fraction
 python utils/find_optimal_configs.py inference --overlap-fraction 1.5

--- a/docs/TRAINING_PIPELINE.md
+++ b/docs/TRAINING_PIPELINE.md
@@ -177,7 +177,10 @@ Each training step accumulates `accumulation_steps = effective_batch_size /
 (per_replica_batch_size × num_replicas)` micro-batch gradients before applying
 (`_train_epoch()` → `_distributed_train_step()` → `_apply_gradients()`), giving an effective
 batch of 7680 at defaults (chosen so it divides evenly on 4-, 5-, or 6-GPU hosts) regardless of
-per-GPU memory. Guards along the way: all-None
+per-GPU memory. **Note:** 7680 is ~2.5× the previous 3072, so there are ~2.5× fewer optimizer
+updates per epoch; LR-schedule behavior calibrated to the old cadence may differ. On a fixed 4- or
+6-GPU host you can pass `--effective-batch-size 3072` to restore the old cadence (it stays valid
+there). Guards along the way: all-None
 gradient micro-batches are skipped, accumulated gradients are averaged over successful
 micro-steps, NaN/Inf gradients raise immediately, and the global gradient norm is clipped at
 1.0 with the pre-clip norm recorded per step (that's the `clipping_rate` statistic).

--- a/docs/TRAINING_PIPELINE.md
+++ b/docs/TRAINING_PIPELINE.md
@@ -42,7 +42,7 @@ as done, so re-running the identical command resumes exactly where the last atte
    in the producer process while round *k* trains.
 3. **Build datasets** — `prepare_distributed_train_dataset()` over the round's memmaps
    (stratified 80/20 train/val split on the labels array).
-4. **Prepare the latent-viz batch** (first round only) — 240 held-out val cadences per signal
+4. **Prepare the latent-viz batch** (first round only) — 960 held-out val cadences per signal
    type, persisted across rounds so latent-space snapshots aren't confounded by curriculum
    distribution shift.
 5. **Epoch loop** — `_train_epoch()` + `_validate_epoch()`, ~21 `training_stats` rows per
@@ -176,7 +176,8 @@ of `effective_batch_size` (train) and the global val batch size. With `shuffle=F
 Each training step accumulates `accumulation_steps = effective_batch_size /
 (per_replica_batch_size × num_replicas)` micro-batch gradients before applying
 (`_train_epoch()` → `_distributed_train_step()` → `_apply_gradients()`), giving an effective
-batch of 3072 at defaults regardless of per-GPU memory. Guards along the way: all-None
+batch of 7680 at defaults (chosen so it divides evenly on 4-, 5-, or 6-GPU hosts) regardless of
+per-GPU memory. Guards along the way: all-None
 gradient micro-batches are skipped, accumulated gradients are averaged over successful
 micro-steps, NaN/Inf gradients raise immediately, and the global gradient norm is clipped at
 1.0 with the pre-clip norm recorded per step (that's the `clipping_rate` statistic).

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -2391,11 +2391,6 @@ def collect_validation_errors(
 # gymnastics, and so the validation + proposal logic stays colocated.
 # ---------------------------------------------------------------------------
 
-# Grid-search ranges for the six interdependent training params that govern
-# how data is divided across replicas, batches, and train/val splits. Most
-# cross-replica violations can't be fixed by clamping one field — the solver
-# below grid-searches these ranges minimizing L1 distance to the current
-# values.
 # Neighborhoods for the fields the solver prefers to keep near their base value (data sizes +
 # the throughput-optimal per-replica batch). effective_batch_size and per_replica_val_batch_size
 # are deliberately NOT here: they are generated exactly from the divisibility structure (divisors
@@ -2495,9 +2490,13 @@ def _solve_cross_param_constraints(
     fields — are enumerated *exactly* from the structure: the effective batch must be a divisor of
     the train split that is a multiple of ``per_replica_batch_size * num_replicas`` for every replica
     count; the global val batch must divide the gcd of the val split, num_samples_rf, and (if given)
-    latent_total. The data sizes and per-replica batch are only nudged across small neighborhoods
-    (changing them is a last resort). Every candidate is confirmed with the shared
-    :func:`_check_cross_constraints`, which stays the single source of truth."""
+    latent_total. The data sizes and per-replica batch are only searched over small neighborhoods
+    (seeded with the base value, so they're preferred when a solution keeps them) — but because the
+    result is chosen purely by L1 distance, a multi-count solve can still move per_replica_batch when
+    doing so is closer than raising the effective batch to the larger multiple all counts share (e.g.
+    a 4/5/6-GPU solve drops it to 64 rather than lifting the effective batch to lcm(128*{4,5,6})).
+    Every candidate is confirmed with the shared :func:`_check_cross_constraints`, which stays the
+    single source of truth."""
     latent_total = base.get("latent_total")
     tvs = base["train_val_split"]
     b_nsb = base["num_samples_beta_vae"]

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -11,7 +11,7 @@ import os
 import re
 import shutil
 from dataclasses import dataclass, field, is_dataclass
-from itertools import product
+from math import gcd, lcm
 from typing import Any
 
 from aetherscan.config import get_config
@@ -2396,13 +2396,16 @@ def collect_validation_errors(
 # cross-replica violations can't be fixed by clamping one field — the solver
 # below grid-searches these ranges minimizing L1 distance to the current
 # values.
+# Neighborhoods for the fields the solver prefers to keep near their base value (data sizes +
+# the throughput-optimal per-replica batch). effective_batch_size and per_replica_val_batch_size
+# are deliberately NOT here: they are generated exactly from the divisibility structure (divisors
+# of the train split / of the gcd of the val-side counts), so the search is small and complete
+# rather than a coarse grid that either explodes or steps over the only valid values.
 _SEARCH_RANGES: dict[str, tuple[int, int, int]] = {
     # (min, max, step)
     "num_samples_beta_vae": (400_000, 600_000, 10_240),
     "num_samples_rf": (80_000, 120_000, 2_048),
-    "per_replica_batch_size": (64, 256, 1),
-    "effective_batch_size": (2_048, 6_144, 64),
-    "per_replica_val_batch_size": (256, 768, 1),
+    "per_replica_batch_size": (64, 256, 64),
 }
 
 _CROSS_PARAM_FIELDS = (
@@ -2414,6 +2417,22 @@ _CROSS_PARAM_FIELDS = (
 )
 
 
+def _divisors(n: int) -> list[int]:
+    """Sorted positive divisors of ``n`` (empty for n < 1)."""
+    if n < 1:
+        return []
+    small: list[int] = []
+    large: list[int] = []
+    i = 1
+    while i * i <= n:
+        if n % i == 0:
+            small.append(i)
+            if i != n // i:
+                large.append(n // i)
+        i += 1
+    return small + large[::-1]
+
+
 def _check_cross_constraints(
     num_samples_beta_vae: int,
     num_samples_rf: int,
@@ -2422,10 +2441,14 @@ def _check_cross_constraints(
     effective_batch_size: int,
     per_replica_val_batch_size: int,
     num_replicas_list: list[int],
+    latent_total: int | None = None,
 ) -> bool:
     """Return True iff the six-tuple satisfies all cross-replica constraints for every
     num_replicas in the list. Mirrors the cross-replica checks in
-    :func:`collect_validation_errors`."""
+    :func:`collect_validation_errors`. When ``latent_total`` (= latent_viz_num_cadences_per_type
+    * 4) is supplied, the latent-viz divisibility check is included too, so a returned solution is
+    valid against every cross-replica constraint the pipeline enforces — pass None to skip it (e.g.
+    when the caller doesn't vary anything the latent batch depends on)."""
     if not (0 <= train_val_split <= 1):
         return False
     if num_samples_rf % 2 != 0:
@@ -2452,87 +2475,109 @@ def _check_cross_constraints(
             return False
         if num_samples_rf % gval != 0:
             return False
+        if latent_total is not None and latent_total % gval != 0:
+            return False
     return True
 
 
 def _solve_cross_param_constraints(
     base: dict[str, int | float],
     num_replicas_list: list[int],
-    max_candidates: int = 10_000_000,
+    max_candidates: int = 5_000_000,
 ) -> dict[str, int | float] | None:
-    """Grid-search the six batch/sample params for a configuration satisfying all
-    cross-replica constraints, minimizing L1 distance from ``base``. Returns None if no
-    solution found within the search ranges or the candidate budget."""
-    if _check_cross_constraints(
-        base["num_samples_beta_vae"],
-        base["num_samples_rf"],
-        base["train_val_split"],
-        base["per_replica_batch_size"],
-        base["effective_batch_size"],
-        base["per_replica_val_batch_size"],
-        num_replicas_list,
-    ):
-        return dict(base)
+    """Find the batch/sample configuration nearest (L1) to ``base`` that satisfies every
+    cross-replica constraint for all replica counts in ``num_replicas_list``, or None if none
+    exists. ``base`` may carry an optional ``latent_total`` key (= latent_viz_num_cadences_per_type
+    * 4) so the latent-viz constraint is honored.
 
-    ranges: dict[str, list[int]] = {}
-    for f_name in _CROSS_PARAM_FIELDS:
-        lo, hi, step = _SEARCH_RANGES[f_name]
-        ranges[f_name] = list(range(lo, hi + 1, step))
+    Rather than a blind grid (which both explodes past the candidate budget and steps over the only
+    valid values), the effective batch and per-replica val batch — the two purely divisibility-bound
+    fields — are enumerated *exactly* from the structure: the effective batch must be a divisor of
+    the train split that is a multiple of ``per_replica_batch_size * num_replicas`` for every replica
+    count; the global val batch must divide the gcd of the val split, num_samples_rf, and (if given)
+    latent_total. The data sizes and per-replica batch are only nudged across small neighborhoods
+    (changing them is a last resort). Every candidate is confirmed with the shared
+    :func:`_check_cross_constraints`, which stays the single source of truth."""
+    latent_total = base.get("latent_total")
+    tvs = base["train_val_split"]
+    b_nsb = base["num_samples_beta_vae"]
+    b_nsr = base["num_samples_rf"]
+    b_p = base["per_replica_batch_size"]
+    b_e = base["effective_batch_size"]
+    b_v = base["per_replica_val_batch_size"]
 
-    total = 1
-    for r in ranges.values():
-        total *= len(r)
-    if total > max_candidates:
-        logger.debug(
-            "Cross-param solver search space (%d) exceeds budget (%d); skipping.",
-            total,
-            max_candidates,
+    def _ok(nsb, nsr, p, e, v):
+        return _check_cross_constraints(
+            nsb, nsr, tvs, p, e, v, num_replicas_list, latent_total=latent_total
         )
-        return None
 
-    train_val_split = base["train_val_split"]  # held fixed across the search
+    if _ok(b_nsb, b_nsr, b_p, b_e, b_v):
+        return {
+            "num_samples_beta_vae": b_nsb,
+            "num_samples_rf": b_nsr,
+            "train_val_split": tvs,
+            "per_replica_batch_size": b_p,
+            "effective_batch_size": b_e,
+            "per_replica_val_batch_size": b_v,
+        }
+
+    def _neighborhood(field: str) -> list[int]:
+        lo, hi, step = _SEARCH_RANGES[field]
+        return sorted({base[field]} | set(range(lo, hi + 1, step)))
+
+    nsb_cands = _neighborhood("num_samples_beta_vae")
+    nsr_cands = _neighborhood("num_samples_rf")
+    p_cands = _neighborhood("per_replica_batch_size")
+
     best: dict[str, int | float] | None = None
     best_dist = float("inf")
-    for (
-        num_samples_beta_vae,
-        num_samples_rf,
-        per_replica_batch_size,
-        effective_batch_size,
-        per_replica_val_batch_size,
-    ) in product(
-        ranges["num_samples_beta_vae"],
-        ranges["num_samples_rf"],
-        ranges["per_replica_batch_size"],
-        ranges["effective_batch_size"],
-        ranges["per_replica_val_batch_size"],
-    ):
-        if not _check_cross_constraints(
-            num_samples_beta_vae,
-            num_samples_rf,
-            train_val_split,
-            per_replica_batch_size,
-            effective_batch_size,
-            per_replica_val_batch_size,
-            num_replicas_list,
-        ):
-            continue
-        dist = (
-            abs(num_samples_beta_vae - base["num_samples_beta_vae"])
-            + abs(num_samples_rf - base["num_samples_rf"])
-            + abs(per_replica_batch_size - base["per_replica_batch_size"])
-            + abs(effective_batch_size - base["effective_batch_size"])
-            + abs(per_replica_val_batch_size - base["per_replica_val_batch_size"])
-        )
-        if dist < best_dist:
-            best_dist = dist
-            best = {
-                "num_samples_beta_vae": num_samples_beta_vae,
-                "num_samples_rf": num_samples_rf,
-                "train_val_split": train_val_split,
-                "per_replica_batch_size": per_replica_batch_size,
-                "effective_batch_size": effective_batch_size,
-                "per_replica_val_batch_size": per_replica_val_batch_size,
-            }
+    checked = 0
+    for nsb in nsb_cands:
+        train_samples = round(nsb * tvs)
+        val_samples = round(nsb * (1 - tvs))
+        train_divisors = _divisors(train_samples)
+        for p in p_cands:
+            gtrains = [p * nr for nr in num_replicas_list]
+            lcm_gtrain = 1
+            for gt in gtrains:
+                lcm_gtrain = lcm(lcm_gtrain, gt)
+            min_e = max(gtrains)
+            e_cands = [d for d in train_divisors if d >= min_e and d % lcm_gtrain == 0]
+            if not e_cands:
+                continue
+            for nsr in nsr_cands:
+                if nsr % 2 != 0:
+                    continue
+                g = gcd(val_samples, nsr)
+                if latent_total is not None:
+                    g = gcd(g, latent_total)
+                v_cands = [
+                    d for d in _divisors(g) if all(g % (d * nr) == 0 for nr in num_replicas_list)
+                ]
+                for e in e_cands:
+                    for v in v_cands:
+                        if checked >= max_candidates:
+                            return best
+                        checked += 1
+                        if not _ok(nsb, nsr, p, e, v):
+                            continue
+                        dist = (
+                            abs(nsb - b_nsb)
+                            + abs(nsr - b_nsr)
+                            + abs(p - b_p)
+                            + abs(e - b_e)
+                            + abs(v - b_v)
+                        )
+                        if dist < best_dist:
+                            best_dist = dist
+                            best = {
+                                "num_samples_beta_vae": nsb,
+                                "num_samples_rf": nsr,
+                                "train_val_split": tvs,
+                                "per_replica_batch_size": p,
+                                "effective_batch_size": e,
+                                "per_replica_val_batch_size": v,
+                            }
     return best
 
 
@@ -2599,6 +2644,7 @@ def _build_suggestion_block(errors: list[ValidationError], num_replicas: int | N
             "per_replica_batch_size": config.training.per_replica_batch_size,
             "effective_batch_size": config.training.effective_batch_size,
             "per_replica_val_batch_size": config.training.per_replica_val_batch_size,
+            "latent_total": config.training.latent_viz_num_cadences_per_type * 4,
         }
         solution = _solve_cross_param_constraints(base, [num_replicas])
         if solution is not None:

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -197,9 +197,24 @@ class TrainingConfig:
     num_samples_rf: int = 99840  # NOTE: come back to this later
     train_val_split: float = 0.8
 
-    per_replica_batch_size: int = 128
-    effective_batch_size: int = 3072  # Effective batch size for gradient accumulation
-    per_replica_val_batch_size: int = 80  # Used for both model validation, viz batch latent generation, and random forest latent generation
+    per_replica_batch_size: int = (
+        128  # Throughput-optimal per GPU (see benchmarks/README.md GPU sweep)
+    )
+    # Gradient-accumulation target. 7680 = lcm(per_replica_batch_size * {4,5,6}), so effective_batch_size
+    # is divisible by per_replica_batch_size * num_replicas on 4-, 5-, or 6-GPU hosts (and divides the
+    # 399360-sample train split); it makes the defaults valid on every supported GPU count, including
+    # the 5-GPU Blackwell cluster where the previous 3072 failed. On a fixed GPU count you can override
+    # with a smaller multiple (e.g. --effective-batch-size 3072 on 4 or 6 GPUs) to accumulate over fewer
+    # micro-batches; per-GPU throughput is unchanged (set by per_replica_batch_size).
+    effective_batch_size: int = 7680
+    # Validation / viz / RF-latent-generation batch per GPU. Its global size (64 * num_replicas) must
+    # divide the val split (99840), num_samples_rf (99840), and latent_viz_num_cadences_per_type * 4;
+    # 64 is paired with latent_viz_num_cadences_per_type=960 (below) so all three hold on 4-, 5-, or
+    # 6-GPU hosts. Runs off the training hot path, but 64 (vs the bare divisibility floor of 16 at
+    # latent_viz=240) keeps validation / latent-generation out of the small-batch launch-overhead
+    # regime (see the encode sweep in benchmarks/README.md) — a net win over a full run's ~2000
+    # validations. Raising V requires raising latent_viz in lockstep (V=128 needs latent_viz=1920).
+    per_replica_val_batch_size: int = 64
 
     # Signal injection params
     # TODO: experiment with larger chunk sizes (how to track chunk processing efficiency)
@@ -230,9 +245,11 @@ class TrainingConfig:
     )
 
     # Latent space visualization params
-    latent_viz_num_cadences_per_type: int = (
-        240  # Cadences per signal type for viz batch (total = 4×)
-    )
+    # Cadences per signal type for the latent-space viz batch (total = 4×). 960 rather than a smaller
+    # value so latent_viz*4 (3840) is divisible by per_replica_val_batch_size * num_replicas on 4-, 5-,
+    # or 6-GPU hosts (this is the binding constraint that lets per_replica_val_batch_size be 64 instead
+    # of 16); it also yields denser latent-space plots. Must stay <= the val split (99840).
+    latent_viz_num_cadences_per_type: int = 960
     latent_viz_step_interval: int = 10  # Capture snapshot every N training steps
     latent_viz_umap_fit_max_samples: int = (
         100_000  # Max pooled vectors for UMAP fit (rest are projected via .transform())

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -420,6 +420,19 @@ class TestCrossParamSolver:
         base = {**self._BASE_4_6, "effective_batch_size": 3070}
         assert _solve_cross_param_constraints(base, [5], max_candidates=0) is None
 
+    def test_solver_picks_the_l1_nearest_not_the_first_valid(self):
+        # Strict L1-minimality guard: for the 5-GPU fix, keeping the data sizes + per-replica batch,
+        # the nearest valid effective batch to 3072 is 2560 (2560 divides the 399360 train split and
+        # is a multiple of 128*5=640; 3840 is the next one up and is farther), and the val batch lands
+        # 16 from 80 (64 or 96). A refactor that returned the first valid candidate instead of the
+        # closest would drift off these exact values.
+        base = {**self._BASE_4_6, "latent_total": self._LATENT_TOTAL}
+        sol = _solve_cross_param_constraints(base, [5])
+        assert sol is not None
+        assert sol["per_replica_batch_size"] == 128
+        assert sol["effective_batch_size"] == 2560
+        assert abs(sol["per_replica_val_batch_size"] - 80) == 16
+
 
 class TestApplySavedConfigPrecedence:
     def test_saved_config_overrides_defaults(self, tmp_path):

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -91,22 +91,13 @@ class TestTagPattern:
 
 
 class TestCrossReplicaDivisibilityMatrix:
-    """Default config divides cleanly across 4 or 6 replicas but NOT 5; the blpc3 smoke config
-    is the inverse. collect_validation_errors must reproduce that matrix exactly."""
+    """The default config divides cleanly across 4, 5, AND 6 replicas (issue #254 — Option B
+    defaults); the blpc3 smoke config is valid for 5 only. collect_validation_errors must
+    reproduce that matrix exactly."""
 
-    @pytest.mark.parametrize("num_replicas", [4, 6])
-    def test_defaults_valid_for_4_and_6_replicas(self, num_replicas):
+    @pytest.mark.parametrize("num_replicas", [4, 5, 6])
+    def test_defaults_valid_for_4_5_6_replicas(self, num_replicas):
         assert _cross_param_errors(_parse(["train"]), num_replicas) == []
-
-    def test_defaults_invalid_for_5_replicas(self):
-        errors = _cross_param_errors(_parse(["train"]), 5)
-        violated = {e.field for e in errors}
-        assert violated == {
-            "training.effective_batch_size",
-            "training.num_samples_beta_vae",
-            "training.num_samples_rf",
-            "training.latent_viz_num_cadences_per_type",
-        }
 
     def test_smoke_config_valid_for_5_replicas(self):
         assert _cross_param_errors(_parse(["train", *_SMOKE_FLAGS_5_REPLICAS]), 5) == []
@@ -366,8 +357,8 @@ class TestSemanticChecks:
 
 
 class TestCrossParamSolver:
-    _VALID_BASE = {
-        # The repo defaults: valid for 4 and 6 replicas.
+    # A config valid for 4 and 6 replicas but not 5 — the shape of the pre-Option-B defaults.
+    _BASE_4_6 = {
         "num_samples_beta_vae": 499200,
         "num_samples_rf": 99840,
         "train_val_split": 0.8,
@@ -375,91 +366,59 @@ class TestCrossParamSolver:
         "effective_batch_size": 3072,
         "per_replica_val_batch_size": 80,
     }
+    _LATENT_TOTAL = 960  # latent_viz_num_cadences_per_type (240) * 4
 
     def test_check_cross_constraints_matrix(self):
-        assert _check_cross_constraints(**self._VALID_BASE, num_replicas_list=[4])
-        assert _check_cross_constraints(**self._VALID_BASE, num_replicas_list=[6])
-        assert not _check_cross_constraints(**self._VALID_BASE, num_replicas_list=[5])
+        assert _check_cross_constraints(**self._BASE_4_6, num_replicas_list=[4])
+        assert _check_cross_constraints(**self._BASE_4_6, num_replicas_list=[6])
+        assert not _check_cross_constraints(**self._BASE_4_6, num_replicas_list=[5])
+
+    def test_check_cross_constraints_latent_is_optional_and_enforced(self):
+        # per_replica_val_batch_size 13 -> global 78 on 6 GPUs, which divides the val split and
+        # num_samples_rf (both 99840) but NOT latent_viz*4 = 960.
+        base = {**self._BASE_4_6, "per_replica_val_batch_size": 13}
+        assert _check_cross_constraints(**base, num_replicas_list=[6])  # latent skipped by default
+        assert not _check_cross_constraints(**base, num_replicas_list=[6], latent_total=960)
 
     def test_solver_returns_base_when_already_valid(self):
-        assert _solve_cross_param_constraints(self._VALID_BASE, [4, 6]) == self._VALID_BASE
+        assert _solve_cross_param_constraints(self._BASE_4_6, [4, 6]) == self._BASE_4_6
+
+    def test_solver_keeps_data_and_batch_when_fixing_5_replicas(self):
+        # The signature failure (valid for 6, not 5): the solver must keep the data sizes and the
+        # throughput-optimal per-replica batch, moving only the two divisibility-bound batches.
+        base = {**self._BASE_4_6, "latent_total": self._LATENT_TOTAL}
+        sol = _solve_cross_param_constraints(base, [5])
+        assert sol is not None
+        assert sol["num_samples_beta_vae"] == base["num_samples_beta_vae"]
+        assert sol["num_samples_rf"] == base["num_samples_rf"]
+        assert sol["per_replica_batch_size"] == base["per_replica_batch_size"]
+        assert sol["train_val_split"] == base["train_val_split"]
+        assert _check_cross_constraints(
+            **sol, num_replicas_list=[5], latent_total=self._LATENT_TOTAL
+        )
+
+    def test_solver_is_latent_aware(self):
+        # Every proposed global val batch must divide latent_total when it is supplied.
+        base = {**self._BASE_4_6, "effective_batch_size": 3070, "latent_total": self._LATENT_TOTAL}
+        sol = _solve_cross_param_constraints(base, [5])
+        assert sol is not None
+        assert self._LATENT_TOTAL % (sol["per_replica_val_batch_size"] * 5) == 0
+
+    def test_solver_satisfies_all_requested_replica_counts(self):
+        # A multi-count solve must hold for every requested replica count simultaneously.
+        base = {**self._BASE_4_6, "effective_batch_size": 3070, "latent_total": self._LATENT_TOTAL}
+        sol = _solve_cross_param_constraints(base, [4, 5, 6])
+        assert sol is not None
+        fields = {k: sol[k] for k in self._BASE_4_6}
+        for nr in (4, 5, 6):
+            assert _check_cross_constraints(
+                **fields, num_replicas_list=[nr], latent_total=self._LATENT_TOTAL
+            )
 
     def test_solver_respects_candidate_budget(self):
-        # The default search ranges exceed a tiny budget, so the solver must bail with None
-        # rather than grind through the grid.
-        base = dict(self._VALID_BASE)
-        base["effective_batch_size"] = 3070  # invalidate so the grid search is attempted
-        assert _solve_cross_param_constraints(base, [4], max_candidates=10) is None
-
-    def test_solver_finds_nearest_valid_config(self, monkeypatch):
-        # Shrink the search ranges to a tractable grid and verify the solver picks the
-        # L1-nearest satisfying combination.
-        monkeypatch.setattr(
-            cli,
-            "_SEARCH_RANGES",
-            {
-                "num_samples_beta_vae": (160, 320, 80),
-                "num_samples_rf": (40, 80, 20),
-                "per_replica_batch_size": (4, 8, 4),
-                "effective_batch_size": (16, 64, 16),
-                "per_replica_val_batch_size": (4, 8, 4),
-            },
-        )
-        base = {
-            "num_samples_beta_vae": 250,
-            "num_samples_rf": 50,
-            "train_val_split": 0.8,
-            "per_replica_batch_size": 5,
-            "effective_batch_size": 20,
-            "per_replica_val_batch_size": 5,
-        }
-        solution = _solve_cross_param_constraints(base, [4])
-        assert solution is not None
-        assert solution["train_val_split"] == base["train_val_split"]  # held fixed
-        assert _check_cross_constraints(**solution, num_replicas_list=[4])
-        # Every solved field must come from the (patched) search grid.
-        for field_name, (lo, hi, step) in cli._SEARCH_RANGES.items():
-            assert solution[field_name] in range(lo, hi + 1, step)
-        # And the solution must be L1-minimal among all valid grid points.
-        assert self._l1(solution, base) == min(
-            self._l1(candidate, base) for candidate in self._valid_grid_points(base)
-        )
-
-    @staticmethod
-    def _l1(candidate, base):
-        return sum(
-            abs(candidate[f] - base[f])
-            for f in (
-                "num_samples_beta_vae",
-                "num_samples_rf",
-                "per_replica_batch_size",
-                "effective_batch_size",
-                "per_replica_val_batch_size",
-            )
-        )
-
-    @staticmethod
-    def _valid_grid_points(base):
-        from itertools import product  # noqa: PLC0415
-
-        ranges = {f: range(lo, hi + 1, step) for f, (lo, hi, step) in cli._SEARCH_RANGES.items()}
-        for nsb, nsr, prb, eb, prvb in product(
-            ranges["num_samples_beta_vae"],
-            ranges["num_samples_rf"],
-            ranges["per_replica_batch_size"],
-            ranges["effective_batch_size"],
-            ranges["per_replica_val_batch_size"],
-        ):
-            candidate = {
-                "num_samples_beta_vae": nsb,
-                "num_samples_rf": nsr,
-                "train_val_split": base["train_val_split"],
-                "per_replica_batch_size": prb,
-                "effective_batch_size": eb,
-                "per_replica_val_batch_size": prvb,
-            }
-            if _check_cross_constraints(**candidate, num_replicas_list=[4]):
-                yield candidate
+        # The budget is a backstop; zero means bail before checking any candidate.
+        base = {**self._BASE_4_6, "effective_batch_size": 3070}
+        assert _solve_cross_param_constraints(base, [5], max_candidates=0) is None
 
 
 class TestApplySavedConfigPrecedence:

--- a/utils/find_optimal_configs.py
+++ b/utils/find_optimal_configs.py
@@ -13,8 +13,8 @@ Examples:
     # Check default config against a 4-GPU setup
     %(prog)s --num-gpus 4 train
 
-    # Check defaults overridden by --effective-batch-size and search across 4 & 6 GPUs
-    %(prog)s --num-gpus 4,6 train --effective-batch-size 3072
+    # An override that's invalid for 5 GPUs — propose the nearest valid combination
+    %(prog)s --num-gpus 5 train --effective-batch-size 3072
 
     # Check inference defaults with an invalid overlap-fraction
     %(prog)s inference --overlap-fraction 1.5
@@ -188,6 +188,7 @@ def main() -> int:
             "per_replica_batch_size": config.training.per_replica_batch_size,
             "effective_batch_size": config.training.effective_batch_size,
             "per_replica_val_batch_size": config.training.per_replica_val_batch_size,
+            "latent_total": config.training.latent_viz_num_cadences_per_type * 4,
         }
         print(
             f"\n  Searching for a coordinated patch across {len(num_replicas_list)} replica count(s)..."


### PR DESCRIPTION
Closes #254

Two coupled changes: make the default training config valid on every supported GPU count (4/5/6),
and fix the `find_optimal_configs.py` solver that couldn't find configs that exist.

## 1. Defaults valid on 4/5/6 GPUs (`config.py`)

The production defaults failed to run on a **5-GPU host** (blpc3): `effective_batch_size 3072` isn't
divisible by `per_replica_batch_size 128 × 5 = 640`, and `per_replica_val_batch_size 80 × 5 = 400`
divides none of the val split (99840), `num_samples_rf` (99840), or `latent_viz*4` (960). They
happened to be valid on 4- and 6-GPU hosts, not 5.

| field | old | new | why |
|---|---|---|---|
| `per_replica_batch_size` | 128 | **128** | throughput-optimal per the GPU sweep — unchanged |
| `effective_batch_size` | 3072 | **7680** | `lcm(128×{4,5,6})`, divides the 399360 train split → valid on 4/5/6 |
| `per_replica_val_batch_size` | 80 | **64** | global size divides val/rf/`latent_viz*4` on 4/5/6 |
| `latent_viz_num_cadences_per_type` | 240 | **960** | raised in lockstep so `latent_viz*4` stays divisible by the larger val batch |

`num_samples_*` unchanged. **Performance:** per-GPU **training throughput is unchanged** (set by
`per_replica_batch_size=128`; `effective_batch_size` only changes the gradient-accumulation count).
`effective_batch_size=7680` is 2.5× the previous 3072 — a fixed-GPU-count run can override
`--effective-batch-size 3072` (valid on 4 or 6 GPUs) to keep the old value; the maintainer will watch
loss convergence during the final training run. `per_replica_val_batch_size=64` (rather than the bare
divisibility floor of 16 at `latent_viz=240`) keeps validation / latent-generation out of the
small-batch launch-overhead regime the encode benchmark shows — a net win over a full run's ~2000
validations — at the cost of 4× denser latent-space plots and a negligible per-round viz-gen bump.

Verified valid for 4/5/6 via `find_optimal_configs.py --num-gpus 4,5,6 train`.

## 2. Robust cross-param solver (`cli.py`, `find_optimal_configs.py`)

`_solve_cross_param_constraints` returned "No valid configuration found" even when one existed, from
three compounding bugs:

1. **Miscalibrated range** — `_SEARCH_RANGES['per_replica_val_batch_size'] = (256, 768)`, but the real
   val batch is ~16–96, and any `global_val ≥ 1024` can't divide `latent_viz*4 = 960`; the range
   excluded the entire solution region.
2. **Search-space explosion** — with `step=1` the grid was ~2.8e9 candidates, over the 1e7 budget, so
   it bailed to `None` before searching.
3. **Latent constraint ignored** — `_check_cross_constraints` omitted the `latent_viz*4 % global_val`
   check that `collect_validation_errors` enforces, so a returned "solution" could be latent-invalid.

Fix: enumerate the two purely divisibility-bound fields **exactly** from the structure — the effective
batch from divisors of the train split (multiples of `per_replica_batch × nr`), the global val batch
from divisors of `gcd(val, rf, latent_total)` — so the search is tiny and complete rather than a coarse
grid that explodes or steps over the only valid values. Data sizes and per-replica batch are only
nudged (a last resort). Every candidate is confirmed by the now **latent-aware**
`_check_cross_constraints`, which stays the single source of truth (so this is not overfit to the
current batch problem — any constraint it enforces is honored). Both `find_optimal_configs.py` and the
inline `validate_args` "Suggested fixes" block use the same solver, so both improve.

## Tests

`tests/unit/test_cli_validation.py`: flipped the divisibility matrix (defaults now valid on 4/5/6);
rewrote the solver suite for the new behavior — keeps data + per-replica batch when fixing a 5-GPU
config, is latent-aware, satisfies multiple replica counts simultaneously, and the candidate budget is
a backstop. Verified locally (TF-free): all pass, and the new defaults + solver produce
`nr=5 → E=2560/V=64`, `nr=4/5/6 → E=3840/V=16`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
