### PR TITLE
perf: training optimization round 2 — 21.9× generation, parallel GIF sweep, query-window fix, A/B-gated fp16/bf16 flags

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -20,6 +20,9 @@ python benchmarks/bench_rf.py                    # Random Forest stage: latent p
 # Container-only (need the full TF/umap stack; bench_input_pipeline's step mode needs GPUs):
 ./utils/run_container.sh python benchmarks/bench_input_pipeline.py --mode iterate --variant current
 ./utils/run_container.sh python benchmarks/bench_latent_gif.py --mode all
+# Generation-path A/B (real pooled producer path; --preload-tf needs TF, so run containerized):
+./utils/run_container.sh python benchmarks/bench_datagen.py --preload-tf \
+    --data-dir /datax/scratch/$USER/bench_datagen
 ```
 
 `bench_gpu.py` is a different animal — it profiles the Beta-VAE on a real GPU (throughput +
@@ -43,6 +46,7 @@ comparing against the baselines.
 | `bench_rf.py` | `RandomForestClassifier` fit + `predict_proba` and the `prepare_latent_features` reshape (sklearn, CPU) | Second-stage RF training + inference (`train.train_random_forest`) |
 | `bench_input_pipeline.py` | The REAL memmap → tf.data → distribute → train-step input path (gather / iterate / step modes; legacy vs current builder; `--gil-load` contention knob) — **container-only; step mode needs GPUs** | The training input pipeline `bench_gpu.py` deliberately excludes (`train.prepare_distributed_train_dataset`) — see [#276 audit](#input-pipeline-audit-276) |
 | `bench_latent_gif.py` | Latent-GIF stage decomposition (UMAP fit / transform / frame render / GIF assembly) with output-equality checks on every candidate optimization — **container-only** | The `vae_plots` latent-GIF tail (`train.plot_latent_space_gif`) — see [#278 audit](#latent-gif-audit-278) |
+| `bench_datagen.py` | Seeded round generation through the REAL pooled `generate_round_to_memmap` path (shared-memory plates, `_init_worker`, per-task seed derivation, batched memmap tasks) with per-array sha256 checksums — the byte-compatibility gate for generation-path changes; `--preload-tf` mirrors the producer workers' TF import graph | The producer wall (`train.round_XX.data_generation`) that `bench_injection.py`'s single-process kernel can't reach — see [Producer/data-generation follow-up](#producerdata-generation-follow-up) |
 | `parse_xplane_occupancy.py` | Post-processor, not a benchmark: per-GPU busy time / occupancy from a `--profile` run's XPlane trace (merged event intervals, strict kernel-time measure) | The "GPUs idle >90%" profiler evidence in the [#276 audit](#input-pipeline-audit-276) and its follow-up |
 
 ## Baseline numbers
@@ -454,6 +458,69 @@ stats.
   backend and float summation order changed); determinism itself is preserved — same seed, same
   split, same per-epoch batch order, byte-identical reruns — and is pinned by unit tests
   (`test_train_datasets.py`, `test_train_accumulation.py`, `test_train_distribution.py`).
+
+## Producer/data-generation follow-up
+
+With the training hot path Python-free, the wall moved. The real-run A/B above already showed
+it at test scale (round-1 training finished long before round-2 generation), and a killed
+production-scale run on blpc3 confirmed it live: ~6.2 h of data generation per round with the
+GPUs at 0% and all 32 pool workers at ~94.5% CPU, ~97% user-mode — compute inside the workers,
+not IO or scheduling. `bench_datagen.py` is the harness this follow-up was gated on: it drives
+the real pooled `generate_round_to_memmap` path (shared-memory plates, `_init_worker`, per-task
+seed derivation, batched memmap tasks) at reduced scale and sha256s every output array, so a
+generation-path change lands only if its checksums match master's byte-for-byte. `--preload-tf`
+imports TensorFlow (CUDA-blanked) into the parent before the pool forks, mirroring the import
+graph the production producer's workers inherit — without it the gc/interpreter costs read
+optimistically low against exactly the regime the live run measured.
+
+Three mechanisms shipped, all byte-identical by construction and by checksum
+(`data_generation.py`):
+
+1. **The per-injection `gc.collect()` in `new_cadence` is gone.** A full generational
+   collection ran once per injection — ~2.5M times per production round — inside pool workers
+   carrying the full TF import graph, and measured ~23 ms per call against ~4.5 ms for the
+   entire rest of the function: the dominant term of the generation wall. Refcounting already
+   frees the setigen Frame's arrays immediately; the per-chunk collect in
+   `generate_round_to_memmap` stays for cycle cleanup.
+2. **Draw-first `create_true_double`.** The intersection-acceptance test is a pure function of
+   the pre-array RNG draws, but the retry loop materialized BOTH full setigen injections before
+   testing — at the measured p≈0.42 acceptance, ~41% of all injections in a production round
+   were computed and discarded. `new_cadence` is split into `_draw_signal_params` (consumes the
+   exact 4-draw RNG sequence) and `_inject_drawn_signal` (consumes no RNG); the retry loop now
+   replays the identical per-attempt draws and materializes only the accepted pair — same
+   order, same values, pinned by byte-compat tests in `test_data_generation.py`.
+3. **One msync per array, not per task.** `_run_memmap_task`'s finally flushed its whole
+   mapping once per task — ~23,400 concurrent full-mapping msyncs per production round, a
+   driver of the #117/#118 chunk-tail stragglers. Replaced by one flush per output array
+   immediately before the `.done` manifest. The durability contract is unchanged: no array
+   bytes are trusted until the manifest exists, and the manifest is written strictly after
+   every array is msync'd.
+
+### A/B ladder (blpc3, 8192 samples × 3 arrays, 32 workers, `--preload-tf`, seed 11)
+
+| arm | wall | speedup | sha256s (all 7 outputs) |
+|---|---|---|---|
+| A: master | 282.0 s | 1.0× | baseline |
+| B: + gc removal | 18.6 s | 15.2× | identical to A |
+| C: + draw-first (as shipped) | 13.1 s | **21.5×** | identical to A |
+
+The msync change lands with arm C — it alters no bytes, only when they are flushed, and is
+covered by the same checksum gate. Projected to production scale on the same 32-core host:
+~6.2 h/round → **~20 min/round**. That is a projection from the benchmark ratio, not a measured
+production round — the next full-scale run's `data_generation` stage timers are the check.
+
+**Deferred with rationale (do not silently resurrect):** RF-dataset pre-generation on the
+producer, a direct-numpy injection bundle (bypassing setigen Frames), SHAP-stage overlap, pool
+thread-pinning, and fused moment computation — the 21.5× result collapsed their absolute value
+to ~minutes each.
+
+**Related fix from the same audit, outside the generation path:** `plot_injection_stats` issues
+~165 round-scoped queries per call against an index that leads with `(tag, timestamp)` and does
+not contain `round_number`, so its run-wide time window re-scanned the tag's whole row history
+on every query — measured **10.5× slower at 12M rows**, and quadratic over a campaign as
+history accumulates. `Database.query_injection_stat_time_span` (one whole-partition MIN/MAX
+aggregate; a superset bound, so intersecting it with a query window can never change a result
+set) now tightens the window to the plotted rounds' actual span — see `docs/DATABASE.md`.
 
 ## Latent-GIF audit (#278)
 

--- a/benchmarks/bench_datagen.py
+++ b/benchmarks/bench_datagen.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+Round-generation benchmark: the real pooled generate_round_to_memmap path (the producer wall).
+
+bench_injection.py times the single-process new_cadence kernel; this script measures the
+whole round-generation machinery at reduced scale exactly as the producer runs it — a
+worker pool initialized via _init_worker against shared-memory background plates, per-task
+seed derivation from the root seed, batched memmap-writing tasks, per-chunk barriers — and
+then sha256s every output array. Two invocations with identical arguments on different
+code (e.g. master vs a candidate branch) must produce identical checksums: that is the
+byte-compatibility gate for any generation-path optimization, alongside the wall-time delta.
+
+    # arm A (checkout master), then arm B (checkout branch), same args:
+    ./utils/run_container.sh python benchmarks/bench_datagen.py \
+        --n-samples 8192 --workers 32 --seed 11 \
+        --data-dir /datax/scratch/$USER/bench_datagen --output /tmp/arm_a.json
+
+Compare: python -c "import json,sys; a,b=(json.load(open(p)) for p in sys.argv[1:3]); \
+    print('IDENTICAL' if a['checksums']==b['checksums'] else 'MISMATCH')" /tmp/arm_a.json /tmp/arm_b.json
+
+Stats callbacks are exercised with a counting stub (no DB) — the DB drain is off the
+generation critical path (#277) and singleton bootstrap is out of scope for a benchmark.
+Writes a JSON result to benchmarks/results/ (or --output), like the other benchmarks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import shutil
+import time
+from multiprocessing import Pool
+from multiprocessing.shared_memory import SharedMemory
+
+import numpy as np
+from _common import write_result
+
+from aetherscan.data_generation import _init_worker, generate_round_to_memmap
+from aetherscan.round_data import RoundDataPaths
+
+# Production cadence geometry (DataConfig defaults after 8x downsampling)
+NUM_OBSERVATIONS = 6
+TIME_BINS = 16
+WIDTH_BIN = 512
+FREQ_RESOLUTION = 2.7939677238464355  # Hz
+TIME_RESOLUTION = 18.25361108  # seconds
+
+
+def _sha256(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for block in iter(lambda: f.read(1 << 22), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--n-samples", type=int, default=8192, help="Cadences per array (%%4==0)")
+    parser.add_argument("--n-plates", type=int, default=4096, help="Synthetic background plates")
+    parser.add_argument("--chunk-size", type=int, default=4096, help="Samples per chunk (%%4==0)")
+    parser.add_argument("--task-size", type=int, default=64, help="Cadences per pool task")
+    parser.add_argument(
+        "--workers", type=int, default=os.cpu_count(), help="Pool size (1 = in-process)"
+    )
+    parser.add_argument(
+        "--seed", type=int, default=11, help="Root seed (plates + per-task streams)"
+    )
+    parser.add_argument("--snr-base", type=float, default=10.0)
+    parser.add_argument("--snr-range", type=float, default=40.0)
+    parser.add_argument("--data-dir", required=True, help="Scratch dir for the generated round")
+    parser.add_argument("--keep", action="store_true", help="Keep the round dir (default: delete)")
+    parser.add_argument("--output", default=None, help="Result JSON path")
+    args = parser.parse_args()
+
+    # Synthetic chi2 plates — seeded, so identical across arms with identical args
+    rng = np.random.default_rng(args.seed)
+    plates = rng.chisquare(
+        df=4, size=(args.n_plates, NUM_OBSERVATIONS, TIME_BINS, WIDTH_BIN)
+    ).astype(np.float32)
+    print(f"Plates: {plates.shape} float32 ({plates.nbytes / 2**20:.0f} MiB), seed {args.seed}")
+
+    paths = RoundDataPaths.for_round(args.data_dir, 1)
+    stats_counts = {"segments": 0, "samples": 0}
+
+    def stats_cb(segment: dict) -> None:
+        stats_counts["segments"] += 1
+        stats_counts["samples"] += len(segment["stats_list"])
+
+    shm = None
+    pool = None
+    try:
+        if args.workers > 1:
+            shm = SharedMemory(create=True, size=plates.nbytes, name=f"bench_datagen_{os.getpid()}")
+            shared = np.ndarray(plates.shape, dtype=plates.dtype, buffer=shm.buf)
+            shared[:] = plates[:]
+            pool = Pool(
+                processes=args.workers,
+                initializer=_init_worker,
+                initargs=(shm.name, plates.shape, plates.dtype),
+            )
+        print(f"Generating {args.n_samples} samples x3 arrays with {args.workers} worker(s)")
+        wall_start = time.time()
+        manifest = generate_round_to_memmap(
+            paths,
+            args.n_samples,
+            args.snr_base,
+            args.snr_range,
+            width_bin=WIDTH_BIN,
+            num_observations=NUM_OBSERVATIONS,
+            time_bins=TIME_BINS,
+            chunk_size=args.chunk_size,
+            task_size=args.task_size,
+            freq_resolution=FREQ_RESOLUTION,
+            time_resolution=TIME_RESOLUTION,
+            pool=pool,
+            backgrounds=None if pool is not None else plates,
+            round_num=1,
+            seed=args.seed,
+            stats_cb=stats_cb,
+        )
+        wall = time.time() - wall_start
+    finally:
+        if pool is not None:
+            pool.close()
+            pool.join()
+        if shm is not None:
+            shm.close()
+            shm.unlink()  # creator-only unlink, per the shared-memory rules
+
+    checksums = {}
+    for name, path in paths.array_paths.items():
+        checksums[name] = _sha256(path)
+    for name, path in paths.lognorm_paths.items():
+        checksums[f"{name}_lognorm"] = _sha256(path)
+    checksums["labels"] = _sha256(paths.labels_path)
+
+    throughput = args.n_samples / wall
+    print(f"Wall: {wall:.1f} s ({throughput:.1f} samples/s x3 arrays)")
+    print(
+        f"Stats callbacks: {stats_counts['segments']} segments, {stats_counts['samples']} samples"
+    )
+    for key in sorted(checksums):
+        print(f"  sha256 {key}: {checksums[key][:16]}")
+
+    params = {
+        k: getattr(args, k)
+        for k in (
+            "n_samples",
+            "n_plates",
+            "chunk_size",
+            "task_size",
+            "workers",
+            "seed",
+            "snr_base",
+            "snr_range",
+        )
+    }
+    results = {
+        "wall_s": wall,
+        "samples_per_s": throughput,
+        "manifest_wall_s": manifest["wall_time_s"],
+        "stats_segments": stats_counts["segments"],
+        "stats_samples": stats_counts["samples"],
+        "checksums": checksums,
+    }
+    write_result("bench_datagen", params, results, args.output)
+
+    if not args.keep:
+        shutil.rmtree(paths.round_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_datagen.py
+++ b/benchmarks/bench_datagen.py
@@ -71,8 +71,22 @@ def main() -> None:
     parser.add_argument("--snr-range", type=float, default=40.0)
     parser.add_argument("--data-dir", required=True, help="Scratch dir for the generated round")
     parser.add_argument("--keep", action="store_true", help="Keep the round dir (default: delete)")
+    parser.add_argument(
+        "--preload-tf",
+        action="store_true",
+        help="Import TensorFlow (CUDA-blanked) before forking the pool, so workers inherit "
+        "the same import graph the production producer's workers carry — without it, "
+        "gc/interpreter costs read optimistically low vs production",
+    )
     parser.add_argument("--output", default=None, help="Result JSON path")
     args = parser.parse_args()
+
+    if args.preload_tf:
+        # Mirror the producer: TF importable but never CUDA-initialized in generation workers
+        os.environ.setdefault("CUDA_VISIBLE_DEVICES", "")
+        import tensorflow  # noqa: F401, PLC0415
+
+        print("Preloaded TensorFlow into the parent (workers fork with the full import graph)")
 
     # Synthetic chi2 plates — seeded, so identical across arms with identical args
     rng = np.random.default_rng(args.seed)

--- a/benchmarks/bench_gpu.py
+++ b/benchmarks/bench_gpu.py
@@ -31,8 +31,9 @@ until a GPU OOMs and reports the largest power of two that fits — use it to si
 What this does and does NOT cover:
   - Covers the VAE training step (composite loss + backprop + clipped Adam), encoder inference,
     the decoder (inside the train step), and — with `--num-gpus > 1` — the MirroredStrategy
-    cross-replica gradient all-reduce and multi-GPU scaling. fp32, matching the pipeline (which
-    uses no mixed precision or XLA).
+    cross-replica gradient all-reduce and multi-GPU scaling. fp32 by default, matching the
+    pipeline default (no XLA); `--mixed-precision` sets the same keras mixed_bfloat16 global
+    policy as the pipeline's `beta_vae.mixed_precision` flag for A/B throughput comparisons.
   - Models gradient accumulation with `--accumulation-steps K`: one optimizer step accumulates
     all-reduced grads over K micro-batches then applies once with the global-norm clip — the
     accumulate-then-apply *cadence* of train.py's `_train_epoch` (K=1, the default, is a plain
@@ -290,6 +291,13 @@ def main() -> None:
         help="Train only: micro-batches accumulated per optimizer step (mirrors _train_epoch). "
         "Default 1 = apply every step. Ignored for --mode encode.",
     )
+    parser.add_argument(
+        "--mixed-precision",
+        action="store_true",
+        help="Set the keras mixed_bfloat16 global policy before building the model (same "
+        "policy as the pipeline's beta_vae.mixed_precision flag, incl. the fp32 islands "
+        "in models/vae.py). Default off = fp32, matching the pipeline default.",
+    )
     parser.add_argument("--output", default=None, help="Result JSON path.")
     args = parser.parse_args()
 
@@ -298,6 +306,9 @@ def main() -> None:
     config = get_config()
     if config is None:
         raise ValueError("get_config() returned None")
+    # Must run before create_beta_vae_model so every layer picks the policy up (train.py order).
+    if args.mixed_precision:
+        tf.keras.mixed_precision.set_global_policy("mixed_bfloat16")
     # Build the model once (weights are batch-independent) and reuse across sizes.
     strategy = tf.distribute.MirroredStrategy(devices=[f"/{d}" for d in devices])
     with strategy.scope():
@@ -314,7 +325,7 @@ def main() -> None:
     )
     print(
         f"mode={args.mode}  num_gpus={len(devices)}  latent_dim={config.beta_vae.latent_dim}  "
-        f"example_shape={shape}" + train_note
+        f"example_shape={shape}  mixed_precision={args.mixed_precision}" + train_note
     )
     print(
         f"throughput = aggregate across {len(devices)} GPU(s); VRAM = peak per GPU (SI GB, 1e9 B)"
@@ -365,6 +376,7 @@ def main() -> None:
             "warmup": args.warmup,
             "steps": args.steps,
             "accumulation_steps": args.accumulation_steps if args.mode == "train" else 1,
+            "mixed_precision": args.mixed_precision,
             "gpu": machine_info()["hostname"],
         },
         results,

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -183,9 +183,11 @@ python benchmarks/bench_injection.py            # setigen signal injection (trai
 python benchmarks/bench_lognorm_downsample.py   # per-cadence downsample + log-norm (load path)
 python benchmarks/bench_pfb_vs_spline.py        # PFB static equalization vs per-channel spline fit
 python benchmarks/bench_rf.py                   # Random Forest stage: latent prep + fit + predict
-# Container-only additions (#276/#278 audits; bench_input_pipeline's step mode needs GPUs):
+# Container-only additions (#276/#278 audits + the generation-path A/B; bench_input_pipeline's
+# step mode needs GPUs):
 # ./utils/run_container.sh python benchmarks/bench_input_pipeline.py --mode step --variant current --num-gpus 5
 # ./utils/run_container.sh python benchmarks/bench_latent_gif.py --mode all
+# ./utils/run_container.sh python benchmarks/bench_datagen.py --preload-tf --data-dir /datax/scratch/$USER/bench_datagen
 # On the clusters, through the container:
 ./utils/run_container.sh python benchmarks/bench_normality.py
 # GPU-only, container required — real Beta-VAE profiler on a cluster GPU:
@@ -206,6 +208,7 @@ the maintained per-host baseline tables.
 | `bench_gpu.py` | Beta-VAE training step (`compute_total_loss` + gradients + clipped Adam) and encoder forward on one or more GPUs | VAE training (`train.round_XX`) and encoder inference — **GPU-only, container required** |
 | `bench_input_pipeline.py` | The real memmap → tf.data → distribute → train-step input path, legacy vs current builder (current = the zero-copy pure-TF gather AND the graph-side accumulated step, mirroring train.py as checked out), with a `--gil-load` contention knob and `--profile` TF-profiler hook | The training input pipeline `bench_gpu.py` deliberately excludes — the #276 audit harness. Its profiler traces are what established that the GPUs sit idle >90% of the wall clock while doing exactly the kernel work `bench_gpu` predicts; the follow-up section of `benchmarks/README.md` carries the before/after ladder for the Python-free rewrite |
 | `bench_latent_gif.py` | Latent-GIF stage decomposition (UMAP fit / transform / render / assemble) with output-equality gates on every candidate optimization | The `vae_plots` latent-GIF tail — the #278 audit harness (numbers in `benchmarks/README.md`) |
+| `bench_datagen.py` | Seeded round generation through the real pooled `generate_round_to_memmap` path (shared-memory plates, per-task seed derivation, batched memmap tasks), sha256-ing every output array as the byte-compatibility gate for generation-path changes; `--preload-tf` mirrors the producer workers' TF import graph | The producer wall (`train.round_XX.data_generation`) that `bench_injection.py`'s single-process kernel can't reach — the generation-path A/B harness (ladder + mechanisms in `benchmarks/README.md`) |
 
 Only the four CPU micro-benchmarks (`bench_normality`, `bench_injection`,
 `bench_lognorm_downsample`, `bench_pfb_vs_spline`) are single-process; the pipeline

--- a/docs/CONFIG_AND_CLI.md
+++ b/docs/CONFIG_AND_CLI.md
@@ -75,11 +75,11 @@ subcommand uses it:
 | `MonitorConfig`      | Resource-monitor cadence and timeouts, stage-band plot annotation toggle, live-dashboard enable (`dashboard_enabled`) and port (`dashboard_port`) |
 | `LoggerConfig`       | Console / file / Slack log routing                                                                                                 |
 | `ReproducibilityConfig` | The pipeline root seed (`seed`, default 11 — every random stream in **both** modes derives from it; see `seeding.py`) and `tf_deterministic_ops` |
-| `BetaVAEConfig`      | Beta-VAE model hyperparameters                                                                                                     |
+| `BetaVAEConfig`      | Beta-VAE model hyperparameters, plus the A/B-gated `mixed_precision` (bf16) opt-in (default off)                                   |
 | `RandomForestConfig` | RF classifier hyperparameters, the #282 latent-variant sweep/selection/calibration knobs, and the override-only `seed` (default `None` = derived from the root seed) |
-| `GPUConfig`          | TF strategy: replica count, memory growth, NCCL packs, allocator toggles                                                           |
+| `GPUConfig`          | TF strategy: replica count, memory growth, NCCL packs, allocator toggles, GPU thread mode (`gpu_thread_mode` / `gpu_thread_count`) |
 | `DataConfig`         | Data shape, file lists, chunk sizes                                                                                                |
-| `TrainingConfig`     | Anything specific to the `train` command — sample counts, batch sizes, LR schedule, curriculum, latent-viz, retries                |
+| `TrainingConfig`     | Anything specific to the `train` command — sample counts, batch sizes, LR schedule, curriculum, round-data layout/dtype, latent-viz, retries |
 | `InferenceConfig`    | Anything specific to the `inference` command — encoder/RF paths, classification threshold, energy-detection preprocessing, retries |
 | `HFConfig`           | HuggingFace Hub integration — target repo id, opt-in post-training upload, inference revision pin                                  |
 | `CheckpointConfig`   | Load/save tags, start round, tag-collision-guard override                                                                          |
@@ -100,6 +100,18 @@ are changed by editing their default in `config.py`. One worth knowing:
 Random Forest's validation ROC-AUC. When set and unmet after the RF fit, training logs a
 loud WARNING (which reaches the Slack summary) rather than failing the run, so a run
 that "completes" but learned nothing is caught before its model is promoted.
+
+Four config-only fields from the 2026-07 training-performance pass follow the same
+pattern (no CLI flags): `gpu.gpu_thread_mode` (default `"gpu_private"`; also
+`"global"`/`"gpu_shared"`) and `gpu.gpu_thread_count` (default 2) set
+`TF_GPU_THREAD_MODE`/`TF_GPU_THREAD_COUNT` in `setup_gpu_strategy` before the GPU
+runtime initializes; `training.round_array_dtype` (default `"float32"`; `"float16"`
+halves the on-disk round footprint and gather volume) and `beta_vae.mixed_precision`
+(default `False`; `True` = keras `mixed_bfloat16` with fp32 islands) are **A/B-gated
+numerics levers — leave both at their defaults until the val-metric A/B documented in
+[`TRAINING_PIPELINE.md`](TRAINING_PIPELINE.md#performance-engineering-the-276-follow-up-july-2026)
+passes on the target host.** All four are emitted by `Config.to_dict()` and so are part
+of the persisted config snapshot.
 
 ## The CLI surface
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -326,6 +326,20 @@ conventions:
 - JSON-typed columns (`latent_vector`, `cadence_key`, `confidence_summary`) come back as
   strings; callers `json.loads` them.
 
+One deliberate exception to the list-of-rows shape:
+**`query_injection_stat_time_span(tag, start_round_number=None, end_round_number=None)`**
+returns the `(MIN, MAX)` timestamp pair over a tag's `injection_stats` rows (optionally
+bounded to a round range), or `None` when no rows match. It is a single whole-partition
+aggregate with **no timestamp filter and no superseded/`is_finite` filtering** — a deliberate
+**superset bound**: the span covers every row a filtered query could return for those rounds,
+so a caller that intersects its own time window with the span can only narrow index scans,
+never change a result set. It exists because `idx_injection_stats_filter` leads with
+`(tag, timestamp)` and `round_number` is not in the index, so a round-scoped query with a
+run-wide window re-scans the tag's entire row history (measured 10.5× slower at 12M rows,
+quadratic over a campaign as history accumulates) — `plot_injection_stats` issues ~165 such
+queries per call and now pays this one aggregate up front, tightening every window to the
+plotted rounds' actual span (±1 s).
+
 `get_db_stats()` returns row counts per table, the covered time range, and the database file
 size — logged at startup.
 

--- a/docs/TRAINING_PIPELINE.md
+++ b/docs/TRAINING_PIPELINE.md
@@ -331,9 +331,13 @@ fast, with the same byte-identity discipline:
    [`DATABASE.md`](DATABASE.md#query-api)).
 3. **The UMAP GIF sweep** — the 24-combo sweep in `plot_latent_space_gif` ran strictly
    serially at ~95% single-core (~1.7–1.9 h per run) even after #278 parallelized frame
-   rendering; whole combos now run across forkserver workers. Expected ~10–15 min on
-   24+ cores (not yet measured at production scale); byte-identity pinned by test. Details
-   in [the latent-GIF plot section](#latent_space_obscadence_nnn_mdm_taggif) below.
+   rendering; whole combos now run across forkserver workers. First parallel measurement
+   (reduced 60-frame shape, 24 workers on blpc3): ~93 min — 24 concurrent single-threaded
+   UMAP fits/transforms contend for memory bandwidth, so the wall is well below the naive
+   per-combo × 24 serial bound but far from core-count scaling; the production-scale number
+   and the fit-vs-transform-vs-JIT attribution (plus whether a smaller worker cap beats 24
+   under contention) are open follow-ups. Byte-identity pinned by test. Details in
+   [the latent-GIF plot section](#latent_space_obscadence_nnn_mdm_taggif) below.
 4. **GPU thread mode** — `gpu.gpu_thread_mode` (default `"gpu_private"`, also
    `"global"`/`"gpu_shared"`) and `gpu.gpu_thread_count` (default 2) set
    `TF_GPU_THREAD_MODE`/`TF_GPU_THREAD_COUNT` in `setup_gpu_strategy` before the GPU runtime
@@ -610,10 +614,12 @@ obs/cadence) combos is an independent UMAP fit with its own derived `random_stat
 on-disk joblib bundle), and writes distinct files — so
 [`latent_gif.py`](../src/aetherscan/latent_gif.py)`:run_umap_gif_sweep` farms WHOLE combos
 (fit + joblib persist + per-snapshot transforms + frame render + GIF assembly) to forkserver
