### PR TITLE
feat(train): parallelize RF SHAP explainability across CPU cores

### DIFF
--- a/docs/TRAINING_PIPELINE.md
+++ b/docs/TRAINING_PIPELINE.md
@@ -403,6 +403,58 @@ share `rf_shap_values_{tag}.joblib` (computed once, cached).
 | `rf_oob_accuracy_curve_{tag}.png` (from `plot_rf_ensemble_accuracy_curve`) | Cumulative accuracy vs number of trees (val + train-subsample baseline), elbow annotated. Also persists the per-tree `ensemble_val_accuracy` series to `training_stats` (`model_name='rf'`, `epoch_number` = tree count) for the dashboard RF tab — so the DB series only lands when `rf_plots` succeeds. | Should saturate well before 1000 trees; if it's still climbing at the end, raise `rf.n_estimators`. |
 | `rf_latent_decision_boundary_nn{n}_md{m}_{tag}.png` | RF P(true) contour over each persisted cadence-level UMAP plane, val points + 0.5 contour. | A coherent boundary separating the true classes; ragged islands = the forest partitioning noise. Depends on the UMAPs from `plot_latent_space_gif`, so `vae_plots` must have succeeded. |
 
+### SHAP explainability performance (CPU multiprocessing; GPU is a documented alternative)
+
+The five SHAP figures share `rf_shap_values_{tag}.joblib`, computed once by
+`_compute_or_load_shap_values`. shap's TreeSHAP C extension is **single-threaded** (no OpenMP, no
+`n_jobs`; the RF's own `n_jobs` does not apply — shap re-walks the trees itself), so on a 1000-tree
+forest the step is dominated by the **interaction** pass and runs for hours-to-days if left serial
+(measured ~183 s/sample on a depth-53 RF → ~76 h for 1500 interaction samples; the whole tail is
+~95% interaction).
+
+SHAP values are per-sample independent, so we **chunk the samples across all cores**
+(`aetherscan.shap_parallel`, driven by `manager.n_processes` = `cpu_count()` by default): each worker
+rebuilds a *stock* `TreeExplainer` and explains its chunk, and the results are byte-identical to the
+serial computation (measured ~40-45x on a 96-core node). This is the shipped path for all three
+passes (summary, interaction, log-loss).
+
+#### GPU is faster on interaction, but we don't use it — here's why, and how to switch
+
+shap's `GPUTreeExplainer` (GPUTreeShap) runs each pass in ~seconds regardless of sample count (~1000x
+on interaction). We benchmarked it on both clusters; it works and is **correct** for the summary and
+interaction passes (`np.allclose` vs CPU). We still ship CPU multiprocessing, because the GPU route
+buys only a few minutes at the very end of a multi-day/-week run in exchange for maintaining an extra
+CUDA + from-source dependency on an experimental shap code path:
+
+- **Not in the stock wheel.** `GPUTreeExplainer` needs a `_cext_gpu` CUDA extension that exists only
+  if shap is built from source with `SHAP_ENABLE_CUDA=1` + a CUDA toolkit — a bespoke build baked into
+  the container/conda and re-verified on every container/shap/CUDA bump.
+- **Hard depth limit (fixed lane overflow).** GPUTreeShap maps one path element per CUDA warp *lane*
+  (`warpSize == 32`, fixed on every NVIDIA arch), so an over-long root-to-leaf path overflows and the
+  kernel aborts (`Tree depth must be < 32`, core dump). Precisely, it caps the number of **distinct
+  features per root-to-leaf path at ≤ 31** (paths are de-duplicated by feature before the length
+  check), so `max_depth ≤ 31` is a *sufficient*, guaranteed-safe setting; a deeper forest can still
+  run if no path uses > 31 features, but that is not guaranteed. It is **not** fixable by a different
+  build.
+- **Log-loss is broken on GPU.** The interventional `model_output="log_loss"` path silently returns
+  raw-margin numbers (the GPU kernel drops the output-transform pointer — shap #4270/#3936/#1726,
+  unfixed as of 0.46.0) and fails the additivity axiom, so log-loss would have to stay on CPU anyway.
+
+**To switch to GPU later** (if interaction runtime ever becomes the bottleneck): (1) cap the RF at
+`max_depth = 31` in `RandomForestConfig` and confirm val-AUC is unaffected with an A/B; (2) bake a
+CUDA-built shap into `aetherscan.def` / `environment.yml`
+(`SHAP_ENABLE_CUDA=1 CUDA_PATH=/usr/local/cuda pip install --no-binary shap shap==<pinned>`);
+(3) route **summary + interaction** through `shap.explainers.GPUTree`, keeping **log-loss** on the CPU
+multiprocessing path; (4) CPU-validate the GPU output with `np.allclose` before trusting it.
+
+**On the depth cap:** we keep `max_depth` **unbounded** (its sklearn default; not set in
+`RandomForestConfig`) — the `< 32` limit only matters *if* we adopt GPU SHAP. A cap would be low-risk
+in practice: the Beta-VAE's objective is to make the classes separable in latent space, so a
+well-trained VAE yields simple decision boundaries and naturally shallow trees, and the cap then just
+acts as a mild regularizer aligned with the upstream objective. It could bite an **undertrained** VAE
+(muddy latents → deep trees) or a future extension to more complex signal morphologies whose latents
+genuinely need deeper trees for accuracy — which the val-AUC A/B in step (1) would catch.
+
 ### `resource_utilization_{tag}.png`
 
 Written by the resource monitor at shutdown, not by `train.py` — see

