### PR TITLE
feat(paths): PFB cache + training plots relocation, keep_round_data docs, tmux tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -886,8 +886,8 @@ options:
   --bandpass-debug-plot, --no-bandpass-debug-plot
                         Save a per-cadence bandpass-flattening overlay debug
                         plot (raw vs flattened integrated spectrum for a few
-                        sampled coarse channels) under plots/inference/
-                        (default: off)
+                        sampled coarse channels) under plots/inference/{save-
+                        tag}/ (default: off)
   --spline-order SPLINE_ORDER
                         Spline order for bandpass fitting with --bandpass-
                         method spline (default: 16)

--- a/README.md
+++ b/README.md
@@ -287,6 +287,23 @@ PYTHONPATH=src python -m aetherscan.main train \
     --save-tag test_v1
 ```
 
+**Watching the live dashboard from your local browser (SSH port forwarding)**
+
+Each `train`/`inference` run auto-launches a Streamlit dashboard on the cluster node (enabled by
+default), served on that node's `localhost:8501` (`config.monitor.dashboard_port`, default `8501`).
+It reads the run's live SQLite DB, so it updates as the pipeline progresses. Because it binds to the
+node's loopback interface, view it locally by opening an SSH tunnel that forwards the port, then
+browsing to the forwarded address:
+
+```bash
+# From your local machine — forward the dashboard port from the cluster node running the pipeline:
+ssh -L 8501:localhost:8501 <cluster-host>
+# ...then open http://localhost:8501 in your local browser. Keep the tunnel open while you watch.
+```
+
+If you launched the run on a non-default port, forward that port instead. The pipeline also logs the
+exact `ssh -L …` command when it starts the dashboard.
+
 ### Inference
 
 > [!TIP]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -233,13 +233,15 @@ Three roots, set by `AETHERSCAN_{DATA,MODEL,OUTPUT}_PATH` (defaults under
 ├── run_state_{tag}.json               # training run manifest (stage machine + completed rounds)
 ├── db/aetherscan.db                   # SQLite (WAL) — all stats/results tables
 ├── logs/aetherscan_{tag}.log          # this run's log (mode="w": overwrites the same tag's log on rerun)
-├── pfb_cache/pfb_response_*.npy       # content-addressed PFB passband responses
+├── cache/pfb/pfb_response_*.npy       # content-addressed PFB passband responses (tag-independent)
 ├── round_data/{tag}/round_XX/         # per-round training memmaps (deleted after the round trains)
 │   └── rf/                            #   plus the RF training dataset
 └── plots/
-    ├── *_{tag}.png                    # end-of-training diagnostics + resource_utilization plot
-    ├── checkpoints/*_round_XX.png     # per-round diagnostics (archived like model checkpoints)
-    └── inference/{tag}/*.png          # inference visualization suite
+    ├── resource_utilization_{tag}.png # monitor resource plot (mode-agnostic)
+    ├── benchmark_report_{tag}.png      # end-of-run resource report (mode-agnostic)
+    ├── training/{tag}/*.png            # end-of-training diagnostics
+    │   └── checkpoints/*_round_XX.png  #   per-round diagnostics (archived like model checkpoints)
+    └── inference/{tag}/*.png           # inference visualization suite
 ```
 
 Startup hygiene: `train.py:archive_directory()` moves (fresh run) or copies (resume) existing

--- a/docs/INFERENCE_PIPELINE.md
+++ b/docs/INFERENCE_PIPELINE.md
@@ -258,7 +258,33 @@ flagged while later writes stay live (`Database.mark_superseded`).
 | Config snapshot | `{output_path}/config_{tag}.json` | The resolved (saved-config + CLI) view this run actually used. |
 | Figures | `{output_path}/plots/inference/{tag}/` | The visualization suite below; also uploaded to the run's Slack thread. |
 | Resource plot | `{output_path}/plots/resource_utilization_{tag}.png` | Written by the monitor at shutdown. |
