### PR TITLE
feat(cli): simplify tag scheme to {command}_{datetime} + robust in-place resume

### DIFF
--- a/.claude/skills/aetherscan-repo-context/SKILL.md
+++ b/.claude/skills/aetherscan-repo-context/SKILL.md
@@ -35,10 +35,10 @@ CLI flags are identical between the two paths; only the launcher differs. `PYTHO
 
 ```bash
 # Train (container, canonical)
-./utils/run_container.sh python -m aetherscan.main train --save-tag final_v1
+./utils/run_container.sh python -m aetherscan.main train --save-tag train
 
 # Train (conda source, Ampere)
-PYTHONPATH=src python -m aetherscan.main train --save-tag final_v1
+PYTHONPATH=src python -m aetherscan.main train --save-tag train
 
 # Inference from a pre-processed .npy
 ./utils/run_container.sh python -m aetherscan.main inference \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,9 @@ Aetherscan: Breakthrough Listen's deep-learning SETI pipeline. Two-stage ML (Bet
 
 ```bash
 # Canonical: NGC container (only option on Blackwell)
-./utils/run_container.sh python -m aetherscan.main {train|inference} --save-tag final_v1
+./utils/run_container.sh python -m aetherscan.main {train|inference} --save-tag train
 # Alternative: conda env (Ampere only) — prefix with PYTHONPATH=src
-PYTHONPATH=src python -m aetherscan.main {train|inference} --save-tag final_v1
+PYTHONPATH=src python -m aetherscan.main {train|inference} --save-tag train
 # Lint + format (also enforced via pre-commit)
 ruff check src/ && ruff format src/
 ```

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The `AETHERSCAN_*` paths are bind-mounted 1:1 between host and container, so the
 
 ```bash
 ./utils/run_container.sh python -m aetherscan.main {train|inference} \
-  --save-tag final_v1
+  --save-tag train
 ```
 
 The `utils/run_container.sh` wrapper auto-detects whether `apptainer` or `singularity` is on PATH (Apptainer wins when both are present), sets `--nv` for GPU passthrough, and binds the repo + `AETHERSCAN_{DATA,MODEL,OUTPUT}_PATH` 1:1 between host and container so absolute paths persisted in the DB stay valid across both. `PYTHONPATH` is set automatically inside the container — no inline prefix needed.
@@ -201,7 +201,7 @@ Multiprocess worker pools inherit the values via `os.environ` as usual.
 
 ```bash
 PYTHONPATH=src python -m aetherscan.main {train|inference} \
-  --save-tag final_v1
+  --save-tag train
 ```
 
 `PYTHONPATH=src` makes the `aetherscan` package importable from `src/` without a `pip install -e .` step. No inline `KEY=VALUE` prefix is needed for Slack credentials — the `.env` auto-load runs before any worker process is spawned, so `os.environ` inheritance to multiprocess pools is automatic.
@@ -243,7 +243,7 @@ PYTHONPATH=src python -m aetherscan.main train
     --num-training-rounds 20 \
     --epochs-per-round 100 \
     --curriculum-schedule exponential \
-    --save-tag test_v1
+    --save-tag test
 
 # Source
 PYTHONPATH=src python -m aetherscan.main train \
@@ -251,7 +251,7 @@ PYTHONPATH=src python -m aetherscan.main train \
     --num-training-rounds 20 \
     --epochs-per-round 100 \
     --curriculum-schedule exponential \
-    --save-tag test_v1
+    --save-tag test
 ```
 
 **Resume from checkpoint**
@@ -261,13 +261,13 @@ PYTHONPATH=src python -m aetherscan.main train \
 ./utils/run_container.sh python -m aetherscan.main train \
     --load-dir checkpoints \
     --load-tag round_10 \
-    --save-tag test_v1
+    --save-tag test
 
 # Source
 PYTHONPATH=src python -m aetherscan.main train \
     --load-dir checkpoints \
     --load-tag round_10 \
-    --save-tag test_v1
+    --save-tag test
 ```
 
 > [!WARNING]
@@ -279,12 +279,12 @@ PYTHONPATH=src python -m aetherscan.main train \
 # Container
 ./utils/run_container.sh python -m aetherscan.main train \
     --gpu-memory-limit-mb 14000 \
-    --save-tag test_v1
+    --save-tag test
 
 # Source
 PYTHONPATH=src python -m aetherscan.main train \
     --gpu-memory-limit-mb 14000 \
-    --save-tag test_v1
+    --save-tag test
 ```
 
 **Watching the live dashboard from your local browser (SSH port forwarding)**
@@ -325,17 +325,17 @@ PYTHONPATH=src python -m aetherscan.main inference
 # Container
 ./utils/run_container.sh python -m aetherscan.main inference \
     --test-files real_filtered_LARGE_test_HIP15638.npy \
-    --encoder-path /datax/scratch/zachy/models/aetherscan/vae_encoder_final_v1.keras \
-    --rf-path /datax/scratch/zachy/models/aetherscan/random_forest_final_v1.joblib \
-    --config-path /datax/scratch/zachy/models/aetherscan/config_final_v1.json \
+    --encoder-path /datax/scratch/zachy/models/aetherscan/vae_encoder_train_20260101_120000.keras \
+    --rf-path /datax/scratch/zachy/models/aetherscan/random_forest_train_20260101_120000.joblib \
+    --config-path /datax/scratch/zachy/models/aetherscan/config_train_20260101_120000.json \
     --classification-threshold 0.99
 
 # Source
 PYTHONPATH=src python -m aetherscan.main inference \
     --test-files real_filtered_LARGE_test_HIP15638.npy \
-    --encoder-path /datax/scratch/zachy/models/aetherscan/vae_encoder_final_v1.keras \
-    --rf-path /datax/scratch/zachy/models/aetherscan/random_forest_final_v1.joblib \
-    --config-path /datax/scratch/zachy/models/aetherscan/config_final_v1.json \
+    --encoder-path /datax/scratch/zachy/models/aetherscan/vae_encoder_train_20260101_120000.keras \
+    --rf-path /datax/scratch/zachy/models/aetherscan/random_forest_train_20260101_120000.joblib \
+    --config-path /datax/scratch/zachy/models/aetherscan/config_train_20260101_120000.json \
     --classification-threshold 0.99
 ```
 
@@ -730,16 +730,19 @@ options:
                         upload/download (default: zachtheyek/aetherscan)
   --load-dir LOAD_DIR   Subdirectory for checkpoint loading (relative to
                         --model-path)
-  --load-tag LOAD_TAG   Model tag for checkpoint loading. Accepted formats:
-                        final_vX, round_XX, YYYYMMDD_HHMMSS, test_vX. If
-                        round_XX format used, and --start-round not specified,
-                        training will resume from round following loaded
-                        checkpoint (i.e., XX + 1)
+  --load-tag LOAD_TAG   Checkpoint to load. A full run tag
+                        ({command}_YYYYMMDD_HHMMSS) resumes that run in place
+                        (its tag is adopted, so the resumed attempt writes
+                        under the same run). round_XX (requires --load-dir
+                        checkpoints) seeds a fresh run from that per-round
+                        checkpoint, resuming from round XX+1 unless --start-
+                        round is given.
   --start-round START_ROUND
                         Round to begin/resume training from
-  --save-tag SAVE_TAG   Tag for current pipeline run. Accepted formats:
-                        final_vX, round_XX, test_vX. Current timestamp used
-                        (YYYYMMDD_HHMMSS) if none specified
+  --save-tag SAVE_TAG   Run label prefix: one of test, train, inf, bench. The
+                        datetime is appended automatically at runtime (e.g.
+                        train_20260101_120000). Defaults to the subcommand
+                        (train->train, inference->inf) if omitted.
   --force-tag, --no-force-tag
                         Override the fail-early save-tag collision guard:
                         proceed even when an explicitly-provided --save-tag
@@ -956,10 +959,12 @@ options:
                         pin the model download to when no local artifact paths
                         are given (default: v{package version} when running as
                         an installed release, else the repo's latest release
-                        tag — highest semver vX.Y.Z tag, falling back to the
-                        highest final_vX training tag)
-  --save-tag SAVE_TAG   Tag for current pipeline run. Current timestamp used
-                        (YYYYMMDD_HHMMSS) if none specified
+                        tag — highest semver vX.Y.Z tag; a release tag is
+                        required for a no-artifact download)
+  --save-tag SAVE_TAG   Run label prefix: one of test, train, inf, bench. The
+                        datetime is appended automatically at runtime (e.g.
+                        inf_20260101_120000). Defaults to the subcommand
+                        (train->train, inference->inf) if omitted.
   --force-tag, --no-force-tag
                         Override the fail-early save-tag collision guard:
                         proceed even when an explicitly-provided --save-tag

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ AETHERSCAN_EXTRA_BINDS=/datag ./utils/run_container.sh python -m aetherscan.main
     --encoder-path /path/to/vae_encoder.keras \
     --rf-path /path/to/random_forest.joblib \
     --config-path /path/to/config.json \
-    --save-tag run_v1
+    --save-tag inf
 
 # Source
 PYTHONPATH=src python -m aetherscan.main inference \
@@ -357,7 +357,7 @@ PYTHONPATH=src python -m aetherscan.main inference \
     --encoder-path /path/to/vae_encoder.keras \
     --rf-path /path/to/random_forest.joblib \
     --config-path /path/to/config.json \
-    --save-tag run_v1
+    --save-tag inf
 ```
 
 **Inference with async-allocator fallbacks (e.g. on a 5-GPU Blackwell topology)**
@@ -366,12 +366,12 @@ PYTHONPATH=src python -m aetherscan.main inference \
 # Container
 ./utils/run_container.sh python -m aetherscan.main inference \
     --no-async-allocator \
-    --save-tag run_v1
+    --save-tag inf
 
 # Source
 PYTHONPATH=src python -m aetherscan.main inference \
     --no-async-allocator \
-    --save-tag run_v1
+    --save-tag inf
 ```
 
 ---

--- a/aetherscan.def
+++ b/aetherscan.def
@@ -61,4 +61,4 @@ From: nvcr.io/nvidia/tensorflow:25.02-tf2-py3@sha256:c83b37d26f19ab00d8a13cf974e
     forward compatibility) -- one recipe, both clusters.
 
     Use utils/run_container.sh from the repo root to launch commands, e.g.:
-        ./utils/run_container.sh python -m aetherscan.main train --save-tag test_v1
+        ./utils/run_container.sh python -m aetherscan.main train --save-tag test

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -140,8 +140,8 @@ The order is load-bearing — each step depends on the previous:
    name the per-tag log file `aetherscan_{tag}.log`. A pure CLI-syntax error therefore exits
    before any singleton or thread is created.
 4. `init_logger(save_tag=…)` — queue-based logging up before anything else wants to log; names
-   this run's log file from the save_tag resolved in step 3 (falls back to the config default
-   timestamp tag when `--save-tag` is omitted).
+   this run's log file from the tag `resolve_save_tag()` produced in step 3
+   (`{command}_{datetime}`, or the loaded tag when resuming in place via `--load-tag`).
 5. `init_manager()` — the ResourceManager registers its `atexit` + `SIGINT`/`SIGTERM` handlers.
 6. `register_logger()` — hands the logger to the manager so it is stopped **last** during
    cleanup (you can log during teardown of everything else).
@@ -190,21 +190,24 @@ spawn); they must never touch the DB singleton and must route logging through
 ## Tag conventions
 
 Every run is identified by `config.checkpoint.save_tag` — the **tag** — which stamps every
-artifact filename and every DB row. Accepted formats
-(`cli.py:_TAG_PATTERN`):
+artifact filename and every DB row. A tag is `{command}_{YYYYMMDD_HHMMSS}`, resolved once at
+startup by `cli.resolve_save_tag()` (before `init_logger`, so the log / config / artifacts all
+share one datetime):
 
-| Format            | Example           | Use                                                                                                                                                                               |
-| ----------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `YYYYMMDD_HHMMSS` | `20260712_143000` | Default (import-time timestamp) — every untagged run gets a unique one.                                                                                                           |
-| `final_vX`        | `final_v1`        | Release-grade training runs.                                                                                                                                                      |
-| `round_XX`        | `round_05`        | Per-round checkpoints (written by the pipeline; passed as `--load-tag` with `--load-dir checkpoints` to resume from a specific round — `CheckpointConfig.infer_start_round()` derives the start round from it). |
-| `test_vX`         | `test_v17`        | Smoke/test runs.                                                                                                                                                                  |
+| On the CLI | Resolves to | Use |
+| --- | --- | --- |
+| `--save-tag {test\|train\|inf\|bench}` | `{prefix}_{YYYYMMDD_HHMMSS}` | The user supplies only the prefix; the datetime is stamped at run time. |
+| `--save-tag` omitted | `{subcommand}_{YYYYMMDD_HHMMSS}` (`train`→`train_…`, `inference`→`inf_…`) | The default label per subcommand. |
+| `--load-tag {prefix}_{YYYYMMDD_HHMMSS}` | *(that tag is adopted)* | **Resume in place** — the run continues under the loaded tag (same `run_state` / DB rows / artifacts). |
+| `--load-tag round_XX` | *(a fresh save-tag)* | Load a per-round checkpoint (needs `--load-dir checkpoints`; `CheckpointConfig.infer_start_round()` sets the start round to `XX+1`) into a **new** run. |
 