-workers (empty preload, native thread pools pinned incl. `NUMBA_NUM_THREADS` — the
-`shap_parallel.py` isolation pattern), turning a ~1.7–1.9 h serial tail (~95% single-core,
-even after #278 parallelized frame rendering) into an expected ~10–15 min on 24+ cores (not
-yet measured at production scale). Logging and Slack uploads stay in the parent process, in
+workers (empty preload; BLAS-family thread pools pinned per the `shap_parallel.py` isolation
+pattern — but deliberately NOT numba's or OMP's: UMAP grows numba's pool itself on large-N
+paths and numba hard-errors past a capped launch, see `_sweep_worker_init`). The ~1.7–1.9 h
+serial tail (~95% single-core, even after #278 parallelized frame rendering) drops to ~93 min
+at a reduced 60-frame shape with 24 workers (first measurement; memory-bandwidth contention
+between concurrent single-threaded fits — the production-scale number is pending). Logging and Slack uploads stay in the parent process, in
 the serial loop's order; byte-identity of the GIFs is pinned by a slow-marked unit test
 comparing serial vs pooled output. This is disjoint from the #278-**rejected** within-fit
 ideas: batching the per-snapshot `.transform()` calls and reusing a precomputed kNN graph

--- a/docs/TRAINING_PIPELINE.md
+++ b/docs/TRAINING_PIPELINE.md
@@ -88,13 +88,16 @@ and `injection_stats` and shows up as background shading on the training plots.
 ## Round data: memmaps + background producer
 
 A full-scale round is three arrays (`main`, `true`, `false`) of shape
-`(499200, 6, 16, 512)` float32 ≈ 98 GB each — ~294 GB per round. Holding that in RAM is what
-used to OOM-kill 503 GB training nodes; instead each round lives on disk under
-`{round_data_dir}/{save_tag}/round_{k:02d}/` (default root `{data_path}/training/round_data`):
+`(499200, 6, 16, 512)` — float32 at the `training.round_array_dtype` default ≈ 98 GB each,
+~294 GB per round (the A/B-gated `"float16"` setting halves all of that; see the
+[performance-engineering section](#performance-engineering-the-276-follow-up-july-2026)).
+Holding that in RAM is what used to OOM-kill 503 GB training nodes; instead each round lives
+on disk under `{round_data_dir}/{save_tag}/round_{k:02d}/` (default root
+`{data_path}/training/round_data`):
 
 ```
 round_02/
-├── main.npy  true.npy  false.npy        # (n, 6, 16, 512) float32 memmaps
+├── main.npy  true.npy  false.npy        # (n, 6, 16, 512) round_array_dtype memmaps
 ├── main_lognorm.npy  true_lognorm.npy  false_lognorm.npy   # (n, 6, 2) log-norm params
 ├── labels.npy                            # (n,) signal-type strings
 └── round_02.done                         # atomic JSON manifest
@@ -109,9 +112,14 @@ Key properties (all in [`round_data.py`](../src/aetherscan/round_data.py) /
   returns only small stats dicts. No per-sample IPC pickling, one `pool.map` barrier per
   chunk.
 - **The `.done` manifest is the completion contract.** Written atomically
-  (`.tmp` → `os.replace`) only after every chunk finishes; it records shapes, SNR params, and
-  cheap sampled checksums. `validate_done_manifest()` re-checks all of it — a directory
-  without a valid manifest is garbage and gets regenerated.
+  (`.tmp` → `os.replace`) only after every chunk finishes and every array is msync'd; it
+  records shapes, per-array dtypes (plus the requested `array_dtype`), SNR params, and cheap
+  sampled checksums. `validate_done_manifest()` re-checks all of it — a directory without a
+  valid manifest is garbage and gets regenerated, and every reuse/resume path (producer
+  short-circuit, round reuse, RF-dataset reuse, `prepare_round_data_dir`) also gates on the
+  dtype, so a round generated under a different `round_array_dtype` is regenerated rather than
+  silently changing input numerics mid-run (manifests predating the dtype keys validate as
+  float32).
 - **Page-cache-backed reads.** Training opens the arrays with `np.load(mmap_mode="r")`;
   after the first epoch the OS caches the round in otherwise-free RAM, so steady-state reads
   run at RAM speed — but under memory pressure the kernel evicts pages instead of OOM-killing
@@ -296,6 +304,70 @@ End-to-end effect (5 GPUs, accumulation 12): optimizer-step throughput 1,453 →
 writer at full flood (−0.3%), and real-run training epochs went 48.5 → 5.8 s quiet /
 56.5 → 10.9 s with generation overlapped (8.4× / 5.2×), validation 16.7 → 1.7 s. The full
 A/B and the measured ladder live in `benchmarks/README.md`.
+
+**The second pass (late July 2026)** attacked the walls left standing once training epochs got
+fast, with the same byte-identity discipline:
+
+1. **Data generation** — with training 8.5× faster, generation became the run's dominant wall
+   (a killed production-scale blpc3 run measured ~6.2 h/round, GPUs at 0%, 32 workers at
+   ~94.5% CPU / ~97% user-mode). Three producer-path fixes, all byte-identical and gated by
+   `benchmarks/bench_datagen.py`'s per-array sha256 A/B: the per-injection `gc.collect()` in
+   `new_cadence` is gone (~2.5M calls per round in TF-laden pool workers; measured ~23 ms per
+   call against ~4.5 ms for the entire rest of the function), `create_true_double` draws both
+   signals' geometry first and materializes setigen injections only for the accepted pair (at
+   the measured p≈0.42 acceptance, ~41% of injections were computed and discarded), and the
+   per-task memmap msync is one flush per array before the `.done` manifest (same durability
+   contract). Measured on blpc3 (8192 samples × 3 arrays, 32 workers, TF preloaded):
+   282.0 → 13.1 s (**21.5×**), checksums identical — projecting a production round from
+   ~6.2 h to ~20 min on the same 32-core host (a projection, not a measured production
+   round). Ladder + mechanisms in `benchmarks/README.md`.
+2. **Injection-plot query windows** — `plot_injection_stats` issues ~165 round-scoped queries
+   per call, but `idx_injection_stats_filter` leads with `(tag, timestamp)` and
+   `round_number` is not in it, so the run-wide `[run-start, now]` window re-scanned the
+   tag's entire row history per query (measured 10.5× slower at 12M rows).
+   `Database.query_injection_stat_time_span` — one whole-partition MIN/MAX aggregate, a
+   deliberate superset bound — now tightens the window to the plotted rounds' actual row
+   span (±1 s); intersection can only narrow scans, never change a result set (see
+   [`DATABASE.md`](DATABASE.md#query-api)).
+3. **The UMAP GIF sweep** — the 24-combo sweep in `plot_latent_space_gif` ran strictly
+   serially at ~95% single-core (~1.7–1.9 h per run) even after #278 parallelized frame
+   rendering; whole combos now run across forkserver workers. Expected ~10–15 min on
+   24+ cores (not yet measured at production scale); byte-identity pinned by test. Details
+   in [the latent-GIF plot section](#latent_space_obscadence_nnn_mdm_taggif) below.
+4. **GPU thread mode** — `gpu.gpu_thread_mode` (default `"gpu_private"`, also
+   `"global"`/`"gpu_shared"`) and `gpu.gpu_thread_count` (default 2) set
+   `TF_GPU_THREAD_MODE`/`TF_GPU_THREAD_COUNT` in `setup_gpu_strategy` before the GPU runtime
+   initializes: dedicated per-GPU kernel-launch threads that tf.data host work cannot steal,
+   aimed at the measured ~7.6% input h2d/scheduling interference (the one residual with no
+   pinned null result). The flipped default is provisional pending the bench A/B on blpc3
+   (validation in flight) — flip back to `"global"` if the step ladder regresses.
+
+Two further levers landed **default-off behind an A/B gate**, because flipping either changes
+numerics. The gate is a val-metric A/B (3 seeds × 2 arms): val AUC within max(2σ, 0.002),
+losses and recalls within 2σ, the same active-dimension count, and zero NaN-guard trips.
+Until it passes on the target host, both flags stay at their defaults — which reproduce the
+pre-flag pipeline byte-for-byte (neither makes so much as a policy call when off):
+
+- **`training.round_array_dtype`** (`"float32"` default). `"float16"` halves the ~294.5 GB
+  round footprint to ~147 GB — and with it the gather volume and the page-cache working set,
+  the lever that keeps overlapped epochs at page-cache speed once two rounds no longer fit in
+  RAM at full scale. Quantization is ≤ 2⁻¹² on the [0, 1] log-normed inputs; the gather map's
+  existing `tf.cast` becomes the host-side upcast (the viz fancy-index path upcasts
+  identically), so the training graph and loss math see float32 unchanged either way. Labels
+  and lognorm sidecars stay float32; `.done` manifests record the dtypes and every
+  reuse/resume path gates on them (legacy manifests read as float32).
+- **`beta_vae.mixed_precision`** (`False` default). `True` sets the keras `mixed_bfloat16`
+  global policy before the model build, with fp32 islands pinned in `models/vae.py` — the
+  z_mean/z_log_var heads, `Sampling`, and the decoder's sigmoid output — so everything
+  reaching `compute_total_loss` stays fp32. bf16 needs no loss scaling; variables, Adam
+  state, and the step's gradient/loss accumulators stay fp32. Saved `.keras` files carry the
+  per-layer dtypes, so inference follows automatically. `bench_gpu.py --mixed-precision` is
+  the Phase-0 throughput A/B.
+
+Deferred with rationale (recorded in `benchmarks/README.md` so they are not blindly retried):
+RF-dataset pre-generation on the producer, a direct-numpy injection bundle, SHAP-stage
+overlap, pool thread-pinning, and fused moments — the 21.5× generation result collapsed their
+absolute value.
 
 ### Adaptive learning rate
 
@@ -532,15 +604,22 @@ late rounds mean the faint-SNR curriculum is destroying earlier structure. The f
 models are persisted (`umap_*.joblib`) and reused by the RF decision-boundary plot and by
 inference's latent-projection figure.
 
-Frame rendering is process-parallel (#278): frames are independent, so
-[`latent_gif.py`](../src/aetherscan/latent_gif.py) renders the PNGs across a forkserver
-process pool (`n_workers = manager.n_processes`, mirroring `shap_parallel.py`'s isolation
-pattern — empty preload, so workers never import the parent's TF stack), with the figure and
-scatter artists built once per worker and updated per frame; output PNGs are byte-identical
-regardless of worker count. The UMAP fits/transforms, GIF assembly, and Slack upload are
-unchanged — batching the per-snapshot `.transform()` calls and reusing a precomputed kNN
-graph across the sweep were both measured and **rejected** because they change UMAP outputs
-(the library consumes its `random_state` stream differently), which #278 forbids.
+The sweep is combo-parallel (the #278 follow-up): each of the 24 (n_neighbors × min_dist ×
+obs/cadence) combos is an independent UMAP fit with its own derived `random_state` (sub-keyed
+`(level, nn, md)`, #279), reads the shared inputs read-only (shipped to workers through one
+on-disk joblib bundle), and writes distinct files — so
+[`latent_gif.py`](../src/aetherscan/latent_gif.py)`:run_umap_gif_sweep` farms WHOLE combos
+(fit + joblib persist + per-snapshot transforms + frame render + GIF assembly) to forkserver
+workers (empty preload, native thread pools pinned incl. `NUMBA_NUM_THREADS` — the
+`shap_parallel.py` isolation pattern), turning a ~1.7–1.9 h serial tail (~95% single-core,
+even after #278 parallelized frame rendering) into an expected ~10–15 min on 24+ cores (not
+yet measured at production scale). Logging and Slack uploads stay in the parent process, in
+the serial loop's order; byte-identity of the GIFs is pinned by a slow-marked unit test
+comparing serial vs pooled output. This is disjoint from the #278-**rejected** within-fit
+ideas: batching the per-snapshot `.transform()` calls and reusing a precomputed kNN graph
+across the sweep remain rejected because they change how UMAP consumes its `random_state`
+stream (per-snapshot transforms stay serial *within* each combo) — process isolation between
+combos changes no stream at all.
 
 ### `latent_traversal_{signal_type}_{tag}.png` + `latent_traversal_spectra_{signal_type}_{tag}.png`
 
@@ -733,7 +812,7 @@ Training-specific fields live on `TrainingConfig`
 | Scale | `num_training_rounds`, `epochs_per_round`, `num_samples_beta_vae`, `num_samples_rf`, `train_val_split` |
 | Posterior-collapse guard | `posterior_collapse_kl_epsilon`, `min_active_units_fraction`, `posterior_collapse_patience` |
 | Batching | `per_replica_batch_size`, `effective_batch_size`, `per_replica_val_batch_size` |
-| Round data | `round_data_dir`, `overlap_data_generation`, `keep_round_data`, `signal_injection_chunk_size`, `data_gen_task_size` |
+| Round data | `round_data_dir`, `overlap_data_generation`, `keep_round_data`, `signal_injection_chunk_size`, `data_gen_task_size`, `round_array_dtype` (A/B-gated) |
 | Curriculum | `snr_base`, `initial_snr_range`, `final_snr_range`, `curriculum_schedule`, `exponential_decay_rate`, `step_easy_rounds`, `step_hard_rounds` |
 | Adaptive LR | `base_learning_rate`, `min_learning_rate`, `min_pct_improvement`, `patience_threshold`, `reduction_factor` |
 | Latent viz / traversal | `latent_viz_*`, `latent_traversal_every_round`, `latent_traversal_num_steps`, `latent_traversal_max_sigma` |

--- a/docs/TRAINING_PIPELINE.md
+++ b/docs/TRAINING_PIPELINE.md
@@ -616,11 +616,12 @@ on-disk joblib bundle), and writes distinct files — so
 (fit + joblib persist + per-snapshot transforms + frame render + GIF assembly) to forkserver
 workers (empty preload; BLAS-family thread pools pinned per the `shap_parallel.py` isolation
 pattern — but deliberately NOT numba's or OMP's: UMAP grows numba's pool itself on large-N
-paths and numba hard-errors past a capped launch, see `_sweep_worker_init`). The ~1.7–1.9 h
-serial tail (~95% single-core, even after #278 parallelized frame rendering) drops to ~93 min
-at a reduced 60-frame shape with 24 workers (first measurement; memory-bandwidth contention
-between concurrent single-threaded fits — the production-scale number is pending). Logging and Slack uploads stay in the parent process, in
-the serial loop's order; byte-identity of the GIFs is pinned by a slow-marked unit test
+paths and numba hard-errors past a capped launch, see `_sweep_worker_init`). At production
+shape the serial tail is ~1.7–1.9 h (~95% single-core, even after #278 parallelized frame
+rendering); the first parallel measurement, at a reduced 60-frame shape with 24 workers on
+blpc3, is ~93 min (memory-bandwidth contention between concurrent single-threaded fits), so
+no production-shape speedup can be quoted yet. Logging and Slack uploads stay in the parent
+process, in the serial loop's order; byte-identity of the GIFs is pinned by a slow-marked unit test
 comparing serial vs pooled output. This is disjoint from the #278-**rejected** within-fit
 ideas: batching the per-snapshot `.transform()` calls and reusing a precomputed kNN graph
 across the sweep remain rejected because they change how UMAP consumes its `random_state`

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -102,15 +102,21 @@ def _resolve(args: argparse.Namespace, arg_name: str, default: Any) -> Any:
 
 
 def _estimate_round_data_nbytes(
-    n_samples: int, num_observations: int, time_bins: int, width_bin_downsampled: int
+    n_samples: int,
+    num_observations: int,
+    time_bins: int,
+    width_bin_downsampled: int,
+    bytes_per_element: int = 4,
 ) -> int:
     """
     Estimate the on-disk size of one round's disk-backed dataset (see round_data.py): three
-    float32 arrays of shape (n_samples, num_observations, time_bins, width_bin_downsampled)
-    plus a tiny U20 labels array. Kept stdlib-only (no numpy) so utils/print_cli_help.py can
-    keep importing cli.py without the scientific stack.
+    cadence arrays of shape (n_samples, num_observations, time_bins, width_bin_downsampled)
+    at `bytes_per_element` (4 for the float32 default, 2 under
+    training.round_array_dtype="float16") plus a tiny U20 labels array. Kept stdlib-only
+    (no numpy) so utils/print_cli_help.py can keep importing cli.py without the scientific
+    stack.
     """
-    per_sample_bytes = num_observations * time_bins * width_bin_downsampled * 4  # float32
+    per_sample_bytes = num_observations * time_bins * width_bin_downsampled * bytes_per_element
     labels_bytes = n_samples * 20 * 4  # numpy "U20" = 20 UCS-4 code points per label
     return 3 * n_samples * per_sample_bytes + labels_bytes
 
@@ -1723,7 +1729,7 @@ def collect_validation_errors(
         # two rounds coexist on disk (round k trains while round k+1 generates), so require
         # 2.2x one round's estimated size free; 1.1x when overlap is disabled. Estimated from
         # sample counts only — actual usage tracks the estimate closely since the arrays are
-        # fixed-shape float32.
+        # fixed-shape (float32; halved under training.round_array_dtype="float16").
         nob = _resolve(args, "num_observations", config.data.num_observations)
         tb = _resolve(args, "time_bins", config.data.time_bins)
         overlap = _resolve(args, "overlap_data_generation", config.training.overlap_data_generation)
@@ -1733,7 +1739,10 @@ def collect_validation_errors(
             # training data, so they live under the training-data root
             round_data_dir = config.get_training_file_path("round_data", data_path)
         if all(v is not None for v in (nsb, nob, tb, wb)) and df:
-            round_nbytes = _estimate_round_data_nbytes(nsb, nob, tb, wb // df)
+            element_bytes = 2 if config.training.round_array_dtype == "float16" else 4
+            round_nbytes = _estimate_round_data_nbytes(
+                nsb, nob, tb, wb // df, bytes_per_element=element_bytes
+            )
             required_factor = 2.2 if overlap else 1.1
             required_bytes = required_factor * round_nbytes
             try:

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -199,7 +199,10 @@ class GPUConfig:
     # interference (measured at ~7.6% of step throughput on blpc3, benchmarks/README.md
     # "Corrected ceiling decomposition"). "global" restores TF's default shared pool;
     # "gpu_shared" is the third TF-supported value. Applied in setup_gpu_strategy before the
-    # GPU runtime initializes; inert in the producer tree (CUDA-blanked).
+    # GPU runtime initializes; inert in the producer tree (CUDA-blanked). NOTE: this config is
+    # the source of truth — "global" actively CLEARS any shell-set TF_GPU_THREAD_MODE/COUNT
+    # (same semantics as use_async_allocator vs TF_GPU_ALLOCATOR above), so an env-only
+    # override will not survive; set the config field instead.
     gpu_thread_mode: str = "gpu_private"
     # TF_GPU_THREAD_COUNT: threads per GPU when gpu_thread_mode="gpu_private" (TF default 2)
     gpu_thread_count: int = 2

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -187,6 +187,15 @@ class GPUConfig:
     per_gpu_memory_limit_mb: int | None = None
     nccl_num_packs: int = 2
     use_async_allocator: bool = True
+    # TF_GPU_THREAD_MODE: "gpu_private" gives each GPU dedicated kernel-launch threads that
+    # tf.data host work cannot steal — the standard NGC lever for input-pipeline h2d/scheduling
+    # interference (measured at ~7.6% of step throughput on blpc3, benchmarks/README.md
+    # "Corrected ceiling decomposition"). "global" restores TF's default shared pool;
+    # "gpu_shared" is the third TF-supported value. Applied in setup_gpu_strategy before the
+    # GPU runtime initializes; inert in the producer tree (CUDA-blanked).
+    gpu_thread_mode: str = "gpu_private"
+    # TF_GPU_THREAD_COUNT: threads per GPU when gpu_thread_mode="gpu_private" (TF default 2)
+    gpu_thread_count: int = 2
 
 
 # TODO: make sure the entire pipeline respects DataConfig() values, instead of hard coding
@@ -759,6 +768,8 @@ class Config:
                 "per_gpu_memory_limit_mb": self.gpu.per_gpu_memory_limit_mb,
                 "nccl_num_packs": self.gpu.nccl_num_packs,
                 "use_async_allocator": self.gpu.use_async_allocator,
+                "gpu_thread_mode": self.gpu.gpu_thread_mode,
+                "gpu_thread_count": self.gpu.gpu_thread_count,
             },
             "data": {
                 "num_observations": self.data.num_observations,

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -99,6 +99,13 @@ class BetaVAEConfig:
     kernel_size: tuple[int, int] = (3, 3)  # For Conv2D & Conv2DTranspose layers
     beta: float = 1.5  # KL divergence weight
     alpha: float = 10.0  # Clustering loss weight
+    # Opt-in keras mixed_bfloat16 policy for the Beta-VAE (train.py sets the global policy
+    # before model build). A/B-gated: changes training numerics — bf16 needs no loss scaling,
+    # variables/optimizer state stay fp32 under keras mixed precision, and the numerically
+    # sensitive layers (z_mean/z_log_var/Sampling, decoder sigmoid output → loss math) are
+    # pinned fp32 in models/vae.py. Default False = fp32 end-to-end, byte-identical to before
+    # this flag existed (no policy call is made at all).
+    mixed_precision: bool = False
 
 
 @dataclass
@@ -302,6 +309,15 @@ class TrainingConfig:
     # overhead; 64 was near-optimal on both (256 ran ~2x slower on bla0).
     # TODO: re-confirm at production sample sizes (~500k) before treating as final.
     data_gen_task_size: int = 64  # Cadences per batched worker task (workers write results straight into the round memmap)
+    # On-disk dtype of the three round cadence arrays (main/true/false). "float16" halves the
+    # round footprint (~294.5 -> ~147 GB at full scale), the gather volume, and the page-cache
+    # working set — the lever that keeps overlapped epochs at page-cache speed once two rounds
+    # no longer fit in RAM — at a quantization cost of <= 2^-12 on the [0, 1] log-normalized
+    # inputs. A/B-GATED: changes input numerics; keep "float32" until the val-metric A/B on the
+    # target host shows parity. The gather map upcasts to float32 host-side, so the training
+    # graph and loss math are unchanged either way; labels + lognorm sidecars stay float32.
+    # Recorded in each round's .done manifest and validated on resume/reuse.
+    round_array_dtype: str = "float32"
 
     # Round data pipeline params (disk-backed per-round datasets, see round_data.py)
     round_data_dir: str | None = None  # Defaults to get_training_file_path("round_data") at runtime
@@ -732,6 +748,7 @@ class Config:
                 "kernel_size": self.beta_vae.kernel_size,
                 "beta": self.beta_vae.beta,
                 "alpha": self.beta_vae.alpha,
+                "mixed_precision": self.beta_vae.mixed_precision,
             },
             "reproducibility": {
                 "seed": self.reproducibility.seed,
@@ -800,6 +817,7 @@ class Config:
                 "per_replica_val_batch_size": self.training.per_replica_val_batch_size,
                 "signal_injection_chunk_size": self.training.signal_injection_chunk_size,
                 "data_gen_task_size": self.training.data_gen_task_size,
+                "round_array_dtype": self.training.round_array_dtype,
                 "round_data_dir": self.training.round_data_dir,
                 "overlap_data_generation": self.training.overlap_data_generation,
                 "keep_round_data": self.training.keep_round_data,

--- a/src/aetherscan/data_generation.py
+++ b/src/aetherscan/data_generation.py
@@ -239,9 +239,12 @@ def new_cadence(
     # Extract the modified data (with signal injection) from the setigen Frame
     modified_data = frame.data.copy()
 
-    # Cleanup intermediate data
+    # Cleanup intermediate data. Refcounting frees the Frame's arrays immediately — do NOT
+    # add a gc.collect() here: this function runs once per injection (~2.5M times per
+    # production round), and a full collection per call cost ~23 ms against ~4.5 ms for
+    # everything else in this function (~5x the total generation wall). The per-chunk
+    # collect in generate_round_to_memmap covers cycle cleanup.
     del frame, signal
-    gc.collect()
 
     # Build signal info dictionary
     signal_info = {

--- a/src/aetherscan/data_generation.py
+++ b/src/aetherscan/data_generation.py
@@ -1045,6 +1045,7 @@ def generate_round_to_memmap(
     seed: int | None = None,
     stats_cb=None,
     progress_cb=None,
+    array_dtype: str = "float32",
 ) -> dict:
     """
     Generate one round's triplet dataset straight into disk-backed .npy memmaps.
@@ -1075,6 +1076,8 @@ def generate_round_to_memmap(
         raise ValueError(f"chunk_size must be divisible by 4, got {chunk_size}")
     if pool is None and backgrounds is None:
         raise ValueError("backgrounds must be provided when no pool is given")
+    if array_dtype not in ("float32", "float16"):
+        raise ValueError(f"array_dtype must be 'float32' or 'float16', got {array_dtype!r}")
 
     wall_start = time.time()
 
@@ -1083,11 +1086,13 @@ def generate_round_to_memmap(
     shutil.rmtree(paths.round_dir, ignore_errors=True)
     os.makedirs(paths.round_dir, exist_ok=True)
 
-    # Pre-create the three destination memmaps; workers reopen them r+ per task
+    # Pre-create the three destination memmaps; workers reopen them r+ per task and numpy
+    # downcasts on row assignment, so array_dtype="float16" needs no worker-side changes
+    # (the config.py field documents the quantization bound and the A/B gate)
     shape = (n_samples, num_observations, time_bins, width_bin)
     array_paths = paths.array_paths
     for path in array_paths.values():
-        mm = np.lib.format.open_memmap(path, mode="w+", dtype=np.float32, shape=shape)
+        mm = np.lib.format.open_memmap(path, mode="w+", dtype=np.dtype(array_dtype), shape=shape)
         del mm  # Close immediately: creation only reserves the file; workers do the writing
 
     # Sibling per-observation log-norm parameter arrays ((min_log, range_log) per obs —
@@ -1220,6 +1225,7 @@ def generate_round_to_memmap(
         snr_range=snr_range,
         wall_time_s=time.time() - wall_start,
         chunk_count=n_chunks,
+        array_dtype=array_dtype,
     )
     write_done_manifest(paths, manifest)
 
@@ -1405,4 +1411,5 @@ class DataGenerator:
             round_num=round_num,
             seed=self.config.reproducibility.seed,
             stats_cb=_stats_cb,
+            array_dtype=self.config.training.round_array_dtype,
         )

--- a/src/aetherscan/data_generation.py
+++ b/src/aetherscan/data_generation.py
@@ -886,13 +886,14 @@ def _run_memmap_task(args: tuple, backgrounds: np.ndarray) -> tuple[float, list[
                 lognorm_out[start_idx + i] = lognorm_params
             all_sample_info.append(sample_info)
     finally:
-        # Flush in the finally so rows written before a mid-task exception still reach disk
-        # deterministically (a failed round has no .done manifest and reads as garbage either
-        # way, but not all filesystems are guaranteed to write back dirty pages on munmap)
-        out.flush()
+        # No per-task flush: memmap.flush() is an msync over the task's whole mapping, and at
+        # ~23,400 tasks per production round the concurrent full-mapping msyncs stack into the
+        # chunk-tail stragglers (#117/#118). Durability is unchanged: written pages live in the
+        # shared page cache regardless, and generate_round_to_memmap msyncs every array once,
+        # before the .done manifest is written — a crash before that leaves no manifest, so the
+        # dir reads as garbage either way.
         del out
         if lognorm_out is not None:
-            lognorm_out.flush()
             del lognorm_out
 
     return time.time() - task_start, all_sample_info
@@ -1200,6 +1201,15 @@ def generate_round_to_memmap(
         logger.info(f"Chunk {chunk_idx + 1}/{n_chunks} complete")
 
     np.save(paths.labels_path, labels)
+
+    # One msync per array replaces the per-task flushes that used to live in
+    # _run_memmap_task's finally: everything the workers wrote must reach disk before the
+    # .done manifest can exist (the same durability contract, without ~23,400 concurrent
+    # full-mapping msyncs per production round).
+    for path in (*array_paths.values(), *lognorm_paths.values()):
+        arr = np.lib.format.open_memmap(path, mode="r+")
+        arr.flush()
+        del arr
 
     # The .done manifest is only written after every chunk has finished — the same atomicity
     # idea as preprocessing's .tmp -> os.replace stamp extraction

--- a/src/aetherscan/data_generation.py
+++ b/src/aetherscan/data_generation.py
@@ -143,16 +143,19 @@ def log_norm(
 
 
 # NOTE: not 100% sure how this function works. ported from Peter's code. comments added by Claude. assuming it works as intended?
-def new_cadence(
-    data: np.ndarray, snr: float, width_bin: int, freq_resolution: float, time_resolution: float
-) -> tuple[np.ndarray, dict[str, float], bool]:
+def _draw_signal_params(
+    total_time: int, width_bin: int, freq_resolution: float, time_resolution: float
+) -> tuple[dict[str, float], bool]:
     """
-    Inject a single drifting narrowband signal into a stacked cadence array.
+    Consume the RNG draws for one signal injection and return the realized geometry
+    {drift_rate, signal_width, starting_bin, slope_pixel, y_intercept} plus
+    slope_was_clamped — WITHOUT materializing anything.
 
-    Returns (modified_data, signal_info, slope_was_clamped). signal_info carries the realized
-    parameters {snr, drift_rate, signal_width, starting_bin, slope_pixel, y_intercept};
-    slope_was_clamped is True if the drift slope was forced away from ~0 to avoid a degenerate
-    near-vertical injection (downstream queries can filter on this).
+    The draw order — random.random (starting_bin), np.random.choice (drift direction),
+    random.random (slope noise), random.random (signal width) — is the byte-compatibility
+    contract with the pre-split new_cadence: create_true_double replays this exact sequence
+    per retry attempt and materializes only the accepted pair, so reordering, adding, or
+    removing a draw changes every seeded round (pinned by tests).
     """
     # NOTE: should noise = 3 parametrized?
     # Set noise parameter (for simulating randomness in drift rate calculation)
@@ -161,9 +164,6 @@ def new_cadence(
     # Randomly select a starting frequency bin (channel) to start the signal injection
     # Avoids edges (bin 0)
     starting_bin = int(random.random() * (width_bin - 1)) + 1
-
-    # Get the total number of time samples in stacked array (typically 96 for 6 obs x 16 time bins)
-    total_time = data.shape[0]
 
     # Randomly select a positive or negative drift direction
     if np.random.choice([-1, 1]) > 0:
@@ -213,6 +213,43 @@ def new_cadence(
     # Calculate y-intercept for linear signal trajectory
     y_intercept = total_time - slope_pixel * (starting_bin)
 
+    params = {
+        "drift_rate": drift_rate,
+        "signal_width": signal_width,
+        "starting_bin": starting_bin,
+        "slope_pixel": slope_pixel,
+        "y_intercept": y_intercept,
+    }
+    return params, slope_was_clamped
+
+
+def _signal_info_from_params(snr: float, params: dict[str, float]) -> dict[str, float]:
+    """Build the signal_info dict from drawn geometry. Key order is the DB row-order contract
+    (write_segment_stats iterates signal_info.items()) — keep it stable."""
+    return {
+        "snr": float(snr),
+        "drift_rate": float(params["drift_rate"]),
+        "signal_width": float(params["signal_width"]),
+        "starting_bin": float(params["starting_bin"]),
+        "slope_pixel": float(params["slope_pixel"]),
+        "y_intercept": float(params["y_intercept"]),
+    }
+
+
+def _inject_drawn_signal(
+    data: np.ndarray,
+    snr: float,
+    params: dict[str, float],
+    freq_resolution: float,
+    time_resolution: float,
+) -> np.ndarray:
+    """
+    Materialize one drawn signal into `data` and return the modified array.
+
+    Contract: consumes NO RNG (pinned by test) — create_true_double relies on this to defer
+    materialization until after the intersection-acceptance test without shifting the seeded
+    per-task stream.
+    """
     # Create setigen Frame
     frame = stg.Frame.from_data(
         df=freq_resolution * u.Hz,
@@ -226,12 +263,13 @@ def new_cadence(
     signal = frame.add_signal(
         # Use linear drift trajectory starting at starting_bin & with the calculated drift rate
         stg.constant_path(
-            f_start=frame.get_frequency(index=starting_bin), drift_rate=drift_rate * u.Hz / u.s
+            f_start=frame.get_frequency(index=int(params["starting_bin"])),
+            drift_rate=params["drift_rate"] * u.Hz / u.s,
         ),
         # Constant intensity over time, calibrated to achieve target snr
         stg.constant_t_profile(level=frame.get_intensity(snr=snr)),
         # Gaussian shape in frequency domain with calculated signal width
-        stg.gaussian_f_profile(width=signal_width * u.Hz),
+        stg.gaussian_f_profile(width=params["signal_width"] * u.Hz),
         # Constant bandpass profile (no frequency-dependent scaling)
         stg.constant_bp_profile(level=1),
     )
@@ -246,18 +284,26 @@ def new_cadence(
     # collect in generate_round_to_memmap covers cycle cleanup.
     del frame, signal
 
-    # Build signal info dictionary
-    signal_info = {
-        "snr": float(snr),
-        "drift_rate": float(drift_rate),
-        "signal_width": float(signal_width),
-        "starting_bin": float(starting_bin),
-        "slope_pixel": float(slope_pixel),
-        "y_intercept": float(y_intercept),
-    }
+    return modified_data
 
-    # Return the modified data array, signal info, and clamping flag
-    return modified_data, signal_info, slope_was_clamped
+
+def new_cadence(
+    data: np.ndarray, snr: float, width_bin: int, freq_resolution: float, time_resolution: float
+) -> tuple[np.ndarray, dict[str, float], bool]:
+    """
+    Inject a single drifting narrowband signal into a stacked cadence array.
+
+    Returns (modified_data, signal_info, slope_was_clamped). signal_info carries the realized
+    parameters {snr, drift_rate, signal_width, starting_bin, slope_pixel, y_intercept};
+    slope_was_clamped is True if the drift slope was forced away from ~0 to avoid a degenerate
+    near-vertical injection (downstream queries can filter on this). Composition of
+    _draw_signal_params + _inject_drawn_signal; byte-identical to the pre-split function.
+    """
+    params, slope_was_clamped = _draw_signal_params(
+        data.shape[0], width_bin, freq_resolution, time_resolution
+    )
+    modified_data = _inject_drawn_signal(data, snr, params, freq_resolution, time_resolution)
+    return modified_data, _signal_info_from_params(snr, params), slope_was_clamped
 
 
 # Float-rounding pad for the ON-band boundary comparison in check_valid_intersection (#118).
@@ -546,30 +592,35 @@ def create_true_double(
     snr = random.random() * snr_range + snr_base
 
     # NOTE: quantified in #118 — acceptance is i.i.d. geometric with p~=0.42, so the worst
-    # sample over a full 499200-round is ~25 retries (~3s); a >100-retry sample is effectively
-    # impossible (P~1e-24). This loop is therefore NOT the ~10-min single-worker stall seen in
-    # the #117 smoke (that is gc/IO/scheduling, see #118). MAX_INTERSECTION_RETRIES is the
+    # sample over a full 499200-round is ~25 retries; a >100-retry sample is effectively
+    # impossible (P~1e-24). Since the draw-first split, a retry costs only the ~microsecond
+    # parameter draws — the two setigen injections are materialized once, after acceptance —
+    # so the loop is timing-noise regardless of draw luck. MAX_INTERSECTION_RETRIES is the
     # defensive cap #118 called for: on exhaustion keep the last drawn pair and flag the sample
     # (clamp-and-flag, mirroring slope_was_clamped) rather than raise and kill a whole round.
-    # Retry signal injection until we get valid non-intersecting signals (or the cap is hit)
+    # Retry the geometry draws until they are valid non-intersecting (or the cap is hit)
+    total_time = data.shape[0]
     intersection_retries = 0
     intersection_retry_capped = False
     while True:
         intersection_retries += 1
-        # Inject RFI
-        cadence_1, rfi_signal_info, rfi_slope_clamped = new_cadence(
-            data, snr, width_bin, freq_resolution, time_resolution
+        # Draw both signals' geometry, consuming the exact per-attempt RNG sequence the
+        # pre-split inject-then-test loop consumed (RFI draws, then ETI draws) — but
+        # materialize nothing: the acceptance test below is a pure function of the drawn
+        # slopes/intercepts, and at p~=0.42 acceptance, injecting before testing wasted
+        # ~41% of all setigen injections in a production round.
+        rfi_params, rfi_slope_clamped = _draw_signal_params(
+            total_time, width_bin, freq_resolution, time_resolution
         )
-        # Inject ETI
-        cadence_2, eti_signal_info, eti_slope_clamped = new_cadence(
-            cadence_1, snr * dynamic_range, width_bin, freq_resolution, time_resolution
+        eti_params, eti_slope_clamped = _draw_signal_params(
+            total_time, width_bin, freq_resolution, time_resolution
         )
 
         # Extract slope and intercept for intersection check
-        slope_1 = rfi_signal_info["slope_pixel"]
-        intercept_1 = rfi_signal_info["y_intercept"]
-        slope_2 = eti_signal_info["slope_pixel"]
-        intercept_2 = eti_signal_info["y_intercept"]
+        slope_1 = rfi_params["slope_pixel"]
+        intercept_1 = rfi_params["y_intercept"]
+        slope_2 = eti_params["slope_pixel"]
+        intercept_2 = eti_params["y_intercept"]
 
         if slope_1 != slope_2 and check_valid_intersection(
             slope_1, slope_2, intercept_1, intercept_2
@@ -588,6 +639,16 @@ def create_true_double(
                 f"exhausted; keeping last drawn (rejected) signal pair and flagging the sample"
             )
             break
+
+    # Materialize only the accepted (or cap-flagged last-drawn) pair: RFI into the stacked
+    # background, then ETI on top of the RFI-injected cadence — same order, same arrays,
+    # same values as the pre-split inject-then-test loop.
+    cadence_1 = _inject_drawn_signal(data, snr, rfi_params, freq_resolution, time_resolution)
+    cadence_2 = _inject_drawn_signal(
+        cadence_1, snr * dynamic_range, eti_params, freq_resolution, time_resolution
+    )
+    rfi_signal_info = _signal_info_from_params(snr, rfi_params)
+    eti_signal_info = _signal_info_from_params(snr * dynamic_range, eti_params)
 
     # Track if any slope was clamped (either RFI or ETI)
     slope_was_clamped = rfi_slope_clamped or eti_slope_clamped

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -1769,6 +1769,38 @@ class Database:
             # Pair column names with values and return to user as a dict
             return [dict(zip(result_columns, row, strict=False)) for row in cursor.fetchall()]
 
+    def query_injection_stat_time_span(
+        self,
+        tag: str,
+        start_round_number: int | None = None,
+        end_round_number: int | None = None,
+    ) -> tuple[float, float] | None:
+        """
+        MIN/MAX timestamp over a tag's injection_stats rows, optionally bounded to a round
+        range. One deliberate full-partition aggregate (no timestamp filter; superseded and
+        non-finite rows included) that lets callers tighten the (tag, timestamp) index window
+        for the many row-level queries that follow — idx_injection_stats_filter leads with
+        (tag, timestamp) and round_number is not in it, so a run-wide window makes every
+        round-scoped query re-scan the tag's whole history. The span covers every row a
+        filtered query could return for those rounds, so intersecting a query window with it
+        never changes that query's result set. Returns None when no rows match.
+        """
+        with self._get_connection() as conn:
+            cursor = conn.cursor()
+            query = "SELECT MIN(timestamp), MAX(timestamp) FROM injection_stats WHERE tag = ?"
+            params: list = [tag]
+            if start_round_number is not None:
+                query += " AND round_number >= ?"
+                params.append(start_round_number)
+            if end_round_number is not None:
+                query += " AND round_number <= ?"
+                params.append(end_round_number)
+            cursor.execute(query, params)
+            row = cursor.fetchone()
+        if row is None or row[0] is None:
+            return None
+        return float(row[0]), float(row[1])
+
     # NOTE: how to additionally filter by metadata (e.g. machine_name)?
     # NOTE: should we also let user filter by value (e.g. >= or <= some value)?
     def query_injection_stat(

--- a/src/aetherscan/inference.py
+++ b/src/aetherscan/inference.py
@@ -339,6 +339,9 @@ class InferencePipeline:
 
         try:
             # Load encoder within strategy scope
+            # NOTE: per-layer dtype policies are baked into the saved .keras file, so an
+            # encoder trained with beta_vae.mixed_precision infers in bf16 automatically
+            # (z_mean/z_log_var/Sampling stay fp32 islands) — no global policy call here.
             logger.info(f"Loading encoder from {encoder_path} within strategy scope")
             with self.strategy.scope():
                 self.encoder = tf.keras.models.load_model(encoder_path)

--- a/src/aetherscan/latent_gif.py
+++ b/src/aetherscan/latent_gif.py
@@ -360,16 +360,25 @@ def build_snapshot_frames(
 
 
 def _sweep_worker_init() -> None:
-    """Pin native thread pools before numpy/umap/numba initialize in the fresh forkserver
-    interpreter (same pattern as shap_parallel; numba added for UMAP's kernels)."""
+    """Pin BLAS-family thread pools before numpy/umap initialize in the fresh forkserver
+    interpreter (the shap_parallel pattern) — but deliberately NOT numba's.
+
+    UMAP calls numba.set_num_threads(cpu_count) on its large-N paths, and numba hard-errors
+    when asked to grow past the pool it launched ("Cannot set NUMBA_NUM_THREADS to a
+    different value once the threads have been launched") — so capping NUMBA_NUM_THREADS at
+    1 breaks production-scale fits outright (found by the first full-scale run; the small-N
+    unit fits take the brute-force path and never touch the thread API). OMP_NUM_THREADS is
+    left unpinned for the same reason: numba's threading layer may be OpenMP-backed, in
+    which case the OMP cap is the same trap under a different name. Shrinking is always
+    legal, so an unpinned launch matches the pre-parallel serial behavior exactly (the old
+    in-process sweep also ran with an unpinned numba pool); the seeded fits force their
+    single-threaded deterministic paths regardless."""
     for var in (
-        "OMP_NUM_THREADS",
         "OPENBLAS_NUM_THREADS",
         "MKL_NUM_THREADS",
         "NUMEXPR_NUM_THREADS",
         "VECLIB_MAXIMUM_THREADS",
         "BLIS_NUM_THREADS",
-        "NUMBA_NUM_THREADS",
     ):
         os.environ.setdefault(var, "1")
 

--- a/src/aetherscan/latent_gif.py
+++ b/src/aetherscan/latent_gif.py
@@ -211,3 +211,284 @@ def render_latent_gif_frames(
         chunk_results = list(pool.map(_render_chunk, tasks))
 
     return [path for chunk_paths in chunk_results for path in chunk_paths]
+
+
+# ---------------------------------------------------------------------------
+# Whole-combo parallelism (the #278 follow-up): one (level, nn, md) UMAP combo —
+# fit + persist + per-snapshot transforms + frame render + GIF assembly — per worker.
+#
+# The 24-combo sweep was strictly serial in train.plot_latent_space_gif at ~95% single-core
+# (~1.7-1.9 h per run) even after frame rendering parallelized: every combo is an independent
+# UMAP fit with its own derived random_state, reads the same shared inputs read-only, and
+# writes distinct files. Farming WHOLE combos to forkserver workers therefore cannot change
+# any output byte — unlike the rejected within-fit ideas (batched_umap_transform above,
+# precomputed-knn reuse), nothing changes how any single fit consumes its RNG stream.
+
+# Palettes moved verbatim from train.plot_latent_space_gif so combo workers build their
+# categories without importing train (obs/cadence palettes deliberately distinct — the
+# cadence colors are shared with downstream RF plots).
+OBS_COLORS = {
+    ("false_no_signal", "ON"): "#1565C0",
+    ("false_no_signal", "OFF"): "#64B5F6",
+    ("false_with_rfi", "ON"): "#F9A825",
+    ("false_with_rfi", "OFF"): "#FFF176",
+    ("true_only_eti", "ON"): "#2E7D32",
+    ("true_only_eti", "OFF"): "#81C784",
+    ("true_eti_rfi", "ON"): "#C62828",
+    ("true_eti_rfi", "OFF"): "#EF5350",
+}
+OBS_MARKERS = {"ON": "^", "OFF": "x"}
+OBS_DISPLAY_NAMES = {
+    ("false_no_signal", "ON"): "No Signal (ON)",
+    ("false_no_signal", "OFF"): "No Signal (OFF)",
+    ("false_with_rfi", "ON"): "RFI Only (ON)",
+    ("false_with_rfi", "OFF"): "RFI Only (OFF)",
+    ("true_only_eti", "ON"): "ETI Only (ON)",
+    ("true_only_eti", "OFF"): "ETI Only (OFF)",
+    ("true_eti_rfi", "ON"): "ETI+RFI (ON)",
+    ("true_eti_rfi", "OFF"): "ETI+RFI (OFF)",
+}
+CADENCE_COLORS = {
+    "false_no_signal": "tab:blue",
+    "false_with_rfi": "tab:green",
+    "true_only_eti": "tab:red",
+    "true_eti_rfi": "tab:orange",
+}
+CADENCE_DISPLAY_NAMES = {
+    "false_no_signal": "No Signal",
+    "false_with_rfi": "RFI Only",
+    "true_only_eti": "ETI Only",
+    "true_eti_rfi": "ETI+RFI",
+}
+
+# Worker-global cache of the shared input bundle: one ProcessPoolExecutor worker handles
+# several combos, and they all read the same bundle file
+_SWEEP_BUNDLE: dict | None = None
+_SWEEP_BUNDLE_PATH: str | None = None
+
+
+def categories_for_mode(mode: str) -> tuple[list[FrameCategory], dict]:
+    """The scatter categories + legend kwargs for one GIF level (moved verbatim from
+    train.plot_latent_space_gif's closure)."""
+    if mode == "obs":
+        categories = [
+            FrameCategory(
+                signal_type=stype,
+                onoff=status,
+                color=color,
+                marker=OBS_MARKERS[status],
+                display_name=OBS_DISPLAY_NAMES[(stype, status)],
+            )
+            for (stype, status), color in OBS_COLORS.items()
+        ]
+        legend_kwargs = {
+            "loc": "upper right",
+            "fontsize": 8,
+            "markerscale": 2,
+            "ncol": 2,
+            "framealpha": 0.8,
+        }
+    elif mode == "cadence":
+        categories = [
+            FrameCategory(
+                signal_type=stype,
+                onoff=None,
+                color=color,
+                marker="o",
+                display_name=CADENCE_DISPLAY_NAMES[stype],
+            )
+            for stype, color in CADENCE_COLORS.items()
+        ]
+        legend_kwargs = {
+            "loc": "upper right",
+            "fontsize": 8,
+            "markerscale": 2,
+            "framealpha": 0.8,
+        }
+    else:
+        raise ValueError(f"mode must be 'obs' or 'cadence', got {mode!r}")
+    return categories, legend_kwargs
+
+
+def compute_frame_limits(
+    transformed_list: list[np.ndarray],
+) -> tuple[tuple[float, float], tuple[float, float]]:
+    """Shared axis limits over every frame's 2D projection, padded 5% (moved verbatim)."""
+    x_min = min(t[:, 0].min() for t in transformed_list)
+    x_max = max(t[:, 0].max() for t in transformed_list)
+    y_min = min(t[:, 1].min() for t in transformed_list)
+    y_max = max(t[:, 1].max() for t in transformed_list)
+    x_pad = (x_max - x_min) * 0.05
+    y_pad = (y_max - y_min) * 0.05
+    return (x_min - x_pad, x_max + x_pad), (y_min - y_pad, y_max + y_pad)
+
+
+def build_snapshot_frames(
+    transformed_list: list[np.ndarray],
+    snapshot_metadata: list[dict],
+    labels_list: list,
+    onoff_list: list | None,
+    display_method: str,
+) -> list[dict]:
+    """Assemble render_latent_gif_frames' frame dicts (coords/labels/onoff/title) for one
+    combo — the title logic moved verbatim from train.plot_latent_space_gif's closure."""
+    frames = []
+    for frame_idx, meta in enumerate(snapshot_metadata):
+        meta_snr_base = meta["snr_base"]
+        meta_snr_range = meta["snr_range"]
+        meta_snr_floor = meta_snr_base if meta_snr_base is not None else "?"
+        meta_snr_ceil = (
+            meta_snr_base + meta_snr_range
+            if meta_snr_base is not None and meta_snr_range is not None
+            else "?"
+        )
+        frames.append(
+            {
+                "coords": transformed_list[frame_idx],
+                "labels": labels_list[frame_idx],
+                "onoff": onoff_list[frame_idx] if onoff_list is not None else None,
+                "title": (
+                    f"Beta-VAE Latent Space: {display_method} — "
+                    f"Round {meta['round_number']}, "
+                    f"Epoch {meta['epoch_number']}, "
+                    f"Step {meta['step_number']} "
+                    f"(SNR: {meta_snr_floor}–{meta_snr_ceil})"
+                ),
+            }
+        )
+    return frames
+
+
+def _sweep_worker_init() -> None:
+    """Pin native thread pools before numpy/umap/numba initialize in the fresh forkserver
+    interpreter (same pattern as shap_parallel; numba added for UMAP's kernels)."""
+    for var in (
+        "OMP_NUM_THREADS",
+        "OPENBLAS_NUM_THREADS",
+        "MKL_NUM_THREADS",
+        "NUMEXPR_NUM_THREADS",
+        "VECLIB_MAXIMUM_THREADS",
+        "BLIS_NUM_THREADS",
+        "NUMBA_NUM_THREADS",
+    ):
+        os.environ.setdefault(var, "1")
+
+
+def _load_sweep_bundle(path: str) -> dict:
+    global _SWEEP_BUNDLE, _SWEEP_BUNDLE_PATH
+    if path != _SWEEP_BUNDLE_PATH:
+        import joblib  # noqa: PLC0415  (deferred so _sweep_worker_init pins threads first)
+
+        _SWEEP_BUNDLE = joblib.load(path)
+        _SWEEP_BUNDLE_PATH = path
+    return _SWEEP_BUNDLE
+
+
+def run_umap_gif_combo(task: dict) -> dict:
+    """
+    One (mode, nn, md) combo end-to-end: fit the UMAP on the mode's fit pool, persist it
+    (warn-not-fail, matching the serial path), transform every snapshot serially (the
+    output-identical form — see batched_umap_transform's rejection note), render the frame
+    PNGs in-process, and assemble the GIF. Runs in a forkserver worker (or inline when the
+    sweep is serial); consumes only the combo's own derived random_state.
+
+    Returns {method_name, display_method, gif_path, umap_path, n_frames, warnings} —
+    `warnings` carries messages for the parent to log (forkserver workers have no handler),
+    and gif assembly/Slack stay split: assembly here, upload in the caller.
+    """
+    import imageio.v3 as iio  # noqa: PLC0415  (deferred so _sweep_worker_init pins threads first)
+    import joblib  # noqa: PLC0415
+    import umap  # noqa: PLC0415
+
+    bundle = _load_sweep_bundle(task["bundle_path"])
+    mode = task["mode"]
+    warnings: list[str] = []
+
+    if mode == "obs":
+        fit_pool = bundle["fit_pool_obs"]
+        coords_list = bundle["coords_obs"]
+        labels_list = bundle["labels_obs"]
+        onoff_list = bundle["onoff_obs"]
+    else:
+        fit_pool = bundle["fit_pool_cadence"]
+        coords_list = bundle["coords_cadence"]
+        labels_list = bundle["labels_cadence"]
+        onoff_list = None
+
+    model = umap.UMAP(
+        n_components=2,
+        random_state=task["seed"],
+        n_neighbors=task["nn"],
+        min_dist=task["md"],
+    ).fit(fit_pool)
+
+    try:
+        os.makedirs(os.path.dirname(task["umap_path"]), exist_ok=True)
+        joblib.dump(model, task["umap_path"])
+    except Exception as exc:
+        warnings.append(f"Failed to persist {mode}-level UMAP model ({task['umap_path']}): {exc}")
+
+    transformed = [model.transform(coords) for coords in coords_list]
+    del model
+
+    xlim, ylim = compute_frame_limits(transformed)
+    categories, legend_kwargs = categories_for_mode(mode)
+    frames = build_snapshot_frames(
+        transformed, bundle["snapshot_metadata"], labels_list, onoff_list, task["display_method"]
+    )
+
+    frame_paths = render_latent_gif_frames(
+        frames,
+        categories=categories,
+        xlim=xlim,
+        ylim=ylim,
+        legend_kwargs=legend_kwargs,
+        out_dir=task["frames_dir"],
+        method_name=task["method_name"],
+        n_workers=1,  # combos are the parallel unit; frames render inline per combo
+    )
+
+    n_frames = len(frame_paths)
+    if n_frames > 0:
+        # Assemble the GIF by streaming one frame at a time (moved verbatim from train)
+        with iio.imopen(task["gif_path"], "w", plugin="pillow") as gif_writer:
+            for frame_path in frame_paths:
+                frame = iio.imread(frame_path)
+                gif_writer.write(
+                    frame,
+                    duration=task["duration_ms"],
+                    loop=0,
+                    is_batch=False,
+                )
+                del frame
+
+    return {
+        "method_name": task["method_name"],
+        "display_method": task["display_method"],
+        "gif_path": task["gif_path"],
+        "umap_path": task["umap_path"],
+        "n_frames": n_frames,
+        "warnings": warnings,
+    }
+
+
+def run_umap_gif_sweep(tasks: list[dict], n_workers: int) -> list[dict]:
+    """
+    Run every (mode, nn, md) combo across a forkserver pool (empty preload, threads pinned —
+    the shap_parallel isolation pattern), or serially in-process when n_workers <= 1. Results
+    come back in task order. Outputs are byte-identical either way: each combo's fit consumes
+    only its own derived random_state, and process isolation cannot change that stream.
+    """
+    if not tasks:
+        return []
+
+    n_workers = max(1, min(n_workers, len(tasks)))
+    if n_workers == 1:
+        return [run_umap_gif_combo(task) for task in tasks]
+
+    ctx = mp.get_context("forkserver")
+    ctx.set_forkserver_preload([])
+    with ProcessPoolExecutor(
+        max_workers=n_workers, mp_context=ctx, initializer=_sweep_worker_init
+    ) as pool:
+        return list(pool.map(run_umap_gif_combo, tasks))

--- a/src/aetherscan/latent_gif.py
+++ b/src/aetherscan/latent_gif.py
@@ -484,7 +484,16 @@ def run_umap_gif_sweep(tasks: list[dict], n_workers: int) -> list[dict]:
 
     n_workers = max(1, min(n_workers, len(tasks)))
     if n_workers == 1:
-        return [run_umap_gif_combo(task) for task in tasks]
+        # In-process combos cache the shared bundle in THIS process's module globals — clear
+        # them afterwards so the caller's pre-sweep memory cleanup (train.py dels its copies
+        # of the bundled inputs) isn't quietly undone by a lingering multi-hundred-MB cache.
+        # The pooled arm needs no equivalent: its cache lives in short-lived workers.
+        global _SWEEP_BUNDLE, _SWEEP_BUNDLE_PATH
+        try:
+            return [run_umap_gif_combo(task) for task in tasks]
+        finally:
+            _SWEEP_BUNDLE = None
+            _SWEEP_BUNDLE_PATH = None
 
     ctx = mp.get_context("forkserver")
     ctx.set_forkserver_preload([])

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -90,6 +90,22 @@ def setup_gpu_strategy():
     # Enable aggressive cleanup of intermediate tensors
     os.environ["TF_ENABLE_GPU_GARBAGE_COLLECTION"] = "true"
 
+    # Dedicated per-GPU kernel-launch threads (see GPUConfig.gpu_thread_mode). Read lazily by
+    # TF at GPU-runtime init like the allocator var above.
+    valid_thread_modes = {"global", "gpu_private", "gpu_shared"}
+    if config.gpu.gpu_thread_mode not in valid_thread_modes:
+        raise ValueError(
+            f"gpu.gpu_thread_mode must be one of {sorted(valid_thread_modes)}, "
+            f"got {config.gpu.gpu_thread_mode!r}"
+        )
+    if config.gpu.gpu_thread_mode == "global":
+        # Explicitly clear so a previous run's env doesn't leak in.
+        os.environ.pop("TF_GPU_THREAD_MODE", None)
+        os.environ.pop("TF_GPU_THREAD_COUNT", None)
+    else:
+        os.environ["TF_GPU_THREAD_MODE"] = config.gpu.gpu_thread_mode
+        os.environ["TF_GPU_THREAD_COUNT"] = str(config.gpu.gpu_thread_count)
+
     gpus = tf.config.list_physical_devices("GPU")
     if not gpus:
         logger.warning("No GPUs detected")

--- a/src/aetherscan/models/vae.py
+++ b/src/aetherscan/models/vae.py
@@ -479,9 +479,13 @@ def build_encoder(
 
     # Latent space
     # z_mean: (dense_size,) → (latent_dim,) - mean of latent distribution
+    # dtype="float32": fp32 island under beta_vae.mixed_precision — the latent heads feed the
+    # KL exp/square math and the Sampling layer, which must not run in bf16. A no-op under
+    # the default fp32 policy (identical graph).
     z_mean = layers.Dense(
         latent_dim,
         name="z_mean",
+        dtype="float32",
         kernel_initializer=GlorotNormal(),
         bias_initializer=Zeros(),
         activity_regularizer=l1(0.001),
@@ -493,6 +497,7 @@ def build_encoder(
     z_log_var = layers.Dense(
         latent_dim,
         name="z_log_var",
+        dtype="float32",  # fp32 island under beta_vae.mixed_precision (see z_mean above)
         kernel_initializer=GlorotNormal(),
         bias_initializer=Constant(
             -3.0  # Negative bias initialization tightens initial posterior around prior
@@ -503,7 +508,9 @@ def build_encoder(
     )(x)
 
     # Sampling: sample z from N(z_mean, exp(z_log_var)) using reparameterization trick
-    z = Sampling()([z_mean, z_log_var])
+    # dtype="float32": fp32 island under beta_vae.mixed_precision — the exp() and epsilon
+    # draw stay fp32 (its z_mean/z_log_var inputs are fp32 via the heads above)
+    z = Sampling(dtype="float32")([z_mean, z_log_var])
 
     encoder = keras.Model(encoder_inputs, [z_mean, z_log_var, z], name="encoder")
 
@@ -732,12 +739,16 @@ def build_decoder(
     # Uses sigmoid activation to bound output to [0, 1] for binary cross-entropy loss
     # Uses GlorotNormal (like encoder's latent layers) as this is the "boundary" layer
     # Includes full regularization for symmetry with encoder's first conv layer
+    # dtype="float32": fp32 island under beta_vae.mixed_precision — the sigmoid output feeds
+    # the BCE reconstruction loss, which must compute on fp32 tensors. A no-op under the
+    # default fp32 policy (identical graph).
     decoder_outputs = layers.Conv2DTranspose(
         1,
         kernel_size,
         activation="sigmoid",
         strides=2,
         padding="same",
+        dtype="float32",
         kernel_initializer=GlorotNormal(),
         bias_initializer=Zeros(),
         activity_regularizer=l1(0.001),

--- a/src/aetherscan/round_data.py
+++ b/src/aetherscan/round_data.py
@@ -170,19 +170,26 @@ def build_manifest(
     snr_range: float,
     wall_time_s: float,
     chunk_count: int,
+    array_dtype: str = "float32",
 ) -> dict:
-    """Assemble the .done manifest dict by re-opening the finished arrays read-only."""
+    """Assemble the .done manifest dict by re-opening the finished arrays read-only.
+    `array_dtype` is the requested cadence-array dtype; the per-array `dtypes` map records
+    what is actually on disk (labels/lognorm sidecars stay float32/U regardless)."""
     shapes: dict[str, list[int]] = {}
+    dtypes: dict[str, str] = {}
     checksums: dict[str, dict] = {}
     for name, path in _manifest_paths(paths).items():
         arr = np.load(path, mmap_mode="r")
         shapes[name] = list(arr.shape)
+        dtypes[name] = str(arr.dtype)
         checksums[name] = _array_checksum(arr)
         del arr
     return {
         "round_idx": paths.round_idx,
         "n_samples": int(n_samples),
         "shapes": shapes,
+        "dtypes": dtypes,
+        "array_dtype": str(array_dtype),
         "snr_base": float(snr_base),
         "snr_range": float(snr_range),
         "checksums": checksums,
@@ -203,7 +210,9 @@ def write_done_manifest(paths: RoundDataPaths, manifest: dict) -> None:
 
 
 def validate_done_manifest(
-    paths: RoundDataPaths, expected_n_samples: int | None = None
+    paths: RoundDataPaths,
+    expected_n_samples: int | None = None,
+    expected_array_dtype: str | None = None,
 ) -> dict | None:
     """
     Validate a round dir's .done manifest against the arrays on disk. Returns the manifest
@@ -234,7 +243,20 @@ def validate_done_manifest(
                 f"({expected_n_samples}) in {paths.done_path}"
             )
             return None
+        # Cadence-array dtype gate: a dir generated under a different round_array_dtype must
+        # not be silently reused (a float16 round fed to a float32-config resume — or vice
+        # versa — changes input numerics mid-run). Manifests predating the dtypes key are all
+        # float32 rounds.
+        if expected_array_dtype is not None:
+            manifest_dtype = manifest.get("array_dtype", "float32")
+            if manifest_dtype != expected_array_dtype:
+                logger.warning(
+                    f"Manifest array_dtype ({manifest_dtype}) != expected "
+                    f"({expected_array_dtype}) in {paths.done_path}"
+                )
+                return None
 
+        manifest_dtypes = manifest.get("dtypes")
         for name, path in _manifest_paths(paths).items():
             if not os.path.isfile(path):
                 logger.warning(f"Manifest array missing on disk: {path}")
@@ -243,6 +265,9 @@ def validate_done_manifest(
             try:
                 if list(arr.shape) != manifest["shapes"][name]:
                     logger.warning(f"Shape mismatch for {path}")
+                    return None
+                if manifest_dtypes is not None and str(arr.dtype) != manifest_dtypes[name]:
+                    logger.warning(f"Dtype mismatch for {path}")
                     return None
                 checksum = manifest["checksums"][name]
                 if int(arr.size) != checksum["elements"]:
@@ -332,7 +357,9 @@ def _reap_stale_producer(base_dir: str, term_timeout: float = 5.0) -> None:
         os.remove(pidfile)
 
 
-def prepare_round_data_dir(base_dir: str, start_round: int) -> None:
+def prepare_round_data_dir(
+    base_dir: str, start_round: int, expected_array_dtype: str = "float32"
+) -> None:
     """
     Startup cleanup of a tag's round-data directory, mirroring checkpoint-archiving semantics
     (train.archive_directory) for resumable runs — except entries are deleted rather than
@@ -361,7 +388,12 @@ def prepare_round_data_dir(base_dir: str, start_round: int) -> None:
         if round_idx >= start_round:
             logger.info(f"Deleting round-data dir for round >= {start_round}: {entry_path}")
             shutil.rmtree(entry_path, ignore_errors=True)
-        elif validate_done_manifest(RoundDataPaths(entry_path, round_idx)) is None:
+        elif (
+            validate_done_manifest(
+                RoundDataPaths(entry_path, round_idx), expected_array_dtype=expected_array_dtype
+            )
+            is None
+        ):
             logger.info(f"Deleting round-data dir with missing/invalid manifest: {entry_path}")
             shutil.rmtree(entry_path, ignore_errors=True)
         else:
@@ -400,6 +432,7 @@ def _default_generate(paths, round_idx, snr_base, snr_range, pool, params, stats
         seed=params["seed"],
         stats_cb=stats_cb,
         progress_cb=progress_cb,
+        array_dtype=params.get("array_dtype", "float32"),
     )
 
 
@@ -535,7 +568,11 @@ def _producer_main(
             _, round_idx, snr_base, snr_range = message
             paths = RoundDataPaths.for_round(params["base_dir"], round_idx)
 
-            existing = validate_done_manifest(paths, expected_n_samples=params["n_samples"])
+            existing = validate_done_manifest(
+                paths,
+                expected_n_samples=params["n_samples"],
+                expected_array_dtype=params.get("array_dtype", "float32"),
+            )
             if existing is not None:
                 logger.info(f"RoundDataProducer: reusing validated round {round_idx} data")
                 result_queue.put(("done", round_idx, existing))
@@ -604,6 +641,7 @@ class RoundDataProducer:
         db,
         tag: str,
         seed: int | None = None,
+        array_dtype: str = "float32",
     ):
         self._params = {
             "base_dir": base_dir,
@@ -623,6 +661,8 @@ class RoundDataProducer:
             # rest of the params so producer-generated rounds derive the same per-round
             # streams as in-process generation. None = OS entropy
             "seed": seed,
+            # On-disk dtype for the cadence arrays (config.training.round_array_dtype)
+            "array_dtype": str(array_dtype),
         }
         self._db = db
         self._tag = tag

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -21,7 +21,6 @@ import time
 from collections.abc import Callable
 from datetime import datetime
 
-import imageio.v3 as iio
 import joblib
 import matplotlib.lines as mlines
 import matplotlib.patches as mpatches
@@ -51,7 +50,7 @@ from aetherscan.config import get_config
 from aetherscan.data_generation import DataGenerator
 from aetherscan.db import get_db, get_system_metadata
 from aetherscan.hf_hub import upload_run_to_hf
-from aetherscan.latent_gif import FrameCategory, render_latent_gif_frames
+from aetherscan.latent_gif import run_umap_gif_sweep
 from aetherscan.latent_variants import (
     VARIANT_ORDER,
     active_latent_dims,
@@ -5296,55 +5295,6 @@ class TrainingPipeline:
         )
 
         # Compute consistent axis limits with 5% padding (streaming min/max to avoid concat)
-        def _compute_limits(transformed_list):
-            x_min = min(t[:, 0].min() for t in transformed_list)
-            x_max = max(t[:, 0].max() for t in transformed_list)
-            y_min = min(t[:, 1].min() for t in transformed_list)
-            y_max = max(t[:, 1].max() for t in transformed_list)
-            x_pad = (x_max - x_min) * 0.05
-            y_pad = (y_max - y_min) * 0.05
-            return (x_min - x_pad, x_max + x_pad), (y_min - y_pad, y_max + y_pad)
-
-        # NOTE: come back to this later
-        # Obs-level palette: 8 categories (signal_type × ON/OFF) with ON/OFF as triangle/x
-        obs_colors = {
-            ("false_no_signal", "ON"): "#1565C0",
-            ("false_no_signal", "OFF"): "#64B5F6",
-            ("false_with_rfi", "ON"): "#F9A825",
-            ("false_with_rfi", "OFF"): "#FFF176",
-            ("true_only_eti", "ON"): "#2E7D32",
-            ("true_only_eti", "OFF"): "#81C784",
-            ("true_eti_rfi", "ON"): "#C62828",
-            ("true_eti_rfi", "OFF"): "#EF5350",
-        }
-        obs_markers = {"ON": "^", "OFF": "x"}
-        obs_display_names = {
-            ("false_no_signal", "ON"): "No Signal (ON)",
-            ("false_no_signal", "OFF"): "No Signal (OFF)",
-            ("false_with_rfi", "ON"): "RFI Only (ON)",
-            ("false_with_rfi", "OFF"): "RFI Only (OFF)",
-            ("true_only_eti", "ON"): "ETI Only (ON)",
-            ("true_only_eti", "OFF"): "ETI Only (OFF)",
-            ("true_eti_rfi", "ON"): "ETI+RFI (ON)",
-            ("true_eti_rfi", "OFF"): "ETI+RFI (OFF)",
-        }
-
-        # NOTE: come back to this later (change colors, add markers. potentially need to change _render_frames_and_write_gif: docstring & collapse mode arg?)
-        # Cadence-level palette: 4 categories, kept distinct from the obs palette on
-        # purpose so downstream RF plots can reuse the same colors
-        cadence_colors = {
-            "false_no_signal": "tab:blue",
-            "false_with_rfi": "tab:green",
-            "true_only_eti": "tab:red",
-            "true_eti_rfi": "tab:orange",
-        }
-        cadence_display_names = {
-            "false_no_signal": "No Signal",
-            "false_with_rfi": "RFI Only",
-            "true_only_eti": "ETI Only",
-            "true_eti_rfi": "ETI+RFI",
-        }
-
         # NOTE: instead of temp_dir, save frames in persistent dir. update dir archiving to handle
         temp_dir = tempfile.mkdtemp(prefix="latent_gif_")
 
@@ -5354,234 +5304,103 @@ class TrainingPipeline:
         n_neighbors_values = self.config.training.latent_viz_umap_n_neighbors
         min_dist_values = self.config.training.latent_viz_umap_min_dist
 
-        def _render_frames_and_write_gif(
-            transformed_list,
-            method_name,
-            display_method,
-            xlim,
-            ylim,
-            mode,
-        ):
-            """
-            Render one scatter frame per snapshot (across a process pool — see
-            aetherscan.latent_gif, #278) and assemble them into a GIF.
+        # Bundle the shared inputs once for the combo workers: every (mode, nn, md) combo
+        # reads the same fit pools / snapshot coords / labels read-only, so they ship to the
+        # forkserver workers through one on-disk joblib bundle instead of a per-task pickle.
+        bundle_path = os.path.join(temp_dir, "sweep_inputs.joblib")
+        joblib.dump(
+            {
+                "fit_pool_obs": fit_pool_obs,
+                "fit_pool_cadence": fit_pool_cadence,
+                "coords_obs": all_coords_obs,
+                "coords_cadence": all_coords_cadence,
+                "labels_obs": all_snapshot_labels_obs,
+                "labels_cadence": all_snapshot_labels_cadence,
+                "onoff_obs": all_snapshot_onoff_obs,
+                "snapshot_metadata": snapshot_metadata,
+            },
+            bundle_path,
+        )
 
-            mode="obs"     → 8-category (signal_type × ON/OFF) scatter with triangle/x markers
-            mode="cadence" → 4-category (signal_type) scatter with single-marker style
-            """
-            if mode == "obs":
-                categories = [
-                    FrameCategory(
-                        signal_type=stype,
-                        onoff=status,
-                        color=color,
-                        marker=obs_markers[status],
-                        display_name=obs_display_names[(stype, status)],
+        # One task per (nn, md, level): the whole combo pipeline (UMAP fit + persist +
+        # per-snapshot transforms + frame render + GIF assembly) runs in a forkserver worker
+        # (aetherscan.latent_gif.run_umap_gif_sweep). The sweep was strictly serial here at
+        # ~95% single-core (~1.7-1.9 h per run) even after #278 parallelized frame
+        # rendering; combos are independent fits with their own derived random_state, so
+        # process isolation preserves every output byte — unlike the rejected within-fit
+        # ideas (batched transforms / precomputed-knn reuse, see latent_gif.py).
+        sweep_tasks = []
+        for nn in n_neighbors_values:
+            for md in min_dist_values:
+                for level_idx, mode in ((0, "obs"), (1, "cadence")):
+                    method_name = f"{mode}_umap_nn{nn}_md{md}"
+                    level_display = "Obs-level" if mode == "obs" else "Cadence-level"
+                    sweep_tasks.append(
+                        {
+                            "mode": mode,
+                            "nn": nn,
+                            "md": md,
+                            # random_state derives from the root seed, sub-keyed (level, nn,
+                            # md) so every fit gets its own reproducible stream (#279; md
+                            # keyed at 1e-3 resolution) — the same derivation the serial
+                            # loop used
+                            "seed": derive_seed(
+                                self.config.reproducibility.seed,
+                                STREAM_UMAP,
+                                level_idx,
+                                nn,
+                                round(md * 1000),
+                            ),
+                            "method_name": method_name,
+                            "display_method": (
+                                f"{level_display} UMAP (n_neighbors: {nn}, min_dist: {md})"
+                            ),
+                            "bundle_path": bundle_path,
+                            "frames_dir": temp_dir,
+                            "gif_path": os.path.join(
+                                save_dir, f"latent_space_{method_name}_{tag}.gif"
+                            ),
+                            "umap_path": os.path.join(
+                                self.config.model_path,
+                                f"umap_{mode}_nn{nn}_md{md}_{tag}.joblib",
+                            ),
+                            "duration_ms": duration_ms,
+                        }
                     )
-                    for (stype, status), color in obs_colors.items()
-                ]
-                legend_kwargs = {
-                    "loc": "upper right",
-                    "fontsize": 8,
-                    "markerscale": 2,
-                    "ncol": 2,
-                    "framealpha": 0.8,
-                }
-            else:  # cadence
-                categories = [
-                    FrameCategory(
-                        signal_type=stype,
-                        onoff=None,
-                        color=color,
-                        marker="o",
-                        display_name=cadence_display_names[stype],
-                    )
-                    for stype, color in cadence_colors.items()
-                ]
-                legend_kwargs = {
-                    "loc": "upper right",
-                    "fontsize": 8,
-                    "markerscale": 2,
-                    "framealpha": 0.8,
-                }
 
-            frames = []
-            for frame_idx, meta in enumerate(snapshot_metadata):
-                meta_snr_base = meta["snr_base"]
-                meta_snr_range = meta["snr_range"]
-                meta_snr_floor = meta_snr_base if meta_snr_base is not None else "?"
-                meta_snr_ceil = (
-                    meta_snr_base + meta_snr_range
-                    if meta_snr_base is not None and meta_snr_range is not None
-                    else "?"
-                )
-                frames.append(
-                    {
-                        "coords": transformed_list[frame_idx],
-                        "labels": (
-                            all_snapshot_labels_obs[frame_idx]
-                            if mode == "obs"
-                            else all_snapshot_labels_cadence[frame_idx]
-                        ),
-                        "onoff": all_snapshot_onoff_obs[frame_idx] if mode == "obs" else None,
-                        "title": (
-                            f"Beta-VAE Latent Space: {display_method} — "
-                            f"Round {meta['round_number']}, "
-                            f"Epoch {meta['epoch_number']}, "
-                            f"Step {meta['step_number']} "
-                            f"(SNR: {meta_snr_floor}–{meta_snr_ceil})"
-                        ),
-                    }
-                )
+        # The parent's copies of the bundled inputs are dead weight during the sweep
+        del fit_pool_obs, fit_pool_cadence
+        del all_coords_obs, all_coords_cadence
+        del all_snapshot_labels_obs, all_snapshot_labels_cadence, all_snapshot_onoff_obs
+        gc.collect()
 
-            frame_paths = render_latent_gif_frames(
-                frames,
-                categories=categories,
-                xlim=xlim,
-                ylim=ylim,
-                legend_kwargs=legend_kwargs,
-                out_dir=temp_dir,
-                method_name=method_name,
-                n_workers=self.config.manager.n_processes,
-            )
-            del frames
-            gc.collect()
+        n_sweep_workers = min(len(sweep_tasks), self.config.manager.n_processes)
+        logger.info(
+            f"Running {len(sweep_tasks)} UMAP GIF combos across {n_sweep_workers} worker(s)"
+        )
+        sweep_results = run_umap_gif_sweep(sweep_tasks, n_workers=n_sweep_workers)
 
-            # Assemble GIF by streaming one frame at a time via imageio (reduces memory pressure)
-            gif_filename = f"latent_space_{method_name}_{tag}.gif"
-            gif_path = os.path.join(save_dir, gif_filename)
-
-            n_frames = len(frame_paths)
-            if n_frames > 0:
-                with iio.imopen(gif_path, "w", plugin="pillow") as gif_writer:
-                    for frame_path in frame_paths:
-                        frame = iio.imread(frame_path)
-                        gif_writer.write(
-                            frame,
-                            duration=duration_ms,
-                            loop=0,
-                            is_batch=False,
-                        )
-                        del frame
-
+        # Logging, bookkeeping and Slack uploads stay parental (forkserver workers have no
+        # log handler and no Slack client), in task order — the serial loop's output order
+        for result in sweep_results:
+            for warning in result["warnings"]:
+                logger.warning(warning)
+            if os.path.exists(result["umap_path"]):
+                logger.info(f"Saved UMAP model: {result['umap_path']}")
+            gif_paths[result["method_name"]] = result["gif_path"]
+            if result["n_frames"] > 0:
                 logger.info(
-                    f"Latent space {method_name.upper()} GIF saved: {gif_path} ({n_frames} frames)"
+                    f"Latent space {result['method_name'].upper()} GIF saved: "
+                    f"{result['gif_path']} ({result['n_frames']} frames)"
                 )
-
-                # Upload to Slack
                 logger_instance = get_logger()
                 if logger_instance:
                     logger_instance.upload_image_to_slack(
-                        gif_path,
-                        title=f"Latent Space {display_method} - ({tag})",
+                        result["gif_path"],
+                        title=f"Latent Space {result['display_method']} - ({tag})",
                     )
 
-            del frame_paths
-            gc.collect()
-
-            return gif_path
-
-        for nn in n_neighbors_values:
-            for md in min_dist_values:
-                # Obs-level UMAP
-                logger.info(f"Fitting obs-level UMAP with n_neighbors={nn}, min_dist={md}")
-                # Note that by setting random_state, we get a deterministic UMAP fit, at the
-                # expense of single-thread performance (n_jobs=1). This is a hard constraint of
-                # the UMAP library. We compensate by fitting UMAP on a stratified subsample.
-                # random_state derives from the root seed, sub-keyed (level, nn, md) so every
-                # fit gets its own reproducible stream (#279; md keyed at 1e-3 resolution)
-                umap_obs = umap.UMAP(
-                    n_components=2,
-                    random_state=derive_seed(
-                        self.config.reproducibility.seed, STREAM_UMAP, 0, nn, round(md * 1000)
-                    ),
-                    n_neighbors=nn,
-                    min_dist=md,
-                ).fit(fit_pool_obs)
-
-                obs_umap_path = os.path.join(
-                    self.config.model_path, f"umap_obs_nn{nn}_md{md}_{tag}.joblib"
-                )
-                try:
-                    os.makedirs(self.config.model_path, exist_ok=True)
-                    joblib.dump(umap_obs, obs_umap_path)
-                    logger.info(f"Saved obs-level UMAP model: {obs_umap_path}")
-                except Exception as exc:
-                    logger.warning(
-                        f"Failed to persist obs-level UMAP model ({obs_umap_path}): {exc}"
-                    )
-
-                transformed_obs = [umap_obs.transform(c) for c in all_coords_obs]
-                del umap_obs
-                gc.collect()
-
-                xlim_obs, ylim_obs = _compute_limits(transformed_obs)
-                method_name_obs = f"obs_umap_nn{nn}_md{md}"
-                display_method_obs = f"Obs-level UMAP (n_neighbors: {nn}, min_dist: {md})"
-
-                gif_path_obs = _render_frames_and_write_gif(
-                    transformed_obs,
-                    method_name_obs,
-                    display_method_obs,
-                    xlim_obs,
-                    ylim_obs,
-                    mode="obs",
-                )
-                gif_paths[method_name_obs] = gif_path_obs
-
-                del transformed_obs
-                gc.collect()
-
-                # Cadence-level UMAP
-                logger.info(f"Fitting cadence-level UMAP with n_neighbors={nn}, min_dist={md}")
-                # Note that by setting random_state, we get a deterministic UMAP fit, at the
-                # expense of single-thread performance (n_jobs=1). This is a hard constraint of
-                # the UMAP library. We compensate by fitting UMAP on a stratified subsample.
-                umap_cadence = umap.UMAP(
-                    n_components=2,
-                    random_state=derive_seed(
-                        self.config.reproducibility.seed, STREAM_UMAP, 1, nn, round(md * 1000)
-                    ),
-                    n_neighbors=nn,
-                    min_dist=md,
-                ).fit(fit_pool_cadence)
-
-                cadence_umap_path = os.path.join(
-                    self.config.model_path, f"umap_cadence_nn{nn}_md{md}_{tag}.joblib"
-                )
-                try:
-                    os.makedirs(self.config.model_path, exist_ok=True)
-                    joblib.dump(umap_cadence, cadence_umap_path)
-                    logger.info(f"Saved cadence-level UMAP model: {cadence_umap_path}")
-                except Exception as exc:
-                    logger.warning(
-                        f"Failed to persist cadence-level UMAP model ({cadence_umap_path}): {exc}"
-                    )
-
-                transformed_cadence = [umap_cadence.transform(c) for c in all_coords_cadence]
-                del umap_cadence
-                gc.collect()
-
-                xlim_cad, ylim_cad = _compute_limits(transformed_cadence)
-                method_name_cad = f"cadence_umap_nn{nn}_md{md}"
-                display_method_cad = f"Cadence-level UMAP (n_neighbors: {nn}, min_dist: {md})"
-
-                gif_path_cad = _render_frames_and_write_gif(
-                    transformed_cadence,
-                    method_name_cad,
-                    display_method_cad,
-                    xlim_cad,
-                    ylim_cad,
-                    mode="cadence",
-                )
-                gif_paths[method_name_cad] = gif_path_cad
-
-                del transformed_cadence
-                gc.collect()
-
-        # Cleanup — leave closure-captured variables for Python's scope teardown rather
-        # than `del`ing them here (ruff F821 flags closure refs when the enclosing
-        # scope explicitly deletes the name, even if the closure already ran).
+        # Cleanup (frame PNGs + the sweep input bundle)
         # NOTE: temp_dir isn't cleaned on exception (should use try/finally or tempfile.TemporaryDirectory() with context manager)
         shutil.rmtree(temp_dir, ignore_errors=True)
         gc.collect()

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -883,7 +883,9 @@ def prepare_distributed_train_dataset(
     def map_gather(batch_indices):
         # Pure tf.data ops on CPU: the gather runs in TF's C++ threadpool, releases nothing
         # to Python, and parallel map workers scale with cores instead of convoying on the
-        # GIL. tf.cast is a no-op passthrough for the production float32 arrays.
+        # GIL. tf.cast is a no-op passthrough for float32 round arrays and the host-side
+        # upcast under round_array_dtype="float16" (the gather itself moves half the bytes;
+        # the training graph sees float32 either way).
         with tf.device("/CPU:0"):
             concat_batch = tf.cast(tf.gather(concat_t, batch_indices), tf.float32)
             true_batch = tf.cast(tf.gather(true_t, batch_indices), tf.float32)
@@ -1143,6 +1145,18 @@ class TrainingPipeline:
 
         # Set distributed strategy
         self.strategy = strategy or tf.distribute.get_strategy()
+
+        # Opt-in bf16 mixed precision (A/B-gated; see BetaVAEConfig.mixed_precision): the
+        # global policy must be set BEFORE the models are built so every layer picks it up.
+        # bf16 needs no loss scaling, and keras keeps variables/optimizer state — and hence
+        # the gradients reaching the fp32 accumulators and NaN guard — in fp32. Flag off =>
+        # no policy call at all, preserving the fp32 pipeline's numerics byte-for-byte.
+        if self.config.beta_vae.mixed_precision:
+            tf.keras.mixed_precision.set_global_policy("mixed_bfloat16")
+            logger.info(
+                "Mixed precision enabled: keras global policy set to mixed_bfloat16 "
+                "(fp32 islands: z_mean/z_log_var/Sampling, decoder output, loss math)"
+            )
 
         # Create VAE model & optimizer inside distributed context
         with self.strategy.scope():
@@ -1460,7 +1474,11 @@ class TrainingPipeline:
             "round_data"
         )
         self._round_data_base_dir = os.path.join(round_data_root, self.config.checkpoint.save_tag)
-        prepare_round_data_dir(self._round_data_base_dir, start_round)
+        prepare_round_data_dir(
+            self._round_data_base_dir,
+            start_round,
+            expected_array_dtype=self.config.training.round_array_dtype,
+        )
 
         logger.info("Setup directories complete")
 
@@ -1537,6 +1555,7 @@ class TrainingPipeline:
                     db=self.db,
                     tag=self.config.checkpoint.save_tag,
                     seed=self.config.reproducibility.seed,
+                    array_dtype=self.config.training.round_array_dtype,
                 )
                 self._round_producer.start()
                 # Kick off the first round's data right away (nothing to overlap with yet —
@@ -1617,7 +1636,14 @@ class TrainingPipeline:
         # Obtain this round's disk-backed data: reuse a validated on-disk dataset if one
         # exists, otherwise wait on the background producer (which was asked to generate it
         # while the previous round trained) or generate in-process (overlap disabled)
-        if validate_done_manifest(paths, expected_n_samples=n_samples) is not None:
+        if (
+            validate_done_manifest(
+                paths,
+                expected_n_samples=n_samples,
+                expected_array_dtype=self.config.training.round_array_dtype,
+            )
+            is not None
+        ):
             logger.info(f"Reusing validated round {round_number} data at {paths.round_dir}")
         elif self._round_producer is not None:
             logger.info(f"Waiting for round {round_number} data from the background producer")
@@ -2679,7 +2705,14 @@ class TrainingPipeline:
             round_dir=os.path.join(self._round_data_base_dir, "rf"), round_idx=0
         )
         rf_trained = False  # Set True once RF training fully completes (drives dir deletion)
-        if validate_done_manifest(rf_paths, expected_n_samples=n_samples) is not None:
+        if (
+            validate_done_manifest(
+                rf_paths,
+                expected_n_samples=n_samples,
+                expected_array_dtype=self.config.training.round_array_dtype,
+            )
+            is not None
+        ):
             logger.info(f"Reusing validated RF dataset at {rf_paths.round_dir}")
         else:
             # RF data is always generated in-process (no background producer for the RF phase);
@@ -6983,9 +7016,11 @@ class TrainingPipeline:
             self._latent_viz_lognorm_params = None
             return
 
-        # Fancy indexing already creates a new independent array (no .copy() needed)
+        # Fancy indexing already creates a new independent array (no .copy() needed); the
+        # astype is a no-op for float32 rounds and upcasts float16 rounds so traversal math
+        # and plain-model encodes always see float32 (mirrors map_gather's cast)
         all_indices = np.concatenate(selected_indices)
-        self._latent_viz_batch = concat_data[all_indices]
+        self._latent_viz_batch = concat_data[all_indices].astype(np.float32, copy=False)
         self._latent_viz_labels = np.array(selected_labels, dtype="U20")
         self._latent_viz_lognorm_params = (
             lognorm_params[all_indices] if lognorm_params is not None else None

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -4130,6 +4130,23 @@ class TrainingPipeline:
             )
         logger.info("Database flushed")
 
+        # Tighten the timestamp window to the queried rounds' actual row span:
+        # idx_injection_stats_filter leads with (tag, timestamp) and round_number is not in
+        # it, so with the run-wide window every query below re-scans the tag's entire row
+        # history (measured 10.5x slower at 12M rows) — and this function issues ~165 such
+        # queries per call. The span is MIN/MAX over ALL rows for these rounds (superseded
+        # included), so intersecting it with the existing [run-start, now] window can only
+        # narrow each scan — never change a result set.
+        window_start, window_end = self.start_time, current_time
+        span = self.db.query_injection_stat_time_span(
+            tag=self.config.checkpoint.save_tag,
+            start_round_number=start_round_number,
+            end_round_number=end_round_number,
+        )
+        if span is not None:
+            window_start = max(window_start, span[0] - 1.0)
+            window_end = min(window_end, span[1] + 1.0)
+
         # Figure 1: Injected signal characteristics
         signal_stats = [
             "snr",
@@ -4150,8 +4167,8 @@ class TrainingPipeline:
                 start_round_number=start_round_number,
                 end_round_number=end_round_number,
                 tag=self.config.checkpoint.save_tag,
-                start_time=self.start_time,
-                end_time=current_time,
+                start_time=window_start,
+                end_time=window_end,
                 columns=["value"],
             )
             eti_stats[stat_name] = [r["value"] for r in results]
@@ -4164,8 +4181,8 @@ class TrainingPipeline:
                 start_round_number=start_round_number,
                 end_round_number=end_round_number,
                 tag=self.config.checkpoint.save_tag,
-                start_time=self.start_time,
-                end_time=current_time,
+                start_time=window_start,
+                end_time=window_end,
                 columns=["value"],
             )
             rfi_stats[stat_name] = [r["value"] for r in results]
@@ -4179,8 +4196,8 @@ class TrainingPipeline:
             start_round_number=start_round_number,
             end_round_number=end_round_number,
             tag=self.config.checkpoint.save_tag,
-            start_time=self.start_time,
-            end_time=current_time,
+            start_time=window_start,
+            end_time=window_end,
             columns=["background_index"],
         )
         eti_background_indices = [
@@ -4195,8 +4212,8 @@ class TrainingPipeline:
             start_round_number=start_round_number,
             end_round_number=end_round_number,
             tag=self.config.checkpoint.save_tag,
-            start_time=self.start_time,
-            end_time=current_time,
+            start_time=window_start,
+            end_time=window_end,
             columns=["background_index"],
         )
         rfi_background_indices = [
@@ -4237,8 +4254,8 @@ class TrainingPipeline:
                 start_round_number=start_round_number,
                 end_round_number=end_round_number,
                 tag=self.config.checkpoint.save_tag,
-                start_time=self.start_time,
-                end_time=current_time,
+                start_time=window_start,
+                end_time=window_end,
             )
             for row in agg_results:
                 round_num = row["round_number"]
@@ -4258,8 +4275,8 @@ class TrainingPipeline:
             start_round_number=start_round_number,
             end_round_number=end_round_number,
             tag=self.config.checkpoint.save_tag,
-            start_time=self.start_time,
-            end_time=current_time,
+            start_time=window_start,
+            end_time=window_end,
         )
         for row in clamping_results:
             round_num = row["round_number"]
@@ -4305,8 +4322,8 @@ class TrainingPipeline:
                         start_round_number=start_round_number,
                         end_round_number=end_round_number,
                         tag=self.config.checkpoint.save_tag,
-                        start_time=self.start_time,
-                        end_time=current_time,
+                        start_time=window_start,
+                        end_time=window_end,
                         columns=["value"],
                     )
                     stats_by_stage[stage][stat_name] = [r["value"] for r in results]
@@ -4336,8 +4353,8 @@ class TrainingPipeline:
                     start_round_number=start_round_number,
                     end_round_number=end_round_number,
                     tag=self.config.checkpoint.save_tag,
-                    start_time=self.start_time,
-                    end_time=current_time,
+                    start_time=window_start,
+                    end_time=window_end,
                     columns=["value"],
                 )
                 values_a = [r["value"] for r in results_a]
@@ -4351,8 +4368,8 @@ class TrainingPipeline:
                     start_round_number=start_round_number,
                     end_round_number=end_round_number,
                     tag=self.config.checkpoint.save_tag,
-                    start_time=self.start_time,
-                    end_time=current_time,
+                    start_time=window_start,
+                    end_time=window_end,
                     columns=["value"],
                 )
                 values_b = [r["value"] for r in results_b]
@@ -4378,8 +4395,8 @@ class TrainingPipeline:
                     start_round_number=start_round_number,
                     end_round_number=end_round_number,
                     tag=self.config.checkpoint.save_tag,
-                    start_time=self.start_time,
-                    end_time=current_time,
+                    start_time=window_start,
+                    end_time=window_end,
                     columns=["value"],
                 )
                 stats_by_type[signal_type][stat_name] = [r["value"] for r in results]

--- a/tests/unit/test_data_generation.py
+++ b/tests/unit/test_data_generation.py
@@ -308,23 +308,29 @@ class TestCreateCadences:
         assert sample_info["intersection_retry_capped"] is False
 
     def _stub_injections(self, monkeypatch):
-        # Replace the expensive setigen injection with a shape-preserving stub whose slope
-        # differs on every call, so the slope_1 != slope_2 guard never causes a retry and
-        # the retry count is driven purely by the (patched) intersection check.
+        # Replace the expensive draw+materialize pair with shape-preserving stubs whose slope
+        # differs on every draw, so the slope_1 != slope_2 guard never causes a retry and
+        # the retry count is driven purely by the (patched) intersection check. Since the
+        # draw-first split, create_true_double calls _draw_signal_params per attempt and
+        # _inject_drawn_signal only for the final pair — patch both.
         calls = itertools.count(1)
 
-        def fake_new_cadence(data, snr, width_bin, freq_resolution, time_resolution):
-            signal_info = {
-                "snr": float(snr),
+        def fake_draw_signal_params(total_time, width_bin, freq_resolution, time_resolution):
+            params = {
                 "drift_rate": 1.0,
                 "signal_width": 1.0,
                 "starting_bin": 1.0,
                 "slope_pixel": float(next(calls)),
                 "y_intercept": 0.0,
             }
-            return data, signal_info, False
+            return params, False
 
-        monkeypatch.setattr(data_generation, "new_cadence", fake_new_cadence)
+        monkeypatch.setattr(data_generation, "_draw_signal_params", fake_draw_signal_params)
+        monkeypatch.setattr(
+            data_generation,
+            "_inject_drawn_signal",
+            lambda data, snr, params, freq_resolution, time_resolution: data,
+        )
 
     def test_true_double_retry_cap_clamps_and_flags(self, plate, monkeypatch):
         # Always-rejecting geometry must terminate at the cap, keep the last drawn pair,
@@ -342,6 +348,136 @@ class TestCreateCadences:
         _, sample_info = create_true_double(plate, **self._kwargs())
         assert sample_info["intersection_retries"] == 1
         assert sample_info["intersection_retry_capped"] is False
+
+
+class TestDrawFirstEquivalence:
+    """Byte-compatibility pins for the draw-first split of new_cadence (#TBD).
+
+    The split moved setigen materialization out of create_true_double's retry loop; these
+    tests pin the two contracts that make that byte-identical: materialization consumes no
+    RNG, and create_true_double's draw order matches the pre-split inject-then-test loop
+    exactly.
+    """
+
+    def test_inject_drawn_signal_consumes_no_rng(self):
+        data = np.abs(np.random.randn(96, _WIDTH_BIN)) + 1.0
+        params, _ = data_generation._draw_signal_params(96, _WIDTH_BIN, _FREQ_RES, _TIME_RES)
+        py_state = random.getstate()
+        np_state = np.random.get_state()
+        data_generation._inject_drawn_signal(data, 20.0, params, _FREQ_RES, _TIME_RES)
+        assert random.getstate() == py_state
+        np_state_after = np.random.get_state()
+        assert np_state[0] == np_state_after[0]
+        np.testing.assert_array_equal(np_state[1], np_state_after[1])
+        assert np_state[2:] == np_state_after[2:]
+
+    def test_new_cadence_is_draw_then_inject_composition(self):
+        data = np.abs(np.random.randn(96, _WIDTH_BIN)) + 1.0
+        state_py = random.getstate()
+        state_np = np.random.get_state()
+        modified, signal_info, clamped = new_cadence(data, 20.0, _WIDTH_BIN, _FREQ_RES, _TIME_RES)
+        random.setstate(state_py)
+        np.random.set_state(state_np)
+        params, clamped_ref = data_generation._draw_signal_params(
+            data.shape[0], _WIDTH_BIN, _FREQ_RES, _TIME_RES
+        )
+        modified_ref = data_generation._inject_drawn_signal(
+            data, 20.0, params, _FREQ_RES, _TIME_RES
+        )
+        np.testing.assert_array_equal(modified, modified_ref)
+        assert signal_info == data_generation._signal_info_from_params(20.0, params)
+        assert clamped == clamped_ref
+
+    @staticmethod
+    def _pre_split_true_double_reference(
+        plate, snr_base, snr_range, width_bin, freq_resolution, time_resolution, dynamic_range=1.0
+    ):
+        """The pre-split create_true_double loop (inject both, then test), reproduced verbatim
+        via the public new_cadence so the equivalence test compares against the exact legacy
+        RNG-consumption and materialization order."""
+        background_index = int(plate.shape[0] * random.random())
+        base = plate[background_index, :, :, :]
+        n_obs = plate.shape[1]
+        n_time = plate.shape[2]
+        final = np.zeros((n_obs, n_time, width_bin))
+        stats_a = _compute_intensity_stats(base)
+        data = np.zeros((n_obs * n_time, width_bin))
+        for i in range(n_obs):
+            data[i * n_time : (i + 1) * n_time, :] = base[i, :, :]
+        snr = random.random() * snr_range + snr_base
+        intersection_retries = 0
+        intersection_retry_capped = False
+        while True:
+            intersection_retries += 1
+            cadence_1, rfi_signal_info, rfi_slope_clamped = new_cadence(
+                data, snr, width_bin, freq_resolution, time_resolution
+            )
+            cadence_2, eti_signal_info, eti_slope_clamped = new_cadence(
+                cadence_1, snr * dynamic_range, width_bin, freq_resolution, time_resolution
+            )
+            slope_1 = rfi_signal_info["slope_pixel"]
+            intercept_1 = rfi_signal_info["y_intercept"]
+            slope_2 = eti_signal_info["slope_pixel"]
+            intercept_2 = eti_signal_info["y_intercept"]
+            if slope_1 != slope_2 and check_valid_intersection(
+                slope_1, slope_2, intercept_1, intercept_2
+            ):
+                break
+            if intersection_retries >= MAX_INTERSECTION_RETRIES:
+                intersection_retry_capped = True
+                break
+        slope_was_clamped = rfi_slope_clamped or eti_slope_clamped
+        signal_info = {
+            **{f"rfi_{k}": v for k, v in rfi_signal_info.items()},
+            **{f"eti_{k}": v for k, v in eti_signal_info.items()},
+        }
+        stats_b = _compute_intensity_stats(cadence_2)
+        lognorm_params = np.zeros((n_obs, 2), dtype=np.float32)
+        for i in range(n_obs):
+            source = cadence_2 if i % 2 == 0 else cadence_1
+            final[i, :, :], lognorm_params[i] = log_norm(
+                source[i * n_time : (i + 1) * n_time, :], return_params=True
+            )
+        stats_c = _compute_intensity_stats(final)
+        return final, {
+            "background_index": background_index,
+            "intensity_stats": {"A": stats_a, "B": stats_b, "C": stats_c},
+            "signal_info": signal_info,
+            "slope_was_clamped": slope_was_clamped,
+            "intersection_retries": intersection_retries,
+            "intersection_retry_capped": intersection_retry_capped,
+            "lognorm_params": lognorm_params,
+        }
+
+    @pytest.mark.parametrize("seed", [11, 12, 13, 14])
+    def test_true_double_matches_pre_split_reference(self, plate, seed):
+        kwargs = {
+            "snr_base": 10.0,
+            "snr_range": 5.0,
+            "width_bin": _WIDTH_BIN,
+            "freq_resolution": _FREQ_RES,
+            "time_resolution": _TIME_RES,
+        }
+        random.seed(seed)
+        np.random.seed(seed)
+        final_ref, info_ref = self._pre_split_true_double_reference(plate, **kwargs)
+        state_py_ref = random.getstate()
+        state_np_ref = np.random.get_state()
+        random.seed(seed)
+        np.random.seed(seed)
+        final_new, info_new = create_true_double(plate, **kwargs)
+        np.testing.assert_array_equal(final_new, final_ref)
+        np.testing.assert_array_equal(
+            info_new.pop("lognorm_params"), info_ref.pop("lognorm_params")
+        )
+        assert info_new == info_ref
+        # Both arms must also leave the global RNG streams in the same state (no extra or
+        # missing draws) — the property the per-task seeding contract depends on.
+        assert random.getstate() == state_py_ref
+        state_np_new = np.random.get_state()
+        assert state_np_new[0] == state_np_ref[0]
+        np.testing.assert_array_equal(state_np_new[1], state_np_ref[1])
+        assert state_np_new[2:] == state_np_ref[2:]
 
 
 class TestComputeIntensityStats:

--- a/tests/unit/test_data_generation.py
+++ b/tests/unit/test_data_generation.py
@@ -20,10 +20,12 @@ from aetherscan.data_generation import (
     create_false,
     create_true_double,
     create_true_single,
+    generate_round_to_memmap,
     log_norm,
     new_cadence,
     write_segment_stats,
 )
+from aetherscan.round_data import RoundDataPaths, validate_done_manifest
 
 # Keep injection fast: small frequency axis, real-ish resolutions.
 _WIDTH_BIN = 128
@@ -348,6 +350,53 @@ class TestCreateCadences:
         _, sample_info = create_true_double(plate, **self._kwargs())
         assert sample_info["intersection_retries"] == 1
         assert sample_info["intersection_retry_capped"] is False
+
+
+class TestFloat16RoundArrays:
+    """round_array_dtype="float16" (A/B-gated): same seeded generation, on-disk quantization
+    only — the manifest records and gates the dtype."""
+
+    def _generate(self, plate, tmp_path, subdir, array_dtype):
+        paths = RoundDataPaths.for_round(str(tmp_path / subdir), 1)
+        generate_round_to_memmap(
+            paths,
+            8,
+            10.0,
+            5.0,
+            width_bin=_WIDTH_BIN,
+            num_observations=6,
+            time_bins=16,
+            chunk_size=8,
+            task_size=4,
+            freq_resolution=_FREQ_RES,
+            time_resolution=_TIME_RES,
+            backgrounds=plate,
+            round_num=1,
+            seed=11,
+            array_dtype=array_dtype,
+        )
+        return paths
+
+    def test_float16_generation_is_quantization_only(self, plate, tmp_path):
+        paths32 = self._generate(plate, tmp_path, "f32", "float32")
+        paths16 = self._generate(plate, tmp_path, "f16", "float16")
+        a32 = np.load(paths32.main_path)
+        a16 = np.load(paths16.main_path)
+        assert a32.dtype == np.float32
+        assert a16.dtype == np.float16
+        # Same seed => identical generated values; the only difference is the on-disk
+        # downcast, bounded by half-precision resolution on the [0, 1] log-normed data
+        np.testing.assert_allclose(a16.astype(np.float32), a32, atol=2**-11)
+        # Sidecars stay float32; labels identical
+        assert np.load(paths16.lognorm_paths["main"]).dtype == np.float32
+        np.testing.assert_array_equal(np.load(paths16.labels_path), np.load(paths32.labels_path))
+        # Manifest gates reuse by dtype
+        assert validate_done_manifest(paths16, expected_array_dtype="float16") is not None
+        assert validate_done_manifest(paths16, expected_array_dtype="float32") is None
+
+    def test_unknown_dtype_rejected(self, plate, tmp_path):
+        with pytest.raises(ValueError, match="array_dtype"):
+            self._generate(plate, tmp_path, "bad", "float64")
 
 
 class TestDrawFirstEquivalence:

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -790,6 +790,42 @@ def _wait_backlog_empty(database, timeout: float = 15.0) -> bool:
     return False
 
 
+class TestInjectionStatTimeSpan:
+    """query_injection_stat_time_span: the whole-partition MIN/MAX aggregate that callers use
+    to tighten (tag, timestamp) index windows for round-scoped queries."""
+
+    def test_span_by_round_and_missing_tag(self, db):
+        rows = _bulk_rows(3, round_number=1) + _bulk_rows(3, round_number=2)
+        for i, r in enumerate(rows[:3]):
+            r["timestamp"] = 100.0 + i  # round 1: 100..102
+        for i, r in enumerate(rows[3:]):
+            r["timestamp"] = 200.0 + i  # round 2: 200..202
+        db.write_injection_stats_bulk(rows, tag="span_v1")
+        assert _wait_backlog_empty(db)
+        assert db.query_injection_stat_time_span(tag="span_v1") == (100.0, 202.0)
+        assert db.query_injection_stat_time_span(tag="span_v1", start_round_number=2) == (
+            200.0,
+            202.0,
+        )
+        assert db.query_injection_stat_time_span(
+            tag="span_v1", start_round_number=1, end_round_number=1
+        ) == (100.0, 102.0)
+        assert db.query_injection_stat_time_span(tag="no_such_tag") is None
+
+    def test_span_includes_superseded_and_non_finite_rows(self, db):
+        # The span deliberately ignores the is_finite / superseded filters row-level queries
+        # apply: it must be a SUPERSET bound, so intersecting a query window with it can
+        # never drop a row that query would have returned.
+        rows = _bulk_rows(2, round_number=1)
+        rows[0]["timestamp"] = 50.0
+        rows[0]["value"] = float("nan")  # sanitized to is_finite=0 at write time
+        rows[1]["timestamp"] = 60.0
+        db.write_injection_stats_bulk(rows, tag="span_v2")
+        assert _wait_backlog_empty(db)
+        db.mark_superseded("injection_stats", tag="span_v2", round_ge=1)
+        assert db.query_injection_stat_time_span(tag="span_v2") == (50.0, 60.0)
+
+
 class TestBulkLane:
     """#277: high-volume injection stats ride a bounded bulk lane separate from the
     foreground queue, with per-round pending accounting."""

--- a/tests/unit/test_latent_gif.py
+++ b/tests/unit/test_latent_gif.py
@@ -4,12 +4,18 @@ per-snapshot splits. TF-free by design — the module mirrors shap_parallel's is
 
 from __future__ import annotations
 
+import os
+
+import joblib
 import numpy as np
+import pytest
 
 from aetherscan.latent_gif import (
     FrameCategory,
     batched_umap_transform,
+    categories_for_mode,
     render_latent_gif_frames,
+    run_umap_gif_sweep,
 )
 
 _CATEGORIES = [
@@ -156,3 +162,93 @@ class TestBatchedUmapTransform:
 
     def test_empty_list(self):
         assert batched_umap_transform(self._FakeModel(), []) == []
+
+
+@pytest.mark.slow
+class TestRunUmapGifSweep:
+    """The whole-combo sweep (fit + persist + transform + render + GIF) must be
+    byte-identical between serial and pooled execution — the #278-follow-up contract that
+    lets the 24-combo sweep parallelize without changing any output."""
+
+    def _bundle(self, tmp_path):
+        rng = np.random.default_rng(11)
+        n_frames, n_obs, n_cad, d_obs, d_cad = 3, 48, 24, 4, 8
+        labels_pool = ["false_no_signal", "false_with_rfi", "true_only_eti", "true_eti_rfi"]
+        bundle = {
+            "fit_pool_obs": rng.normal(size=(96, d_obs)).astype(np.float32),
+            "fit_pool_cadence": rng.normal(size=(64, d_cad)).astype(np.float32),
+            "coords_obs": [
+                rng.normal(size=(n_obs, d_obs)).astype(np.float32) for _ in range(n_frames)
+            ],
+            "coords_cadence": [
+                rng.normal(size=(n_cad, d_cad)).astype(np.float32) for _ in range(n_frames)
+            ],
+            "labels_obs": [
+                np.array((labels_pool * (n_obs // 4))[:n_obs], dtype="U20") for _ in range(n_frames)
+            ],
+            "labels_cadence": [
+                np.array((labels_pool * (n_cad // 4))[:n_cad], dtype="U20") for _ in range(n_frames)
+            ],
+            "onoff_obs": [
+                np.array(["ON", "OFF"] * (n_obs // 2), dtype="U3") for _ in range(n_frames)
+            ],
+            "snapshot_metadata": [
+                {
+                    "round_number": 1,
+                    "epoch_number": e,
+                    "step_number": e * 10,
+                    "snr_base": 10.0,
+                    "snr_range": 40.0,
+                }
+                for e in range(1, n_frames + 1)
+            ],
+        }
+        path = str(tmp_path / "bundle.joblib")
+        joblib.dump(bundle, path)
+        return path
+
+    def _tasks(self, bundle_path, root_dir, leg):
+        tasks = []
+        for level_idx, mode in ((0, "obs"), (1, "cadence")):
+            method_name = f"{mode}_umap_nn5_md0.1"
+            out = os.path.join(root_dir, f"{mode}_{leg}")
+            os.makedirs(out, exist_ok=True)
+            tasks.append(
+                {
+                    "mode": mode,
+                    "nn": 5,
+                    "md": 0.1,
+                    "seed": 11 + level_idx,
+                    "method_name": method_name,
+                    "display_method": f"{mode} UMAP (test)",
+                    "bundle_path": bundle_path,
+                    "frames_dir": out,
+                    "gif_path": os.path.join(out, f"latent_space_{method_name}_t.gif"),
+                    "umap_path": os.path.join(out, f"umap_{mode}_t.joblib"),
+                    "duration_ms": 200,
+                }
+            )
+        return tasks
+
+    def test_pooled_sweep_byte_identical_to_serial(self, tmp_path):
+        bundle_path = self._bundle(tmp_path)
+        serial = run_umap_gif_sweep(self._tasks(bundle_path, str(tmp_path), "s"), n_workers=1)
+        pooled = run_umap_gif_sweep(self._tasks(bundle_path, str(tmp_path), "p"), n_workers=2)
+        assert len(serial) == len(pooled) == 2
+        for s, p in zip(serial, pooled, strict=True):
+            assert s["method_name"] == p["method_name"]
+            assert s["n_frames"] == p["n_frames"] == 3
+            assert s["warnings"] == p["warnings"] == []
+            assert os.path.exists(s["umap_path"]) and os.path.exists(p["umap_path"])
+            with open(s["gif_path"], "rb") as f1, open(p["gif_path"], "rb") as f2:
+                assert f1.read() == f2.read()
+
+    def test_categories_for_mode(self):
+        obs_categories, obs_legend = categories_for_mode("obs")
+        assert len(obs_categories) == 8
+        assert obs_legend["ncol"] == 2
+        cad_categories, cad_legend = categories_for_mode("cadence")
+        assert len(cad_categories) == 4
+        assert all(c.onoff is None for c in cad_categories)
+        with pytest.raises(ValueError):
+            categories_for_mode("nope")

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -181,6 +181,61 @@ class TestEncoderDecoderSymmetry:
         assert recon.max() <= 1.0
 
 
+@pytest.mark.slow
+class TestMixedPrecisionDtypeIslands:
+    """beta_vae.mixed_precision: under the keras mixed_bfloat16 policy the interior conv
+    stack computes in bf16, while the numerically sensitive islands — the z_mean/z_log_var
+    heads, the Sampling layer, and the decoder's sigmoid output (which feeds the BCE loss
+    math) — are pinned to fp32 in models/vae.py."""
+
+    def test_bf16_policy_keeps_fp32_islands(self):
+        import tensorflow as tf  # noqa: PLC0415
+
+        from aetherscan.models.vae import build_decoder, build_encoder  # noqa: PLC0415
+
+        previous = tf.keras.mixed_precision.global_policy().name
+        try:
+            tf.keras.mixed_precision.set_global_policy("mixed_bfloat16")
+            encoder = build_encoder()
+            decoder = build_decoder()
+        finally:
+            tf.keras.mixed_precision.set_global_policy(previous)
+
+        # fp32 islands: the latent heads, the sampled z, and the sigmoid reconstruction.
+        z_mean, z_log_var, z = encoder.outputs
+        assert tf.as_dtype(z_mean.dtype) == tf.float32
+        assert tf.as_dtype(z_log_var.dtype) == tf.float32
+        assert tf.as_dtype(z.dtype) == tf.float32
+        assert tf.as_dtype(decoder.outputs[0].dtype) == tf.float32
+        sampling = next(layer for layer in encoder.layers if isinstance(layer, Sampling))
+        assert sampling.compute_dtype == "float32"
+
+        # The interior conv stack actually picked up the bf16 compute dtype.
+        encoder_convs = [
+            layer for layer in encoder.layers if isinstance(layer, tf.keras.layers.Conv2D)
+        ]
+        assert encoder_convs
+        assert all(layer.compute_dtype == "bfloat16" for layer in encoder_convs)
+        # Variables stay fp32 under keras mixed precision (why bf16 needs no loss scaling).
+        assert all(v.dtype == tf.float32 for v in encoder.trainable_variables)
+        assert all(v.dtype == tf.float32 for v in decoder.trainable_variables)
+
+    def test_default_policy_builds_all_float32(self):
+        """Regression pin: with the flag off (no policy call), every layer is fp32 — the
+        dtype="float32" island kwargs must be no-ops under the default policy."""
+        import tensorflow as tf  # noqa: PLC0415
+
+        from aetherscan.models.vae import build_decoder, build_encoder  # noqa: PLC0415
+
+        assert tf.keras.mixed_precision.global_policy().name == "float32"
+        encoder = build_encoder()
+        decoder = build_decoder()
+        for model in (encoder, decoder):
+            for layer in model.layers:
+                assert layer.compute_dtype == "float32", layer.name
+                assert layer.dtype == "float32", layer.name
+
+
 class TestSeededSamplingReproducibility:
     """#279: seed_tensorflow makes the Sampling layer's draws reproducible — the mechanism
     that makes inference candidate sets repeatable (the layer used to be entirely unseeded

--- a/tests/unit/test_round_data.py
+++ b/tests/unit/test_round_data.py
@@ -48,13 +48,15 @@ def _seed_rngs():
     np.random.seed(11)
 
 
-def _write_small_round(paths: RoundDataPaths, n_samples=8, width_bin=16, snr_base=10.0):
+def _write_small_round(
+    paths: RoundDataPaths, n_samples=8, width_bin=16, snr_base=10.0, dtype=np.float32
+):
     """Write a tiny but structurally-complete round dataset + validated manifest."""
     os.makedirs(paths.round_dir, exist_ok=True)
     rng = np.random.default_rng(paths.round_idx + 1)
     shape = (n_samples, 6, 4, width_bin)
     for path in paths.array_paths.values():
-        arr = np.lib.format.open_memmap(path, mode="w+", dtype=np.float32, shape=shape)
+        arr = np.lib.format.open_memmap(path, mode="w+", dtype=np.dtype(dtype), shape=shape)
         arr[:] = rng.random(shape, dtype=np.float32)
         del arr
     lognorm_shape = (n_samples, 6, 2)
@@ -74,6 +76,7 @@ def _write_small_round(paths: RoundDataPaths, n_samples=8, width_bin=16, snr_bas
         snr_range=40.0,
         wall_time_s=1.0,
         chunk_count=1,
+        array_dtype=str(np.dtype(dtype)),
     )
     write_done_manifest(paths, manifest)
     return manifest
@@ -120,6 +123,37 @@ class TestManifest:
         _write_small_round(paths)
         os.remove(paths.done_path)
         assert validate_done_manifest(paths) is None
+
+    def test_array_dtype_gate(self, tmp_path):
+        # A float32 round validates against a float32 expectation but must not be silently
+        # reused when the config now wants float16 (and vice versa) — mid-run input-numerics
+        # switches are a resume hazard, not a reuse opportunity.
+        paths = RoundDataPaths.for_round(str(tmp_path), 1)
+        _write_small_round(paths)
+        assert validate_done_manifest(paths, expected_array_dtype="float32") is not None
+        assert validate_done_manifest(paths, expected_array_dtype="float16") is None
+
+    def test_float16_round_validates_and_gates(self, tmp_path):
+        paths = RoundDataPaths.for_round(str(tmp_path), 1)
+        _write_small_round(paths, dtype=np.float16)
+        manifest = validate_done_manifest(paths, expected_array_dtype="float16")
+        assert manifest is not None
+        assert manifest["array_dtype"] == "float16"
+        assert manifest["dtypes"]["main"] == "float16"
+        # Sidecars stay float32 regardless of the cadence-array dtype
+        assert manifest["dtypes"]["main_lognorm"] == "float32"
+        assert validate_done_manifest(paths, expected_array_dtype="float32") is None
+
+    def test_legacy_manifest_without_dtype_keys_validates_as_float32(self, tmp_path):
+        # Manifests written before the dtype keys existed are all float32 rounds: they must
+        # keep validating under a float32 expectation and be rejected under float16.
+        paths = RoundDataPaths.for_round(str(tmp_path), 1)
+        manifest = _write_small_round(paths)
+        manifest.pop("dtypes")
+        manifest.pop("array_dtype")
+        write_done_manifest(paths, manifest)
+        assert validate_done_manifest(paths, expected_array_dtype="float32") is not None
+        assert validate_done_manifest(paths, expected_array_dtype="float16") is None
 
     def test_expected_n_samples_mismatch_invalid(self, tmp_path):
         paths = RoundDataPaths.for_round(str(tmp_path), 1)


### PR DESCRIPTION
Closes #287

## Summary

Training-pipeline optimization round 2 — the walls left standing after #283 moved the hot path off Python. Everything here is either **byte-identical by construction and by checksum**, or lands **behind a default-off flag** whose default reproduces the pre-flag pipeline byte-for-byte.

**Headline measurement** (`bench_datagen.py` A/B ladder; blpc3, 8192 samples × 3 arrays, 32 workers, `--preload-tf`, seed 11):

| arm | wall | speedup | sha256s (all 7 outputs) |
|---|---|---|---|
| A: master (`fa08b0f`) | 282.0 s | 1.0× | baseline |
| B: + gc removal | 18.6 s | 15.2× | identical to A |
| C: + draw-first (as shipped) | 13.1 s | **21.5×** | identical to A |

Projected production round generation on blpc3: **~6.2 h → ~20 min** (projection from the benchmark ratio; the next full-scale run's `data_generation` stage timers are the check). The live-run evidence behind the ranking: 32 producer workers at ~94.5% CPU / ~97% user-mode while the GPUs sat at 0% for ~6.2 h/round.

## What changed

- **`gc.collect()` per injection removed** (`data_generation.new_cadence`): a full generational collection ran ~2.5M times/round inside pool workers carrying the whole TF import graph — measured ~23 ms/call vs ~4.5 ms for the entire rest of the function. Refcounting already frees the setigen Frame; the per-chunk collect stays.
- **Draw-first `create_true_double`**: the intersection-acceptance test only needs `slope_pixel`/`y_intercept` — pure functions of the pre-array RNG draws — but the retry loop materialized BOTH setigen injections before testing (~41% of all injections discarded at p≈0.42). `new_cadence` is split into `_draw_signal_params` (consumes the exact 4-draw sequence) + `_inject_drawn_signal` (consumes no RNG — pinned by test); the loop replays identical per-attempt draws and materializes only the accepted pair. Byte-equivalence pinned by a verbatim pre-split reference loop over 4 seeds, including final RNG stream states.
- **One msync per array** instead of ~23,400 per-task full-mapping msyncs per round; the `.done` manifest is still written strictly after every array is flushed (same durability contract).
- **`bench_datagen.py`**: the seeded A/B harness gating all of the above (real pooled path, per-array sha256s, `--preload-tf` to mirror the producer workers' import graph).
- **Injection-plot query windows** (`plot_injection_stats` + new `Database.query_injection_stat_time_span`): ~165 round-scoped queries per call re-scanned the tag's whole `(tag, timestamp)` index partition because `round_number` is not in the index (measured 10.5× at 12M rows, quadratic over a campaign). One whole-partition MIN/MAX aggregate — a deliberate superset bound (superseded + non-finite rows included) — tightens the window; intersection can only narrow scans, never change a result set. Unit tests pin the superset-bound property.
- **UMAP GIF sweep parallelized across whole combos** (`latent_gif.run_umap_gif_sweep`): the 24 (n_neighbors × min_dist × obs/cadence) combos ran strictly serially at ~95% single-core (~1.7–1.9 h/run) even after #278 parallelized frame rendering. Each combo is an independent fit consuming only its own derived random_state (#279 sub-keys), reads shared inputs read-only, writes distinct files — forkserver workers (empty preload, pinned native threads incl. numba, the `shap_parallel` pattern) preserve every output byte. **Disjoint from the #278-rejected within-fit ideas**: batched transforms / precomputed-knn reuse stay rejected; per-snapshot transforms stay serial within each combo. Expected ~10–15 min on 24+ cores (not yet measured at production scale). Byte-identity pinned by a slow test comparing serial vs pooled GIF bytes (first real UMAP fit in CI — adds ~1 min of numba JIT once).
- **`gpu.gpu_thread_mode` / `gpu.gpu_thread_count`** → `TF_GPU_THREAD_MODE`/`TF_GPU_THREAD_COUNT` set before GPU-runtime init, aimed at the measured ~7.6% h2d/scheduling interference. Step-ladder A/B result below.
- **Two A/B-gated numerics levers, DEFAULT OFF** (neither makes so much as a policy call when off):
  - `training.round_array_dtype="float16"`: halves the round footprint (~294.5 → ~147 GB), gather volume, and page-cache working set — the lever that matters once the 2-round overlapped working set (~589 GB at full scale) exceeds the hosts' 503 GB RAM. Quantization ≤ 2⁻¹² on [0, 1] log-normed inputs; the gather map's existing `tf.cast` becomes the host-side upcast so the training graph/loss math are unchanged either way. `.done` manifests record dtypes and every reuse/resume path gates on them (legacy manifests read as float32); the cli disk-budget guard is dtype-aware.
  - `beta_vae.mixed_precision`: keras `mixed_bfloat16` set before the model build, with fp32 islands (z_mean/z_log_var heads, `Sampling`, decoder sigmoid) so everything reaching `compute_total_loss` stays fp32; variables/Adam/step accumulators fp32; no loss scaling; no new collectives (the Blackwell NCCL constraint is untouched). `bench_gpu.py --mixed-precision` added for the Phase-0 gate.
  - **The gate for flipping either flag**: 3 seeds × 2 arms at scaled shape; val AUC within max(2σ, 0.002), losses/recalls within 2σ, identical active-dim count, zero NaN-guard trips. Phase-0/1 numbers from this branch are below; the bf16 **A4000 VRAM leg is deliberately deferred** — bla0 is running the Phase-2 release model and must not be touched.

## Validation (blpc3, NGC container)

- **Full unit suite** (NGC container): **937 passed** (master baseline on this host: 909), 5 deselected (gpu/cluster), 5m52s — includes the new pins: RNG-replay equivalence over 4 seeds incl. final stream states, no-RNG materialization contract, manifest dtype gates (incl. legacy manifests), GIF-sweep byte-identity (serial vs pooled GIF bytes), bf16 dtype islands + an all-fp32 regression pin at the default policy.
- **Generation ladder**: master 282.0 s → branch tip **12.9 s (21.9×)**, sha256s identical to master across all 7 outputs — the tip number includes the msync change (bytes unchanged, only when they flush).
- **fp16 mechanics smoke** (container, CPU): a float16 round generates, its `.done` manifest dtype-gates reuse, `_as_cpu_tensor` dlpack-wraps it zero-copy as float16, and gather+cast yields float32.
- **bf16 Phase-0 gate** (`bench_gpu.py`, 1× RTX PRO 6000, batch 128, K=12): 2983 → 3443 agg cadences/s (**1.15×**, above the 1.1× abort threshold) with bench-loop peak VRAM 23.42 → 12.59 GB. The production tf.range loop peaks far lower than the bench's unrolled loop; the **A4000 VRAM leg is deferred until bla0 frees** (Phase-2 release run in flight — not to be touched).
- **TF_GPU_THREAD_MODE step A/B** (`bench_input_pipeline` step mode, 5 GPUs, 3 reps/arm): default mean 7159 (6933–7435) vs `gpu_private` mean 7400 (7271–7622) = **+3.4% mean, no regression**. The flipped default stays with these numbers as the evidence; `gpu.gpu_thread_mode="global"` restores the old behavior.
- **The val-metric A/Bs that gate FLIPPING the two numerics flags run next on blpc3** (3 seeds × 2 arms each at scaled shape, per the gate above) — they can run concurrently with review; the flags stay off in this PR regardless of their outcome.

## Deferred with rationale

RF-dataset pre-generation on the producer, direct-numpy injection bundle, SHAP-stage overlap, pool thread-pinning, fused moments — the 21.5× generation result collapsed their absolute value to ~minutes each. Recorded in `benchmarks/README.md` so they are not silently resurrected.

## Out of scope, flagged for the maintainer

The 12-agent pass surfaced (M5, unverified): the documented L1/L2 regularizers on the VAE appear to be **silently inactive** (kernel-count check pending). That is a potential correctness/documentation issue, not a performance one — deliberately not touched here; happy to file it separately once the kernel-count check runs.

## Docs

`benchmarks/README.md` (bench_datagen + producer follow-up section with the full evidence chain), `docs/TRAINING_PIPELINE.md` (second-pass performance-engineering continuation + the A/B-gated flags), `docs/CONFIG_AND_CLI.md`, `docs/DATABASE.md`, `docs/BENCHMARKING.md`. No `cli.py` argparse surface changed → README CLI Reference unchanged (verified imports stay stdlib-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