-| PFB response cache | `{output_path}/pfb_cache/pfb_response_*.npy` | Content-addressed; reused across runs. |
+| PFB response cache | `{output_path}/cache/pfb/pfb_response_*.npy` | Content-addressed by channelization geometry; one file per `(width, coarse count, taps)`, shared across all `.h5` and all runs. See [The PFB response cache](#the-pfb-response-cache). |
+
+### The PFB response cache
+
+`{output_path}/cache/pfb/pfb_response_w{W}_c{C}_t{T}.npy` caches the **static PFB coarse-channel
+passband response** — the filter shape that `pfb.equalize_passband` divides each coarse channel by
+during bandpass flattening. It is **not** a cache of preprocessed `.h5` output: it holds a single
+~8 MB array, computed once per channelization *geometry* by an ~`n_chans`-point FFT
+(`gen_coarse_channel_response`) and content-addressed by its parameters — `W` = fine channels per
+coarse, `C` = coarse-channel count, `T` = `pfb_taps_per_channel`.
+
+- **What hits the cache:** every `.h5` that shares the same `(W, C, T)` channelization — which, for a
+  given telescope/receiver/product, is all of them. The first cadence of a run computes the response
+  (the one-time FFT — ~7–12 s at GBT scale) and writes the sidecar; every later cadence *in that run*,
+  and every *future run* on any `.h5` of the same geometry, reads the cached array instead of
+  recomputing.
+- **What misses:** an `.h5` with a *different* channelization (different fine-per-coarse, coarse count,
+  or `--pfb-taps-per-channel`) is a distinct key and computes + caches its own response. Mixing
+  geometries in one campaign simply yields one cached file per geometry — none of them ever collide.
+- **What it does and doesn't speed up:** it removes the one-time response FFT from all but the first
+  cadence of each geometry. It does **not** change the per-channel flattening cost — `equalize_passband`
+  (a vectorized divide) still runs for every coarse channel of every file. So the win is "compute the
+  response once, not once per file," not "preprocess each `.h5` once."
+- **Tag-independent by design:** the cache key is the geometry, never `--save-tag`, so it is shared
+  across runs and never invalidated by a new tag. Because it is content-addressed, a corrupt or
+  mismatched sidecar is transparently rewritten — stale-run leftovers are impossible, and the cache is
+  safe to delete at any time (it just rebuilds on next use).
 
 ## The visualization suite — what each figure shows
 

--- a/docs/PREPROCESSING.md
+++ b/docs/PREPROCESSING.md
@@ -89,7 +89,7 @@ reference implementation):
 
 At GBT scale the one-time FFT is an ~`n_chans`-point transform with a tens-of-GB transient,
 so it runs **once in the parent**, is persisted to a content-addressed sidecar
-(`{output_path}/pfb_cache/pfb_response_w{W}_c{C}_t{T}.npy`, atomic write), and workers just
+(`{output_path}/cache/pfb/pfb_response_w{W}_c{C}_t{T}.npy`, atomic write), and workers just
 read the ~8 MB file (cached per process by `_load_pfb_response`). Afterwards, flattening a
 channel is a single vectorized divide — versus a fresh spline fit per channel per file.
 

--- a/docs/TRAINING_PIPELINE.md
+++ b/docs/TRAINING_PIPELINE.md
@@ -48,7 +48,7 @@ as done, so re-running the identical command resumes exactly where the last atte
 5. **Epoch loop** — `_train_epoch()` + `_validate_epoch()`, ~21 `training_stats` rows per
    epoch (losses, gradient norms, LR, durations, SNR range), adaptive LR update.
 6. **Per-round plots** — loss curves, training stability, injection stats (tagged
-   `round_XX`, saved under `plots/checkpoints/`), plus the latent traversal when
+   `round_XX`, saved under `plots/training/{save_tag}/checkpoints/`), plus the latent traversal when
    `--latent-traversal-every-round` is set.
 7. **Checkpoint** — `save_models(tag="round_XX", dir="checkpoints")`, then the round is
    recorded in the run manifest (`completed_rounds`).
@@ -112,6 +112,15 @@ Key properties (all in [`round_data.py`](../src/aetherscan/round_data.py) /
   (`_estimate_round_data_nbytes`: 2.2× one round with overlap, 1.1× without) and hard-fails
   with the computed numbers. Round *k*'s directory is deleted as soon as round *k* finishes
   training (`--keep-round-data` retains it for debugging).
+
+> [!TIP]
+> **For official tagged training releases, pass `--keep-round-data`.** By default each round's
+> memmaps are deleted the moment that round finishes training (delete-as-you-go keeps the disk
+> footprint at ~590 GB). `--keep-round-data` retains every round's exact on-disk dataset (plus the
+> RF training set) under `{data_path}/training/round_data/{save_tag}/{round_XX,rf}/`, so a release
+> model's training data is reproducible/inspectable after the fact — at the cost of holding the full
+> run on disk (~295 GB × num_training_rounds, e.g. ~6 TB for a 20-round run). Nothing in the pipeline
+> *reads* an earlier round once it has trained, so this flag is purely for post-hoc retention.
 
 ### The producer process
 
@@ -292,8 +301,9 @@ artifacts already exist from a previous attempt, they are loaded instead of rege
 
 ## Training plots — what each one shows
 