--- a/src/aetherscan/shap_parallel.py
+++ b/src/aetherscan/shap_parallel.py
@@ -1,0 +1,160 @@
+"""
+Process-pool wrapper for the RF SHAP passes.
+
+shap's TreeSHAP C extension is single-threaded (no OpenMP, no ``n_jobs``), so explaining a
+1000-tree forest at production sample counts runs for hours-to-days — dominated by the interaction
+pass. SHAP values are per-sample independent, though, so we chunk the samples across processes and
+call a **stock** ``shap.TreeExplainer`` in each worker (not a fork of the algorithm — just
+parallelism). Measured ~40-45x on a 96-core node, byte-identical to the single-threaded result.
+
+This module is deliberately **TensorFlow-free**: ``train.py`` imports TF at module level, and the
+workers use the ``spawn`` start method (which re-imports the worker's module), so keeping the worker
+code here means each worker starts a lightweight sklearn+shap process instead of dragging TF (and its
+GPU context) into every core. See ``_compute_or_load_shap_values`` in ``train.py`` for the caller and
+``docs/TRAINING_PIPELINE.md`` for the CPU-vs-GPU comparison behind this choice.
+
+Design notes:
+  * **Rebuild the explainer inside each worker** from the picklable sklearn RF — never pickle a
+    pre-built ``TreeExplainer`` into workers (segfaults large-model workers; shap #1204). Workers
+    load the RF from its persisted joblib path so the model isn't re-serialised through the pool.
+  * **Pin BLAS/OpenMP threads to 1 per worker** (set before numpy/shap import in each fresh spawn
+    process) so N workers don't each spin up a full thread pool and oversubscribe the CPU.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import multiprocessing as mp
+import os
+from concurrent.futures import ProcessPoolExecutor
+
+import numpy as np
+
+# Kinds of SHAP pass a worker can run.
+_RAW_KINDS = ("summary", "interaction")
+_LOGLOSS_KIND = "logloss"
+
+# Per-worker globals, populated once by the pool initializer (or in-process for the n_workers==1
+# fallback). Module-level so the spawn workers can resolve them.
+_RF = None
+_BACKGROUND = None
+
+
+def select_positive_class_shap(values, log_loss: bool = False) -> np.ndarray:
+    """
+    Normalize SHAP output across shap versions into a single positive-class ndarray.
+
+    TreeExplainer returns results in several shapes depending on shap version & task:
+    - classic binary classification: list ``[neg, pos]`` of ``(n, F)`` arrays
+    - newer shap, last axis is class: ``(n, F, 2)`` for values, ``(n, F, F, 2)`` for interactions
+    - log-loss (single scalar output): ``(n, F)`` or ``(n, F, F)``
+
+    Picks the positive-class slice in all cases. For log-loss there is only one output, so it is
+    returned as-is (modulo a preserved class axis). Kept here (not in train.py) so both the pipeline
+    and the TF-free workers share one definition.
+    """
+    if log_loss:
+        if isinstance(values, list):
+            return np.asarray(values[0])
+        values = np.asarray(values)
+        # newer shap preserves the class axis even for model_output="log_loss":
+        # (n, F, 2) -> (n, F); (n, F, F, 2) -> (n, F, F)
+        if values.ndim >= 3 and values.shape[-1] == 2:
+            return values[..., 1]
+        return values
+
+    if isinstance(values, list):
+        return np.asarray(values[1])
+
+    values = np.asarray(values)
+    # (n, F, 2) -> (n, F); (n, F, F, 2) -> (n, F, F)
+    if values.ndim >= 3 and values.shape[-1] == 2:
+        return values[..., 1]
+    return values
+
+
+def _pin_worker_threads() -> None:
+    # Must run before numpy/shap import their native thread pools. shap's TreeSHAP is single-threaded
+    # anyway, so this only tames incidental numpy/BLAS threads — but with all cores as workers that
+    # still matters. setdefault so an explicitly-set env is respected.
+    for var in (
+        "OMP_NUM_THREADS",
+        "OPENBLAS_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "NUMEXPR_NUM_THREADS",
+        "VECLIB_MAXIMUM_THREADS",
+        "BLIS_NUM_THREADS",
+    ):
+        os.environ.setdefault(var, "1")
+
+
+def _worker_init(rf_path: str, background) -> None:
+    """Pool initializer: pin threads, then load the RF once per worker (rebuild-per-worker source)."""
+    _pin_worker_threads()
+    import joblib  # noqa: PLC0415  (deferred so _pin_worker_threads() sets env before numpy/BLAS init)
+
+    global _RF, _BACKGROUND
+    _RF = joblib.load(rf_path)
+    _BACKGROUND = background
+
+
+def _worker(task):
+    """Compute one SHAP pass on one chunk of samples using the module-global RF. Returns
+    ``(chunk_index, positive_class_array)`` so the caller can restore sample order."""
+    chunk_index, kind, x_chunk, y_chunk = task
+    import shap  # noqa: PLC0415  (deferred so the spawn worker pins threads before shap/BLAS init)
+
+    # Suppress shap's tqdm (it writes to stderr, which the pipeline logger forwards to Slack).
+    with open(os.devnull, "w") as devnull, contextlib.redirect_stderr(devnull):
+        if kind == _LOGLOSS_KIND:
+            explainer = shap.TreeExplainer(_RF, data=_BACKGROUND, model_output="log_loss")
+            raw = explainer.shap_values(x_chunk, y=y_chunk)
+        else:
+            explainer = shap.TreeExplainer(_RF)
+            raw = (
+                explainer.shap_interaction_values(x_chunk)
+                if kind == "interaction"
+                else explainer.shap_values(x_chunk)
+            )
+    return chunk_index, select_positive_class_shap(raw, log_loss=(kind == _LOGLOSS_KIND))
+
+
+def parallel_shap(
+    rf_path: str,
+    x: np.ndarray,
+    kind: str,
+    n_workers: int,
+    *,
+    background: np.ndarray | None = None,
+    y: np.ndarray | None = None,
+) -> np.ndarray:
+    """
+    Compute the positive-class SHAP values for ``x`` under one pass ``kind`` in
+    ``{"summary", "interaction", "logloss"}``, chunked across up to ``n_workers`` spawn processes.
+
+    ``rf_path`` is the persisted sklearn RF joblib (each worker loads it). ``background`` and ``y`` are
+    required only for the ``"logloss"`` (interventional) pass. Result is concatenated back into
+    original sample order and is byte-identical to the single-threaded computation.
+    """
+    if kind != _LOGLOSS_KIND and kind not in _RAW_KINDS:
+        raise ValueError(f"unknown SHAP kind {kind!r}")
+
+    n = len(x)
+    n_workers = max(1, min(n_workers, n))
+
+    # n_workers == 1: run in-process (no pool) — used on single-core hosts or tiny inputs.
+    if n_workers == 1:
+        _worker_init(rf_path, background)
+        _, out = _worker((0, kind, x, y))
+        return out
+
+    chunks = np.array_split(np.arange(n), n_workers)
+    tasks = [(i, kind, x[c], (None if y is None else y[c])) for i, c in enumerate(chunks) if len(c)]
+    with ProcessPoolExecutor(
+        max_workers=n_workers,
+        mp_context=mp.get_context("spawn"),
+        initializer=_worker_init,
+        initargs=(rf_path, background),
+    ) as pool:
+        results = sorted(pool.map(_worker, tasks), key=lambda r: r[0])
+    return np.concatenate([r[1] for r in results], axis=0)

--- a/src/aetherscan/shap_parallel.py
+++ b/src/aetherscan/shap_parallel.py
@@ -7,18 +7,22 @@ pass. SHAP values are per-sample independent, though, so we chunk the samples ac
 call a **stock** ``shap.TreeExplainer`` in each worker (not a fork of the algorithm — just
 parallelism). Measured ~40-45x on a 96-core node, byte-identical to the single-threaded result.
 
-This module is deliberately **TensorFlow-free**: ``train.py`` imports TF at module level, and the
-workers use the ``spawn`` start method (which re-imports the worker's module), so keeping the worker
-code here means each worker starts a lightweight sklearn+shap process instead of dragging TF (and its
-GPU context) into every core. See ``_compute_or_load_shap_values`` in ``train.py`` for the caller and
+This module is deliberately kept small and off the TF/training import graph. ``train.py`` imports
+TensorFlow at module level (and pulls in matplotlib/umap/…), and multiprocessing's ``spawn`` re-imports
+the parent's ``__main__`` (``aetherscan.main`` → TF → the whole training stack) into every worker. So
+the pool runs under the **forkserver** start method with an **empty preload**: the fork server is
+spawned once, clean (no ``__main__`` re-import), and workers fork from it — importing only this module
++ shap, never TF. See ``_compute_or_load_shap_values`` in ``train.py`` for the caller and
 ``docs/TRAINING_PIPELINE.md`` for the CPU-vs-GPU comparison behind this choice.
 
 Design notes:
   * **Rebuild the explainer inside each worker** from the picklable sklearn RF — never pickle a
     pre-built ``TreeExplainer`` into workers (segfaults large-model workers; shap #1204). Workers
     load the RF from its persisted joblib path so the model isn't re-serialised through the pool.
-  * **Pin BLAS/OpenMP threads to 1 per worker** (set before numpy/shap import in each fresh spawn
-    process) so N workers don't each spin up a full thread pool and oversubscribe the CPU.
+  * **forkserver + empty preload** keeps workers off the TF/training stack (see above); the fork
+    server is spawned once and forks lightweight workers.
+  * **Pin BLAS/OpenMP threads to 1 per worker** so N workers don't oversubscribe the CPU (best-effort:
+    shap's TreeSHAP is single-threaded, so this only tames incidental numpy/BLAS threads).
 """
 
 from __future__ import annotations