-`train.py:get_latest_tag()` ranks the families `final_vX > round_XX > timestamp > test_vX`
-when hunting for the newest checkpoint pair. Same-tag **retries** are first-class: the
-run-state manifest (training) and the `inference_cadences` manifest (inference) make re-running
-the identical command resume rather than collide, with stale rows from dead attempts flagged
-`superseded` in the DB ([`DATABASE.md`](DATABASE.md)).
+`round_XX` is the intermediate per-round checkpoint tag and is **load-only** (rejected on
+`--save-tag`). There is no cross-run "latest tag" search: on resume, `_resolve_load_tag` loads
+the run's own final weights or, failing that, its last completed round (per the manifest) —
+never another run's model; it fails loudly instead. **Retries** are first-class: re-run with
+`--load-tag {full-tag}` and the run-state manifest (training) / `inference_cadences` manifest
+(inference) make it resume in place rather than collide, with stale rows from dead attempts
+flagged `superseded` in the DB ([`DATABASE.md`](DATABASE.md)).
 
 ## Directory layout & artifact map
 

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -122,9 +122,9 @@ imports), so it also runs against a database fetched from a cluster with
 
 ```bash
 # Default db path: {AETHERSCAN_OUTPUT_PATH}/db/aetherscan.db
-python utils/benchmark_report.py --save-tag final_v1
+python utils/benchmark_report.py --save-tag train
 # Explicit db (e.g. a copy pulled off the cluster)
-python utils/benchmark_report.py --save-tag test_v18 --db-path /path/to/aetherscan.db
+python utils/benchmark_report.py --save-tag test --db-path /path/to/aetherscan.db
 ```
 
 The same report is also generated **automatically at the tail of every `train`/`inference`

--- a/docs/GPU_RUNTIME_GUIDE.md
+++ b/docs/GPU_RUNTIME_GUIDE.md
@@ -129,13 +129,13 @@ The conda env was bumped to TF 2.17 / numpy 1.26 to match the container's API su
 # Blackwell — memory-growth only, full 96 GB per GPU
 ./utils/run_container.sh \
     python -m aetherscan.main train \
-    --save-tag final_v1
+    --save-tag train
 
 # Ampere — same wrapper, 14 GB cap to match the A4000s' prior behavior
 ./utils/run_container.sh \
     python -m aetherscan.main train \
     --gpu-memory-limit-mb 14000 \
-    --save-tag final_v1
+    --save-tag train
 ```
 
 The wrapper auto-detects `apptainer` vs `singularity`, binds the repo and `AETHERSCAN_*` paths into the container, sets `--nv` for GPU passthrough, and forwards `AETHERSCAN_*` / `SLACK_*` env vars. Environment loading happens at two layers: the wrapper auto-loads `<repo>/.env` at shell time (needed before Python starts so the `AETHERSCAN_*` paths are resolved into the right `--bind` arguments), and `aetherscan.main` calls `python-dotenv`'s `load_dotenv()` at process start (covers Slack credentials inside the container, with `os.environ` then inherited by multiprocess workers). Values already in the wrapper's env — including inline `VAR=val ./utils/run_container.sh ...` or real exports — win at both layers. By default no `--gpu-memory-limit-mb` is passed, so each Blackwell GPU uses memory-growth allocation against its full 96 GB; on Ampere, pass `--gpu-memory-limit-mb 14000` to preserve the legacy A4000 cap.
@@ -145,7 +145,7 @@ The wrapper auto-detects `apptainer` vs `singularity`, binds the repo and `AETHE
 ```bash
 PYTHONPATH=src python -m aetherscan.main train \
     --gpu-memory-limit-mb 14000 \
-    --save-tag final_v1
+    --save-tag train
 ```
 
 The legacy hardcoded `memory_limit=14000` is now a CLI flag with `GPUConfig` as the source of truth. Setting it preserves the original behavior on the A4000s.
@@ -156,9 +156,9 @@ The legacy hardcoded `memory_limit=14000` is now a CLI flag with `GPUConfig` as 
 ./utils/run_container.sh \
     python -m aetherscan.main inference \
     --inference-files complete_cadences_catalog.csv \
-    --encoder-path /datax/scratch/zachy/models/aetherscan/vae_encoder_final_v1.keras \
-    --rf-path /datax/scratch/zachy/models/aetherscan/random_forest_final_v1.joblib \
-    --config-path /datax/scratch/zachy/models/aetherscan/config_final_v1.json
+    --encoder-path /datax/scratch/zachy/models/aetherscan/vae_encoder_train_20260101_120000.keras \
+    --rf-path /datax/scratch/zachy/models/aetherscan/random_forest_train_20260101_120000.joblib \
+    --config-path /datax/scratch/zachy/models/aetherscan/config_train_20260101_120000.json
 
 # Add --gpu-memory-limit-mb 14000 when running on Ampere (container or conda).
 # For the Ampere conda alternative, drop the run_container.sh wrapper and prepend PYTHONPATH=src.

--- a/docs/INFERENCE_PIPELINE.md
+++ b/docs/INFERENCE_PIPELINE.md
@@ -122,8 +122,8 @@ paths:
   (`width_bin`, `stamp_width`, `latent_dim`, `dense_layer_size`, ...) match what the encoder
   was trained with. The saved `checkpoint` section is deliberately skipped — most damagingly
   `save_tag`: without the skip, an inference run would masquerade under the training run's
-  tag, corrupting DB provenance and output paths. The CLI `--save-tag` (or the default
-  timestamp) stays authoritative.
+  tag, corrupting DB provenance and output paths. This run's resolved save_tag (the
+  `{command}_{datetime}` tag set once in `main()`) stays authoritative.
 
 `collect_validation_errors` enforces the trio all-or-none (a partial set is the error above);
 every path that *is* set must exist on disk. The three artifacts should carry the same training
@@ -145,11 +145,11 @@ markers (`find_inference_tag_collisions`) are:
   non-superseded `inference_results` rows for the tag.
 
 Manifest rows are deliberately **not** a collision: they mark an in-progress streaming run that
-the resume flow below consumes, so same-tag DB state there is expected. Default datetime tags
-are immune by construction (a fresh second-resolution timestamp can't collide), so the guard
-only fires for explicit tags; `--force-tag` consciously overrides it. (The same module also
-guards training tags and, under `--hf-upload`, checks the Hub for the tag at startup rather
-than after ~30 h of training.)
+the resume flow below consumes, so same-tag DB state there is expected. Every resolved tag
+carries a fresh second-resolution `{command}_{datetime}` stamp, so a fresh inference run can't
+collide; `--force-tag` overrides the guard if it ever fires. (The same module also guards
+training tags and, under `--hf-upload`, checks the Hub for the tag at startup rather than after
+~30 h of training.)
 
 ## The streaming loop
 
@@ -202,7 +202,9 @@ than after ~30 h of training.)
 The retry loop wraps all of it: transient failures (I/O hiccups, GPU errors) retry up to
 `inference.max_retries` with `inference.retry_delay` between passes; `KeyboardInterrupt`
 propagates; state-based resume (stamp `.npy` for preprocessing, manifest rows for inference)
-makes an in-process retry and a full relaunch of the identical command behave identically.
+lets the in-process retry loop pick up where the last pass died. A full relaunch mints a fresh
+datetime tag and starts clean — to reuse a prior run's preprocessing, point
+`--preprocess-output-dir` at its stamp directory.
 
 ## The GPU stage: `InferencePipeline.run_inference()`
 

--- a/docs/INFERENCE_PIPELINE.md
+++ b/docs/INFERENCE_PIPELINE.md
@@ -86,8 +86,8 @@ after argument parsing). The trio is **all-or-none**
 
 When downloading, the **revision** is chosen by `resolve_hf_revision` in precedence order:
 
-1. **`--hf-revision <tag>`** — an explicit revision (a training tag `final_v1`, a release tag
-   `v1.0.0`, or a commit); returned as-is, existence checked by the download itself.
+1. **`--hf-revision <tag>`** — an explicit revision (a training tag `train_20260101_120000`, a
+   release tag `v1.0.0`, or a commit); returned as-is, existence checked by the download itself.
 2. **`v{__version__}`** — the version-coupled default. When the package is an **installed
    release**, `version_default_revision()` returns `f"v{__version__}"`, so
    `pip install aetherscan==1.0.0` + bare inference pulls exactly the `v1.0.0` weights. The
@@ -98,9 +98,9 @@ When downloading, the **revision** is chosen by `resolve_hf_revision` in precede
    fail the match — all fall through to step 3. This is deliberately **not** existence-checked:
    an installed release whose weights tag is missing must fail loudly (the release blessing
    step was skipped), never silently pull some other version.