-Per-round copies (tagged `round_XX`) land in `{output_path}/plots/checkpoints/`; the
-end-of-training set (tagged with the run tag) in `{output_path}/plots/`. Every figure is also
+Per-round copies (tagged `round_XX`) land in `{output_path}/plots/training/{save_tag}/checkpoints/`;
+the end-of-training set (tagged with the run tag) in `{output_path}/plots/training/{save_tag}/`. Every
+figure is also
 uploaded to the run's Slack thread. All of them query the DB with `start_time =
 run_start_time`, so multi-attempt runs plot complete histories with superseded rows filtered
 out.

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -860,7 +860,7 @@ def _add_inference_flags_to(parser):
         "--bandpass-debug-plot",
         action=argparse.BooleanOptionalAction,
         default=None,
-        help="Save a per-cadence bandpass-flattening overlay debug plot (raw vs flattened integrated spectrum for a few sampled coarse channels) under plots/inference/ (default: off)",
+        help="Save a per-cadence bandpass-flattening overlay debug plot (raw vs flattened integrated spectrum for a few sampled coarse channels) under plots/inference/{save-tag}/ (default: off)",
     )
     parser.add_argument(
         "--spline-order",

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -2038,7 +2038,7 @@ class DataPreprocessor:
         Opt-in debug artifact (--bandpass-debug-plot): for a few coarse channels sampled evenly
         across the band of the cadence's primary ON-source file, plot the time-integrated
         spectrum raw vs flattened, overlaying the model being removed (the scaled PFB response
-        H, or the spline fit). Saved under {output_path}/plots/inference/. Deliberately
+        H, or the spline fit). Saved under {output_path}/plots/inference/{save_tag}/. Deliberately
         minimal — PR-08's inference visualization suite formalizes this figure.
 
         Uses matplotlib's object-oriented Figure API rather than pyplot: _process_cadence runs
@@ -2099,10 +2099,10 @@ class DataPreprocessor:
         fig.suptitle(f"Bandpass flattening overlay ({method}): {os.path.basename(h5_path)}")
         fig.tight_layout()
 
-        save_dir = os.path.join(self.config.output_path, "plots", "inference")
+        tag = self.config.checkpoint.save_tag
+        save_dir = os.path.join(self.config.output_path, "plots", "inference", tag)
         os.makedirs(save_dir, exist_ok=True)
         stem = os.path.splitext(os.path.basename(npy_path))[0]
-        tag = self.config.checkpoint.save_tag
         out_path = os.path.join(save_dir, f"bandpass_overlay_{stem}_{tag}.png")
         # No close/registry bookkeeping needed: an OO-API Figure is garbage-collected
         fig.savefig(out_path, dpi=120)

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -1877,7 +1877,7 @@ class DataPreprocessor:
     ) -> str:
         """
         Compute the PFB passband response in the parent process and persist it to a
-        deterministic sidecar .npy under {output_path}/pfb_cache/, returning its path.
+        deterministic sidecar .npy under {output_path}/cache/pfb/, returning its path.
 
         The heavy work (an ~n_chans-point FFT) runs exactly once per parameter combination in
         the parent — gen_coarse_channel_response is process-cached and the file is reused when
@@ -1890,7 +1890,7 @@ class DataPreprocessor:
             fine_per_coarse, num_coarse_channels, taps_per_channel
         )
 
-        cache_dir = os.path.join(self.config.output_path, "pfb_cache")
+        cache_dir = os.path.join(self.config.output_path, "cache", "pfb")
         os.makedirs(cache_dir, exist_ok=True)
         path = os.path.join(
             cache_dir,

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -1265,7 +1265,13 @@ class TrainingPipeline:
         model_checkpoints_dir = os.path.join(self.config.model_path, "checkpoints")
         archive_directory(model_checkpoints_dir, target_dirs=None, round_num=start_round)
 
-        plot_checkpoints_dir = os.path.join(self.config.output_path, "plots", "checkpoints")
+        plot_checkpoints_dir = os.path.join(
+            self.config.output_path,
+            "plots",
+            "training",
+            self.config.checkpoint.save_tag,
+            "checkpoints",
+        )
         archive_directory(plot_checkpoints_dir, target_dirs=None, round_num=start_round)
 
         # Disk-backed round-data directory for this tag: delete round dirs >= start_round,
@@ -3027,11 +3033,20 @@ class TrainingPipeline:
         # Save plot
         if dir is not None:
             save_path = os.path.join(
-                self.config.output_path, "plots", dir, f"beta_vae_loss_curves_{tag}.png"
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                dir,
+                f"beta_vae_loss_curves_{tag}.png",
             )
         else:
             save_path = os.path.join(
-                self.config.output_path, "plots", f"beta_vae_loss_curves_{tag}.png"
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                f"beta_vae_loss_curves_{tag}.png",
             )
 
         os.makedirs(os.path.dirname(save_path), exist_ok=True)  # Create dir if it doesn't exist
@@ -3272,11 +3287,20 @@ class TrainingPipeline:
         # Save plot
         if dir is not None:
             save_path = os.path.join(
-                self.config.output_path, "plots", dir, f"beta_vae_training_stability_{tag}.png"
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                dir,
+                f"beta_vae_training_stability_{tag}.png",
             )
         else:
             save_path = os.path.join(
-                self.config.output_path, "plots", f"beta_vae_training_stability_{tag}.png"
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                f"beta_vae_training_stability_{tag}.png",
             )
 
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
@@ -3432,9 +3456,13 @@ class TrainingPipeline:
             tag = self.config.checkpoint.save_tag
 
         if dir is not None:
-            save_dir = os.path.join(self.config.output_path, "plots", dir)
+            save_dir = os.path.join(
+                self.config.output_path, "plots", "training", self.config.checkpoint.save_tag, dir
+            )
         else:
-            save_dir = os.path.join(self.config.output_path, "plots")
+            save_dir = os.path.join(
+                self.config.output_path, "plots", "training", self.config.checkpoint.save_tag
+            )
         os.makedirs(save_dir, exist_ok=True)
 
         metadata_json = get_system_metadata()
@@ -4387,9 +4415,13 @@ class TrainingPipeline:
             tag = self.config.checkpoint.save_tag
 
         if dir is not None:
-            save_dir = os.path.join(self.config.output_path, "plots", dir)
+            save_dir = os.path.join(
+                self.config.output_path, "plots", "training", self.config.checkpoint.save_tag, dir
+            )
         else:
-            save_dir = os.path.join(self.config.output_path, "plots")
+            save_dir = os.path.join(
+                self.config.output_path, "plots", "training", self.config.checkpoint.save_tag
+            )
 
         os.makedirs(save_dir, exist_ok=True)  # Create dir if it doesn't exist
 
@@ -5024,9 +5056,22 @@ class TrainingPipeline:
         """Standard plot tail shared by the two traversal renderers: save under the plots
         directory (optionally nested in `dir`), close the figure, and upload to Slack."""
         if dir is not None:
-            save_path = os.path.join(self.config.output_path, "plots", dir, filename)
+            save_path = os.path.join(
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                dir,
+                filename,
+            )
         else:
-            save_path = os.path.join(self.config.output_path, "plots", filename)
+            save_path = os.path.join(
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                filename,
+            )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         fig.savefig(save_path, dpi=300, bbox_inches="tight")
         plt.close(fig)
@@ -5282,11 +5327,20 @@ class TrainingPipeline:
 
         if dir is not None:
             save_path = os.path.join(
-                self.config.output_path, "plots", dir, f"rf_confusion_matrices_{tag}.png"
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                dir,
+                f"rf_confusion_matrices_{tag}.png",
             )
         else:
             save_path = os.path.join(
-                self.config.output_path, "plots", f"rf_confusion_matrices_{tag}.png"
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                f"rf_confusion_matrices_{tag}.png",
             )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
@@ -5461,11 +5515,20 @@ class TrainingPipeline:
 
         if dir is not None:
             save_path = os.path.join(
-                self.config.output_path, "plots", dir, f"rf_classification_curves_{tag}.png"
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                dir,
+                f"rf_classification_curves_{tag}.png",
             )
         else:
             save_path = os.path.join(
-                self.config.output_path, "plots", f"rf_classification_curves_{tag}.png"
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                f"rf_classification_curves_{tag}.png",
             )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
@@ -5539,10 +5602,21 @@ class TrainingPipeline:
 
         if dir is not None:
             save_path = os.path.join(
-                self.config.output_path, "plots", dir, f"rf_shap_summary_{tag}.png"
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                dir,
+                f"rf_shap_summary_{tag}.png",
             )
         else:
-            save_path = os.path.join(self.config.output_path, "plots", f"rf_shap_summary_{tag}.png")
+            save_path = os.path.join(
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                f"rf_shap_summary_{tag}.png",
+            )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
         plt.close(fig)
@@ -5629,11 +5703,20 @@ class TrainingPipeline:
 
         if dir is not None:
             save_path = os.path.join(
-                self.config.output_path, "plots", dir, f"rf_shap_dependence_{tag}.png"
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                dir,
+                f"rf_shap_dependence_{tag}.png",
             )
         else:
             save_path = os.path.join(
-                self.config.output_path, "plots", f"rf_shap_dependence_{tag}.png"
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                f"rf_shap_dependence_{tag}.png",
             )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
@@ -5706,11 +5789,20 @@ class TrainingPipeline:
 
         if dir is not None:
             save_path = os.path.join(
-                self.config.output_path, "plots", dir, f"rf_shap_interactions_{tag}.png"
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                dir,
+                f"rf_shap_interactions_{tag}.png",
             )
         else:
             save_path = os.path.join(
-                self.config.output_path, "plots", f"rf_shap_interactions_{tag}.png"
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                f"rf_shap_interactions_{tag}.png",
             )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
@@ -5815,11 +5907,20 @@ class TrainingPipeline:
 
         if dir is not None:
             save_path = os.path.join(
-                self.config.output_path, "plots", dir, f"rf_shap_loss_monitoring_{tag}.png"
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                dir,
+                f"rf_shap_loss_monitoring_{tag}.png",
             )
         else:
             save_path = os.path.join(
-                self.config.output_path, "plots", f"rf_shap_loss_monitoring_{tag}.png"
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                f"rf_shap_loss_monitoring_{tag}.png",
             )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
@@ -5978,11 +6079,20 @@ class TrainingPipeline:
 
         if dir is not None:
             save_path = os.path.join(
-                self.config.output_path, "plots", dir, f"rf_shap_explanation_clustering_{tag}.png"
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                dir,
+                f"rf_shap_explanation_clustering_{tag}.png",
             )
         else:
             save_path = os.path.join(
-                self.config.output_path, "plots", f"rf_shap_explanation_clustering_{tag}.png"
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                f"rf_shap_explanation_clustering_{tag}.png",
             )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
@@ -6092,11 +6202,20 @@ class TrainingPipeline:
 
         if dir is not None:
             save_path = os.path.join(
-                self.config.output_path, "plots", dir, f"rf_calibration_curve_{tag}.png"
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                dir,
+                f"rf_calibration_curve_{tag}.png",
             )
         else:
             save_path = os.path.join(
-                self.config.output_path, "plots", f"rf_calibration_curve_{tag}.png"
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                f"rf_calibration_curve_{tag}.png",
             )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
@@ -6220,11 +6339,20 @@ class TrainingPipeline:
 
         if dir is not None:
             save_path = os.path.join(
-                self.config.output_path, "plots", dir, f"rf_oob_accuracy_curve_{tag}.png"
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                dir,
+                f"rf_oob_accuracy_curve_{tag}.png",
             )
         else:
             save_path = os.path.join(
-                self.config.output_path, "plots", f"rf_oob_accuracy_curve_{tag}.png"
+                self.config.output_path,
+                "plots",
+                "training",
+                self.config.checkpoint.save_tag,
+                f"rf_oob_accuracy_curve_{tag}.png",
             )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
@@ -6410,9 +6538,22 @@ class TrainingPipeline:
 
                 filename = f"rf_latent_decision_boundary_nn{nn}_md{md}_{tag}.png"
                 if dir is not None:
-                    save_path = os.path.join(self.config.output_path, "plots", dir, filename)
+                    save_path = os.path.join(
+                        self.config.output_path,
+                        "plots",
+                        "training",
+                        self.config.checkpoint.save_tag,
+                        dir,
+                        filename,
+                    )
                 else:
-                    save_path = os.path.join(self.config.output_path, "plots", filename)
+                    save_path = os.path.join(
+                        self.config.output_path,
+                        "plots",
+                        "training",
+                        self.config.checkpoint.save_tag,
+                        filename,
+                    )
                 os.makedirs(os.path.dirname(save_path), exist_ok=True)
                 plt.savefig(save_path, dpi=300, bbox_inches="tight")
                 plt.close(fig)

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -1265,13 +1265,7 @@ class TrainingPipeline:
         model_checkpoints_dir = os.path.join(self.config.model_path, "checkpoints")
         archive_directory(model_checkpoints_dir, target_dirs=None, round_num=start_round)
 
-        plot_checkpoints_dir = os.path.join(
-            self.config.output_path,
-            "plots",
-            "training",
-            self.config.checkpoint.save_tag,
-            "checkpoints",
-        )
+        plot_checkpoints_dir = self._training_plots_dir("checkpoints")
         archive_directory(plot_checkpoints_dir, target_dirs=None, round_num=start_round)
 
         # Disk-backed round-data directory for this tag: delete round dirs >= start_round,
@@ -2872,6 +2866,13 @@ class TrainingPipeline:
 
     # TODO: reorder plot methods (def & call sites): train -> latent -> injection
     # NOTE: combine plot_beta_vae_loss_curves(), plot_beta_vae_training_stability(), and plot_latent_space_gif() into plot_training_progress()?
+    def _training_plots_dir(self, subdir: str | None = None) -> str:
+        """This run's training-plots base: ``{output_path}/plots/training/{save_tag}[/subdir]``."""
+        base = os.path.join(
+            self.config.output_path, "plots", "training", self.config.checkpoint.save_tag
+        )
+        return os.path.join(base, subdir) if subdir else base
+
     def plot_beta_vae_loss_curves(self, tag: str | None = None, dir: str | None = None):
         """Plot beta-VAE training history"""
         if tag is None:
@@ -3031,23 +3032,7 @@ class TrainingPipeline:
         plt.tight_layout()
 
         # Save plot
-        if dir is not None:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                dir,
-                f"beta_vae_loss_curves_{tag}.png",
-            )
-        else:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                f"beta_vae_loss_curves_{tag}.png",
-            )
+        save_path = os.path.join(self._training_plots_dir(dir), f"beta_vae_loss_curves_{tag}.png")
 
         os.makedirs(os.path.dirname(save_path), exist_ok=True)  # Create dir if it doesn't exist
 
@@ -3285,23 +3270,9 @@ class TrainingPipeline:
         plt.tight_layout(rect=[0, 0, 0.72, 1])  # More room on right for annotations
 
         # Save plot
-        if dir is not None:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                dir,
-                f"beta_vae_training_stability_{tag}.png",
-            )
-        else:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                f"beta_vae_training_stability_{tag}.png",
-            )
+        save_path = os.path.join(
+            self._training_plots_dir(dir), f"beta_vae_training_stability_{tag}.png"
+        )
 
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
 
@@ -3455,14 +3426,7 @@ class TrainingPipeline:
         if tag is None:
             tag = self.config.checkpoint.save_tag
 
-        if dir is not None:
-            save_dir = os.path.join(
-                self.config.output_path, "plots", "training", self.config.checkpoint.save_tag, dir
-            )
-        else:
-            save_dir = os.path.join(
-                self.config.output_path, "plots", "training", self.config.checkpoint.save_tag
-            )
+        save_dir = self._training_plots_dir(dir)
         os.makedirs(save_dir, exist_ok=True)
 
         metadata_json = get_system_metadata()
@@ -4414,14 +4378,7 @@ class TrainingPipeline:
         if tag is None:
             tag = self.config.checkpoint.save_tag
 
-        if dir is not None:
-            save_dir = os.path.join(
-                self.config.output_path, "plots", "training", self.config.checkpoint.save_tag, dir
-            )
-        else:
-            save_dir = os.path.join(
-                self.config.output_path, "plots", "training", self.config.checkpoint.save_tag
-            )
+        save_dir = self._training_plots_dir(dir)
 
         os.makedirs(save_dir, exist_ok=True)  # Create dir if it doesn't exist
 
@@ -5055,23 +5012,7 @@ class TrainingPipeline:
     def _save_traversal_figure(self, fig, filename: str, dir: str | None, slack_title: str):
         """Standard plot tail shared by the two traversal renderers: save under the plots
         directory (optionally nested in `dir`), close the figure, and upload to Slack."""
-        if dir is not None:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                dir,
-                filename,
-            )
-        else:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                filename,
-            )
+        save_path = os.path.join(self._training_plots_dir(dir), filename)
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         fig.savefig(save_path, dpi=300, bbox_inches="tight")
         plt.close(fig)
@@ -5325,23 +5266,7 @@ class TrainingPipeline:
 
         plt.tight_layout()
 
-        if dir is not None:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                dir,
-                f"rf_confusion_matrices_{tag}.png",
-            )
-        else:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                f"rf_confusion_matrices_{tag}.png",
-            )
+        save_path = os.path.join(self._training_plots_dir(dir), f"rf_confusion_matrices_{tag}.png")
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
         plt.close(fig)
@@ -5513,23 +5438,9 @@ class TrainingPipeline:
 
         plt.tight_layout()
 
-        if dir is not None:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                dir,
-                f"rf_classification_curves_{tag}.png",
-            )
-        else:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                f"rf_classification_curves_{tag}.png",
-            )
+        save_path = os.path.join(
+            self._training_plots_dir(dir), f"rf_classification_curves_{tag}.png"
+        )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
         plt.close(fig)
@@ -5600,23 +5511,7 @@ class TrainingPipeline:
             y=1.02,
         )
 
-        if dir is not None:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                dir,
-                f"rf_shap_summary_{tag}.png",
-            )
-        else:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                f"rf_shap_summary_{tag}.png",
-            )
+        save_path = os.path.join(self._training_plots_dir(dir), f"rf_shap_summary_{tag}.png")
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
         plt.close(fig)
@@ -5701,23 +5596,7 @@ class TrainingPipeline:
 
         plt.tight_layout(rect=[0, 0, 1, 0.96])
 
-        if dir is not None:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                dir,
-                f"rf_shap_dependence_{tag}.png",
-            )
-        else:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                f"rf_shap_dependence_{tag}.png",
-            )
+        save_path = os.path.join(self._training_plots_dir(dir), f"rf_shap_dependence_{tag}.png")
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
         plt.close(fig)
@@ -5787,23 +5666,7 @@ class TrainingPipeline:
             y=1.02,
         )
 
-        if dir is not None:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                dir,
-                f"rf_shap_interactions_{tag}.png",
-            )
-        else:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                f"rf_shap_interactions_{tag}.png",
-            )
+        save_path = os.path.join(self._training_plots_dir(dir), f"rf_shap_interactions_{tag}.png")
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
         plt.close(fig)
@@ -5905,23 +5768,9 @@ class TrainingPipeline:
 
         plt.tight_layout()
 
-        if dir is not None:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                dir,
-                f"rf_shap_loss_monitoring_{tag}.png",
-            )
-        else:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                f"rf_shap_loss_monitoring_{tag}.png",
-            )
+        save_path = os.path.join(
+            self._training_plots_dir(dir), f"rf_shap_loss_monitoring_{tag}.png"
+        )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
         plt.close(fig)
@@ -6077,23 +5926,9 @@ class TrainingPipeline:
 
         plt.tight_layout()
 
-        if dir is not None:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                dir,
-                f"rf_shap_explanation_clustering_{tag}.png",
-            )
-        else:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                f"rf_shap_explanation_clustering_{tag}.png",
-            )
+        save_path = os.path.join(
+            self._training_plots_dir(dir), f"rf_shap_explanation_clustering_{tag}.png"
+        )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
         plt.close(fig)
@@ -6200,23 +6035,7 @@ class TrainingPipeline:
 
         plt.tight_layout()
 
-        if dir is not None:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                dir,
-                f"rf_calibration_curve_{tag}.png",
-            )
-        else:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                f"rf_calibration_curve_{tag}.png",
-            )
+        save_path = os.path.join(self._training_plots_dir(dir), f"rf_calibration_curve_{tag}.png")
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
         plt.close(fig)
@@ -6337,23 +6156,7 @@ class TrainingPipeline:
 
         plt.tight_layout()
 
-        if dir is not None:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                dir,
-                f"rf_oob_accuracy_curve_{tag}.png",
-            )
-        else:
-            save_path = os.path.join(
-                self.config.output_path,
-                "plots",
-                "training",
-                self.config.checkpoint.save_tag,
-                f"rf_oob_accuracy_curve_{tag}.png",
-            )
+        save_path = os.path.join(self._training_plots_dir(dir), f"rf_oob_accuracy_curve_{tag}.png")
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
         plt.close(fig)
@@ -6537,23 +6340,7 @@ class TrainingPipeline:
                 plt.tight_layout()
 
                 filename = f"rf_latent_decision_boundary_nn{nn}_md{md}_{tag}.png"
-                if dir is not None:
-                    save_path = os.path.join(
-                        self.config.output_path,
-                        "plots",
-                        "training",
-                        self.config.checkpoint.save_tag,
-                        dir,
-                        filename,
-                    )
-                else:
-                    save_path = os.path.join(
-                        self.config.output_path,
-                        "plots",
-                        "training",
-                        self.config.checkpoint.save_tag,
-                        filename,
-                    )
+                save_path = os.path.join(self._training_plots_dir(dir), filename)
                 os.makedirs(os.path.dirname(save_path), exist_ok=True)
                 plt.savefig(save_path, dpi=300, bbox_inches="tight")
                 plt.close(fig)

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -726,6 +726,7 @@ class TestProcessCadenceEndToEnd:
             config.output_path,
             "plots",
             "inference",
+            config.checkpoint.save_tag,
             f"bandpass_overlay_cadence_dbg_{config.checkpoint.save_tag}.png",
         )
         assert os.path.exists(plot_path)

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -748,7 +748,7 @@ class TestBandpassFlattenerSelection:
         response_path = flattener.keywords["response_path"]
         # The sidecar file lives under the run's output path and holds exactly the response
         # the parent computed for (width, coarse count, taps)
-        assert response_path.startswith(os.path.join(config.output_path, "pfb_cache"))
+        assert response_path.startswith(os.path.join(config.output_path, "cache", "pfb"))
         expected = gen_coarse_channel_response(512, 4, config.inference.pfb_taps_per_channel)
         np.testing.assert_array_equal(np.load(response_path), expected)
 

--- a/tests/unit/test_train_utils.py
+++ b/tests/unit/test_train_utils.py
@@ -147,6 +147,29 @@ class TestResolveLoadTag:
             _resolve_load_tag(str(tmp_path), None)
 
 
+class TestTrainingPlotsDir:
+    """_training_plots_dir centralizes this run's plots base:
+    {output_path}/plots/training/{save_tag}[/subdir]."""
+
+    def _pipeline(self, tag):
+        pipeline = TrainingPipeline.__new__(TrainingPipeline)
+        pipeline.config = get_config()
+        pipeline.config.checkpoint.save_tag = tag
+        return pipeline
+
+    def test_base_dir(self):
+        pipeline = self._pipeline("run_a")
+        assert pipeline._training_plots_dir() == os.path.join(
+            pipeline.config.output_path, "plots", "training", "run_a"
+        )
+
+    def test_subdir(self):
+        pipeline = self._pipeline("run_a")
+        assert pipeline._training_plots_dir("checkpoints") == os.path.join(
+            pipeline.config.output_path, "plots", "training", "run_a", "checkpoints"
+        )
+
+
 class TestTrainRandomForestSkipIsLoud:
     def test_pretrained_rf_skip_warns_and_records_source_tag(self, caplog):
         """The is_trained early-return (issue #142) must warn loudly, name the tag the stale

--- a/utils/start_tmux_session.sh
+++ b/utils/start_tmux_session.sh
@@ -35,17 +35,13 @@ tmux send-keys -t "$TOP" 'export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$COND
 tmux send-keys -t "$TOP" 'export TF_CPP_MIN_LOG_LEVEL=1' C-m
 tmux send-keys -t "$TOP" 'cd Aetherscan/' C-m
 
-# Top pane stays full-width; A is bottom-left, B is bottom-right.
-A=$(tmux split-window -v -t "$TOP" -P -F '#{pane_id}')
-B=$(tmux split-window -h -t "$A" -P -F '#{pane_id}')
-
-tmux send-keys -t "$A" 'watch -n 1 tree -L 3 /datax/scratch/zachy/models/aetherscan/' C-m
-tmux send-keys -t "$B" 'watch -n 1 tree -L 4 /datax/scratch/zachy/outputs/aetherscan/' C-m
+# Single full-window working pane (the filesystem watches now live in the "data" window).
 
 # ───── Window 2: htop ─────
 tmux new-window -t "$SESSION" -n htop
+# htop keeps the top 75%; the CPU/MEM ticker takes the bottom 25%.
 C=$(tmux display-message -p -t "$SESSION:htop" '#{pane_id}')
-D=$(tmux split-window -v -t "$C" -P -F '#{pane_id}')
+D=$(tmux split-window -v -l 25% -t "$C" -P -F '#{pane_id}')
 
 tmux send-keys -t "$C" 'htop' C-m
 tmux send-keys -t "$D" 'conda activate aetherscan' C-m
@@ -59,9 +55,19 @@ tmux select-pane -t "$C"
 tmux new-window -t "$SESSION" -n nvidia-smi
 tmux send-keys -t "$SESSION:nvidia-smi" 'watch -n 1 nvidia-smi' C-m
 
-# ───── Window 4: shm ─────
-tmux new-window -t "$SESSION" -n shm
-tmux send-keys -t "$SESSION:shm" 'watch -n 1 ls -lh /dev/shm' C-m
+# ───── Window 4: data ─────
+# Four even-vertical panes (top→bottom): /dev/shm, then the data / models / outputs trees.
+tmux new-window -t "$SESSION" -n data
+E=$(tmux display-message -p -t "$SESSION:data" '#{pane_id}')
+F=$(tmux split-window -v -t "$E" -P -F '#{pane_id}')
+G=$(tmux split-window -v -t "$F" -P -F '#{pane_id}')
+H=$(tmux split-window -v -t "$G" -P -F '#{pane_id}')
+tmux select-layout -t "$SESSION:data" even-vertical
+
+tmux send-keys -t "$E" 'watch -n 1 ls -lh /dev/shm' C-m
+tmux send-keys -t "$F" 'watch -n 1 tree -L 3 /datax/scratch/zachy/data/aetherscan' C-m
+tmux send-keys -t "$G" 'watch -n 1 tree -L 2 /datax/scratch/zachy/models/aetherscan' C-m
+tmux send-keys -t "$H" 'watch -n 1 tree -L 2 /datax/scratch/zachy/outputs/aetherscan' C-m
 
 # Land on the pipeline window, top pane (where you actually type).
 tmux select-window -t "$SESSION:pipeline"


### PR DESCRIPTION
## Summary

Pre-Phase-2 housekeeping — four grouped changes to output-path defaults and the monitoring script.

### 1. PFB response cache → `{output_path}/cache/pfb/`
`_ensure_pfb_response_file` now writes under a `cache/` grouping instead of `{output_path}/pfb_cache/` ([`preprocessing.py`](../blob/feature/output-paths-and-tmux/src/aetherscan/preprocessing.py#L1893)). Stays **tag-independent** — the response is content-addressed by channelization geometry (`w{fine}_c{coarse}_t{taps}`) and shared across all `.h5`/runs/tags. `test_preprocessing.py` assertion updated; `INFERENCE_PIPELINE.md` gains a **"The PFB response cache"** section explaining what it is, what hits vs misses it, what it does/doesn't speed up, and why it's tag-independent.

### 2. Training plots → `{output_path}/plots/training/{save_tag}/`
Symmetric with inference (`plots/inference/{save_tag}/`). Per-round copies land in `plots/training/{save_tag}/checkpoints/`. Uniform reroute across all 31 write sites in `train.py`; the dashboard globs `plots/` **recursively** so it still finds them (no dashboard change).

### 3. Document `--keep-round-data` for tagged releases
Flag already exists (`cli.py`, default off = delete-as-you-go). `TRAINING_PIPELINE.md` now recommends passing it for **official tagged releases** (reproducibility), with the disk-cost caveat (~295 GB × num_rounds ≈ ~6 TB for a 20-round run). Docs-only.

### 4. `utils/start_tmux_session.sh` tweaks
- **pipeline** window → only the working pane (dropped the two bottom `watch tree` panes).
- **htop** window → htop 75% / cpu-mem ticker 25% (was ~50/50), via `-l 25%` (tmux ≥ 3.1; both nodes run 3.4).
- **shm** window → renamed **data**, 4 even-vertical panes: `/dev/shm` ls, then `data`/`models`/`outputs` trees (consolidates the filesystem watches previously split across `pipeline` + `shm`).

## Judgment calls (flagging for review)
- **`resource_utilization_{tag}.png` and `benchmark_report_{tag}.png` intentionally stay at `plots/` root** — they're mode-agnostic (emitted by both train and inference), not training diagnostics. Only the training *diagnostic* plots moved. Say the word if you'd rather route the train-run copies under `plots/training/{save_tag}/` too.
- **tmux windows kept in place / referenced by name, not reordered** — the request numbered them loosely ("3rd window (currently named shm)"), so I matched by name and left the window order (`pipeline`, `htop`, `nvidia-smi`, `data`). Easy to reorder if you want `data` earlier.

## Test plan
- [x] `ruff format` + `ruff check` clean on all changed Python.
- [x] `pre-commit` hooks pass on both commits.
- [x] `test_preprocessing.py` pfb-response assertion updated to the new `cache/pfb` path.
- [ ] CI (`pytest -m "not gpu and not cluster"` across 3.10/3.11/3.12) green — the training-plots reroute is a pure path-string change with no logic change; the pfb path change is covered by the updated assertion.
- [ ] Reviewer: skim the `train.py` reroute diff (mechanical, 31 sites) and the tmux script.

Closes #268