@@ -35,7 +39,7 @@ _RAW_KINDS = ("summary", "interaction")
 _LOGLOSS_KIND = "logloss"
 
 # Per-worker globals, populated once by the pool initializer (or in-process for the n_workers==1
-# fallback). Module-level so the spawn workers can resolve them.
+# fallback). Module-level so the forkserver workers can resolve them.
 _RF = None
 _BACKGROUND = None
 
@@ -150,9 +154,13 @@ def parallel_shap(
 
     chunks = np.array_split(np.arange(n), n_workers)
     tasks = [(i, kind, x[c], (None if y is None else y[c])) for i, c in enumerate(chunks) if len(c)]
+    # forkserver with an EMPTY preload: the fork server is spawned clean and does NOT re-import the
+    # parent's __main__ (aetherscan.main -> TF -> the whole training stack), so workers stay light.
+    ctx = mp.get_context("forkserver")
+    ctx.set_forkserver_preload([])
     with ProcessPoolExecutor(
         max_workers=n_workers,
-        mp_context=mp.get_context("spawn"),
+        mp_context=ctx,
         initializer=_worker_init,
         initargs=(rf_path, background),
     ) as pool:

--- a/src/aetherscan/shap_parallel.py
+++ b/src/aetherscan/shap_parallel.py
@@ -103,9 +103,9 @@ def _worker_init(rf_path: str, background) -> None:
 
 
 def _worker(task):
-    """Compute one SHAP pass on one chunk of samples using the module-global RF. Returns
-    ``(chunk_index, positive_class_array)`` so the caller can restore sample order."""
-    chunk_index, kind, x_chunk, y_chunk = task
+    """Compute one SHAP pass on one chunk of samples using the module-global RF. Returns the
+    positive-class array for the chunk; ProcessPoolExecutor.map preserves input order."""
+    kind, x_chunk, y_chunk = task
     import shap  # noqa: PLC0415  (deferred so the spawn worker pins threads before shap/BLAS init)
 
     # Suppress shap's tqdm (it writes to stderr, which the pipeline logger forwards to Slack).
@@ -120,7 +120,7 @@ def _worker(task):
                 if kind == "interaction"
                 else explainer.shap_values(x_chunk)
             )