-3. **Latest `vX.Y.Z` release tag**, else **latest `final_vX` training tag** on the repo
-   (`select_default_revision`; numeric comparison, so `v1.10.0 > v1.9.9`; tags in neither
-   family — `test_vX`, timestamps — never win). Raises `RuntimeError` with guidance when
+3. **Latest `vX.Y.Z` release tag** on the repo (`select_default_revision`; numeric comparison,
+   so `v1.10.0 > v1.9.9`). Training tags never name the default download — a no-artifact
+   inference download requires a blessed release tag. Raises `RuntimeError` with guidance when
    nothing resolves.
 
 Downloads go through `hf_hub_download` (revision-pinned, cached under `HF_HOME` /

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -61,12 +61,13 @@ Inference resolves models in this precedence order:
 
 1. **Explicit local paths** (`--encoder-path` / `--rf-path` / `--config-path`) — always win;
    the offline/cluster path.
-2. **`--hf-revision <tag>`** — pin any HF revision (a training tag like `final_v1`, a
-   release tag like `v1.0.0`, or a commit).
+2. **`--hf-revision <tag>`** — pin any HF revision (a training tag like
+   `train_20260101_120000`, a release tag like `v1.0.0`, or a commit).
 3. **`v{__version__}`** — when running as an installed release, the package's own version is
    the default revision. This is the line that makes `pip install aetherscan==1.0.0` +
    bare inference pull exactly the `v1.0.0` weights.
-4. **Latest `v*` semver tag** on the HF repo, then **latest `final_vX`** training tag.
+4. **Latest `v*` semver tag** on the HF repo. Training tags never name the default download —
+   a no-artifact inference download requires a blessed release tag.
 5. Otherwise: error with guidance.
 
 Downloads happen **lazily at first inference**, never at import time (an import-time network
@@ -83,7 +84,7 @@ versioning**:
 
 | Tag family | Created by | Points at |
 | --- | --- | --- |
-| Training tags (`final_v1`, `test_v17`, ...) | Training runs with `--hf-upload` (tag = the run's `save_tag`) | The commit that upload produced |
+| Training tags (`train_20260101_120000`, ...) | Training runs with `--hf-upload` (tag = the run's `save_tag`) | The commit that upload produced |
 | Release tags (`v1.0.0`, ...) | The release runbook (step 3 below) | The blessed training upload's commit |
 
 Uploads need a write-scoped `HF_TOKEN` in the environment (`.env` on the clusters —
@@ -152,14 +153,15 @@ Steps for cutting `vX.Y.Z` (maintainer + agent together):
 1. **Prereqs** — one-time setup above is done; all intended PRs are merged; `master` is
    green.
 2. **Train the release model** — full-scale
-   `train --save-tag final_vN --hf-upload` on the chosen cluster. Weights land locally and
-   on HF tagged `final_vN`. **Review the training artifacts** — the loss curves, injection
+   `train --save-tag train --hf-upload` on the chosen cluster (the run tag resolves to
+   `train_{YYYYMMDD_HHMMSS}` — note it for the next step). Weights land locally and on HF tagged
+   with that run tag. **Review the training artifacts** — the loss curves, injection
    stats, latent diagnostics, and RF plots ([`TRAINING_PIPELINE.md`](TRAINING_PIPELINE.md))
    are the release-qualification evidence.
 3. **Bless the weights** — create the release tag on HF pointing at the training upload:
-   `utils/hf_tag_release.py --save-tag final_vN --release vX.Y.Z` (a thin wrapper over
-   `HfApi.create_tag`). This is the human "these weights are the release" decision — CD
-   deliberately cannot make it.
+   `utils/hf_tag_release.py --save-tag train_{YYYYMMDD_HHMMSS} --release vX.Y.Z` (the run tag from
+   step 2; a thin wrapper over `HfApi.create_tag`). This is the human "these weights are the
+   release" decision — CD deliberately cannot make it.
 4. **Release PR** — bump `version = "X.Y.Z"` in `pyproject.toml`, revisit the Development
    Status classifier, draft the release notes (curate the `claude-release-notes` comments),
    regenerate anything version-stamped. Merge through normal review.

--- a/docs/RUNTIME_SERVICES.md
+++ b/docs/RUNTIME_SERVICES.md
@@ -232,7 +232,7 @@ reconstruct plus a PNG gallery.
 - **Manual runs against a saved DB.** The `aetherscan-dashboard` console script
   ([`src/aetherscan/dashboard_cli.py`](../src/aetherscan/dashboard_cli.py), registered under
   `[project.scripts]`) forwards its args verbatim to `dashboard.py`'s argparse:
-  `aetherscan-dashboard --db-path /path/to/aetherscan.db --tag final_v1`. In a source checkout /
+  `aetherscan-dashboard --db-path /path/to/aetherscan.db --tag train_20260101_120000`. In a source checkout /
   the container (no installed entry point), run the same shim as
   `PYTHONPATH=src python -m aetherscan.dashboard_cli <args>`. Either way it re-execs
   `python -m streamlit run <packaged dashboard.py> -- <args>` — Streamlit must own the process,

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -45,7 +45,7 @@ tests/
 │   ├── test_round_data.py           # paths/manifest protocol, reuse/delete semantics, producer
 │   ├── test_seeding.py              # root-seed stream derivation (reproducible runs)
 │   ├── test_run_state.py            # manifest round-trip, stage machine transitions
-│   ├── test_train_utils.py          # get_latest_tag ladder, curriculum schedules, archiving
+│   ├── test_train_utils.py          # load-tag resolution, curriculum schedules, archiving
 │   ├── test_train_datasets.py       # batched generators: coverage, stratification, alignment
 │   ├── test_latent_traversal.py     # traversal grid math with a stub decoder
 │   ├── test_models.py               # feature layout, RF train/predict, encoder/decoder symmetry

--- a/docs/TRAINING_PIPELINE.md
+++ b/docs/TRAINING_PIPELINE.md
@@ -29,7 +29,9 @@ recorded in the manifest and retried on the next run, but never cost a data rege
 Stage 6 (`hf_upload`) runs only when `config.hf.upload_after_training` is set — a failed
 upload is recorded but never fails the run, since the weights are already safe locally.
 Every stage is skipped if the persisted manifest (`run_state_{tag}.json`) already records it
-as done, so re-running the identical command resumes exactly where the last attempt died.
+as done, so the in-process retry loop resumes exactly where the last attempt died. Resuming
+across a full process relaunch is explicit: pass `--load-tag {full-tag}` (a bare re-run mints a
+fresh datetime tag and starts a new run).
 
 ## Round lifecycle
 
@@ -288,8 +290,9 @@ clear `stages_done` so downstream stages re-run against the re-trained rounds.
 `training.retry_delay` between attempts. Each attempt rebuilds the `TrainingPipeline` from
 scratch (no corrupted in-memory state survives); the manifest tells the new pipeline where to
 resume. Background plates are loaded once in `train_command` and reused across attempts.
-Because the manifest is on disk, a **full process relaunch of the identical command resumes
-identically** — the in-process loop and a crash-and-relaunch are the same code path.
+The manifest is on disk, so the in-process retry loop resumes off it automatically; a
+crash-and-relaunch resumes identically **only when re-invoked with `--load-tag {full-tag}`** (a
+bare relaunch mints a fresh datetime tag and starts a new run).
 
 Non-critical plot stages (`vae_plots`, `rf_plots`) never trigger a retry: each plot in the
 group is attempted even if a sibling fails (`_run_plot_group`), failures are recorded in

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -11,6 +11,7 @@ import os
 import re
 import shutil
 from dataclasses import dataclass, field, is_dataclass
+from datetime import datetime
 from math import gcd, lcm
 from typing import Any
 
@@ -22,15 +23,40 @@ logger = logging.getLogger(__name__)
 # Validation primitives are expressed as global variables and shared by
 # validate_args() and utility scripts (e.g. utils/find_optimal_configs.py)
 
-# Accepted formats for --load-tag and --save-tag (cli.py help strings document these)
-# NOTE: this whitelist is fairly restrictive — consider broadening it with more accepted
-# tag formats (e.g. free-form descriptive slugs like `smoke_blackwell` or `ampere_v1`) so
-# runs can be labelled meaningfully without being forced into the test_vX / final_vX shapes.
-_TAG_PATTERN = re.compile(r"^(?:\d{8}_\d{6}|final_v\d+|round_\d+|test_v\d+)$")
+# Tag scheme (see resolve_save_tag): a run's save-tag is `{command}_{YYYYMMDD_HHMMSS}`. The user
+# supplies only the command prefix on --save-tag; the datetime is appended at runtime. --load-tag
+# takes a full resolved tag (resume that run in place) or a per-round checkpoint (round_XX).
+_SAVE_TAG_PREFIXES = ("test", "train", "inf", "bench")
+# --save-tag accepts one of the prefixes above (bare); the datetime is auto-appended.
+_SAVE_TAG_PATTERN = re.compile(r"^(?:test|train|inf|bench)$")
+# A fully-resolved run tag `{prefix}_{YYYYMMDD_HHMMSS}` — used to detect a resume-in-place --load-tag.
+_FULL_TAG_PATTERN = re.compile(r"^(?:test|train|inf|bench)_\d{8}_\d{6}$")
+# --load-tag accepts a full resolved tag (resume that run in place) or a per-round checkpoint.
+_LOAD_TAG_PATTERN = re.compile(r"^(?:(?:test|train|inf|bench)_\d{8}_\d{6}|round_\d+)$")
 
-# The round_XX subset of _TAG_PATTERN: per-round checkpoints are saved under the checkpoints/
+# The round_XX subset of _LOAD_TAG_PATTERN: per-round checkpoints are saved under the checkpoints/
 # subdirectory, so loading one requires --load-dir checkpoints (issue #142)
 _ROUND_TAG_PATTERN = re.compile(r"^round_\d+$")
+
+# Default --save-tag prefix per subcommand when --save-tag is omitted.
+_COMMAND_TAG_PREFIX = {"train": "train", "inference": "inf"}
+
+
+def resolve_save_tag(command: str | None, save_tag: str | None, load_tag: str | None) -> str:
+    """Resolve the run's full `{prefix}_{YYYYMMDD_HHMMSS}` save-tag at runtime.
+
+    - A full `{prefix}_{datetime}` ``--load-tag`` resumes that run **in place**: its tag is
+      adopted so the resumed attempt writes under the same ``run_state`` / DB rows / artifacts.
+      (A ``round_XX`` ``--load-tag`` does NOT adopt — it seeds a fresh run from that checkpoint.)
+    - Otherwise the tag is ``{prefix}_{datetime}``, where the prefix is ``--save-tag``
+      (``test|train|inf|bench``) or, when omitted, the subcommand default (``train`` → ``train``,
+      ``inference`` → ``inf``). The datetime is stamped once, here, at run time.
+    """
+    if load_tag is not None and _FULL_TAG_PATTERN.match(load_tag):
+        return load_tag
+    prefix = save_tag if save_tag is not None else _COMMAND_TAG_PREFIX.get(command, "run")
+    return f"{prefix}_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+
 
 # sklearn's RandomForestClassifier accepts these string values for max_features
 _RF_MAX_FEATURES_STR_VALUES = {"sqrt", "log2"}
@@ -670,7 +696,7 @@ def _add_train_flags_to(parser):
         "--load-tag",
         type=str,
         default=None,
-        help="Model tag for checkpoint loading. Accepted formats: final_vX, round_XX, YYYYMMDD_HHMMSS, test_vX. If round_XX format used, and --start-round not specified, training will resume from round following loaded checkpoint (i.e., XX + 1)",
+        help="Checkpoint to load. A full run tag ({command}_YYYYMMDD_HHMMSS) resumes that run in place (its tag is adopted, so the resumed attempt writes under the same run). round_XX (requires --load-dir checkpoints) seeds a fresh run from that per-round checkpoint, resuming from round XX+1 unless --start-round is given.",
     )
     parser.add_argument(
         "--start-round",
@@ -682,7 +708,7 @@ def _add_train_flags_to(parser):
         "--save-tag",
         type=str,
         default=None,
-        help="Tag for current pipeline run. Accepted formats: final_vX, round_XX, test_vX. Current timestamp used (YYYYMMDD_HHMMSS) if none specified",
+        help="Run label prefix: one of test, train, inf, bench. The datetime is appended automatically at runtime (e.g. train_20260101_120000). Defaults to the subcommand (train->train, inference->inf) if omitted.",
     )
     parser.add_argument(
         "--force-tag",
@@ -960,7 +986,7 @@ def _add_inference_flags_to(parser):
         "--hf-revision",
         type=str,
         default=None,
-        help="HuggingFace revision (tag, branch, or commit hash) to pin the model download to when no local artifact paths are given (default: v{package version} when running as an installed release, else the repo's latest release tag — highest semver vX.Y.Z tag, falling back to the highest final_vX training tag)",
+        help="HuggingFace revision (tag, branch, or commit hash) to pin the model download to when no local artifact paths are given (default: v{package version} when running as an installed release, else the repo's latest release tag — highest semver vX.Y.Z tag; a release tag is required for a no-artifact download)",
     )
 
     # Checkpoint configuration
@@ -968,7 +994,7 @@ def _add_inference_flags_to(parser):
         "--save-tag",
         type=str,
         default=None,
-        help="Tag for current pipeline run. Current timestamp used (YYYYMMDD_HHMMSS) if none specified",
+        help="Run label prefix: one of test, train, inf, bench. The datetime is appended automatically at runtime (e.g. inf_20260101_120000). Defaults to the subcommand (train->train, inference->inf) if omitted.",
     )
     parser.add_argument(
         "--force-tag",
@@ -1267,8 +1293,8 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
         config.checkpoint.infer_start_round()  # Try inferring start_round from load_tag first
     if hasattr(args, "start_round") and args.start_round is not None:
         config.checkpoint.start_round = args.start_round  # Override start_round if provided
-    if hasattr(args, "save_tag") and args.save_tag is not None:
-        config.checkpoint.save_tag = args.save_tag
+    # NOTE: config.checkpoint.save_tag is resolved once in main() (before init_logger, so the log
+    # file / config / artifacts share one datetime) via resolve_save_tag — not applied from args here.
     # force_tag uses argparse.BooleanOptionalAction with default=None (same tri-state as
     # hf_upload above)
     if hasattr(args, "force_tag") and args.force_tag is not None:
@@ -1989,12 +2015,12 @@ def collect_validation_errors(
         # TODO: Deferred -- save_tag uniqueness check requires the DB (init_db runs
         # after validate_args).
         load_tag = _resolve(args, "load_tag", config.checkpoint.load_tag)
-        if load_tag is not None and not _TAG_PATTERN.match(load_tag):
+        if load_tag is not None and not _LOAD_TAG_PATTERN.match(load_tag):
             errors.append(
                 ValidationError(
                     field="checkpoint.load_tag",
                     current=load_tag,
-                    message=f"--load-tag must match one of: YYYYMMDD_HHMMSS, final_vX, round_XX, test_vX; got {load_tag!r}",
+                    message=f"--load-tag must be a full run tag ({{test|train|inf|bench}}_YYYYMMDD_HHMMSS) or round_XX; got {load_tag!r}",
                     fix_kind="format",
                 )
             )
@@ -2016,8 +2042,8 @@ def collect_validation_errors(
                         f"--load-tag {load_tag!r} names a per-round checkpoint, and those are "
                         f"saved under the 'checkpoints/' subdirectory — pass --load-dir "
                         f"checkpoints to resume from it. (If you genuinely keep a final model "
-                        f"tagged {load_tag!r} in the models root, re-save it under a final_vX "
-                        f"or test_vX tag and load that instead.)"
+                        f"tagged {load_tag!r} in the models root, re-save it under a full run "
+                        f"tag ({{test|train|inf|bench}}_YYYYMMDD_HHMMSS) and load that instead.)"
                     ),
                     fix_kind="cross_param",
                 )
@@ -2036,13 +2062,13 @@ def collect_validation_errors(
                 )
             )
 
-        save_tag = _resolve(args, "save_tag", config.checkpoint.save_tag)
-        if save_tag is not None and not _TAG_PATTERN.match(save_tag):
+        save_tag = getattr(args, "save_tag", None)
+        if save_tag is not None and not _SAVE_TAG_PATTERN.match(save_tag):
             errors.append(
                 ValidationError(
                     field="checkpoint.save_tag",
                     current=save_tag,
-                    message=f"--save-tag must match one of: YYYYMMDD_HHMMSS, final_vX, round_XX, test_vX; got {save_tag!r}",
+                    message=f"--save-tag must be one of: test, train, inf, bench (the datetime is appended automatically); got {save_tag!r}",
                     fix_kind="format",
                 )
             )
@@ -2368,13 +2394,13 @@ def collect_validation_errors(
             )
 
         # -------------------------------------------------------------- Checkpoint
-        save_tag = _resolve(args, "save_tag", config.checkpoint.save_tag)
-        if save_tag is not None and not _TAG_PATTERN.match(save_tag):
+        save_tag = getattr(args, "save_tag", None)
+        if save_tag is not None and not _SAVE_TAG_PATTERN.match(save_tag):
             errors.append(
                 ValidationError(
                     field="checkpoint.save_tag",
                     current=save_tag,
-                    message=f"--save-tag must match one of: YYYYMMDD_HHMMSS, final_vX, round_XX, test_vX; got {save_tag!r}",
+                    message=f"--save-tag must be one of: test, train, inf, bench (the datetime is appended automatically); got {save_tag!r}",
                     fix_kind="format",
                 )
             )

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -209,8 +209,11 @@ def setup_argument_parser() -> argparse.ArgumentParser:
         description="Aetherscan Pipeline -- Breakthrough Listen's first end-to-end production-grade DL pipeline for SETI @ scale"
     )
 
-    # Add commands
-    subparsers = parser.add_subparsers(dest="command", help="Command to execute")
+    # Add commands. required=True: a subcommand is mandatory. Without it a bare
+    # `python -m aetherscan.main` leaves command=None, and main()'s resolve_save_tag(None, ...)
+    # would raise a ValueError traceback before the logger exists; argparse instead emits a clean
+    # usage error (caught by main()'s SystemExit handler, which prints full help).
+    subparsers = parser.add_subparsers(dest="command", required=True, help="Command to execute")
 
     # Train command
     _add_train_arguments(subparsers)
@@ -1035,8 +1038,8 @@ def apply_saved_config(config_path: str) -> None:
     The `checkpoint` section is skipped entirely: a saved *training* config's
     checkpoint fields (most damagingly `save_tag`) are never what an inference run
     wants — layering them would make this run masquerade under the training run's
-    tag, corrupting DB provenance and output paths. The CLI `--save-tag` (or the
-    default import-time timestamp) stays authoritative.
+    tag, corrupting DB provenance and output paths. This run's resolved save_tag
+    (set once in main() by resolve_save_tag) stays authoritative.
 
     Raises `ValueError` if the file is missing or malformed — caught by main.py's
     wrapper alongside `validate_args` failures.

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -54,7 +54,16 @@ def resolve_save_tag(command: str | None, save_tag: str | None, load_tag: str | 
     """
     if load_tag is not None and _FULL_TAG_PATTERN.match(load_tag):
         return load_tag
-    prefix = save_tag if save_tag is not None else _COMMAND_TAG_PREFIX.get(command, "run")
+    if save_tag is not None:
+        prefix = save_tag
+    elif command in _COMMAND_TAG_PREFIX:
+        prefix = _COMMAND_TAG_PREFIX[command]
+    else:
+        # Fail loudly rather than emit an unloadable tag (a prefix outside {test,train,inf,bench}
+        # would not match _LOAD_TAG_PATTERN, so its artifacts could never be --load-tag'd).
+        raise ValueError(
+            f"Cannot derive a save-tag prefix for command {command!r}; pass --save-tag explicitly."
+        )
     return f"{prefix}_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
 
 

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import os
 import threading
 from dataclasses import dataclass, field
-from datetime import datetime
 from multiprocessing import cpu_count
 
 
@@ -426,7 +425,7 @@ class HFConfig:
     # (requires HF_TOKEN in the environment; default off = local-only).
     upload_after_training: bool = False
     # Inference pin: HF revision (tag/branch/commit) to download artifacts from. None
-    # resolves to the latest release tag (highest semver vX.Y.Z, else highest final_vX).
+    # resolves to the latest release tag (highest semver vX.Y.Z); a release tag is required.
     revision: str | None = None
 
 
@@ -437,7 +436,10 @@ class CheckpointConfig:
     load_dir: str | None = None
     load_tag: str | None = None
     start_round: int = 1
-    save_tag: str = datetime.now().strftime("%Y%m%d_%H%M%S")
+    # Resolved once at runtime by cli.resolve_save_tag (in main(), before init_logger) to
+    # {command}_{YYYYMMDD_HHMMSS}. None until then — the pipeline always runs through the CLI,
+    # which sets it before any stage reads it.
+    save_tag: str | None = None
     # Override the fail-early save-tag dedup guards (local artifact/DB collisions and the
     # HF-side tag check) for an explicitly-provided save_tag.
     force_tag: bool = False

--- a/src/aetherscan/dashboard.py
+++ b/src/aetherscan/dashboard.py
@@ -18,7 +18,7 @@ opt out); to run it by hand against a saved DB, point streamlit at the installed
 
     streamlit run "$(python -c 'import aetherscan, os; \
         print(os.path.join(os.path.dirname(aetherscan.__file__), "dashboard.py"))')" \
-        -- --db-path /path/to/aetherscan.db --tag final_v1
+        -- --db-path /path/to/aetherscan.db --tag train_20260101_120000
 
 To watch a run on a cluster, SSH-forward the port:  ssh -L 8501:localhost:8501 blpc3
 

--- a/src/aetherscan/dashboard_cli.py
+++ b/src/aetherscan/dashboard_cli.py
@@ -5,7 +5,7 @@ main.py auto-launches the dashboard alongside a run (dashboard_launcher.py); thi
 ad-hoc case — inspecting a saved DB after the fact — replacing the verbose manual incantation from
 dashboard.py's docstring with:
 
-    aetherscan-dashboard --db-path /path/to/aetherscan.db --tag final_v1
+    aetherscan-dashboard --db-path /path/to/aetherscan.db --tag train_20260101_120000
 
 Everything on the command line is forwarded verbatim to dashboard.py's argparse (--db-path, --tag,
 --plots-dir, --refresh). Streamlit must OWN the process (`streamlit run <file>`) for the `st.*`

--- a/src/aetherscan/hf_hub.py
+++ b/src/aetherscan/hf_hub.py
@@ -5,16 +5,17 @@ One public model repo (config.hf.repo_id, default zachtheyek/aetherscan) carries
 weights at stable filenames in the repo root — vae_encoder.keras, vae_decoder.keras,
 random_forest.joblib, config.json, plus an auto-generated model card README.md — with HF git
 tags carrying the versioning. Two tag families exist on the Hub: training tags (= a run's
-save_tag, e.g. final_v3, created by upload_run_to_hf after training) and release tags
-(vX.Y.Z, added by the release runbook pointing at the blessed weights commit).
+save_tag, e.g. train_20260101_120000, created by upload_run_to_hf after training) and release
+tags (vX.Y.Z, added by the release runbook pointing at the blessed weights commit).
 
 Upload (train, opt-in via --hf-upload) stages the four run artifacts under the stable names,
 commits them with the save_tag as the commit message, and tags the commit. Download
 (inference, the default when no local artifact paths are given) resolves a revision —
 explicit --hf-revision, else v{__version__} when running as an installed release (see
 version_default_revision — this is what makes `pip install aetherscan==1.0.0` + bare
-inference pull exactly the v1.0.0 weights), else the highest semver vX.Y.Z tag, else the
-highest final_vX tag — and pulls the artifact trio revision-pinned via hf_hub_download.
+inference pull exactly the v1.0.0 weights), else the highest semver vX.Y.Z release tag — and
+pulls the artifact trio revision-pinned via hf_hub_download. A no-artifact download requires a
+release tag; training tags never name the default revision.
 
 Auth: uploads require HF_TOKEN in the environment (loaded from the gitignored .env);
 huggingface_hub reads it implicitly. The repo is public, so downloads need no token. The
@@ -53,10 +54,10 @@ HF_CARD_FILENAME = "README.md"
 
 GITHUB_URL = "https://github.com/zachtheyek/Aetherscan"
 
-# Release tags (vX.Y.Z, from the release runbook) outrank training tags (final_vX) when
-# resolving the default download revision.
+# Release tags (vX.Y.Z, from the release runbook) name the default download revision. Training
+# tags (the {command}_{datetime} run tags) never name it — a no-artifact inference download
+# requires a blessed release tag.
 _SEMVER_TAG_PATTERN = re.compile(r"^v(\d+)\.(\d+)\.(\d+)$")
-_FINAL_TAG_PATTERN = re.compile(r"^final_v(\d+)$")
 
 
 def _hf_api():
@@ -118,17 +119,15 @@ def hf_tag_exists(repo_id: str, tag: str) -> bool:
 def select_default_revision(tags: list[str]) -> str | None:
     """
     Pick the default download revision from a repo's tag list: the highest semver vX.Y.Z
-    release tag; if none exist, the highest final_vX training tag; else None. Comparison is
-    numeric (v1.10.0 > v1.9.9), and tags in neither family (test_vX, timestamps) never win.
+    release tag, or None if the repo carries no release tag. Comparison is numeric
+    (v1.10.0 > v1.9.9); training tags (the {command}_{datetime} run tags) never win — a
+    no-artifact inference download requires a blessed release tag.
     """
     semver = [
         (tuple(int(g) for g in m.groups()), t) for t in tags if (m := _SEMVER_TAG_PATTERN.match(t))
     ]
     if semver:
         return max(semver)[1]
-    final = [(int(m.group(1)), t) for t in tags if (m := _FINAL_TAG_PATTERN.match(t))]
-    if final:
-        return max(final)[1]
     return None
 
 
@@ -186,7 +185,7 @@ def resolve_hf_revision(repo_id: str, revision: str | None) -> str:
     selected = select_default_revision(tags)
     if selected is None:
         raise RuntimeError(
-            f"No release tag (vX.Y.Z) or training tag (final_vX) found on HF repo "
+            f"No release tag (vX.Y.Z) found on HF repo "
             f"'{repo_id}' to download model artifacts from. Either pin a revision with "
             f"--hf-revision, point --hf-repo-id at a repo with released weights, or pass "
             f"all three local artifact paths (--encoder-path/--rf-path/--config-path)."
@@ -378,8 +377,8 @@ a 6-observation cadence (3 ON / 3 OFF, ABACAD) into an 8-dimensional latent, and
 Forest** classifies the cadence's concatenated latents as a technosignature candidate or not.
 
 This repository carries the released model weights at stable filenames, versioned via git
-tags: training tags match the pipeline run's save tag (e.g. `final_v3`), and release tags
-(`vX.Y.Z`) mark blessed weights.
+tags: training tags match the pipeline run's save tag (e.g. `train_20260101_120000`), and
+release tags (`vX.Y.Z`) mark blessed weights.
 
 **Training tag**: `{tag}`
 

--- a/src/aetherscan/hf_hub.py
+++ b/src/aetherscan/hf_hub.py
@@ -408,8 +408,8 @@ The complete configuration is in `{HF_CONFIG_FILENAME}`.
 
 ## Usage
 
-Aetherscan inference downloads these weights by default when no local artifact paths are
-given (pin a version with `--hf-revision`):
+Pin this training tag with `--hf-revision` to download exactly these weights (a bare no-artifact
+inference download resolves to the latest `vX.Y.Z` release tag instead, never a training tag):
 
 ```bash
 python -m aetherscan.main inference --hf-revision {tag} --inference-files <catalog.csv>

--- a/src/aetherscan/logger/logger.py
+++ b/src/aetherscan/logger/logger.py
@@ -134,8 +134,8 @@ class Logger:
         """Initialize logger.
 
         `save_tag` names this run's log file (aetherscan_{save_tag}.log). Callers pass the run's
-        effective tag (the CLI --save-tag if given, else the config default timestamp tag); when
-        omitted, it falls back to config.checkpoint.save_tag directly.
+        resolved {command}_{datetime} tag (main() resolves it via cli.resolve_save_tag before
+        calling init_logger); when omitted, it falls back to config.checkpoint.save_tag directly.
         """
         # Note, __init__ is triggered every time the class's constructor is called,
         # even if __new__ returned the existing singleton instance
@@ -150,9 +150,9 @@ class Logger:
             raise ValueError("get_config() returned None")
 
         # Per-run, tag-scoped log file: each run writes aetherscan_{tag}.log, so a new run no
-        # longer overwrites the previous run's log. init_logger() runs before the CLI --save-tag
-        # is applied to the config, so main.py resolves the effective tag from args and passes it
-        # in here; the config default is the fallback for any other caller.
+        # longer overwrites the previous run's log. main.py resolves the run's {command}_{datetime}
+        # tag onto config.checkpoint.save_tag before calling init_logger and passes it in here; the
+        # config value is the fallback for any other caller.
         tag = save_tag if save_tag is not None else self.config.checkpoint.save_tag
         self.log_path = log_path_for_tag(self.config.output_path, tag)
         os.makedirs(os.path.dirname(self.log_path), exist_ok=True)  # Create dir if it doesn't exist
@@ -345,9 +345,9 @@ def init_logger(save_tag: str | None = None) -> Logger:
     """
     Initialize global logger instance (call once at startup).
 
-    `save_tag` names this run's log file (aetherscan_{save_tag}.log). Pass the run's effective tag
-    (the CLI --save-tag if given, else the config default timestamp tag); when omitted, the Logger
-    falls back to config.checkpoint.save_tag.
+    `save_tag` names this run's log file (aetherscan_{save_tag}.log). Pass the run's resolved
+    {command}_{datetime} tag (main() resolves it via cli.resolve_save_tag beforehand); when
+    omitted, the Logger falls back to config.checkpoint.save_tag.
     """
     logger_instance = Logger(save_tag=save_tag)
 

--- a/src/aetherscan/logger/slack_handler.py
+++ b/src/aetherscan/logger/slack_handler.py
@@ -329,7 +329,7 @@ class SlackHandler(logging.Handler):
             cli_args = sys.argv
         cli_args_str = " ".join(cli_args)
 
-        # NOTE: the command shown does not match the actual command ran (/home/zachy/Aetherscan/src/aetherscan/main.py train --num-training-rounds 1 --max-retries 1 --save-tag test_v0 VS SLACK_BOT_TOKEN=$SLACK_BOT_TOKEN SLACK_CHANNEL=$SLACK_CHANNEL PYTHONPATH=src python -m aetherscan.main train --num-training-rounds 1 --max-retries 1 --save-tag test_v0)
+        # NOTE: the command shown does not match the actual command ran (/home/zachy/Aetherscan/src/aetherscan/main.py train --num-training-rounds 1 --max-retries 1 --save-tag test VS SLACK_BOT_TOKEN=$SLACK_BOT_TOKEN SLACK_CHANNEL=$SLACK_CHANNEL PYTHONPATH=src python -m aetherscan.main train --num-training-rounds 1 --max-retries 1 --save-tag test)
         # Build the run summary message
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         summary_lines = [

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -24,6 +24,7 @@ from aetherscan.benchmark import stage_timer
 from aetherscan.cli import (
     apply_args_to_config,
     apply_saved_config,
+    resolve_save_tag,
     setup_argument_parser,
     validate_args,
 )
@@ -940,14 +941,23 @@ def main():
             parser.print_help()
         raise
 
-    # Initialize logger. Name the run's log file with its effective save_tag: the CLI --save-tag
-    # when provided (present on the train/inference subcommands as args.save_tag), else the config
-    # default timestamp tag. init_logger() runs before apply_args_to_config(), so the tag is
-    # resolved from args here rather than from the not-yet-updated config. Pass None straight
-    # through rather than pre-resolving the default here — Logger.__init__ already does the
-    # is-not-None fallback to config.checkpoint.save_tag internally.
+    # Resolve the run's save-tag ONCE, here, at runtime: a full {command}_{datetime} --load-tag
+    # resumes that run in place (its tag is adopted); otherwise {--save-tag prefix or subcommand}_
+    # {datetime}. Done before init_logger() (which names the log file by tag) and validate_args()
+    # so the log file, config, and every artifact share a single datetime. --save-tag stays a bare
+    # prefix on `args` for validate_args to check; only the resolved full tag lands on the config.
+    config = get_config()
+    if config is None:
+        raise ValueError("get_config() returned None")
+    config.checkpoint.save_tag = resolve_save_tag(
+        getattr(args, "command", None),
+        getattr(args, "save_tag", None),
+        getattr(args, "load_tag", None),
+    )
+
+    # Initialize logger, naming the run's log file with the resolved save_tag.
     try:
-        init_logger(save_tag=getattr(args, "save_tag", None))
+        init_logger(save_tag=config.checkpoint.save_tag)
         logger.info("Logger initialization successful, but not yet registered for cleanup.")
         logger.info("Awaiting resource manager initialization. Do not terminate the process!")
     except Exception as e:

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -964,6 +964,17 @@ def main():
         # Note, can't log if init_logger() fails
         sys.exit(1)
 
+    # A full --load-tag resumes that run in place (its tag is adopted as the save_tag). If the user
+    # ALSO passed an explicit --save-tag prefix, it was silently overridden — surface that so the
+    # save-tag not taking effect isn't a mystery.
+    if getattr(args, "save_tag", None) and config.checkpoint.save_tag == getattr(
+        args, "load_tag", None
+    ):
+        logger.info(
+            f"Resuming in place under --load-tag '{args.load_tag}' — the provided --save-tag "
+            f"'{args.save_tag}' was ignored (a full --load-tag adopts that run's tag)."
+        )
+
     # Initialize resource manager
     try:
         init_manager()

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -358,7 +358,9 @@ def train_command():
             # Reinitialize the training pipeline on each attempt so no corrupted state is
             # persisted. The persisted run manifest (run_state_{save_tag}.json) tells the new
             # pipeline which rounds/stages already completed, so the attempt resumes exactly
-            # where the previous one died (works identically for a full process relaunch)
+            # where the previous one died. The save_tag is fixed for the life of the process, so
+            # these in-process retries resume automatically; a full process relaunch mints a fresh
+            # datetime tag and only resumes when re-invoked with --load-tag {full-tag}.
             pipeline = run_training_pipeline(background_data=background_data, strategy=strategy)
 
             break  # If we get here, training succeeded

--- a/src/aetherscan/tag_guards.py
+++ b/src/aetherscan/tag_guards.py
@@ -2,10 +2,10 @@
 Fail-early save-tag dedup guards.
 
 Reusing a save_tag silently mixes a new run's artifacts, config JSON, and DB rows with a
-previous run's — the stale-artifact confusion the cluster runbook works around by manually
-incrementing test_vNN tags. These guards hard-stop a run at startup (before any expensive
-work or writes) when an explicitly-provided --save-tag collides with existing state, while
-staying out of the way of the two legitimate same-tag flows:
+previous run's — the stale-artifact confusion the cluster runbook used to work around by
+manually incrementing test_vNN tags. These guards hard-stop a run at startup (before any
+expensive work or writes) when its resolved save-tag collides with a completed run's state,
+while staying out of the way of the two legitimate same-tag flows:
 
 - Training retries/relaunches: a run-state manifest (run_state_{tag}.json) marks the tag as
   an in-progress resumable run, so the guard is skipped entirely (PR-04's supersede
@@ -14,9 +14,10 @@ staying out of the way of the two legitimate same-tag flows:
   streaming run. Only a completed run — evidenced by its saved config_{tag}.json, written at
   the very end of a successful pass — or stale legacy-path DB rows count as collisions.
 
-Default (datetime) save tags are immune by construction — a fresh second-resolution
-timestamp can't collide — so the local guards only fire for explicitly-provided tags.
---force-tag consciously overrides every guard.
+Because every resolved save-tag carries a fresh second-resolution {command}_{datetime} stamp,
+a fresh run can't collide by construction; the guards bite only if a completed run's tag is
+deliberately reused, and the resumable-run manifests above exempt the legitimate retry/resume
+flows. --force-tag consciously overrides every guard.
 
 enforce_tag_guards() is called from main() immediately before command dispatch
 (post-validation, post-DB-init, pre-any-work).

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import contextlib
 import gc
-import glob
 import json
 import logging
 import os
@@ -216,91 +215,6 @@ def archive_directory(base_dir: str, target_dirs: list[str] | None = None, round
             logger.info(f"No files with round >= {round_num} found to delete")
 
 
-def get_latest_tag(checkpoints_dir: str) -> str:
-    """
-    Find the latest checkpoint tag (e.g. "round_05") in checkpoints_dir, choosing the most recent
-    tag whose encoder/decoder pair both exist on disk.
-
-    Tag families are ranked by priority: final_vX > round_XX > YYYYMMDD_HHMMSS > test_vX. The
-    highest-priority family present wins, then ties within that family are broken by version /
-    round number / timestamp. Raises FileNotFoundError if no valid pair is found.
-    """
-    if not os.path.exists(checkpoints_dir):
-        raise FileNotFoundError(f"Directory doesn't exist: {checkpoints_dir}")
-
-    # Find all encoder files
-    encoder_pattern = os.path.join(checkpoints_dir, "vae_encoder_*.keras")
-    encoder_files = glob.glob(encoder_pattern)
-
-    if not encoder_files:
-        raise FileNotFoundError(f"No encoder files found in {checkpoints_dir}")
-
-    # Extract tags and find complete pairs
-    valid_tags = []
-    for file in encoder_files:
-        basename = os.path.basename(file)
-        match = re.search(r"vae_encoder_(.+)\.keras", basename)
-        if match:
-            tag = match.group(1)
-            # Verify decoder exists
-            decoder_file = os.path.join(checkpoints_dir, f"vae_decoder_{tag}.keras")
-            if os.path.exists(decoder_file):
-                valid_tags.append(tag)
-
-    if not valid_tags:
-        raise FileNotFoundError(f"No valid model pairs found in {checkpoints_dir}")
-
-    # Sort tags to find the latest
-    def sort_key(tag_str):
-        # Handle final_vX format with highest priority
-        if tag_str.startswith("final_"):
-            try:
-                final_ver = int(tag_str.split("_v")[1])
-                return (0, final_ver)
-            except (ValueError, IndexError):
-                return (1, tag_str)
-        # Handle round_XX format with secondary priority
-        elif tag_str.startswith("round_"):
-            try:
-                round_num = int(tag_str.split("_")[1])
-                return (2, round_num)
-            except (ValueError, IndexError):
-                return (3, tag_str)
-        # Handle timestamp format YYYYMMDD_HHMMSS tertiary priority
-        elif re.match(r"\d{8}_\d{6}", tag_str):
-            try:
-                timestamp = datetime.strptime(tag_str, "%Y%m%d_%H%M%S")
-                return (4, timestamp)
-            except ValueError:
-                return (5, tag_str)
-        # Handle test_vX format with lowest priority
-        if tag_str.startswith("test_"):
-            try:
-                test_ver = int(tag_str.split("_v")[1])
-                return (6, test_ver)
-            except (ValueError, IndexError):
-                return (7, tag_str)
-        # Fallback for all other formats
-        else:
-            return (99, tag_str)
-
-    # Filter for the highest priority group
-    priorities = [sort_key(t)[0] for t in valid_tags]
-    highest_priority = min(priorities)  # smaller = higher priority
-
-    if highest_priority == 99:
-        raise FileNotFoundError(
-            "No valid model tags found (e.g. final_vX, round_XX, YYYYMMDD_HHMMSS, test_vX)"
-        )
-
-    filtered_tags = [t for t in valid_tags if sort_key(t)[0] == highest_priority]
-
-    # Select the latest tag within highest priority group
-    filtered_tags.sort(key=sort_key)
-    tag = filtered_tags[-1]  # Get the latest
-    return tag
-
-
 def _model_pair_exists(base_dir: str, tag: str) -> bool:
     """True when the encoder/decoder pair for `tag` both exist in base_dir."""
     return os.path.exists(os.path.join(base_dir, f"vae_encoder_{tag}.keras")) and os.path.exists(
@@ -312,10 +226,9 @@ def _resolve_load_tag(base_dir: str, tag: str | None) -> str:
     """
     Resolve the tag load_models() should load from base_dir.
 
-    An explicitly requested tag must exist: raising FileNotFoundError beats the old silent
-    get_latest_tag() fallback, which could resume training from a stale, unrelated model while
-    reporting success (issue #142). Only the tag=None default may fall back to the latest tag
-    present in base_dir.
+    An explicitly requested tag must exist on disk — we never fall back to "the latest" tag,
+    which could silently resume from a stale, unrelated model while reporting success (issue
+    #142). The tag=None default loads the conventional "final" model, or fails loudly.
     """
     if tag is not None:
         if _model_pair_exists(base_dir, tag):
@@ -325,30 +238,23 @@ def _resolve_load_tag(base_dir: str, tag: str | None) -> str:
             f"for an explicitly requested tag."
         )
         # The per-round-checkpoint hint only helps for a round_XX tag; for any other explicit
-        # tag (e.g. a typo'd final_v2) it's a red herring, so only append it for round tags.
+        # tag (e.g. a typo'd full run tag) it's a red herring, so only append it for round tags.
         if re.fullmatch(r"round_\d+", tag):
             msg += (
                 " If you meant to resume from a per-round checkpoint, pass --load-dir checkpoints"
             )
         raise FileNotFoundError(msg)
 
-    # NOTE: use a more sensible default
+    # No explicit tag: only the conventional "final" model may be loaded implicitly. We do NOT
+    # scan for the "latest" tag in base_dir — that could silently load a stale, unrelated run's
+    # model (issue #142). If there's no "final" pair, fail loudly.
     logger.info("No tag specified. Defaulting to 'final'")
     if _model_pair_exists(base_dir, "final"):
         return "final"
-
-    logger.warning(f"No models tagged as 'final' in {base_dir}")
-    logger.warning(f"Looking for latest tag in {base_dir} instead")
-
-    latest = get_latest_tag(
-        base_dir
-    )  # get_latest_tag() will raise an error if no valid tags exist in base_dir
-    logger.info(f"Tag 'final' not found. Loading latest model with tag: '{latest}'")
-
-    # Sanity check: get_latest_tag() only returns tags whose pair existed at scan time
-    if not _model_pair_exists(base_dir, latest):
-        raise FileNotFoundError("Models not found")
-    return latest
+    raise FileNotFoundError(
+        f"No models tagged 'final' in {base_dir} and no explicit --load-tag given — refusing to "
+        f"guess a tag. Pass --load-tag (a full run tag, or --load-dir checkpoints --load-tag round_XX)."
+    )
 
 
 def compute_expected_std(layer):
@@ -1060,12 +966,35 @@ class TrainingPipeline:
 
         try:
             # Load models from checkpoints: explicit user flags win; otherwise a
-            # manifest-driven resume reloads the last completed round's checkpoint
-            if self.config.checkpoint.load_tag or self.config.checkpoint.load_dir:
+            # manifest-driven resume reloads the last completed round's checkpoint.
+            load_tag = self.config.checkpoint.load_tag
+            load_dir = self.config.checkpoint.load_dir
+            save_tag = self.config.checkpoint.save_tag
+            # Resume-in-place: a full-tag --load-tag that equals this run's save-tag (the tag was
+            # adopted by resolve_save_tag). If the run's final weights aren't on disk yet (the VAE
+            # didn't finish before the interruption), fall back to the manifest's last completed
+            # round for THIS tag — never to another run's checkpoints; fail loudly if neither.
+            resume_in_place = (
+                load_tag is not None
+                and load_tag == save_tag
+                and not re.fullmatch(r"round_\d+", load_tag)
+            )
+            if resume_in_place and not _model_pair_exists(self.config.model_path, load_tag):
+                if self._start_round > 1:
+                    resume_tag = f"round_{self._start_round - 1:02d}"
+                    logger.info(
+                        f"No final weights for run {load_tag!r} yet; resuming from {resume_tag} "
+                        f"(this run's last completed round, per manifest)"
+                    )
+                    self.load_models(tag=resume_tag, dir="checkpoints")
+                else:
+                    raise FileNotFoundError(
+                        f"Cannot resume run {load_tag!r}: no final weights on disk and no completed "
+                        f"rounds recorded in its manifest. Refusing to load another run's checkpoints."
+                    )
+            elif load_tag or load_dir:
                 logger.info("Resuming from checkpoint")
-                self.load_models(
-                    tag=self.config.checkpoint.load_tag, dir=self.config.checkpoint.load_dir
-                )
+                self.load_models(tag=load_tag, dir=load_dir)
             elif self._start_round > 1:
                 resume_tag = f"round_{self._start_round - 1:02d}"
                 logger.info(f"Resuming from checkpoint {resume_tag} (per run manifest)")

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -974,11 +974,10 @@ class TrainingPipeline:
             # adopted by resolve_save_tag). If the run's final weights aren't on disk yet (the VAE
             # didn't finish before the interruption), fall back to the manifest's last completed
             # round for THIS tag — never to another run's checkpoints; fail loudly if neither.
-            resume_in_place = (
-                load_tag is not None
-                and load_tag == save_tag
-                and not re.fullmatch(r"round_\d+", load_tag)
-            )
+            # --load-tag equals this run's adopted save_tag (always a full {prefix}_{datetime}
+            # tag — resolve_save_tag never adopts a round_XX load-tag), so this is a resume of the
+            # same run whose VAE may not have finished.
+            resume_in_place = load_tag is not None and load_tag == save_tag
             if resume_in_place and not _model_pair_exists(self.config.model_path, load_tag):
                 if self._start_round > 1:
                     resume_tag = f"round_{self._start_round - 1:02d}"
@@ -1079,7 +1078,15 @@ class TrainingPipeline:
                 f"stages done: {state.stages_done}, stages failed: {state.stages_failed})"
             )
 
-        explicit_checkpoint = (
+        # Resume-in-place (--load-tag {full_tag} == this run's save_tag) is a CONTINUATION of the
+        # same run, not a user override — so the manifest (completed_rounds) drives resume, exactly
+        # as a same-command rerun would. Only a genuinely explicit checkpoint (a round_XX/other
+        # --load-tag, or --load-dir) is treated as an override that restarts from start_round and
+        # clears the manifest.
+        resume_in_place = (
+            self.config.checkpoint.load_tag is not None and self.config.checkpoint.load_tag == tag
+        )
+        explicit_checkpoint = (not resume_in_place) and (
             self.config.checkpoint.load_tag is not None
             or self.config.checkpoint.load_dir is not None
         )

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -965,39 +965,13 @@ class TrainingPipeline:
         self._rf_shap_cache: dict[str, dict] = {}
 
         try:
-            # Load models from checkpoints: explicit user flags win; otherwise a
-            # manifest-driven resume reloads the last completed round's checkpoint.
-            load_tag = self.config.checkpoint.load_tag
-            load_dir = self.config.checkpoint.load_dir
-            save_tag = self.config.checkpoint.save_tag
-            # Resume-in-place: a full-tag --load-tag that equals this run's save-tag (the tag was
-            # adopted by resolve_save_tag). If the run's final weights aren't on disk yet (the VAE
-            # didn't finish before the interruption), fall back to the manifest's last completed
-            # round for THIS tag — never to another run's checkpoints; fail loudly if neither.
-            # --load-tag equals this run's adopted save_tag (always a full {prefix}_{datetime}
-            # tag — resolve_save_tag never adopts a round_XX load-tag), so this is a resume of the
-            # same run whose VAE may not have finished.
-            resume_in_place = load_tag is not None and load_tag == save_tag
-            if resume_in_place and not _model_pair_exists(self.config.model_path, load_tag):
-                if self._start_round > 1:
-                    resume_tag = f"round_{self._start_round - 1:02d}"
-                    logger.info(
-                        f"No final weights for run {load_tag!r} yet; resuming from {resume_tag} "
-                        f"(this run's last completed round, per manifest)"
-                    )
-                    self.load_models(tag=resume_tag, dir="checkpoints")
-                else:
-                    raise FileNotFoundError(
-                        f"Cannot resume run {load_tag!r}: no final weights on disk and no completed "
-                        f"rounds recorded in its manifest. Refusing to load another run's checkpoints."
-                    )
-            elif load_tag or load_dir:
-                logger.info("Resuming from checkpoint")
-                self.load_models(tag=load_tag, dir=load_dir)
-            elif self._start_round > 1:
-                resume_tag = f"round_{self._start_round - 1:02d}"
-                logger.info(f"Resuming from checkpoint {resume_tag} (per run manifest)")
-                self.load_models(tag=resume_tag, dir="checkpoints")
+            # Load models from checkpoints per the resume plan (explicit user flags win;
+            # otherwise a manifest-driven resume reloads the last completed round's checkpoint).
+            # The decision is factored into _resume_load_plan() so it stays unit-testable
+            # without building the TF graph.
+            plan = self._resume_load_plan()
+            if plan is not None:
+                self.load_models(tag=plan[0], dir=plan[1])
 
         except Exception as e:
             logger.error(f"Error loading models from checkpoint: {e}")
@@ -1023,6 +997,45 @@ class TrainingPipeline:
     #         self.train_writer.close()
     #     if hasattr(self, "val_writer"):
     #         self.val_writer.close()
+
+    def _resume_load_plan(self) -> tuple[str | None, str | None] | None:
+        """Decide which checkpoint ``(tag, dir)`` __init__ should load, or ``None`` for a fresh
+        run (no load).
+
+        Raises ``FileNotFoundError`` when a resume-in-place run has neither its own final weights
+        nor a completed round to fall back to. This is a pure decision — its only I/O is the
+        on-disk model-pair existence check — so the resume logic is unit-testable without building
+        the TF graph.
+        """
+        load_tag = self.config.checkpoint.load_tag
+        load_dir = self.config.checkpoint.load_dir
+        save_tag = self.config.checkpoint.save_tag
+        # Resume-in-place: a full-tag --load-tag that equals this run's save-tag (the tag was
+        # adopted by resolve_save_tag, which never adopts a round_XX load-tag — so load_tag here is
+        # always a full {prefix}_{datetime} tag). If the run's final weights aren't on disk yet
+        # (the VAE didn't finish before the interruption), fall back to the manifest's last
+        # completed round for THIS tag — never another run's checkpoints; fail loudly if neither.
+        resume_in_place = load_tag is not None and load_tag == save_tag
+        if resume_in_place and not _model_pair_exists(self.config.model_path, load_tag):
+            if self._start_round > 1:
+                resume_tag = f"round_{self._start_round - 1:02d}"
+                logger.info(
+                    f"No final weights for run {load_tag!r} yet; resuming from {resume_tag} "
+                    f"(this run's last completed round, per manifest)"
+                )
+                return resume_tag, "checkpoints"
+            raise FileNotFoundError(
+                f"Cannot resume run {load_tag!r}: no final weights on disk and no completed "
+                f"rounds recorded in its manifest. Refusing to load another run's checkpoints."
+            )
+        if load_tag or load_dir:
+            logger.info("Resuming from checkpoint")
+            return load_tag, load_dir
+        if self._start_round > 1:
+            resume_tag = f"round_{self._start_round - 1:02d}"
+            logger.info(f"Resuming from checkpoint {resume_tag} (per run manifest)")
+            return resume_tag, "checkpoints"
+        return None
 
     def _init_run_state(self):
         """
@@ -6508,8 +6521,8 @@ class TrainingPipeline:
         """Load model weights.
 
         An explicit `tag` must exist in the target directory (FileNotFoundError otherwise);
-        only the tag=None default falls back to 'final' and then the latest tag present —
-        see _resolve_load_tag() and issue #142.
+        the tag=None default loads only the conventional 'final' pair, else fails loudly —
+        there is no scan for "the latest tag present" (see _resolve_load_tag() and issue #142).
         """
         if dir is not None:
             base_dir = os.path.join(self.config.model_path, dir)

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -129,6 +129,13 @@ class TestResolveSaveTag:
         tag = resolve_save_tag("train", "train", "round_05")
         assert tag.startswith("train_") and tag != "round_05"
 
+    @pytest.mark.parametrize("command", [None, "benchmark"])
+    def test_underivable_prefix_raises(self, command):
+        # No --save-tag and a command with no default prefix: refuse rather than emit an
+        # unloadable tag (main() guards the None case earlier via the required subparser).
+        with pytest.raises(ValueError, match="Cannot derive a save-tag prefix"):
+            resolve_save_tag(command, None, None)
+
 
 class TestCrossReplicaDivisibilityMatrix:
     """The default config divides cleanly across 4, 5, AND 6 replicas (issue #254 — Option B

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -12,13 +12,15 @@ import pytest
 
 from aetherscan import cli
 from aetherscan.cli import (
-    _TAG_PATTERN,
+    _LOAD_TAG_PATTERN,
+    _SAVE_TAG_PATTERN,
     _build_suggestion_block,
     _check_cross_constraints,
     _solve_cross_param_constraints,
     apply_args_to_config,
     apply_saved_config,
     collect_validation_errors,
+    resolve_save_tag,
     setup_argument_parser,
 )
 from aetherscan.config import get_config
@@ -62,32 +64,70 @@ def _ample_disk_space(monkeypatch):
 
 
 class TestTagPattern:
+    @pytest.mark.parametrize("tag", ["test", "train", "inf", "bench"])
+    def test_save_tag_accepted_prefixes(self, tag):
+        assert _SAVE_TAG_PATTERN.match(tag)
+
     @pytest.mark.parametrize(
         "tag",
-        ["20260712_123456", "final_v1", "final_v12", "round_01", "round_5", "test_v1", "test_v17"],
+        ["final_v1", "test_v1", "round_01", "train_20260101_000000", "TRAIN", " train", "", "prod"],
     )
-    def test_accepted_formats(self, tag):
-        assert _TAG_PATTERN.match(tag)
+    def test_save_tag_rejected(self, tag):
+        # --save-tag is a bare command prefix only; a full/round tag or old-scheme tag is rejected.
+        assert not _SAVE_TAG_PATTERN.match(tag)
 
     @pytest.mark.parametrize(
         "tag",
         [
-            "smoke_blackwell",  # free-form slug
-            "final_1",  # missing v
-            "final_v",  # missing version number
-            "test_17",  # missing v
-            "TEST_V1",  # wrong case
-            "2026_0712",  # malformed timestamp
+            "train_20260712_123456",
+            "test_20260101_000000",
+            "inf_20991231_235959",
+            "bench_20260712_123456",
+            "round_01",
+            "round_5",
+        ],
+    )
+    def test_load_tag_accepted(self, tag):
+        assert _LOAD_TAG_PATTERN.match(tag)
+
+    @pytest.mark.parametrize(
+        "tag",
+        [
+            "final_v1",  # old scheme, retired
+            "test_v1",  # old scheme
+            "20260712_123456",  # bare datetime, retired
+            "train",  # a bare prefix isn't a full load tag
+            "train_2026",  # incomplete datetime
+            "TRAIN_20260101_000000",  # wrong case
             "20260712-123456",  # wrong separator
-            "20260712_12345",  # HHMMS (5 digits)
             "round_",  # missing round number
-            " test_v1",  # leading whitespace
-            "test_v1 ",  # trailing whitespace
+            " train_20260101_000000",  # leading whitespace
             "",
         ],
     )
-    def test_rejected_formats(self, tag):
-        assert not _TAG_PATTERN.match(tag)
+    def test_load_tag_rejected(self, tag):
+        assert not _LOAD_TAG_PATTERN.match(tag)
+
+
+class TestResolveSaveTag:
+    def test_prefix_gets_datetime_appended(self):
+        tag = resolve_save_tag("train", "test", None)
+        assert tag.startswith("test_") and _LOAD_TAG_PATTERN.match(tag)
+
+    def test_omitted_defaults_to_subcommand(self):
+        assert resolve_save_tag("train", None, None).startswith("train_")
+        assert resolve_save_tag("inference", None, None).startswith("inf_")
+
+    def test_full_load_tag_is_adopted_verbatim(self):
+        # A full {cmd}_{datetime} --load-tag resumes that run in place → its tag is adopted.
+        assert (
+            resolve_save_tag("train", "train", "train_20260101_120000") == "train_20260101_120000"
+        )
+
+    def test_round_load_tag_does_not_adopt(self):
+        # round_XX seeds a fresh run — the save-tag is freshly stamped, not adopted.
+        tag = resolve_save_tag("train", "train", "round_05")
+        assert tag.startswith("train_") and tag != "round_05"
 
 
 class TestCrossReplicaDivisibilityMatrix:
@@ -133,9 +173,11 @@ class TestSemanticChecks:
         )
         assert not any(e.field == "checkpoint.load_dir" for e in errors)
 
-    def test_final_load_tag_without_load_dir_passes(self):
-        # A final model legitimately lives in the models root — no load-dir required.
-        errors = collect_validation_errors(_parse(["train", "--load-tag", "final_v1"]), None)
+    def test_full_load_tag_without_load_dir_passes(self):
+        # A full run tag's final model legitimately lives in the models root — no load-dir required.
+        errors = collect_validation_errors(
+            _parse(["train", "--load-tag", "train_20260101_120000"]), None
+        )
         assert not any(e.field == "checkpoint.load_dir" for e in errors)
 
     def test_num_samples_divisible_by_4(self):

--- a/tests/unit/test_hf_hub.py
+++ b/tests/unit/test_hf_hub.py
@@ -123,7 +123,7 @@ class TestSanitizeConfigForUpload:
             "rf_path": "/datax/rf",
             "classification_threshold": 0.99,
         },
-        "checkpoint": {"load_dir": "/datax/ckpt", "save_tag": "final_v1"},
+        "checkpoint": {"load_dir": "/datax/ckpt", "save_tag": "train_20260101_120000"},
         "beta_vae": {"beta": 1.5, "latent_dim": 8},
     }
 
@@ -137,7 +137,7 @@ class TestSanitizeConfigForUpload:
         # Reproducibility-relevant fields survive.
         assert s["data"]["num_backgrounds"] == 45000
         assert s["inference"]["classification_threshold"] == 0.99
-        assert s["checkpoint"]["save_tag"] == "final_v1"
+        assert s["checkpoint"]["save_tag"] == "train_20260101_120000"
         assert s["beta_vae"] == {"beta": 1.5, "latent_dim": 8}
 
     def test_does_not_mutate_the_input(self):
@@ -146,21 +146,22 @@ class TestSanitizeConfigForUpload:
 
 
 class TestSelectDefaultRevision:
-    def test_semver_outranks_final(self):
-        assert select_default_revision(["final_v9", "v1.2.3", "v0.1.0"]) == "v1.2.3"
+    def test_semver_release_tag_wins_training_tags_ignored(self):
+        # Only vX.Y.Z release tags name the default download; training tags never do.
+        assert select_default_revision(["train_20260101_120000", "v1.2.3", "v0.1.0"]) == "v1.2.3"
 
     def test_semver_sorted_numerically_not_lexicographically(self):
         assert select_default_revision(["v1.9.9", "v1.10.0"]) == "v1.10.0"
         assert select_default_revision(["v2.0.0", "v10.0.0", "v9.9.9"]) == "v10.0.0"
 
-    def test_final_tags_sorted_numerically(self):
-        assert select_default_revision(["final_v2", "final_v12", "final_v3"]) == "final_v12"
-
-    def test_other_tag_families_never_win(self):
-        assert select_default_revision(["test_v17", "20260712_010203", "round_02"]) is None
-
-    def test_partial_semver_is_not_a_release_tag(self):
-        assert select_default_revision(["v1.2", "v1", "final_v1"]) == "final_v1"
+    def test_no_release_tag_returns_none(self):
+        # No vX.Y.Z release tag → None (a no-artifact download requires a blessed release tag).
+        # Training tags, timestamps, round tags, and partial semver never name the default.
+        assert (
+            select_default_revision(["train_20260101_120000", "20260712_010203", "round_02"])
+            is None
+        )
+        assert select_default_revision(["v1.2", "v1", "train_20260101_120000"]) is None
 
     def test_empty(self):
         assert select_default_revision([]) is None
@@ -201,7 +202,7 @@ class TestResolveHfRevision:
 
     def test_explicit_revision_outranks_installed_release(self, monkeypatch):
         _set_version(monkeypatch, "1.2.3")
-        assert resolve_hf_revision("ns/repo", "final_v9") == "final_v9"
+        assert resolve_hf_revision("ns/repo", "train_20260101_120000") == "train_20260101_120000"
 
     def test_installed_release_pins_own_version_without_listing(self, monkeypatch):
         # An installed release resolves v{__version__} directly — no tag listing, and no
@@ -216,12 +217,16 @@ class TestResolveHfRevision:
 
     def test_dev_version_falls_through_to_latest_release(self, monkeypatch):
         _set_version(monkeypatch, "0.9.0.dev0")
-        monkeypatch.setattr(hf_hub, "list_hf_tags", lambda repo_id: ["final_v1", "v0.2.0"])
+        monkeypatch.setattr(
+            hf_hub, "list_hf_tags", lambda repo_id: ["train_20260101_120000", "v0.2.0"]
+        )
         assert resolve_hf_revision("ns/repo", None) == "v0.2.0"
 
     def test_latest_release_selected(self, monkeypatch):
         _set_version(monkeypatch, "0.0.0.dev0")
-        monkeypatch.setattr(hf_hub, "list_hf_tags", lambda repo_id: ["final_v1", "v0.2.0"])
+        monkeypatch.setattr(
+            hf_hub, "list_hf_tags", lambda repo_id: ["train_20260101_120000", "v0.2.0"]
+        )
         assert resolve_hf_revision("ns/repo", None) == "v0.2.0"
 
     def test_no_resolvable_tag_raises_with_guidance(self, monkeypatch):
@@ -247,10 +252,10 @@ class TestListHfTags:
                 self.name = name
 
         class Refs:
-            tags = [Ref("v0.1.0"), Ref("final_v2")]
+            tags = [Ref("v0.1.0"), Ref("train_20260101_120000")]
 
         fake_api.list_repo_refs = lambda repo_id, repo_type=None: Refs()
-        assert hf_hub.list_hf_tags("ns/repo") == ["v0.1.0", "final_v2"]
+        assert hf_hub.list_hf_tags("ns/repo") == ["v0.1.0", "train_20260101_120000"]
 
     def test_missing_repo_yields_empty(self, monkeypatch, fake_api):
         import httpx  # noqa: PLC0415
@@ -348,7 +353,9 @@ class TestResolveInferenceArtifacts:
 
     def test_no_paths_no_revision_resolves_latest_and_records_provenance(self, monkeypatch):
         _set_version(monkeypatch, "0.0.0.dev0")
-        monkeypatch.setattr(hf_hub, "list_hf_tags", lambda repo_id: ["v0.1.0", "final_v3"])
+        monkeypatch.setattr(
+            hf_hub, "list_hf_tags", lambda repo_id: ["v0.1.0", "train_20260101_120000"]
+        )
         monkeypatch.setattr(hf_hub, "_hf_hub_download", lambda **kw: f"/cache/{kw['filename']}")
         args = self._args()
         resolve_inference_artifacts(args)
@@ -406,7 +413,7 @@ class TestResolveInferenceArtifacts:
             "_hf_hub_download",
             lambda **kw: (seen.append(kw["repo_id"]), f"/cache/{kw['filename']}")[1],
         )
-        args = self._args(hf_repo_id="other/repo", hf_revision="final_v1")
+        args = self._args(hf_repo_id="other/repo", hf_revision="train_20260101_120000")
         resolve_inference_artifacts(args)
         assert set(seen) == {"other/repo"}
 

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -437,6 +437,10 @@ class TestProcessCadenceEndToEnd:
 
     def _configure(self, bandpass_method="spline"):
         config = get_config()
+        # In production main() resolves save_tag to {command}_{datetime} before any stage runs
+        # (the dataclass default is None); mirror that here so tag-scoped output paths (e.g. the
+        # bandpass debug overlay under plots/inference/{save_tag}/) resolve to a real directory.
+        config.checkpoint.save_tag = "inf_20260101_120000"
         config.manager.n_processes = 1  # sequential: no pools/shm in unit tests
         config.data.time_bins = 16
         config.data.width_bin = 256

--- a/tests/unit/test_train_utils.py
+++ b/tests/unit/test_train_utils.py
@@ -33,7 +33,6 @@ from aetherscan.train import (
     check_encoder_trained,
     check_val_auc_floor,
     compute_expected_std,
-    get_latest_tag,
 )
 
 
@@ -43,65 +42,6 @@ def _touch_pair(checkpoints_dir, tag):
     for prefix in ("vae_encoder", "vae_decoder"):
         with open(os.path.join(checkpoints_dir, f"{prefix}_{tag}.keras"), "w") as f:
             f.write("stub")
-
-
-class TestGetLatestTag:
-    def test_priority_ladder(self, tmp_path):
-        d = str(tmp_path / "ckpt")
-        for tag in ("test_v3", "20240101_000000", "round_02", "final_v1"):
-            _touch_pair(d, tag)
-        assert get_latest_tag(d) == "final_v1"
-
-    def test_round_beats_timestamp_and_test(self, tmp_path):
-        d = str(tmp_path / "ckpt")
-        for tag in ("test_v9", "20991231_235959", "round_02", "round_10"):
-            _touch_pair(d, tag)
-        # Numeric compare, not lexicographic: round_10 > round_02.
-        assert get_latest_tag(d) == "round_10"
-
-    def test_timestamp_beats_test(self, tmp_path):
-        d = str(tmp_path / "ckpt")
-        for tag in ("test_v9", "20240101_000000", "20250101_000000"):
-            _touch_pair(d, tag)
-        assert get_latest_tag(d) == "20250101_000000"
-
-    def test_test_tags_ranked_by_version(self, tmp_path):
-        d = str(tmp_path / "ckpt")
-        for tag in ("test_v2", "test_v17", "test_v9"):
-            _touch_pair(d, tag)
-        assert get_latest_tag(d) == "test_v17"
-
-    def test_final_ranked_by_version(self, tmp_path):
-        d = str(tmp_path / "ckpt")
-        for tag in ("final_v1", "final_v12", "final_v3"):
-            _touch_pair(d, tag)
-        assert get_latest_tag(d) == "final_v12"
-
-    def test_encoder_without_decoder_ignored(self, tmp_path):
-        d = str(tmp_path / "ckpt")
-        _touch_pair(d, "round_01")
-        # Higher-priority final_v2 lacks its decoder — must not win.
-        with open(os.path.join(d, "vae_encoder_final_v2.keras"), "w") as f:
-            f.write("stub")
-        assert get_latest_tag(d) == "round_01"
-
-    def test_missing_directory_raises(self, tmp_path):
-        with pytest.raises(FileNotFoundError, match="doesn't exist"):
-            get_latest_tag(str(tmp_path / "nope"))
-
-    def test_empty_directory_raises(self, tmp_path):
-        d = tmp_path / "empty"
-        d.mkdir()
-        with pytest.raises(FileNotFoundError, match="No encoder files"):
-            get_latest_tag(str(d))
-
-    def test_no_complete_pair_raises(self, tmp_path):
-        d = tmp_path / "orphans"
-        d.mkdir()
-        with open(d / "vae_encoder_round_01.keras", "w") as f:
-            f.write("stub")
-        with pytest.raises(FileNotFoundError, match="No valid model pairs"):
-            get_latest_tag(str(d))
 
 
 class TestResolveLoadTag:
@@ -125,11 +65,11 @@ class TestResolveLoadTag:
             _resolve_load_tag(str(tmp_path), "round_01")
 
     def test_missing_non_round_tag_message_omits_checkpoints_hint(self, tmp_path):
-        # For a non-round explicit tag (e.g. a typo'd final_v2) the checkpoints hint is a
+        # For a non-round explicit tag (e.g. a typo'd full run tag) the checkpoints hint is a
         # red herring and must not appear.
-        _touch_pair(tmp_path, "final_v1")
+        _touch_pair(tmp_path, "train_20260101_120000")
         with pytest.raises(FileNotFoundError) as excinfo:
-            _resolve_load_tag(str(tmp_path), "final_v2")
+            _resolve_load_tag(str(tmp_path), "train_20260101_130000")
         assert "--load-dir checkpoints" not in str(excinfo.value)
 
     def test_default_prefers_final(self, tmp_path):
@@ -137,10 +77,13 @@ class TestResolveLoadTag:
         _touch_pair(tmp_path, "round_09")
         assert _resolve_load_tag(str(tmp_path), None) == "final"
 
-    def test_default_falls_back_to_latest(self, tmp_path):
+    def test_default_no_final_raises_loudly(self, tmp_path):
+        # tag=None loads only the conventional "final" model — it never scans for the "latest"
+        # tag present (which could be a stale, unrelated run's model). No "final" → fail loudly.
         _touch_pair(tmp_path, "round_02")
-        _touch_pair(tmp_path, "test_v1")
-        assert _resolve_load_tag(str(tmp_path), None) == "round_02"
+        _touch_pair(tmp_path, "train_20260101_120000")
+        with pytest.raises(FileNotFoundError, match="final"):
+            _resolve_load_tag(str(tmp_path), None)
 
     def test_default_empty_dir_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError):

--- a/tests/unit/test_train_utils.py
+++ b/tests/unit/test_train_utils.py
@@ -24,6 +24,9 @@ from aetherscan.run_state import (
     STAGE_VAE_ROUNDS,
     TRAINING_STAGES,
     TrainingRunState,
+    config_fingerprint,
+    run_state_path,
+    save_run_state,
 )
 from aetherscan.train import (
     TrainingPipeline,
@@ -111,6 +114,40 @@ class TestTrainingPlotsDir:
         assert pipeline._training_plots_dir("checkpoints") == os.path.join(
             pipeline.config.output_path, "plots", "training", "run_a", "checkpoints"
         )
+
+
+class TestResumeInPlace:
+    """Resume-in-place (--load-tag {full} == save_tag) is a continuation of the same run, not a
+    user override: _init_run_state must let the manifest's completed_rounds drive _start_round (so
+    the round-checkpoint resume fallback is reachable) instead of resetting it to 1 and wiping the
+    manifest."""
+
+    def test_manifest_rounds_drive_start_round(self, tmp_path):
+        config = get_config()
+        config.output_path = str(tmp_path)
+        tag = "train_20260101_120000"
+        config.checkpoint.save_tag = tag
+        config.checkpoint.load_tag = tag  # resume-in-place: the full load-tag was adopted
+        config.checkpoint.load_dir = None
+        config.checkpoint.start_round = 1  # the default — must NOT clobber the manifest
+
+        # Manifest for THIS tag: rounds 1-3 done, VAE unfinished; fingerprint matches the config.
+        state = TrainingRunState(
+            tag=tag,
+            run_start_time=123.0,
+            config_fingerprint=config_fingerprint(config.to_dict()),
+            completed_rounds=[1, 2, 3],
+        )
+        save_run_state(state, run_state_path(str(tmp_path), tag))
+
+        pipeline = TrainingPipeline.__new__(TrainingPipeline)
+        pipeline.config = config
+        pipeline.db = types.SimpleNamespace(mark_superseded=lambda *a, **k: True)
+        pipeline._init_run_state()
+
+        # Manifest drives resume: start at round 4 (max completed + 1); rounds are NOT wiped.
+        assert pipeline._start_round == 4
+        assert pipeline.run_state.completed_rounds == [1, 2, 3]
 
 
 class TestTrainRandomForestSkipIsLoud:

--- a/tests/unit/test_train_utils.py
+++ b/tests/unit/test_train_utils.py
@@ -150,6 +150,64 @@ class TestResumeInPlace:
         assert pipeline.run_state.completed_rounds == [1, 2, 3]
 
 
+class TestResumeLoadPlan:
+    """__init__'s checkpoint-load decision, factored into TrainingPipeline._resume_load_plan so
+    it is testable without building the TF graph. Composes with TestResumeInPlace: _init_run_state
+    derives _start_round from the manifest, then _resume_load_plan turns it into the actual
+    (tag, dir) to load — resume-in-place with no final weights must fall back to the last
+    completed round, or fail loudly."""
+
+    def _pipeline(self, tmp_path, *, load_tag, save_tag, start_round, final_on_disk):
+        config = get_config()
+        config.model_path = str(tmp_path)
+        config.checkpoint.load_tag = load_tag
+        config.checkpoint.load_dir = None
+        config.checkpoint.save_tag = save_tag
+        if final_on_disk:
+            _touch_pair(str(tmp_path), save_tag)  # final weights at the model root
+        pipeline = TrainingPipeline.__new__(TrainingPipeline)
+        pipeline.config = config
+        pipeline._start_round = start_round
+        return pipeline
+
+    def test_resume_in_place_no_final_falls_back_to_last_round(self, tmp_path):
+        # The whole point of the refactor: no final weights yet → load round_{start_round-1}.
+        tag = "train_20260101_120000"
+        pipeline = self._pipeline(
+            tmp_path, load_tag=tag, save_tag=tag, start_round=4, final_on_disk=False
+        )
+        assert pipeline._resume_load_plan() == ("round_03", "checkpoints")
+
+    def test_resume_in_place_no_final_no_rounds_raises(self, tmp_path):
+        # No final weights and no completed rounds → fail loudly, never load another run's model.
+        tag = "train_20260101_120000"
+        pipeline = self._pipeline(
+            tmp_path, load_tag=tag, save_tag=tag, start_round=1, final_on_disk=False
+        )
+        with pytest.raises(FileNotFoundError, match="Cannot resume run"):
+            pipeline._resume_load_plan()
+
+    def test_resume_in_place_with_final_loads_final(self, tmp_path):
+        # Final weights present (VAE finished, a later stage died) → load them from the model
+        # root (dir=None), not a per-round checkpoint.
+        tag = "train_20260101_120000"
+        pipeline = self._pipeline(
+            tmp_path, load_tag=tag, save_tag=tag, start_round=21, final_on_disk=True
+        )
+        assert pipeline._resume_load_plan() == (tag, None)
+
+    def test_fresh_run_returns_none(self, tmp_path):
+        # No --load-tag, start_round 1 → nothing to load.
+        pipeline = self._pipeline(
+            tmp_path,
+            load_tag=None,
+            save_tag="train_20260101_120000",
+            start_round=1,
+            final_on_disk=False,
+        )
+        assert pipeline._resume_load_plan() is None
+
+
 class TestTrainRandomForestSkipIsLoud:
     def test_pretrained_rf_skip_warns_and_records_source_tag(self, caplog):
         """The is_trained early-return (issue #142) must warn loudly, name the tag the stale

--- a/utils/benchmark_report.py
+++ b/utils/benchmark_report.py
@@ -15,8 +15,8 @@ Reads the SQLite file directly (stdlib sqlite3 + numpy + matplotlib only — no 
 imports), so it also runs against a database fetched from a cluster with
 utils/fetch_run_outputs.sh:
 
-    python utils/benchmark_report.py --save-tag final_v1
-    python utils/benchmark_report.py --save-tag test_v18 --db-path /path/to/aetherscan.db
+    python utils/benchmark_report.py --save-tag train_20260101_120000
+    python utils/benchmark_report.py --save-tag test_20260101_120000 --db-path /path/to/aetherscan.db
 """
 
 from __future__ import annotations

--- a/utils/fetch_run_outputs.sh
+++ b/utils/fetch_run_outputs.sh
@@ -18,15 +18,15 @@
 #   -h, --help      show this help.
 #
 # Examples:
-#   ./utils/fetch_run_outputs.sh train final_v1 blpc0
-#   ./utils/fetch_run_outputs.sh train final_v1 blpc0 blpc1   # same tag, several nodes
-#   ./utils/fetch_run_outputs.sh --all train final_v1 blpc0   # + checkpoints/archive
+#   ./utils/fetch_run_outputs.sh train train_20260101_120000 blpc0
+#   ./utils/fetch_run_outputs.sh train train_20260101_120000 blpc0 blpc1   # same tag, several nodes
+#   ./utils/fetch_run_outputs.sh --all train train_20260101_120000 blpc0   # + checkpoints/archive
 #   ./utils/fetch_run_outputs.sh --db inference run_2026 blpc0 # + the results DB
 #
 # Naming convention: a remote file BASENAME lands locally as
 # "<machine>_BASENAME". e.g. on machine blpc0,
-#   /datax/scratch/zachy/models/aetherscan/config_final_v1.json
-#     -> outputs/models/blpc0_config_final_v1.json
+#   /datax/scratch/zachy/models/aetherscan/config_train_20260101_120000.json
+#     -> outputs/models/blpc0_config_train_20260101_120000.json
 # Pulling the same tag from several machines is therefore collision-free, which
 # is the whole point of the machine prefix.
 #

--- a/utils/hf_tag_release.py
+++ b/utils/hf_tag_release.py
@@ -3,7 +3,7 @@
 Bless trained weights as a release: create the HF release tag (vX.Y.Z) pointing at a
 training upload's commit (docs/RELEASE.md step 3).
 
-    python utils/hf_tag_release.py --save-tag final_v1 --release v1.0.0
+    python utils/hf_tag_release.py --save-tag train_20260101_120000 --release v1.0.0
 
 This is the human "these weights are the release" decision — the release CD workflow
 (.github/workflows/release.yml) verifies the tag exists but deliberately cannot create it.
@@ -44,7 +44,7 @@ def main() -> int:
     parser.add_argument(
         "--save-tag",
         required=True,
-        help="Training run tag whose uploaded weights are being blessed (e.g. final_v1); "
+        help="Training run tag whose uploaded weights are being blessed (e.g. train_20260101_120000); "
         "must already exist on the HF repo (created by `train --hf-upload`)",
     )
     parser.add_argument(

--- a/utils/run_container.sh
+++ b/utils/run_container.sh
@@ -12,7 +12,7 @@
 # either cluster can build and run the image without code changes.
 #
 # Usage:
-#     ./utils/run_container.sh python -m aetherscan.main train --save-tag test_v1
+#     ./utils/run_container.sh python -m aetherscan.main train --save-tag test
 #     ./utils/run_container.sh python -m aetherscan.main inference --inference-files <csv>
 #
 # Override via env var:
@@ -45,7 +45,7 @@ set -euo pipefail
 
 if [[ $# -eq 0 ]]; then
     echo "Usage: $0 <command> [args...]" >&2
-    echo "  e.g. $0 python -m aetherscan.main train --save-tag test_v1" >&2
+    echo "  e.g. $0 python -m aetherscan.main train --save-tag test" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Simplifies the `--save-tag` / `--load-tag` scheme to **`{command}_{YYYYMMDD_HHMMSS}`** and makes resume/tag-resolution robust. Design confirmed with the maintainer (see #271). **Release-critical** — it retires `final_vX`, so the release run trains under the new scheme (`train_{datetime}`), which also dissolves the `final_v1` tag-collision blocker.

### New scheme
- **`--save-tag`** takes a bare prefix `test|train|inf|bench`; the datetime is stamped **at run time** by `cli.resolve_save_tag()` (in `main()`, before `init_logger`, so log / config / artifacts share one datetime — this also fixes the old import-time-frozen `datetime.now()` default). Omitted → defaults to the subcommand (`train`→`train_…`, `inference`→`inf_…`). `round_XX` is rejected on `--save-tag`.
- **`--load-tag`** takes a full `{cmd}_{datetime}` tag or `round_XX`. **Clean break** — `test_vX` / `final_vX` / bare-datetime are rejected by the new patterns.

### Resume = in-place via `--load-tag`
Re-running `--save-tag train` mints a fresh datetime, so resume goes through `--load-tag {full_tag}`: the run **adopts that tag** and resumes from its `run_state` / DB rows / artifacts. The load-fallback is **current-tag-only** — try the run's final weights → else its last completed round (per manifest) → else **fail loudly**. The cross-run `get_latest_tag()` fallback (the issue-#142 footgun that "could resume from a stale, unrelated model") is **removed**.

### HF download resolution
`select_default_revision` drops the `final_vX` training-tag fallback: a no-artifact `inference` download now **requires a blessed `vX.Y.Z` release tag** (maintainer-approved). `hf_tag_release.py` / `RELEASE.md` updated — bless with the actual `train_{datetime}` run tag.

## Touchpoints
`cli.py` (patterns + `resolve_save_tag` + validation + help + apply), `config.py` (`save_tag` default → runtime-resolved `None`), `main.py` (resolve once before the logger), `train.py` (remove `get_latest_tag`, rewrite `_resolve_load_tag` + the resume flow), `hf_hub.py` (drop `_FINAL_TAG_PATTERN`). Tests: new pattern + `resolve_save_tag` cases, `get_latest_tag` tests removed, `_resolve_load_tag` default-fallback now asserts fail-loudly. Docs: ARCHITECTURE / INFERENCE / RELEASE behavior + README CLI regen + all usage/runbook/script examples.

## For review (please eyeball)
- **The resume flow** (`train.py`, `run_training_pipeline` load block): full-tag resume-in-place → final weights → else `round_{start_round-1}` per manifest → else fail loudly. Round checkpoints are still flat under `{model_path}/checkpoints/` (single-run at a time via startup archiving) — the manifest (which is save_tag-scoped) drives *which* round, so resume stays run-specific. (Per-run-scoped checkpoint dirs would be a larger follow-up.)
- **`resolve_save_tag`** adoption rule: a **full** `--load-tag` is adopted; a `round_XX` `--load-tag` is not (seeds a fresh run).

## Test plan
- [x] `ruff` + `pre-commit` clean; GPG-signed commits.
- [x] Core tag logic validated by direct import (patterns, `resolve_save_tag`, `save_tag is None` default) — the full pytest suite can't run on the `.nosync` dev box (TF import deadlock), so CI is the gate.
- [ ] CI (`pytest -m "not gpu and not cluster"` on 3.10/3.11/3.12) green.
- [ ] Reviewer: the resume flow + the "release tag required for no-artifact download" change.

Closes #271