-    return chunk_index, select_positive_class_shap(raw, log_loss=(kind == _LOGLOSS_KIND))
+    return select_positive_class_shap(raw, log_loss=(kind == _LOGLOSS_KIND))
 
 
 def parallel_shap(
@@ -134,26 +134,27 @@ def parallel_shap(
 ) -> np.ndarray:
     """
     Compute the positive-class SHAP values for ``x`` under one pass ``kind`` in
-    ``{"summary", "interaction", "logloss"}``, chunked across up to ``n_workers`` spawn processes.
+    ``{"summary", "interaction", "logloss"}``, chunked across up to ``n_workers`` worker processes.
 
     ``rf_path`` is the persisted sklearn RF joblib (each worker loads it). ``background`` and ``y`` are
-    required only for the ``"logloss"`` (interventional) pass. Result is concatenated back into
-    original sample order and is byte-identical to the single-threaded computation.
+    required only for the ``"logloss"`` (interventional) pass. TreeSHAP is per-sample deterministic, so
+    the concatenated result is bitwise-identical to the single-process computation.
     """
     if kind != _LOGLOSS_KIND and kind not in _RAW_KINDS:
         raise ValueError(f"unknown SHAP kind {kind!r}")
 
     n = len(x)
+    if n == 0:
+        raise ValueError("cannot explain zero samples")
     n_workers = max(1, min(n_workers, n))
 
     # n_workers == 1: run in-process (no pool) — used on single-core hosts or tiny inputs.
     if n_workers == 1:
         _worker_init(rf_path, background)
-        _, out = _worker((0, kind, x, y))
-        return out
+        return _worker((kind, x, y))
 
     chunks = np.array_split(np.arange(n), n_workers)
-    tasks = [(i, kind, x[c], (None if y is None else y[c])) for i, c in enumerate(chunks) if len(c)]
+    tasks = [(kind, x[c], (None if y is None else y[c])) for c in chunks if len(c)]
     # forkserver with an EMPTY preload: the fork server is spawned clean and does NOT re-import the
     # parent's __main__ (aetherscan.main -> TF -> the whole training stack), so workers stay light.
     ctx = mp.get_context("forkserver")
@@ -164,5 +165,6 @@ def parallel_shap(
         initializer=_worker_init,
         initargs=(rf_path, background),
     ) as pool:
-        results = sorted(pool.map(_worker, tasks), key=lambda r: r[0])
-    return np.concatenate([r[1] for r in results], axis=0)
+        # ProcessPoolExecutor.map yields results in input (chunk) order — no re-sort needed.
+        results = list(pool.map(_worker, tasks))
+    return np.concatenate(results, axis=0)

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -2780,8 +2780,9 @@ class TrainingPipeline:
         # (aetherscan.shap_parallel), each rebuilding a stock TreeExplainer — byte-identical to the
         # serial result. Workers load the RF from its persisted joblib, so make sure it is on disk.
         rf_path = os.path.join(self.config.model_path, f"random_forest_{tag}.joblib")
-        if not os.path.exists(rf_path):
-            joblib.dump(self.rf_model.model, rf_path)
+        # Always (re)dump so the workers load exactly the in-process model — a stale on-disk RF under
+        # a reused tag would otherwise silently diverge from the expected_value computed below.
+        joblib.dump(self.rf_model.model, rf_path)
 
         # Expected value (positive-class base value): one lightweight in-process explainer.
         # _silence_stderr() drops SHAP's tqdm (which the logger would otherwise forward to Slack).

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -79,6 +79,7 @@ from aetherscan.run_state import (
     save_run_state,
 )
 from aetherscan.seeding import STREAM_DATASET, STREAM_PLOT, STREAM_VIZ, derive_rng
+from aetherscan.shap_parallel import parallel_shap
 
 logger = logging.getLogger(__name__)
 
@@ -936,39 +937,8 @@ def prepare_distributed_viz_dataset(
     }
 
 
-def _select_positive_class_shap(values, log_loss: bool = False) -> np.ndarray:
-    """
-    Normalize SHAP output across shap versions into a single positive-class ndarray.
-
-    TreeExplainer historically returns results in several shapes depending on shap version & task:
-    - classic binary classification:
-        list [neg, pos] of (n, F) arrays
-    - newer shap, last axis is class:
-        ndarray of shape (n, F, 2) for values, or (n, F, F, 2) for interactions
-    - log-loss model_output — single scalar output:
-        ndarray of shape (n, F) or (n, F, F)
-
-    This helper picks the positive-class slice in all cases.
-    For log-loss model output, there is only one output, so we return as-is.
-    """
-    if log_loss:
-        if isinstance(values, list):
-            return np.asarray(values[0])
-        values = np.asarray(values)
-        # newer shap preserves the class axis even for model_output="log_loss":
-        # (n, F, 2) → (n, F); (n, F, F, 2) → (n, F, F)
-        if values.ndim >= 3 and values.shape[-1] == 2:
-            return values[..., 1]
-        return values
-
-    if isinstance(values, list):
-        return np.asarray(values[1])
-
-    values = np.asarray(values)
-    # (n, F, 2) → (n, F); (n, F, F, 2) → (n, F, F)
-    if values.ndim >= 3 and values.shape[-1] == 2:
-        return values[..., 1]
-    return values
+# _select_positive_class_shap now lives in aetherscan.shap_parallel (shared with the TF-free SHAP
+# worker processes) and is imported at the top of this module under the same name.
 
 
 @contextlib.contextmanager
@@ -2800,60 +2770,57 @@ class TrainingPipeline:
         summary_indices = np.sort(rng.choice(n_val, size=n_summary, replace=False))
         interaction_indices = np.sort(rng.choice(n_val, size=n_interact, replace=False))
 
+        n_workers = self.config.manager.n_processes
         logger.info(
-            f"Computing SHAP summary ({n_summary} samples) and interaction "
-            f"({n_interact} samples) values for RF model"
+            f"Computing SHAP across {n_workers} worker(s) — summary ({n_summary}), interaction "
+            f"({n_interact}), log-loss ({n_summary}). See docs/TRAINING_PIPELINE.md for the passes."
         )
 
-        # NOTE: come back to this later (is this the right way to extract SHAP summary/interaction values? what's the difference between summary vs interaction? what is _select_positive_class_shap() for?)
-        # _silence_stderr() suppresses SHAP's tqdm progress bar (which writes to
-        # stderr and would otherwise flood Slack via the StreamToLogger redirect).
-        # Real exceptions still propagate; only stderr text is dropped.
+        # shap's TreeSHAP C extension is single-threaded, so we chunk the samples across processes
+        # (aetherscan.shap_parallel), each rebuilding a stock TreeExplainer — byte-identical to the
+        # serial result. Workers load the RF from its persisted joblib, so make sure it is on disk.
+        rf_path = os.path.join(self.config.model_path, f"random_forest_{tag}.joblib")
+        if not os.path.exists(rf_path):
+            joblib.dump(self.rf_model.model, rf_path)
+
+        # Expected value (positive-class base value): one lightweight in-process explainer.
+        # _silence_stderr() drops SHAP's tqdm (which the logger would otherwise forward to Slack).
         with _silence_stderr():
-            explainer = shap.TreeExplainer(self.rf_model.model)
+            ev = shap.TreeExplainer(self.rf_model.model).expected_value
+        if isinstance(ev, list | tuple | np.ndarray):
+            ev_arr = np.asarray(ev)
+            expected_value = float(ev_arr[1]) if ev_arr.size > 1 else float(ev_arr.flat[0])
+        else:
+            expected_value = float(ev)
 
-            summary_vals_raw = explainer.shap_values(val_features[summary_indices])
-            shap_values_summary = _select_positive_class_shap(summary_vals_raw)
-            del summary_vals_raw
+        shap_values_summary = parallel_shap(
+            rf_path, val_features[summary_indices], "summary", n_workers
+        )
+        shap_values_interaction = parallel_shap(
+            rf_path, val_features[interaction_indices], "interaction", n_workers
+        )
 
-            interaction_vals_raw = explainer.shap_interaction_values(
-                val_features[interaction_indices]
+        # Log-loss (interventional) decomposition: needs a background subset + per-sample y.
+        n_bg = min(1000, train_features.shape[0])
+        bg_indices = rng.choice(train_features.shape[0], size=n_bg, replace=False)
+        background = train_features[bg_indices]
+        try:
+            shap_values_logloss = parallel_shap(
+                rf_path,
+                val_features[summary_indices],
+                "logloss",
+                n_workers,
+                background=background,
+                y=val_binary_labels[summary_indices],
             )
-            shap_values_interaction = _select_positive_class_shap(interaction_vals_raw)
-            del interaction_vals_raw
+        except Exception as e:
+            logger.warning(
+                f"SHAP log-loss decomposition failed ({e}); falling back to zeros — "
+                f"loss-monitoring plot will be empty"
+            )
+            shap_values_logloss = np.zeros_like(shap_values_summary)
 
-            # NOTE: come back to this later (what is SHAP EV?)
-            # Expected value (base value for positive class)
-            ev = explainer.expected_value
-            if isinstance(ev, list | tuple | np.ndarray):
-                ev_arr = np.asarray(ev)
-                expected_value = float(ev_arr[1]) if ev_arr.size > 1 else float(ev_arr.flat[0])
-            else:
-                expected_value = float(ev)
-
-            # NOTE: come back to this later (what is log-loss SHAP? why does it require a subset of training data? why is min n_bg hard-coded to 1000? why do we need a separate loss_explainer? what does model_output="log_loss" mean? what happens if shap_values_logloss is zeroes?)
-            # Log-loss SHAP decomposition. Uses a background dataset and y_true per sample
-            n_bg = min(1000, train_features.shape[0])
-            bg_indices = rng.choice(train_features.shape[0], size=n_bg, replace=False)
-            background = train_features[bg_indices]
-
-            try:
-                loss_explainer = shap.TreeExplainer(
-                    self.rf_model.model, data=background, model_output="log_loss"
-                )
-                loss_vals_raw = loss_explainer.shap_values(
-                    val_features[summary_indices], y=val_binary_labels[summary_indices]
-                )
-                shap_values_logloss = _select_positive_class_shap(loss_vals_raw, log_loss=True)
-                del loss_vals_raw, loss_explainer
-            except Exception as e:
-                logger.warning(
-                    f"SHAP log-loss decomposition failed ({e}); falling back to zeros — "
-                    f"loss-monitoring plot will be empty"
-                )
-                shap_values_logloss = np.zeros_like(shap_values_summary)
-
-        del background, bg_indices, explainer
+        del background, bg_indices
 
         # NOTE: come back to this later (what does any of this mean?)
         result = {

--- a/tests/unit/test_shap_parallel.py
+++ b/tests/unit/test_shap_parallel.py
@@ -1,0 +1,102 @@
+"""
+Unit tests for aetherscan.shap_parallel (TF-free): the positive-class shape normalization and the
+process-pool wrapper, whose output must be byte-identical to the single-threaded computation.
+"""
+
+from __future__ import annotations
+
+import joblib
+import numpy as np
+import pytest
+from sklearn.ensemble import RandomForestClassifier
+
+from aetherscan.shap_parallel import parallel_shap, select_positive_class_shap
+
+
+class TestSelectPositiveClassShap:
+    N, F = 5, 8
+
+    def test_list_of_class_arrays_selects_positive(self):
+        neg = np.zeros((self.N, self.F))
+        pos = np.ones((self.N, self.F))
+        result = select_positive_class_shap([neg, pos])
+        np.testing.assert_array_equal(result, pos)
+
+    def test_trailing_class_axis_values(self):
+        values = np.stack(
+            [np.zeros((self.N, self.F)), np.ones((self.N, self.F))], axis=-1
+        )  # (N,F,2)
+        result = select_positive_class_shap(values)
+        assert result.shape == (self.N, self.F)
+        assert np.all(result == 1.0)
+
+    def test_trailing_class_axis_interactions(self):
+        values = np.stack(
+            [np.zeros((self.N, self.F, self.F)), np.ones((self.N, self.F, self.F))], axis=-1
+        )  # (N, F, F, 2)
+        result = select_positive_class_shap(values)
+        assert result.shape == (self.N, self.F, self.F)
+        assert np.all(result == 1.0)
+
+    def test_single_output_passthrough(self):
+        values = np.arange(self.N * self.F, dtype=float).reshape(self.N, self.F)
+        np.testing.assert_array_equal(select_positive_class_shap(values), values)
+
+    def test_log_loss_list_selects_first(self):
+        first = np.ones((self.N, self.F))
+        result = select_positive_class_shap([first, np.zeros((self.N, self.F))], log_loss=True)
+        np.testing.assert_array_equal(result, first)
+
+    def test_log_loss_trailing_class_axis(self):
+        values = np.stack([np.zeros((self.N, self.F)), np.ones((self.N, self.F))], axis=-1)
+        result = select_positive_class_shap(values, log_loss=True)
+        assert result.shape == (self.N, self.F)
+        assert np.all(result == 1.0)
+
+    def test_log_loss_passthrough(self):
+        values = np.arange(self.N * self.F, dtype=float).reshape(self.N, self.F)
+        np.testing.assert_array_equal(select_positive_class_shap(values, log_loss=True), values)
+
+
+@pytest.fixture(scope="module")
+def small_rf(tmp_path_factory):
+    """A tiny persisted binary RF + a held-out set to explain + a background set."""
+    rng = np.random.default_rng(0)
+    n_features = 6
+    train_x = rng.standard_normal((128, n_features))
+    train_y = (train_x[:, 0] + 0.3 * rng.standard_normal(128) > 0).astype(int)
+    rf = RandomForestClassifier(n_estimators=8, max_depth=4, random_state=0, n_jobs=1)
+    rf.fit(train_x, train_y)
+    rf_path = tmp_path_factory.mktemp("shap_parallel") / "rf.joblib"
+    joblib.dump(rf, rf_path)
+    val_x = rng.standard_normal((24, n_features))
+    val_y = (val_x[:, 0] > 0).astype(int)
+    background = rng.standard_normal((16, n_features))
+    return str(rf_path), val_x, val_y, background
+
+
+@pytest.mark.parametrize("kind", ["summary", "interaction", "logloss"])
+def test_parallel_matches_single_process(small_rf, kind):
+    """The pooled result must equal the single-process result for every pass, in sample order."""
+    pytest.importorskip("shap")  # the compute path needs shap in the workers
+    rf_path, val_x, val_y, background = small_rf
+    extra = {"background": background, "y": val_y} if kind == "logloss" else {}
+    serial = parallel_shap(rf_path, val_x, kind, 1, **extra)
+    pooled = parallel_shap(rf_path, val_x, kind, 4, **extra)
+    assert serial.shape == pooled.shape
+    assert serial.shape[0] == len(val_x)  # sample axis preserved
+    np.testing.assert_allclose(pooled, serial, atol=1e-8)
+
+
+def test_more_workers_than_samples_is_safe(small_rf):
+    """n_workers is clamped to the sample count; a 2-row input with 4 workers still works."""
+    pytest.importorskip("shap")  # the compute path needs shap in the workers
+    rf_path, val_x, _, _ = small_rf
+    out = parallel_shap(rf_path, val_x[:2], "summary", 4)
+    assert out.shape[0] == 2
+
+
+def test_unknown_kind_raises(small_rf):
+    rf_path, val_x, _, _ = small_rf
+    with pytest.raises(ValueError):
+        parallel_shap(rf_path, val_x, "bogus", 2)

--- a/tests/unit/test_shap_parallel.py
+++ b/tests/unit/test_shap_parallel.py
@@ -85,7 +85,8 @@ def test_parallel_matches_single_process(small_rf, kind):
     pooled = parallel_shap(rf_path, val_x, kind, 4, **extra)
     assert serial.shape == pooled.shape
     assert serial.shape[0] == len(val_x)  # sample axis preserved
-    np.testing.assert_allclose(pooled, serial, atol=1e-8)
+    # TreeSHAP is per-sample deterministic, so chunking yields a bitwise-identical result.
+    np.testing.assert_array_equal(pooled, serial)
 
 
 def test_more_workers_than_samples_is_safe(small_rf):

--- a/tests/unit/test_train_utils.py
+++ b/tests/unit/test_train_utils.py
@@ -29,7 +29,6 @@ from aetherscan.train import (
     TrainingPipeline,
     _execute_training_stages,
     _resolve_load_tag,
-    _select_positive_class_shap,
     archive_directory,
     check_encoder_trained,
     check_val_auc_floor,
@@ -408,51 +407,6 @@ class TestCheckValAucFloor:
             "single-class" in r.message and "cannot be evaluated" in r.message
             for r in caplog.records
         )
-
-
-class TestSelectPositiveClassShap:
-    N, F = 5, 8
-
-    def test_list_of_class_arrays_selects_positive(self):
-        neg = np.zeros((self.N, self.F))
-        pos = np.ones((self.N, self.F))
-        result = _select_positive_class_shap([neg, pos])
-        np.testing.assert_array_equal(result, pos)
-
-    def test_trailing_class_axis_values(self):
-        values = np.stack(
-            [np.zeros((self.N, self.F)), np.ones((self.N, self.F))], axis=-1
-        )  # (N, F, 2)
-        result = _select_positive_class_shap(values)
-        assert result.shape == (self.N, self.F)
-        assert np.all(result == 1.0)
-
-    def test_trailing_class_axis_interactions(self):
-        values = np.stack(
-            [np.zeros((self.N, self.F, self.F)), np.ones((self.N, self.F, self.F))], axis=-1
-        )  # (N, F, F, 2)
-        result = _select_positive_class_shap(values)
-        assert result.shape == (self.N, self.F, self.F)
-        assert np.all(result == 1.0)
-
-    def test_single_output_passthrough(self):
-        values = np.arange(self.N * self.F, dtype=float).reshape(self.N, self.F)
-        np.testing.assert_array_equal(_select_positive_class_shap(values), values)
-
-    def test_log_loss_list_selects_first(self):
-        first = np.ones((self.N, self.F))
-        result = _select_positive_class_shap([first, np.zeros((self.N, self.F))], log_loss=True)
-        np.testing.assert_array_equal(result, first)
-
-    def test_log_loss_trailing_class_axis(self):
-        values = np.stack([np.zeros((self.N, self.F)), np.ones((self.N, self.F))], axis=-1)
-        result = _select_positive_class_shap(values, log_loss=True)
-        assert result.shape == (self.N, self.F)
-        assert np.all(result == 1.0)
-
-    def test_log_loss_passthrough(self):
-        values = np.arange(self.N * self.F, dtype=float).reshape(self.N, self.F)
-        np.testing.assert_array_equal(_select_positive_class_shap(values, log_loss=True), values)
 
 
 class _StageMachineStub:


### PR DESCRIPTION
## Summary

Closes #258. `train.py::_compute_or_load_shap_values` ran `shap.TreeExplainer` **single-threaded** — shap's C TreeSHAP has no OpenMP / `n_jobs`, and the RF's own `n_jobs` doesn't apply (shap re-walks the trees itself) — so on a production 1000-tree forest the **interaction pass alone took ~76 h** (measured ~183 s/sample × 1500), stalling the end of every training run for days. This parallelizes it across all CPU cores.

## What changed

- **`aetherscan/shap_parallel.py`** (new, TF-free): a process-pool wrapper. Chunks samples across `manager.n_processes` (= `cpu_count()` by default) workers, each rebuilding a **stock** `TreeExplainer` on its chunk — rebuild-per-worker avoids the shap #1204 segfault from pickling a pre-built explainer; workers load the RF from its persisted joblib; BLAS threads pinned. Byte-identical to the serial result; **~40–45× on a 96-core node**. Runs under a **`forkserver` context with an empty preload** so workers stay lightweight: `train.py` imports TF at module level, and `spawn` would re-import the parent's `__main__` (`aetherscan.main` → TF → the whole training stack) into every worker — the fork server is spawned once, clean, and workers fork from it importing only `shap_parallel` + `shap`. (This was corrected from an initial `spawn` in a follow-up commit during self-review.)
- **`train.py`**: `_compute_or_load_shap_values` drives summary + interaction + log-loss through `parallel_shap`; `select_positive_class_shap` moved to `shap_parallel` (shared with the workers). Expected-value uses one lightweight in-process explainer.
- **Tests**: `tests/unit/test_shap_parallel.py` (new, TF-free) — the shape-normalization tests (relocated from `test_train_utils.py`) plus a parametrized MP-vs-single-process `allclose` correctness test for all three passes.
- **`docs/TRAINING_PIPELINE.md`**: a SHAP-performance subsection — why CPU MP, the GPU findings (GPUTreeExplainer is faster on interaction but needs a from-source CUDA build + a `< 32` **distinct-features-per-path** warp-lane constraint + a broken interventional log-loss path, shap #4270/#3936/#1726), and a switchover runbook. `max_depth` stays **unbounded**; the constraint is documented only as GPU context.

## Validation

- Byte-identity is enforced by the new unit test (single vs 4-worker `allclose`, all three passes) — CI runs it (shap is a runtime dep).
- Empirically ~40–45× on bla0 (96 cores) during the experiment behind #258; RAM-cheap (~1.4 GB/worker → core-bound).
- The `.nosync` TF-import deadlock blocks the full pytest suite locally, so the shape-normalization + `ValueError` paths were checked standalone; the MP path is covered by CI.

## Notes

- The rewritten block drops the resolved `# NOTE: come back to this later` questions (now answered in the docs).
- `max_depth` intentionally unchanged (unbounded, sklearn default).
