### PR TITLE
perf+fix: #289 NaN hardening, fp16 default ON / bf16 off (A/B verdicts), regularization arc → #293, index audit, RF pre-gen, SHAP overlap

### DIFF
--- a/benchmarks/bench_db_index_shapes.py
+++ b/benchmarks/bench_db_index_shapes.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""
+Micro-benchmark: the schema-v7 index reshapes on training_stats and latent_snapshots
+(companion to bench_injection_index.py, which covers the injection_stats side of v7).
+
+For each table it synthesizes a production-shaped database twice in a scratch directory —
+once with the old (tag, timestamp, ...) filter index, once with the v7 equality-first
+replacement — replicating db.py's schema, pragmas (WAL + synchronous=NORMAL) and each
+table's real write pattern (training_stats: writer-thread flush batches of 5,000 rows;
+latent_snapshots: one 3,840-row executemany per snapshot capture). It then times every
+production query shape observed in the codebase against both variants, with an EXPLAIN
+QUERY PLAN line per shape so the chosen index is visible. No ANALYZE is ever run — db.py
+never runs it, so a plan that needs sqlite_stat1 is a plan production never gets.
+
+Shapes covered (and their call sites):
+- training_stats: the run-wide loss-curve fetch (train.py plot_beta_vae_loss_curves),
+  the stat-scoped snr_range_floor/ceil fetch (train.py _get_snr_by_round), the kl_dim_*
+  IN fetch (train.py plot_posterior_collapse), and the dashboard's stat_name IN + ORDER BY
+  poll (dashboard.py load_training_stats).
+- latent_snapshots: the per-frame capture fetch (train.py plot_latent_space_gif — up to
+  latent_viz_gif_max_frames=500 of these per run), the dashboard's latest-capture lookup
+  (ORDER BY round/epoch/step DESC LIMIT 1), and the DISTINCT key enumeration
+  (query_latent_snapshot_keys) as a regression check — it must stay a bounded tag scan.
+
+Verdict baked into schema v7 (measured on an M-series Mac, sqlite 3.50): the
+latent_snapshots reshape ships — 67x per frame fetch at 2M rows (linear in partition size:
+~1.5 h -> ~2 s per GIF pass at the 100M-row release scale), the latest-capture lookup
+becomes a backward index walk (595 ms -> ~0 ms), keys_distinct unchanged, write cost
+within noise (both shapes append at the b-tree right edge — round/epoch/step grow
+monotonically like timestamp). The training_stats reshape was REJECTED on this bench's
+numbers: it won only the single-stat shape (3.5x on ~9 ms) while regressing the dominant
+run-window loss-curve fetch 1.8x (stat-sorted index order scatters table-row lookups that
+timestamp order visits sequentially), the kl_dims/dashboard IN shapes ~1.2x, and insert
+throughput ~20% — on a table whose tag partitions stay ~58k rows.
+
+    python benchmarks/bench_db_index_shapes.py [--training-tags 18] [--latent-captures 520]
+
+Prints per-shape ms and rows/s per variant plus a release-scale extrapolation of the GIF
+frame pass, and writes a JSON result to benchmarks/results/ (or --output).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import tempfile
+import time
+
+import numpy as np
+from _common import time_repeats, write_result
+
+BASE_TIMESTAMP = 1_700_000_000.0
+FLUSH_BATCH_ROWS = 5_000  # config.db.write_buffer_max_size — the writer's flush batch
+METADATA_JSON = json.dumps(
+    {"machine_name": "bench", "user_name": "bench", "ip_address": "0.0.0.0", "process_id": 0},
+    sort_keys=True,
+)
+
+# --- training_stats: ~29 rows/epoch (21 scalars + latent_dim=8 kl_dim rows), 20 rounds x
+# --- 100 epochs per tag; a campaign db accumulates one such partition per run tag ---
+TRAINING_STATS = (
+    ["total_loss", "reconstruction_loss", "kl_loss", "true_loss", "false_loss"]
+    + ["val_total_loss", "val_reconstruction_loss", "val_kl_loss", "val_true_loss"]
+    + ["val_false_loss", "gradient_norm_mean", "gradient_norm_max", "gradient_norm_std"]
+    + ["clipping_rate", "learning_rate", "epoch_duration", "steps_per_epoch"]
+    + ["train_samples", "snr_range_floor", "snr_range_ceil", "beta"]
+    + [f"kl_dim_{d:02d}" for d in range(8)]
+)
+KL_DIM_STATS = [s for s in TRAINING_STATS if s.startswith("kl_dim_")]
+DASHBOARD_STATS = TRAINING_STATS[:5] + TRAINING_STATS[5:10]  # losses + val_ variants
+ROUNDS, EPOCHS = 20, 100
+
+TRAINING_TABLE_SQL = """
+    CREATE TABLE IF NOT EXISTS training_stats (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp REAL NOT NULL,
+        model_name TEXT NOT NULL,
+        stat_name TEXT NOT NULL,
+        value REAL NOT NULL,
+        round_number INTEGER,
+        epoch_number INTEGER,
+        tag TEXT,
+        metadata TEXT,
+        superseded INTEGER DEFAULT 0,
+        is_finite INTEGER DEFAULT 1
+    )
+"""
+TRAINING_OLD_INDEX = """
+    CREATE INDEX idx_training_stats_filter
+    ON training_stats(tag, timestamp, model_name, stat_name)
+"""
+TRAINING_NEW_INDEX = """
+    CREATE INDEX idx_training_stats_by_stat
+    ON training_stats(tag, model_name, stat_name, timestamp)
+"""
+TRAINING_INSERT = """
+    INSERT INTO training_stats
+    (timestamp, model_name, stat_name, value, round_number, epoch_number, tag, metadata)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+"""
+ALIVE = "superseded = 0 AND is_finite = 1"
+TRAINING_QUERIES = {
+    "loss_curves": (
+        "SELECT timestamp, stat_name, value, round_number, epoch_number FROM training_stats"
+        f" WHERE tag = ? AND model_name = 'beta_vae' AND round_number >= 1 AND {ALIVE}"
+        " AND timestamp >= ? AND timestamp <= ?"
+    ),
+    "stat_scoped": (
+        "SELECT value, round_number FROM training_stats"
+        " WHERE tag = ? AND model_name = 'beta_vae' AND stat_name = 'snr_range_floor'"
+        f" AND {ALIVE} AND timestamp >= ? AND timestamp <= ?"
+    ),
+    "kl_dims": (
+        "SELECT timestamp, stat_name, value, round_number, epoch_number FROM training_stats"
+        " WHERE tag = ? AND model_name = 'beta_vae' AND round_number >= 1"
+        f" AND stat_name IN ({','.join('?' * len(KL_DIM_STATS))})"
+        f" AND {ALIVE} AND timestamp >= ? AND timestamp <= ?"
+    ),
+    "dashboard": (
+        "SELECT timestamp, stat_name, value, round_number, epoch_number FROM training_stats"
+        " WHERE tag = ? AND model_name = 'beta_vae' AND superseded = 0"
+        f" AND stat_name IN ({','.join('?' * len(DASHBOARD_STATS))})"
+        " ORDER BY round_number, epoch_number, timestamp"
+    ),
+}
+
+# --- latent_snapshots: 3,840 rows per capture (960 cadences x 4 signal types), captures
+# --- keyed by (round, epoch, step); ~100M rows per tag at release scale ---
+SIGNAL_TYPES = ["false_no_signal", "false_with_rfi", "true_only_eti", "true_eti_rfi"]
+CADENCES_PER_CAPTURE = 3_840
+STEPS_PER_EPOCH = 10  # Captures per epoch at latent_viz_step_interval defaults
+RELEASE_LATENT_ROWS = 100_000_000  # docs/DATABASE.md growth expectations, full-scale run
+GIF_MAX_FRAMES = 500  # config.training.latent_viz_gif_max_frames
+
+LATENT_TABLE_SQL = """
+    CREATE TABLE IF NOT EXISTS latent_snapshots (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp REAL NOT NULL,
+        model_name TEXT NOT NULL,
+        round_number INTEGER NOT NULL,
+        epoch_number INTEGER NOT NULL,
+        step_number INTEGER NOT NULL,
+        cadence_index INTEGER NOT NULL,
+        signal_type TEXT NOT NULL,
+        latent_vector TEXT NOT NULL,
+        snr_base INTEGER,
+        snr_range INTEGER,
+        tag TEXT,
+        metadata TEXT,
+        superseded INTEGER DEFAULT 0
+    )
+"""
+LATENT_OLD_INDEX = """
+    CREATE INDEX idx_latent_snapshots_filter
+    ON latent_snapshots(tag, timestamp, model_name, round_number, epoch_number, step_number)
+"""
+LATENT_NEW_INDEX = """
+    CREATE INDEX idx_latent_snapshots_by_key
+    ON latent_snapshots(tag, round_number, epoch_number, step_number, model_name, timestamp)
+"""
+LATENT_INSERT = """
+    INSERT INTO latent_snapshots
+    (timestamp, model_name, round_number, epoch_number, step_number, cadence_index,
+     signal_type, latent_vector, snr_base, snr_range, tag, metadata)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+"""
+LATENT_QUERIES = {
+    "frame_fetch": (
+        "SELECT signal_type, latent_vector FROM latent_snapshots"
+        " WHERE tag = ? AND model_name = ? AND round_number = ? AND epoch_number = ?"
+        " AND step_number = ? AND timestamp >= ? AND superseded = 0"
+    ),
+    "latest_key": (
+        "SELECT round_number, epoch_number, step_number FROM latent_snapshots"
+        " WHERE tag = ? AND superseded = 0"
+        " ORDER BY round_number DESC, epoch_number DESC, step_number DESC LIMIT 1"
+    ),
+    "keys_distinct": (
+        "SELECT DISTINCT model_name, round_number, epoch_number, step_number,"
+        " snr_base, snr_range FROM latent_snapshots"
+        " WHERE tag = ? AND timestamp >= ? AND superseded = 0"
+        " ORDER BY model_name, round_number, epoch_number, step_number"
+    ),
+}
+
+
+def create_db(path: str, table_sql: str, index_sql: str) -> sqlite3.Connection:
+    """Scratch db with db.py's schema for one table and pragmas (WAL, synchronous=NORMAL)."""
+    conn = sqlite3.connect(path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    conn.execute(table_sql)
+    conn.execute(index_sql)
+    conn.commit()
+    return conn
+
+
+def insert_batches(conn: sqlite3.Connection, insert_sql: str, batches) -> dict:
+    """executemany + commit per batch (the writer-thread pattern), timing inserts only."""
+    cursor = conn.cursor()
+    insert_s, total = 0.0, 0
+    for batch in batches:
+        begin = time.perf_counter()
+        cursor.executemany(insert_sql, batch)
+        conn.commit()
+        insert_s += time.perf_counter() - begin
+        total += len(batch)
+    return {"rows": total, "insert_s": insert_s, "rows_per_s": total / insert_s}
+
+
+def training_batches(n_tags: int, seed: int):
+    """Per-epoch stat rows for n_tags sequential runs, in FLUSH_BATCH_ROWS-sized batches."""
+    rng = np.random.default_rng(seed)
+    batch, ts = [], BASE_TIMESTAMP
+    for t in range(n_tags):
+        tag = f"bench_run_{t:02d}"
+        for round_number in range(1, ROUNDS + 1):
+            for epoch in range(1, EPOCHS + 1):
+                ts += 30.0  # ~30 s/epoch keeps per-tag time spans disjoint, like real runs
+                for stat in TRAINING_STATS:
+                    batch.append(
+                        (
+                            ts,
+                            "beta_vae",
+                            stat,
+                            float(rng.normal()),
+                            round_number,
+                            epoch,
+                            tag,
+                            METADATA_JSON,
+                        )
+                    )
+                    if len(batch) >= FLUSH_BATCH_ROWS:
+                        yield batch
+                        batch = []
+    if batch:
+        yield batch
+
+
+def latent_batches(n_captures: int, tag: str, seed: int):
+    """One 3,840-row batch per snapshot capture, capture keys advancing like a real run.
+    latent_vector payloads cycle a pre-serialized pool — index cost only depends on the
+    key columns, and 2M json.dumps calls would dominate the bench for nothing."""
+    rng = np.random.default_rng(seed)
+    pool = [json.dumps(np.round(rng.normal(size=(6, 8)), 8).tolist()) for _ in range(256)]
+    ts = BASE_TIMESTAMP
+    for c in range(n_captures):
+        step_idx = c % STEPS_PER_EPOCH
+        epoch_idx = (c // STEPS_PER_EPOCH) % EPOCHS
+        round_number = 1 + c // (STEPS_PER_EPOCH * EPOCHS)
+        ts += 60.0
+        yield [
+            (
+                ts,
+                "beta_vae",
+                round_number,
+                epoch_idx + 1,
+                (step_idx + 1) * 10,
+                i,
+                SIGNAL_TYPES[i % 4],
+                pool[(c + i) % 256],
+                10,
+                2 + round_number,
+                tag,
+                METADATA_JSON,
+            )
+            for i in range(CADENCES_PER_CAPTURE)
+        ]
+
+
+def bench_query(cursor, sql: str, params: tuple, repeats: int) -> dict:
+    rows = len(cursor.execute(sql, params).fetchall())  # Warm + row count
+    durations = time_repeats(lambda: cursor.execute(sql, params).fetchall(), repeats)
+    plan = cursor.execute(f"EXPLAIN QUERY PLAN {sql}", params).fetchall()
+    return {"rows": rows, "ms": min(durations) * 1000.0, "plan": " | ".join(r[3] for r in plan)}
+
+
+def run_variant(scratch, label, table_sql, index_sql, insert_sql, batches, queries, repeats):
+    conn = create_db(os.path.join(scratch, f"{label}.db"), table_sql, index_sql)
+    insert = insert_batches(conn, insert_sql, batches)
+    print(f"[{label}] insert: {insert['rows_per_s']:>10,.0f} rows/s ({insert['rows']:,} rows)")
+    cursor = conn.cursor()
+    shapes = {}
+    for name, (sql, params) in queries.items():
+        shapes[name] = bench_query(cursor, sql, params, repeats)
+        print(
+            f"[{label}] {name}: {shapes[name]['ms']:>9.2f} ms ({shapes[name]['rows']:,} rows)"
+            f"\n[{label}]   plan: {shapes[name]['plan']}"
+        )
+    conn.close()
+    return {"insert": insert, "queries": shapes}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--training-tags", type=int, default=18, help="Run tags (58k rows each)")
+    parser.add_argument("--latent-captures", type=int, default=520, help="3,840-row captures")
+    parser.add_argument("--frames", type=int, default=12, help="Sampled GIF frame fetches")
+    parser.add_argument("--repeats", type=int, default=3, help="Repeats per query (best kept)")
+    parser.add_argument("--seed", type=int, default=11)
+    parser.add_argument("--output", default=None, help="Result JSON path")
+    args = parser.parse_args()
+    rng = np.random.default_rng(args.seed)
+    results: dict = {}
+
+    with tempfile.TemporaryDirectory(prefix="bench_db_index_shapes_") as scratch:
+        # training_stats: query the middle tag over its own run window (start_time/end_time
+        # as train.py passes them), bounds wide enough to cover the whole partition
+        tag = f"bench_run_{args.training_tags // 2:02d}"
+        span = (BASE_TIMESTAMP, BASE_TIMESTAMP + args.training_tags * ROUNDS * EPOCHS * 30.0 + 1)
+        tqueries = {
+            "loss_curves": (TRAINING_QUERIES["loss_curves"], (tag, *span)),
+            "stat_scoped": (TRAINING_QUERIES["stat_scoped"], (tag, *span)),
+            "kl_dims": (TRAINING_QUERIES["kl_dims"], (tag, *KL_DIM_STATS, *span)),
+            "dashboard": (TRAINING_QUERIES["dashboard"], (tag, *DASHBOARD_STATS)),
+        }
+        for label, index_sql in (
+            ("training_old", TRAINING_OLD_INDEX),
+            ("training_new", TRAINING_NEW_INDEX),
+        ):
+            results[label] = run_variant(
+                scratch,
+                label,
+                TRAINING_TABLE_SQL,
+                index_sql,
+                TRAINING_INSERT,
+                training_batches(args.training_tags, args.seed),
+                tqueries,
+                args.repeats,
+            )
+
+        # latent_snapshots: one tag, GIF-style frame fetches on sampled capture keys
+        capture_ids = rng.choice(args.latent_captures, size=args.frames, replace=False)
+        frame_keys = [
+            (
+                1 + int(c) // (STEPS_PER_EPOCH * EPOCHS),
+                (int(c) // STEPS_PER_EPOCH) % EPOCHS + 1,
+                (int(c) % STEPS_PER_EPOCH + 1) * 10,
+            )
+            for c in capture_ids
+        ]
+        lqueries = {
+            f"frame_fetch_{i}": (
+                LATENT_QUERIES["frame_fetch"],
+                ("bench_gif", "beta_vae", r, e, s, BASE_TIMESTAMP),
+            )
+            for i, (r, e, s) in enumerate(frame_keys)
+        }
+        lqueries["latest_key"] = (LATENT_QUERIES["latest_key"], ("bench_gif",))
+        lqueries["keys_distinct"] = (LATENT_QUERIES["keys_distinct"], ("bench_gif", BASE_TIMESTAMP))
+        for label, index_sql in (
+            ("latent_old", LATENT_OLD_INDEX),
+            ("latent_new", LATENT_NEW_INDEX),
+        ):
+            results[label] = run_variant(
+                scratch,
+                label,
+                LATENT_TABLE_SQL,
+                index_sql,
+                LATENT_INSERT,
+                latent_batches(args.latent_captures, "bench_gif", args.seed),
+                lqueries,
+                args.repeats,
+            )
+
+    # Comparisons + the release-scale GIF pass extrapolation. The old shape's frame fetch
+    # scans the tag's whole window (linear in partition rows); the new shape seeks one
+    # capture (~flat), so only the old side is scaled.
+    def frame_ms(variant: str) -> float:
+        shapes = results[variant]["queries"]
+        vals = [s["ms"] for n, s in shapes.items() if n.startswith("frame_fetch_")]
+        return sum(vals) / len(vals)
+
+    latent_rows = results["latent_old"]["insert"]["rows"]
+    scale = RELEASE_LATENT_ROWS / latent_rows
+    comparison = {
+        "training_write_cost_delta_pct": (
+            results["training_old"]["insert"]["rows_per_s"]
+            / results["training_new"]["insert"]["rows_per_s"]
+            - 1
+        )
+        * -100,
+        "latent_write_cost_delta_pct": (
+            results["latent_old"]["insert"]["rows_per_s"]
+            / results["latent_new"]["insert"]["rows_per_s"]
+            - 1
+        )
+        * -100,
+        "training_speedups": {
+            name: results["training_old"]["queries"][name]["ms"]
+            / results["training_new"]["queries"][name]["ms"]
+            for name in tqueries
+        },
+        "latent_speedups": {
+            name: results["latent_old"]["queries"][name]["ms"]
+            / results["latent_new"]["queries"][name]["ms"]
+            for name in lqueries
+        },
+        "frame_fetch_speedup": frame_ms("latent_old") / frame_ms("latent_new"),
+        "gif_pass_extrapolation": {
+            "release_rows": RELEASE_LATENT_ROWS,
+            "frames": GIF_MAX_FRAMES,
+            "old_index_hours": frame_ms("latent_old") / 1000 * scale * GIF_MAX_FRAMES / 3600,
+            "new_index_hours": frame_ms("latent_new") / 1000 * GIF_MAX_FRAMES / 3600,
+        },
+    }
+    results["comparison"] = comparison
+    print(
+        f"write cost: training {comparison['training_write_cost_delta_pct']:+.1f}%, "
+        f"latent {comparison['latent_write_cost_delta_pct']:+.1f}%; "
+        f"frame fetch speedup {comparison['frame_fetch_speedup']:,.1f}x; "
+        f"GIF pass at {RELEASE_LATENT_ROWS / 1e6:.0f}M rows x {GIF_MAX_FRAMES} frames: "
+        f"{comparison['gif_pass_extrapolation']['old_index_hours']:.2f} h (old) -> "
+        f"{comparison['gif_pass_extrapolation']['new_index_hours'] * 3600:.1f} s (new)"
+    )
+
+    path = write_result(
+        "bench_db_index_shapes",
+        {
+            "training_tags": args.training_tags,
+            "latent_captures": args.latent_captures,
+            "frames": args.frames,
+            "repeats": args.repeats,
+            "seed": args.seed,
+        },
+        results,
+        args.output,
+    )
+    print(f"Result written to {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_injection_index.py
+++ b/benchmarks/bench_injection_index.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""
+Micro-benchmark: cost/benefit of the schema-v7 secondary injection_stats index
+(idx_injection_stats_by_stat) against the original idx_injection_stats_filter.
+
+Synthesizes a production-shaped injection_stats database twice in a scratch directory —
+once with only the old (tag, timestamp, ...) index, once with both indexes — replicating
+db.py's schema, pragmas (WAL + synchronous=NORMAL) and the #277 bulk lane's 50k-row
+executemany transactions. Measures (a) bulk-insert throughput under each index setup (the
+write cost of maintaining the second index) and (b) the end-of-run plot query shape
+(equality on tag/stat_name/signal_type/injection_stage with run-wide timestamp bounds —
+the ~165-query pass that scanned the whole tag partition per query on the old index),
+with an EXPLAIN QUERY PLAN line per setup so the chosen index is visible.
+
+The both-indexes query bench runs twice: once without sqlite_stat1 (what production sees —
+db.py never runs ANALYZE, and without stats SQLite's default cost model prefers the range
+term on idx_injection_stats_filter over the four equality columns of the new index) and
+once after ANALYZE, whose stats flip the planner onto idx_injection_stats_by_stat. The gap
+between those two rows is the finding, not a methodology artifact.
+
+    python benchmarks/bench_injection_index.py [--rows 20000000] [--queries 12] [--repeats 2]
+
+Prints rows/s and per-query ms plus an extrapolation to release scale (367M rows), and
+writes a JSON result to benchmarks/results/ (or --output).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import tempfile
+import time
+
+import numpy as np
+from _common import time_repeats, write_result
+
+TAG = "bench_injection_index"
+# Production-shaped categorical axes: ~18 stat_names x 4 signal_types x 3 stages x 10 rounds
+STAT_NAMES = (
+    ["global_mean", "global_median", "global_std", "global_mad", "global_skew", "global_kurtosis"]
+    + ["eti_snr", "eti_drift_rate", "eti_signal_width", "eti_starting_bin", "eti_slope_pixel"]
+    + ["eti_y_intercept", "rfi_snr", "rfi_drift_rate", "rfi_signal_width", "rfi_starting_bin"]
+    + ["rfi_slope_pixel", "rfi_y_intercept"]
+)
+SIGNAL_TYPES = ["false_no_signal", "false_with_rfi", "true_only_eti", "true_eti_rfi"]
+STAGES = ["A", "B", "C"]
+ROUNDS = 10
+BASE_TIMESTAMP = 1_700_000_000.0
+TIMESTAMP_STEP = 0.001  # Sequential timestamps, as the writer thread commits them
+CHUNK_ROWS = 50_000  # config.db.bulk_chunk_rows — the #277 bulk lane's transaction size
+RELEASE_ROWS = 367_000_000  # ~10-round release campaign
+QUERIES_PER_PLOT_PASS = 165  # plot_injection_stats query count per end-of-run call
+
+# Schema + indexes replicated from db.py's _init_database()
+CREATE_TABLE_SQL = """
+    CREATE TABLE IF NOT EXISTS injection_stats (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp REAL NOT NULL,
+        stat_name TEXT NOT NULL,
+        value REAL NOT NULL,
+        round_number INTEGER,
+        chunk_number INTEGER,
+        sample_index INTEGER,
+        background_index INTEGER,
+        signal_class TEXT,
+        signal_type TEXT,
+        injection_stage TEXT,
+        is_finite INTEGER DEFAULT 1,
+        slope_clamped INTEGER DEFAULT 0,
+        tag TEXT,
+        metadata TEXT,
+        superseded INTEGER DEFAULT 0
+    )
+"""
+OLD_INDEX_SQL = """
+    CREATE INDEX IF NOT EXISTS idx_injection_stats_filter
+    ON injection_stats(tag, timestamp, stat_name, signal_type, injection_stage)
+"""
+NEW_INDEX_SQL = """
+    CREATE INDEX IF NOT EXISTS idx_injection_stats_by_stat
+    ON injection_stats(tag, stat_name, signal_type, injection_stage, timestamp)
+"""
+INSERT_SQL = """
+    INSERT INTO injection_stats
+    (timestamp, stat_name, value, round_number, chunk_number, sample_index,
+     background_index, signal_class, signal_type, injection_stage, is_finite,
+     slope_clamped, tag, metadata)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+"""
+# The end-of-run plot query shape: equality on the categorical columns, run-wide time bounds
+QUERY_SQL = """
+    SELECT value FROM injection_stats
+    WHERE tag = ? AND stat_name = ? AND signal_type = ? AND injection_stage = ?
+    AND timestamp BETWEEN ? AND ?
+"""
+
+METADATA_JSON = json.dumps(
+    {"machine_name": "bench", "user_name": "bench", "ip_address": "0.0.0.0", "process_id": 0},
+    sort_keys=True,
+)
+
+
+def make_chunk(start: int, n: int, total_rows: int, seed: int) -> list[tuple]:
+    """Rows [start, start+n) of the synthetic dataset — deterministic in (start, seed), so
+    both database variants ingest byte-identical data."""
+    rng = np.random.default_rng(seed + start)
+    values = rng.normal(loc=1.0, scale=0.3, size=n)
+    n_combos = len(STAT_NAMES) * len(SIGNAL_TYPES) * len(STAGES)
+    rows = []
+    for offset in range(n):
+        idx = start + offset
+        combo = idx % n_combos
+        stat_name = STAT_NAMES[combo % len(STAT_NAMES)]
+        signal_type = SIGNAL_TYPES[(combo // len(STAT_NAMES)) % len(SIGNAL_TYPES)]
+        stage = STAGES[(combo // (len(STAT_NAMES) * len(SIGNAL_TYPES))) % len(STAGES)]
+        rows.append(
+            (
+                BASE_TIMESTAMP + idx * TIMESTAMP_STEP,
+                stat_name,
+                float(values[offset]),
+                1 + (idx * ROUNDS) // total_rows,  # Sequential rounds 1..10
+                idx // CHUNK_ROWS,
+                idx % 512,
+                idx % 1024,
+                signal_type.split("_", 1)[0],  # false_* -> "false", true_* -> "true"
+                signal_type,
+                stage,
+                1,
+                0,
+                TAG,
+                METADATA_JSON,
+            )
+        )
+    return rows
+
+
+def create_db(path: str, with_new_index: bool) -> sqlite3.Connection:
+    """Scratch injection_stats db with db.py's schema and pragmas (WAL, synchronous=NORMAL)."""
+    conn = sqlite3.connect(path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    conn.execute(CREATE_TABLE_SQL)
+    conn.execute(OLD_INDEX_SQL)
+    if with_new_index:
+        conn.execute(NEW_INDEX_SQL)
+    conn.commit()
+    return conn
+
+
+def bench_inserts(conn: sqlite3.Connection, total_rows: int, seed: int) -> dict:
+    """Bulk-insert total_rows in CHUNK_ROWS-sized executemany transactions (the bulk lane
+    pattern), timing only the executemany + commit (row synthesis excluded)."""
+    cursor = conn.cursor()
+    insert_s = 0.0
+    for start in range(0, total_rows, CHUNK_ROWS):
+        chunk = make_chunk(start, min(CHUNK_ROWS, total_rows - start), total_rows, seed)
+        begin = time.perf_counter()
+        cursor.executemany(INSERT_SQL, chunk)
+        conn.commit()
+        insert_s += time.perf_counter() - begin
+    return {"rows": total_rows, "insert_s": insert_s, "rows_per_s": total_rows / insert_s}
+
+
+def bench_queries(conn: sqlite3.Connection, combos: list[tuple], repeats: int) -> dict:
+    """Best-of-`repeats` wall time per sampled (stat_name, signal_type, stage) combo, over
+    run-wide timestamp bounds (MIN/MAX +-1 s, as the span-tightened plot pass computes them)."""
+    cursor = conn.cursor()
+    t_min, t_max = cursor.execute(
+        "SELECT MIN(timestamp), MAX(timestamp) FROM injection_stats WHERE tag = ?", (TAG,)
+    ).fetchone()
+    bounds = (t_min - 1.0, t_max + 1.0)
+
+    per_query_ms = []
+    rows_fetched = 0
+    for stat_name, signal_type, stage in combos:
+        params = (TAG, stat_name, signal_type, stage, *bounds)
+        rows_fetched = len(cursor.execute(QUERY_SQL, params).fetchall())  # Warm + row count
+        durations = time_repeats(lambda p=params: cursor.execute(QUERY_SQL, p).fetchall(), repeats)
+        per_query_ms.append(min(durations) * 1000.0)
+
+    plan = cursor.execute(f"EXPLAIN QUERY PLAN {QUERY_SQL}", params).fetchall()
+    return {
+        "queries": len(combos),
+        "repeats": repeats,
+        "rows_per_query": rows_fetched,
+        "per_query_ms_mean": sum(per_query_ms) / len(per_query_ms),
+        "per_query_ms_max": max(per_query_ms),
+        "query_plan": " | ".join(row[3] for row in plan),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rows", type=int, default=20_000_000, help="Synthetic rows per db")
+    parser.add_argument("--queries", type=int, default=12, help="Sampled combos to query")
+    parser.add_argument("--repeats", type=int, default=2, help="Repeats per query (best kept)")
+    parser.add_argument("--seed", type=int, default=11)
+    parser.add_argument("--output", default=None, help="Result JSON path")
+    args = parser.parse_args()
+
+    rng = np.random.default_rng(args.seed)
+    all_combos = [(s, t, g) for g in STAGES for t in SIGNAL_TYPES for s in STAT_NAMES]
+    combos = [all_combos[i] for i in rng.choice(len(all_combos), args.queries, replace=False)]
+
+    results: dict = {}
+    with tempfile.TemporaryDirectory(prefix="bench_injection_index_") as scratch:
+        for label, with_new_index in (("old_index_only", False), ("both_indexes", True)):
+            db_path = os.path.join(scratch, f"{label}.db")
+            conn = create_db(db_path, with_new_index)
+            print(f"[{label}] inserting {args.rows} rows in {CHUNK_ROWS}-row transactions...")
+            insert = bench_inserts(conn, args.rows, args.seed)
+            print(
+                f"[{label}] insert: {insert['rows_per_s']:>12,.0f} rows/s "
+                f"({insert['insert_s']:.2f}s total)"
+            )
+            query = bench_queries(conn, combos, args.repeats)
+            print(
+                f"[{label}] query:  {query['per_query_ms_mean']:>12.2f} ms/query mean "
+                f"(max {query['per_query_ms_max']:.2f} ms, {query['rows_per_query']} rows/query)"
+            )
+            print(f"[{label}] plan:   {query['query_plan']}")
+            results[label] = {"insert": insert, "query": query}
+            if with_new_index:
+                # The production regime has no sqlite_stat1 (db.py never runs ANALYZE), and
+                # without stats the planner sticks to the old index. Measure the post-ANALYZE
+                # regime too — the realizable benefit, and the gap production leaves unclaimed.
+                begin = time.perf_counter()
+                conn.execute("ANALYZE")
+                conn.commit()
+                analyze_s = time.perf_counter() - begin
+                query = bench_queries(conn, combos, args.repeats)
+                alabel = "both_indexes_analyzed"
+                print(
+                    f"[{alabel}] query:  {query['per_query_ms_mean']:>6.2f} ms/query mean "
+                    f"(ANALYZE itself took {analyze_s:.2f}s)"
+                )
+                print(f"[{alabel}] plan:   {query['query_plan']}")
+                results[alabel] = {"analyze_s": analyze_s, "query": query}
+            conn.close()
+
+    old = results["old_index_only"]
+    new = results["both_indexes"]
+    analyzed = results["both_indexes_analyzed"]
+    write_cost_delta_pct = (old["insert"]["rows_per_s"] / new["insert"]["rows_per_s"] - 1) * 100
+    # Every setup scales ~linearly in partition size for this query (old index: whole-partition
+    # scan; new index: matched rows are a fixed fraction of the partition), so extrapolate
+    # linearly to release scale
+    scale = RELEASE_ROWS / args.rows
+
+    def per_query_s(setup: dict) -> float:
+        return setup["query"]["per_query_ms_mean"] / 1000 * scale
+
+    extrapolation = {
+        "release_rows": RELEASE_ROWS,
+        "queries_per_plot_pass": QUERIES_PER_PLOT_PASS,
+        "old_index_per_query_s": per_query_s(old),
+        "both_indexes_per_query_s": per_query_s(new),
+        "both_indexes_analyzed_per_query_s": per_query_s(analyzed),
+        "old_index_plot_pass_hours": per_query_s(old) * QUERIES_PER_PLOT_PASS / 3600,
+        "both_indexes_plot_pass_hours": per_query_s(new) * QUERIES_PER_PLOT_PASS / 3600,
+        "both_indexes_analyzed_plot_pass_hours": (
+            per_query_s(analyzed) * QUERIES_PER_PLOT_PASS / 3600
+        ),
+    }
+    results["comparison"] = {
+        "write_cost_delta_pct": write_cost_delta_pct,
+        "query_speedup_no_stats": (
+            old["query"]["per_query_ms_mean"] / new["query"]["per_query_ms_mean"]
+        ),
+        "query_speedup_analyzed": (
+            old["query"]["per_query_ms_mean"] / analyzed["query"]["per_query_ms_mean"]
+        ),
+        "new_index_used_without_stats": (
+            "idx_injection_stats_by_stat" in new["query"]["query_plan"]
+        ),
+        "extrapolation": extrapolation,
+    }
+    print(
+        f"second index write cost: {write_cost_delta_pct:+.1f}% insert throughput; "
+        f"query speedup: {results['comparison']['query_speedup_no_stats']:,.1f}x without stats, "
+        f"{results['comparison']['query_speedup_analyzed']:,.1f}x after ANALYZE"
+    )
+    if not results["comparison"]["new_index_used_without_stats"]:
+        print(
+            "WARNING: without sqlite_stat1 the planner never chose idx_injection_stats_by_stat "
+            "— production runs no ANALYZE, so the index buys nothing as-is"
+        )
+    print(
+        f"extrapolated to {RELEASE_ROWS / 1e6:.0f}M rows x {QUERIES_PER_PLOT_PASS} queries: "
+        f"{extrapolation['old_index_plot_pass_hours']:.2f} h (old) -> "
+        f"{extrapolation['both_indexes_plot_pass_hours']:.2f} h (both, no stats) -> "
+        f"{extrapolation['both_indexes_analyzed_plot_pass_hours'] * 3600:.1f} s (both, analyzed) "
+        "per plot pass"
+    )
+
+    path = write_result(
+        "bench_injection_index",
+        {
+            "rows": args.rows,
+            "queries": args.queries,
+            "repeats": args.repeats,
+            "seed": args.seed,
+            "chunk_rows": CHUNK_ROWS,
+        },
+        results,
+        args.output,
+    )
+    print(f"Result written to {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/CONFIG_AND_CLI.md
+++ b/docs/CONFIG_AND_CLI.md
@@ -105,12 +105,12 @@ Four config-only fields from the 2026-07 training-performance pass follow the sa
 pattern (no CLI flags): `gpu.gpu_thread_mode` (default `"gpu_private"`; also
 `"global"`/`"gpu_shared"`) and `gpu.gpu_thread_count` (default 2) set
 `TF_GPU_THREAD_MODE`/`TF_GPU_THREAD_COUNT` in `setup_gpu_strategy` before the GPU
-runtime initializes; `training.round_array_dtype` (default `"float32"`; `"float16"`
-halves the on-disk round footprint and gather volume) and `beta_vae.mixed_precision`
-(default `False`; `True` = keras `mixed_bfloat16` with fp32 islands) are **A/B-gated
-numerics levers — leave both at their defaults until the val-metric A/B documented in
-[`TRAINING_PIPELINE.md`](TRAINING_PIPELINE.md#performance-engineering-the-276-follow-up-july-2026)
-passes on the target host.** All four are emitted by `Config.to_dict()` and so are part
+runtime initializes; `training.round_array_dtype` (default `"float16"` since
+2026-07-29 — passed its val-metric A/B gate; `"float32"` restores the historical input
+numerics byte-for-byte) and `beta_vae.mixed_precision` (default `False` — failed its
+7-seed gate on a reproducible seed-13 pathology; do not enable without new evidence) are
+**A/B-gated numerics levers** — the gates and verdicts are documented in
+[`TRAINING_PIPELINE.md`](TRAINING_PIPELINE.md#performance-engineering-the-276-follow-up-july-2026). All four are emitted by `Config.to_dict()` and so are part
 of the persisted config snapshot.
 
 ## The CLI surface

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -171,7 +171,16 @@ class-segment, on the bounded bulk lane).
 | `slope_clamped` | INTEGER | 1 when the injection's drift slope hit the near-zero clamp |
 | `superseded` | INTEGER | Default 0 |
 
-Index: `(tag, timestamp, stat_name, signal_type, injection_stage)`.
+Indexes: `(tag, timestamp, stat_name, signal_type, injection_stage)`
+(`idx_injection_stats_filter`) plus, since v7, the stat-scoped secondary
+`(tag, stat_name, signal_type, injection_stage, timestamp)`
+(`idx_injection_stats_by_stat`) — shaped for the end-of-run plot queries, whose equality
+filters with run-wide timestamp bounds the first index can only answer by scanning the tag's
+whole timestamp range. The trailing column is deliberately `timestamp`: that shape is chosen
+by SQLite's default cost model with no `ANALYZE` stats (a `round_number`-trailing variant
+measured as never chosen without `sqlite_stat1`), and it serves the round-scoped per-round
+queries too via their span-tightened timestamp windows. No query changes: the planner picks
+the better index per query.
 
 ### `training_stats`
 
@@ -275,7 +284,7 @@ attempt, each with its own span.
 ## Schema migration
 
 `_migrate_schema()` runs on every startup, gated on `PRAGMA user_version`
-(`_SCHEMA_VERSION = 6`). The stamp maps to schema features as:
+(`_SCHEMA_VERSION = 7`). The stamp maps to schema features as:
 
 | `user_version` | What it added | Migration work |
 | --- | --- | --- |
@@ -286,6 +295,7 @@ attempt, each with its own span.
 | v4 | the `pipeline_stages` stage-timing table | none (whole-table `CREATE TABLE IF NOT EXISTS`) |
 | v5 | `screening_proba` / `mc_mean` / `mc_std` on `inference_results` (#282 two-pass inference) | additive `ALTER TABLE ... ADD COLUMN` |
 | v6 | `is_finite INTEGER DEFAULT 1` on `training_stats` (#289 NaN-write hardening) | additive `ALTER TABLE ... ADD COLUMN` |
+| v7 | the `idx_injection_stats_by_stat` secondary index on `injection_stats` | none needed (`CREATE INDEX IF NOT EXISTS`, run in `_init_database()` and re-executed in the migration block) |
 
 - **v0 → v1**: `ALTER TABLE ... ADD COLUMN superseded INTEGER DEFAULT 0` on the four tables
   above — the only in-place change SQLite supports is additive `ADD COLUMN`, which is exactly
@@ -308,6 +318,14 @@ attempt, each with its own span.
   check. The `DEFAULT 1` backfill is exact, not approximate: a non-finite value could never
   have been written before v6 (it bound as NULL and the NOT NULL constraint rejected the
   whole batch), so every pre-v6 row is finite by construction.
+- **v6 → v7** (`idx_injection_stats_by_stat`): the end-of-run `plot_injection_stats` pass
+  issues ~165 queries whose equality filters (tag/stat_name/signal_type/injection_stage)
+  ride run-wide timestamp bounds, so `idx_injection_stats_filter` scanned the whole tag
+  partition per query (~6 h projected at release scale). Like v2/v4, `_init_database()` does
+  the real work — `CREATE INDEX IF NOT EXISTS` runs for old and new databases alike before
+  migration; the `if version < 7` block re-executes the (itself idempotent) statement and
+  advances the stamp. See `benchmarks/bench_injection_index.py` for the cost/benefit
+  measurement.
 
 Fresh databases get the full current schema from the CREATE statements and are just stamped.
 The pattern to follow for future changes: bump `_SCHEMA_VERSION`, add a

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -14,7 +14,7 @@ high-volume injection-stat chunks (#277) — drained by **one background writer 
 batches rows and commits with `executemany()`; reads open short-lived connections directly.
 Failed-attempt rows are never deleted — they're flagged `superseded = 1`, and every query
 filters them out by default. Schema evolution is a minimal `PRAGMA user_version` gate
-(currently version 5).
+(currently version 7).
 
 > [!IMPORTANT]
 > The write queue is a **thread** queue, not process-safe. Worker *processes* must never call
@@ -205,7 +205,13 @@ reused-tag stale scalars are absorbed.
 | `superseded` | INTEGER | Default 0 |
 | `is_finite` | INTEGER | 0 when the value was NaN/Inf/None at write time (stored as 0.0; v6, #289). `query_training_stat`'s `only_finite` default drops these — sqlite binds NaN as SQL NULL, and before v6 the resulting NOT NULL violation silently discarded the *entire* flush batch |
 
-Index: `(tag, timestamp, model_name, stat_name)`.
+Index: `(tag, timestamp, model_name, stat_name)` (`idx_training_stats_filter`).
+Deliberately kept through the v7 index sweep: an equality-first reshape
+(`tag, model_name, stat_name, timestamp`) was benchmarked and rejected — it regressed the
+dominant run-window loss-curve fetch 1.8× (stat-sorted index order scatters the table-row
+lookups timestamp order visits sequentially) and cost ~20% insert throughput, to speed only
+the minor single-stat shape on tag partitions that stay ~58 k rows
+(`benchmarks/bench_db_index_shapes.py`).
 
 ### `latent_snapshots`
 
@@ -221,7 +227,17 @@ steps — the raw material of the latent-space GIFs.
 | `snr_base`, `snr_range` | INTEGER | Curriculum stage at capture time |
 | `superseded` | INTEGER | Default 0 |
 
-Index: `(tag, timestamp, model_name, round_number, epoch_number, step_number)`.
+Index: `(tag, round_number, epoch_number, step_number, model_name, timestamp)`
+(`idx_latent_snapshots_by_key`, reshaped in v7 from the original
+`(tag, timestamp, model_name, round_number, epoch_number, step_number)`). The GIF pass
+loads one capture per frame — up to `latent_viz_gif_max_frames` (500) queries with equality
+on the capture key and the run window trailing — and the old timestamp-second shape
+answered each by scanning the tag's whole window (measured 67× slower per frame at 2 M
+rows; ~1.5 h → ~2 s per GIF pass at the ~100 M-row release scale). Key columns lead so the
+dashboard's model-less latest-capture lookup walks the index backward instead of sorting
+the partition; write cost is unchanged because `round/epoch/step` grow monotonically like
+`timestamp`, so both shapes append at the B-tree's right edge
+(`benchmarks/bench_db_index_shapes.py`).
 
 ### `inference_results`
 
@@ -295,7 +311,7 @@ attempt, each with its own span.
 | v4 | the `pipeline_stages` stage-timing table | none (whole-table `CREATE TABLE IF NOT EXISTS`) |
 | v5 | `screening_proba` / `mc_mean` / `mc_std` on `inference_results` (#282 two-pass inference) | additive `ALTER TABLE ... ADD COLUMN` |
 | v6 | `is_finite INTEGER DEFAULT 1` on `training_stats` (#289 NaN-write hardening) | additive `ALTER TABLE ... ADD COLUMN` |
-| v7 | the `idx_injection_stats_by_stat` secondary index on `injection_stats` | none needed (`CREATE INDEX IF NOT EXISTS`, run in `_init_database()` and re-executed in the migration block) |
+| v7 | the index sweep: the `idx_injection_stats_by_stat` secondary index on `injection_stats`; `latent_snapshots`' index reshaped to `idx_latent_snapshots_by_key` | `DROP INDEX IF EXISTS idx_latent_snapshots_filter` in the migration block; the CREATEs run in `_init_database()` and are re-executed there |
 
 - **v0 → v1**: `ALTER TABLE ... ADD COLUMN superseded INTEGER DEFAULT 0` on the four tables
   above — the only in-place change SQLite supports is additive `ADD COLUMN`, which is exactly
@@ -318,14 +334,27 @@ attempt, each with its own span.
   check. The `DEFAULT 1` backfill is exact, not approximate: a non-finite value could never
   have been written before v6 (it bound as NULL and the NOT NULL constraint rejected the
   whole batch), so every pre-v6 row is finite by construction.
-- **v6 → v7** (`idx_injection_stats_by_stat`): the end-of-run `plot_injection_stats` pass
-  issues ~165 queries whose equality filters (tag/stat_name/signal_type/injection_stage)
-  ride run-wide timestamp bounds, so `idx_injection_stats_filter` scanned the whole tag
-  partition per query (~6 h projected at release scale). Like v2/v4, `_init_database()` does
-  the real work — `CREATE INDEX IF NOT EXISTS` runs for old and new databases alike before
-  migration; the `if version < 7` block re-executes the (itself idempotent) statement and
-  advances the stamp. See `benchmarks/bench_injection_index.py` for the cost/benefit
-  measurement.
+- **v6 → v7** (the index sweep — every table's indexes audited against the production
+  query shapes; per-table cost/benefit in `benchmarks/bench_injection_index.py` and
+  `benchmarks/bench_db_index_shapes.py`):
+  - `injection_stats` gains the secondary `idx_injection_stats_by_stat`: the end-of-run
+    `plot_injection_stats` pass issues ~165 queries whose equality filters
+    (tag/stat_name/signal_type/injection_stage) ride run-wide timestamp bounds, so
+    `idx_injection_stats_filter` scanned the whole tag partition per query (~6 h projected
+    at release scale).
+  - `latent_snapshots`' index is reshaped to `idx_latent_snapshots_by_key`
+    (`tag, round_number, epoch_number, step_number, model_name, timestamp`): the GIF pass's
+    up-to-500 per-frame capture fetches each scanned the tag's whole window under the old
+    timestamp-second shape (~1.5 h → ~2 s per pass at release scale, at no measurable
+    write cost). The old `idx_latent_snapshots_filter` is dropped
+    (`DROP INDEX IF EXISTS`) — the only shape it served better was already run-window ≈
+    whole-partition.
+  - Everything else was audited and deliberately kept — notably a `training_stats` reshape
+    was benchmarked and rejected (see [that table's index note](#training_stats)).
+
+  Like v2/v4, `_init_database()` does the CREATE work — `CREATE INDEX IF NOT EXISTS` runs
+  for old and new databases alike before migration; the `if version < 7` block re-executes
+  the (themselves idempotent) statements, performs the DROP, and advances the stamp.
 
 Fresh databases get the full current schema from the CREATE statements and are just stamped.
 The pattern to follow for future changes: bump `_SCHEMA_VERSION`, add a

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -36,9 +36,11 @@ records into a buffer and flushes when either the buffer reaches
 100 rows was one driver of the ~590 rows/s writer that let multi-hour backlogs build) or
 `db.write_interval` (5 s) elapses. A flush
 (`_flush_buffer`) groups the buffer by table and bulk-inserts each group with a single
-`executemany()` per table — SQL parsed once, one commit per flush; the batch is
-all-or-nothing (errors are logged and the loop continues; a failed write never kills the
-thread). Connections set `PRAGMA synchronous=NORMAL`: under WAL that only skips the
+`executemany()` per table — SQL parsed once, one commit per flush. A failed batch falls
+back to per-row inserts (`_executemany_resilient`, #289): only the unbindable row(s) are
+dropped, with an exact count logged — before v6 a single bad row (a NaN stat binding as
+SQL NULL against a NOT NULL column) silently discarded every row in the flush. Errors are
+logged and the loop continues; a failed write never kills the thread. Connections set `PRAGMA synchronous=NORMAL`: under WAL that only skips the
 per-commit WAL fsync (the WAL is still synced at checkpoints) — a crash can lose the newest
 commits but never corrupts the database, ample durability for diagnostic telemetry and the
 removal of the dominant per-transaction fsync stall.
@@ -192,6 +194,7 @@ reused-tag stale scalars are absorbed.
 | `stat_name`, `value` | TEXT, REAL | |
 | `round_number`, `epoch_number` | INTEGER | 1-based |
 | `superseded` | INTEGER | Default 0 |
+| `is_finite` | INTEGER | 0 when the value was NaN/Inf/None at write time (stored as 0.0; v6, #289). `query_training_stat`'s `only_finite` default drops these — sqlite binds NaN as SQL NULL, and before v6 the resulting NOT NULL violation silently discarded the *entire* flush batch |
 
 Index: `(tag, timestamp, model_name, stat_name)`.
 
@@ -272,7 +275,7 @@ attempt, each with its own span.
 ## Schema migration
 
 `_migrate_schema()` runs on every startup, gated on `PRAGMA user_version`
-(`_SCHEMA_VERSION = 5`). The stamp maps to schema features as:
+(`_SCHEMA_VERSION = 6`). The stamp maps to schema features as:
 
 | `user_version` | What it added | Migration work |
 | --- | --- | --- |
@@ -282,6 +285,7 @@ attempt, each with its own span.
 | v3 | `config_fingerprint TEXT` on `inference_cadences` | additive `ALTER TABLE ... ADD COLUMN` |
 | v4 | the `pipeline_stages` stage-timing table | none (whole-table `CREATE TABLE IF NOT EXISTS`) |
 | v5 | `screening_proba` / `mc_mean` / `mc_std` on `inference_results` (#282 two-pass inference) | additive `ALTER TABLE ... ADD COLUMN` |
+| v6 | `is_finite INTEGER DEFAULT 1` on `training_stats` (#289 NaN-write hardening) | additive `ALTER TABLE ... ADD COLUMN` |
 
 - **v0 → v1**: `ALTER TABLE ... ADD COLUMN superseded INTEGER DEFAULT 0` on the four tables
   above — the only in-place change SQLite supports is additive `ADD COLUMN`, which is exactly
@@ -299,6 +303,11 @@ attempt, each with its own span.
 - **v4 → v5** (`inference_results.{screening_proba,mc_mean,mc_std}`): additive
   `ALTER TABLE ... ADD COLUMN ... REAL` per column, idempotent via the same
   `PRAGMA table_info` existence check.
+- **v5 → v6** (`training_stats.is_finite`, #289): additive
+  `ALTER TABLE training_stats ADD COLUMN is_finite INTEGER DEFAULT 1`, same idempotence
+  check. The `DEFAULT 1` backfill is exact, not approximate: a non-finite value could never
+  have been written before v6 (it bound as NULL and the NOT NULL constraint rejected the
+  whole batch), so every pre-v6 row is finite by construction.
 
 Fresh databases get the full current schema from the CREATE statements and are just stamped.
 The pattern to follow for future changes: bump `_SCHEMA_VERSION`, add a

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -93,18 +93,23 @@ Each training batch is a triplet `(main, true, false)` of cadence batches
 arrays are generated):
 
 ```
-total = reconstruction(main) + β · KL(main) + α · (L_true(true) + L_false(false)) + reg
+total = reconstruction(main) + β · KL(main) + α · (L_true(true) + L_false(false)) [+ reg]
 ```
 
-- **Regularization** (`reg`, activated 2026-07 by maintainer decision): the sum of the
-  layer-declared penalties — L2(0.01) on every conv kernel and bias plus L1(0.001) on conv
-  activations. These declarations existed since inception but were never consumed: a custom
-  training loop only applies them if it adds `model.losses` to the objective, so **every
-  model trained before the activation was effectively unregularized** (the docstrings'
-  claims notwithstanding). Stock keras semantics apply: weight penalties count once;
-  activity penalties are batch-SUM-scaled and accrue once per regularized-layer forward
-  inside the loss (the reconstruction pass and both clustering branches), so the effective
-  activity coefficient scales with the per-replica batch size (128 at defaults).
+- **Regularization** (`reg`, behind `beta_vae.regularization_active`, **default OFF for
+  v1**): the sum of the layer-declared penalties — L2(0.01) on every conv kernel and bias
+  plus L1(0.001) on conv activations. These declarations existed since inception but were
+  never consumed: a custom training loop only applies them if it adds `model.losses` to the
+  objective, so **every model this pipeline has trained is effectively unregularized**. A
+  2026-07 activation attempt at the declared (never-calibrated) coefficients measurably
+  degraded the model in a 5-seed A/B — recall@0.01FPR median .984 → .954 with a worst seed
+  at .72, and 1–4 latent dims per seed pushed below the active-units threshold — so v1
+  ships with the flag off and the objective byte-identical to the historical pipeline.
+  `reg_loss` is still computed and recorded every run for observability (stock keras
+  semantics: weight penalties once; activity penalties batch-SUM-scaled, once per
+  regularized-layer forward inside the loss), so calibration work has live data; the
+  coefficient-calibration question is a tracked follow-up issue. Flipping the flag changes
+  training numerics — A/B-gate it like the other numerics flags.
 - **Reconstruction**: `main` is reshaped to `(B·6, 16, 512, 1)`, encoded, decoded, and scored
   with binary cross-entropy summed over the spectrogram and averaged over the batch
   (`from_logits=False`; the decoder output is already sigmoid-bounded).

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -93,9 +93,18 @@ Each training batch is a triplet `(main, true, false)` of cadence batches
 arrays are generated):
 
 ```
-total = reconstruction(main) + β · KL(main) + α · (L_true(true) + L_false(false))
+total = reconstruction(main) + β · KL(main) + α · (L_true(true) + L_false(false)) + reg
 ```
 
+- **Regularization** (`reg`, activated 2026-07 by maintainer decision): the sum of the
+  layer-declared penalties — L2(0.01) on every conv kernel and bias plus L1(0.001) on conv
+  activations. These declarations existed since inception but were never consumed: a custom
+  training loop only applies them if it adds `model.losses` to the objective, so **every
+  model trained before the activation was effectively unregularized** (the docstrings'
+  claims notwithstanding). Stock keras semantics apply: weight penalties count once;
+  activity penalties are batch-SUM-scaled and accrue once per regularized-layer forward
+  inside the loss (the reconstruction pass and both clustering branches), so the effective
+  activity coefficient scales with the per-replica batch size (128 at defaults).
 - **Reconstruction**: `main` is reshaped to `(B·6, 16, 512, 1)`, encoded, decoded, and scored
   with binary cross-entropy summed over the spectrogram and averaged over the batch
   (`from_logits=False`; the decoder output is already sigmoid-bounded).

--- a/docs/TRAINING_PIPELINE.md
+++ b/docs/TRAINING_PIPELINE.md
@@ -48,7 +48,7 @@ fresh datetime tag and starts a new run).
 4. **Prepare the latent-viz batch** (first round only) — 960 held-out val cadences per signal
    type, persisted across rounds so latent-space snapshots aren't confounded by curriculum
    distribution shift.
-5. **Epoch loop** — `_train_epoch()` + `_validate_epoch()`, ~21 `training_stats` rows per
+5. **Epoch loop** — `_train_epoch()` + `_validate_epoch()`, ~23 `training_stats` rows per
    epoch (losses, gradient norms, LR, durations, SNR range) plus `latent_dim` per-dimension
    KL rows (`kl_dim_NN`), adaptive LR update. At round end `check_posterior_collapse()`
    WARNs loudly (never fails) when latent dims are going dark — see
@@ -512,7 +512,9 @@ out.
 ### `beta_vae_loss_curves_{tag}.png`
 
 Total loss (full-width top panel) plus reconstruction / KL / true-clustering /
-false-clustering components (bottom row), train and val overlaid, epochs on the x-axis with
+false-clustering / regularization components (bottom row; the regularization panel is empty
+for runs predating the 2026-07 L1/L2 activation — see MODELS.md), train and val overlaid,
+epochs on the x-axis with
 per-round SNR-range shading in the background. Since #277 the x-axis is the **real**
 global-epoch position (`(round − 1) · epochs_per_round + epoch`, via `build_epoch_history`):
 epochs with no committed row render as visible NaN gaps instead of silently shifting later

--- a/docs/TRAINING_PIPELINE.md
+++ b/docs/TRAINING_PIPELINE.md
@@ -387,10 +387,11 @@ pre-flag pipeline byte-for-byte (neither makes so much as a policy call when off
   the Phase-0 throughput A/B.
 
 Deferred with rationale (recorded in `benchmarks/README.md` so they are not blindly retried):
-a direct-numpy injection bundle, SHAP-stage overlap, pool thread-pinning, and fused moments —
-the 21.5× generation result collapsed their absolute value. RF-dataset pre-generation on the
-producer, originally deferred with them, has since landed (see the
-[`rf_train` section](#random-forest-training-rf_train-stage)).
+a direct-numpy injection bundle, pool thread-pinning, and fused moments — the 21.5× generation
+result collapsed their absolute value. RF-dataset pre-generation on the producer and the
+SHAP-stage overlap, originally deferred with them, have since landed (see the
+[`rf_train` section](#random-forest-training-rf_train-stage) and the
+[SHAP performance section](#shap-explainability-performance-cpu-multiprocessing-gpu-is-a-documented-alternative)).
 
 ### Adaptive learning rate
 
@@ -531,10 +532,10 @@ out.
 ### `beta_vae_loss_curves_{tag}.png`
 
 Total loss (full-width top panel) plus reconstruction / KL / true-clustering /
-false-clustering / regularization components (bottom row; the regularization panel is empty
-for runs predating the 2026-07 L1/L2 activation — see MODELS.md), train and val overlaid,
-epochs on the x-axis with
-per-round SNR-range shading in the background. Since #277 the x-axis is the **real**
+false-clustering / regularization components (bottom row; the regularization panel shows the
+recorded-but-inactive-by-default penalties — `beta_vae.regularization_active`, see
+MODELS.md — and is empty for runs predating their recording), train and val overlaid,
+epochs on the x-axis with per-round SNR-range shading in the background. Since #277 the x-axis is the **real**
 global-epoch position (`(round − 1) · epochs_per_round + epoch`, via `build_epoch_history`):
 epochs with no committed row render as visible NaN gaps instead of silently shifting later
 epochs left, and a failed pre-plot DB flush now **skips the figure** (raised as a
@@ -679,7 +680,8 @@ in-memory viz batch never existed, so the plot skips with a warning.
 
 All consume `rf_eval_artifacts_{tag}.joblib` (val features/labels/probas thresholded at the
 **deployment** `classification_threshold`, not sklearn's 0.5 default); the five SHAP figures
-share `rf_shap_values_{tag}.joblib` (computed once, cached). Since #282 the artifacts carry
+share `rf_shap_values_{tag}.joblib` (computed once — on a background thread overlapped with
+the five non-SHAP figures, see the next section — and cached). Since #282 the artifacts carry
 the *winning variant's* features, both raw (`val_probas` — rank plots are
 calibration-invariant) and deployment-scored (`val_probas_deployed`, calibrated when a
 calibrator is active) probabilities, plus the sweep record (variant metrics, calibration
@@ -709,9 +711,22 @@ forest the step is dominated by the **interaction** pass and runs for hours-to-d
 
 SHAP values are per-sample independent, so we **chunk the samples across all cores**
 (`aetherscan.shap_parallel`, driven by `manager.n_processes` = `cpu_count()` by default): each worker
-rebuilds a *stock* `TreeExplainer` and explains its chunk, and the results are byte-identical to the
+builds a *stock* `TreeExplainer` and explains its chunks, and the results are byte-identical to the
 serial computation (measured ~40-45x on a 96-core node). This is the shipped path for all three
-passes (summary, interaction, log-loss).
+passes (summary, interaction, log-loss), and they share **one forkserver pool** (`shap_pool`): the
+workers start, load the RF, and parse it into their explainers once per session instead of once per
+pass (one cached explainer per pass family — plain for summary/interaction, interventional for
+log-loss). Each pass is split into ~4 chunks per worker to smooth stragglers; the chunk count can't
+change the numbers, because TreeSHAP is per-sample exact and the ordered-chunk concatenation is
+bitwise-identical for any chunking.
+
+The whole computation also **overlaps the non-SHAP diagnostics**: `plot_rf_diagnostics` runs
+`_compute_or_load_shap_values` on a background thread (which mostly blocks on the worker pool, so
+the GIL stays free for main-thread matplotlib) while the five non-SHAP figures render, then joins
+before the five SHAP figures — saving ~min(SHAP time, non-SHAP plot time) of wall clock. Failure
+semantics are unchanged: every figure is still attempted and recorded individually, and a failed
+SHAP computation marks exactly the five SHAP figures failed while the non-SHAP figures are
+unaffected.
 
 #### GPU is faster on interaction, but we don't use it — here's why, and how to switch
 

--- a/docs/TRAINING_PIPELINE.md
+++ b/docs/TRAINING_PIPELINE.md
@@ -93,8 +93,9 @@ and `injection_stats` and shows up as background shading on the training plots.
 ## Round data: memmaps + background producer
 
 A full-scale round is three arrays (`main`, `true`, `false`) of shape
-`(499200, 6, 16, 512)` — float32 at the `training.round_array_dtype` default ≈ 98 GB each,
-~294 GB per round (the A/B-gated `"float16"` setting halves all of that; see the
+`(499200, 6, 16, 512)` — ≈ 49 GB each at the `training.round_array_dtype` default of
+`"float16"` (~147 GB per round; the `"float32"` setting doubles that and restores the
+historical input numerics byte-for-byte; see the
 [performance-engineering section](#performance-engineering-the-276-follow-up-july-2026)).
 Holding that in RAM is what used to OOM-kill 503 GB training nodes; instead each round lives
 on disk under `{round_data_dir}/{save_tag}/round_{k:02d}/` (default root
@@ -366,11 +367,15 @@ fast, with the same byte-identity discipline:
 
 Two further levers landed **default-off behind an A/B gate**, because flipping either changes
 numerics. The gate is a val-metric A/B (3 seeds × 2 arms): val AUC within max(2σ, 0.002),
-losses and recalls within 2σ, the same active-dimension count, and zero NaN-guard trips.
-Until it passes on the target host, both flags stay at their defaults — which reproduce the
-pre-flag pipeline byte-for-byte (neither makes so much as a policy call when off):
+losses and recalls within 2σ, active-dimension count within the controls' own seed
+variation (the raw count flips 6–8 across control seeds at scaled shape — judge the per-dim
+variance margins, not the count), and zero NaN-guard trips. The 2026-07 verdicts: **fp16
+PASSED** (4 seeds; default flipped) and **bf16 FAILED** (7 seeds; a reproducible seed-13
+pathology — see below). `"float32"` / `False` restore the historical numerics byte-for-byte:
 
-- **`training.round_array_dtype`** (`"float32"` default). `"float16"` halves the ~294.5 GB
+- **`training.round_array_dtype`** (**`"float16"` default since 2026-07-29** — passed the
+  gate: every fp16 seed's scores inside the 6-seed control spread, no calibration trips).
+  `"float16"` halves the ~294.5 GB
   round footprint to ~147 GB — and with it the gather volume and the page-cache working set,
   the lever that keeps overlapped epochs at page-cache speed once two rounds no longer fit in
   RAM at full scale. Quantization is ≤ 2⁻¹² on the [0, 1] log-normed inputs; the gather map's
@@ -378,7 +383,10 @@ pre-flag pipeline byte-for-byte (neither makes so much as a policy call when off
   identically), so the training graph and loss math see float32 unchanged either way. Labels
   and lognorm sidecars stay float32; `.done` manifests record the dtypes and every
   reuse/resume path gates on them (legacy manifests read as float32).
-- **`beta_vae.mixed_precision`** (`False` default). `True` sets the keras `mixed_bfloat16`
+- **`beta_vae.mixed_precision`** (`False` default — **kept off after failing the 7-seed
+  gate**: six seeds clean, but bf16-seed-13 reproducibly degrades, recall .8432 / val AUC
+  .9807 vs the .9449 / .9925 control floor, and was the only configuration to trip the
+  ECE→calibrator gate — twice, across configs). `True` sets the keras `mixed_bfloat16`
   global policy before the model build, with fp32 islands pinned in `models/vae.py` — the
   z_mean/z_log_var heads, `Sampling`, and the decoder's sigmoid output — so everything
   reaching `compute_total_loss` stays fp32. bf16 needs no loss scaling; variables, Adam

--- a/docs/TRAINING_PIPELINE.md
+++ b/docs/TRAINING_PIPELINE.md
@@ -608,10 +608,12 @@ late rounds mean the faint-SNR curriculum is destroying earlier structure. The f
 models are persisted (`umap_*.joblib`) and reused by the RF decision-boundary plot and by
 inference's latent-projection figure.
 
-The sweep is combo-parallel (the #278 follow-up): each of the 24 (n_neighbors × min_dist ×
-obs/cadence) combos is an independent UMAP fit with its own derived `random_state` (sub-keyed
-`(level, nn, md)`, #279), reads the shared inputs read-only (shipped to workers through one
-on-disk joblib bundle), and writes distinct files — so
+The sweep is combo-parallel (the #278 follow-up): each (n_neighbors × min_dist ×
+obs/cadence) combo — 18 at the current defaults (3 × 3 × 2; the sweep was 24 until
+`n_neighbors=30` was dropped as redundant between 15 and 50) — is an independent UMAP fit
+with its own derived `random_state` (sub-keyed `(level, nn, md)`, #279), reads the shared
+inputs read-only (shipped to workers through one on-disk joblib bundle), and writes
+distinct files — so
 [`latent_gif.py`](../src/aetherscan/latent_gif.py)`:run_umap_gif_sweep` farms WHOLE combos
 (fit + joblib persist + per-snapshot transforms + frame render + GIF assembly) to forkserver
 workers (empty preload; BLAS-family thread pools pinned per the `shap_parallel.py` isolation

--- a/docs/TRAINING_PIPELINE.md
+++ b/docs/TRAINING_PIPELINE.md
@@ -41,8 +41,13 @@ fresh datetime tag and starts a new run).
 
 1. **Obtain data** — reuse a validated on-disk round dataset if one exists, else wait on the
    background producer (or generate in-process when overlap is disabled).
-2. **Queue the next round** — generation of round *k+1* is requested immediately, so it runs
-   in the producer process while round *k* trains.
+2. **Queue the producer's next job** — generation of round *k+1* is requested immediately, so
+   it runs in the producer process while round *k* trains. The **last** round instead queues
+   the **RF dataset** (`num_samples_rf` samples at `snr_base` + the wide `initial_snr_range`,
+   into `round_data/{tag}/rf/`), so `rf_train` finds it ready instead of generating it with
+   the GPUs idle. The request carries the same `num_training_rounds + 1` sentinel
+   `round_num` as the in-process path, so per-task seeds derive identically and the arrays
+   are byte-identical to what `rf_train`'s fallback would generate.
 3. **Build datasets** — `prepare_distributed_train_dataset()` over the round's memmaps
    (stratified 80/20 train/val split on the labels array).
 4. **Prepare the latent-viz batch** (first round only) — 960 held-out val cadences per signal
@@ -128,7 +133,9 @@ Key properties (all in [`round_data.py`](../src/aetherscan/round_data.py) /
   (~590 GB peak). `cli.py:collect_validation_errors` checks free space at startup
   (`_estimate_round_data_nbytes`: 2.2× one round with overlap, 1.1× without) and hard-fails
   with the computed numbers. Round *k*'s directory is deleted as soon as round *k* finishes
-  training (`--keep-round-data` retains it for debugging).
+  training (`--keep-round-data` retains it for debugging). During the last round the RF
+  dataset (`num_samples_rf` = ⅕ of a round at defaults) is pre-generated alongside that
+  round's data — well under the two-round peak the preflight budgets for.
 
 > [!TIP]
 > **For official tagged training releases, pass `--keep-round-data`.** By default each round's
@@ -141,17 +148,28 @@ Key properties (all in [`round_data.py`](../src/aetherscan/round_data.py) /
 
 ### The producer process
 
-`RoundDataProducer` generates round *k+1* while round *k* trains, and isolates generation from
-the trainer's GIL (TF's prefetch/callback threads used to make round-2+ generation far slower
-than round 1's):
+`RoundDataProducer` generates round *k+1* while round *k* trains (and pre-generates the RF
+dataset while the last round trains), and isolates generation from the trainer's GIL (TF's
+prefetch/callback threads used to make round-2+ generation far slower than round 1's):
 
 - A **spawn**-started `multiprocessing.Process` (never fork — the TF/NCCL/CUDA-laden parent
   holds locks a forked child can inherit mid-acquisition and deadlock on). The producer owns
   a private fork-started worker pool whose workers attach to the background-plate shared
   memory created by the main process.
 - Protocol over two spawn-context queues: main sends `("generate", round_idx, snr_base,
-  snr_range)` / `("shutdown",)`; the producer streams back `stats` (per class-segment
-  injection statistics), `progress`, and terminal `done`/`error` messages.
+  snr_range[, overrides])` / `("shutdown",)`; the producer streams back `stats` (per
+  class-segment injection statistics), `progress`, and terminal `done`/`error` messages.
+  The optional `overrides` dict serves the RF request: `dir_name` targets `rf/` instead of
+  `round_XX/`, `n_samples` swaps in `num_samples_rf`, and the request's `round_idx` is the
+  seed-identity `round_num` (`num_training_rounds + 1`) rather than a directory index.
+- **Lifecycle.** The producer normally winds down when the round loop exits — except after a
+  successful last round, where it still owes the pre-generated RF dataset: it then stays
+  alive (idle or finishing that generation, including across `vae_plots`) until
+  `train_random_forest` awaits the result and shuts it down. On a producer error — or with
+  no producer at all (overlap disabled, or a resumed run entering `rf_train` directly) —
+  `rf_train` falls back to the unchanged in-process generation path; every failure/skip path
+  (round-loop crash, RF-stage skips, pipeline teardown) still shuts the producer down
+  exactly once.
 - **DB writes stay in the main process**: a drainer thread consumes the `stats` messages and
   calls `data_generation.write_segment_stats()` — the DB writer queue is a thread
   `queue.Queue`, not process-safe. The drainer runs while the GPUs compute, so injection-stat
@@ -369,9 +387,10 @@ pre-flag pipeline byte-for-byte (neither makes so much as a policy call when off
   the Phase-0 throughput A/B.
 
 Deferred with rationale (recorded in `benchmarks/README.md` so they are not blindly retried):
-RF-dataset pre-generation on the producer, a direct-numpy injection bundle, SHAP-stage
-overlap, pool thread-pinning, and fused moments — the 21.5× generation result collapsed their
-absolute value.
+a direct-numpy injection bundle, SHAP-stage overlap, pool thread-pinning, and fused moments —
+the 21.5× generation result collapsed their absolute value. RF-dataset pre-generation on the
+producer, originally deferred with them, has since landed (see the
+[`rf_train` section](#random-forest-training-rf_train-stage)).
 
 ### Adaptive learning rate
 
@@ -740,10 +759,20 @@ overlap enabled) the two should visibly coincide from round 2 onward.
 
 ## Random Forest training (`rf_train` stage)
 
-`train_random_forest()` generates a fresh dataset (`num_samples_rf`, default 99 840; SNR range
-= `initial_snr_range` — the wide range, so the RF sees the full difficulty spectrum) into
-`round_data/{tag}/rf/` using the same memmap machinery (in-process; the producer has already
-shut down). It reuses `prepare_distributed_train_dataset(shuffle=False)` and encodes train and
+`train_random_forest()` consumes a fresh dataset (`num_samples_rf`, default 99 840; SNR range
+= `initial_snr_range` — the wide range, so the RF sees the full difficulty spectrum) at
+`round_data/{tag}/rf/`, built with the same memmap machinery. With overlap enabled the
+background producer **pre-generates it while the last beta-VAE round trains** (queued from
+`train_round`, awaited and validated here, after which the producer shuts down); on a
+producer error or with no producer (overlap disabled, or a resumed run entering `rf_train`
+directly — startup cleanup deletes any stale `rf/` dir) the stage generates it in-process,
+exactly as before. Both paths pass the same `num_training_rounds + 1` sentinel `round_num`
+and root seed, so the arrays — and the sentinel-tagged `injection_stats` rows — are
+identical either way. One span-attribution consequence: the producer-side generation is
+recorded as `train.rf.data_generation` (`source: producer`) but its wall time overlaps the
+last round's training (during `vae_rounds`), so it no longer nests chronologically inside
+the `train.rf` umbrella span the way the in-process (`source: in-process`) span does.
+The stage reuses `prepare_distributed_train_dataset(shuffle=False)` and encodes train and
 val cadences through the (frozen) encoder with `_distributed_encode` — note the
 `train_steps × accumulation_steps` step-count correction, guarded by an exact-count assertion.
 Since #282 the encode keeps **all three** encoder outputs (`z_mean`, `z_log_var`, `z` — the

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -364,9 +364,10 @@ class TrainingConfig:
         # whereas larger values yield better global structure
         # - 5: fine-grained local structure
         # - 15: UMAP default, good baseline
-        # - 30: balanced local/global
         # - 50: global topology emphasis
-        default_factory=lambda: [5, 15, 30, 50]
+        # (30 was dropped from the default sweep 2026-07: it sat between 15 and 50 without
+        # adding a distinct view, and each nn value costs 3 min_dist x 2 level combos)
+        default_factory=lambda: [5, 15, 50]
     )
     latent_viz_umap_min_dist: list[float] = field(
         # UMAP min_dist values to sweep

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -104,7 +104,12 @@ class BetaVAEConfig:
     # variables/optimizer state stay fp32 under keras mixed precision, and the numerically
     # sensitive layers (z_mean/z_log_var/Sampling, decoder sigmoid output → loss math) are
     # pinned fp32 in models/vae.py. Default False = fp32 end-to-end, byte-identical to before
-    # this flag existed (no policy call is made at all).
+    # this flag existed (no policy call is made at all). STAYS OFF after the 7-seed A/B:
+    # 6 seeds clean, but seed 13 reproducibly fails (recall .8432 / val AUC .9807, far below
+    # the 6-seed control envelope, and the only runs to trip the ECE->calibrator gate were
+    # bf16-seed-13, twice, across configs) — a bf16-specific trajectory pathology the gate
+    # exists to catch. Revisit only with that pathology understood (+1.15x step throughput
+    # and ~halved activation VRAM are the upside on the table).
     mixed_precision: bool = False
     # Whether the conv layers' declared L1/L2 penalties are ADDED to the training objective.
     # v1 default False: the declarations were dead code since inception (a custom loop only
@@ -326,11 +331,14 @@ class TrainingConfig:
     # round footprint (~294.5 -> ~147 GB at full scale), the gather volume, and the page-cache
     # working set — the lever that keeps overlapped epochs at page-cache speed once two rounds
     # no longer fit in RAM — at a quantization cost of <= 2^-12 on the [0, 1] log-normalized
-    # inputs. A/B-GATED: changes input numerics; keep "float32" until the val-metric A/B on the
-    # target host shows parity. The gather map upcasts to float32 host-side, so the training
-    # graph and loss math are unchanged either way; labels + lognorm sidecars stay float32.
-    # Recorded in each round's .done manifest and validated on resume/reuse.
-    round_array_dtype: str = "float32"
+    # inputs. DEFAULT FLIPPED to "float16" 2026-07-29 after passing the val-metric A/B gate:
+    # 4 seeds, every score metric inside the 6-seed control spread (val AUC >= .9979, recalls
+    # .9619-.9907 vs control .9449-.9907), AU within the controls' own 6-8 seed variation, no
+    # calibration trips. The gather map upcasts to float32 host-side, so the training graph
+    # and loss math are unchanged either way; labels + lognorm sidecars stay float32.
+    # Recorded in each round's .done manifest and validated on resume/reuse ("float32"
+    # restores the historical behavior byte-for-byte).
+    round_array_dtype: str = "float16"
 
     # Round data pipeline params (disk-backed per-round datasets, see round_data.py)
     round_data_dir: str | None = None  # Defaults to get_training_file_path("round_data") at runtime

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -106,6 +106,16 @@ class BetaVAEConfig:
     # pinned fp32 in models/vae.py. Default False = fp32 end-to-end, byte-identical to before
     # this flag existed (no policy call is made at all).
     mixed_precision: bool = False
+    # Whether the conv layers' declared L1/L2 penalties are ADDED to the training objective.
+    # v1 default False: the declarations were dead code since inception (a custom loop only
+    # applies them by consuming model.losses, which nothing did), and activating them at the
+    # declared, never-calibrated coefficients measurably degraded the model in a 5-seed A/B
+    # (recall@0.01FPR median .984 -> .954, worst seed .72; 1-4 latent dims per seed pushed
+    # below the active-units threshold). reg_loss is computed and recorded regardless, so
+    # every run observes what the penalties WOULD be; coefficient calibration is a tracked
+    # follow-up issue. Flipping this changes training numerics — A/B-gate like the other
+    # numerics flags.
+    regularization_active: bool = False
 
 
 @dataclass
@@ -753,6 +763,7 @@ class Config:
                 "beta": self.beta_vae.beta,
                 "alpha": self.beta_vae.alpha,
                 "mixed_precision": self.beta_vae.mixed_precision,
+                "regularization_active": self.beta_vae.regularization_active,
             },
             "reproducibility": {
                 "seed": self.reproducibility.seed,

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -61,7 +61,11 @@ _MARK_SUPERSEDED_SENTINEL = object()
 #     batch. Non-finite values now store as 0.0 with is_finite=0 (the injection_stats
 #     semantics), and query_training_stat filters them by default.
 # v7: idx_injection_stats_by_stat — the end-of-run plot pass scanned the whole tag
-#     partition ~165x, ~6 h projected at release scale
+#     partition ~165x, ~6 h projected at release scale. Trailing column is timestamp (NOT
+#     round_number): with equality on the three filter columns and the range on timestamp,
+#     SQLite's default cost model picks this index with no ANALYZE stats; a
+#     round_number-trailing shape was measured to lose to idx_injection_stats_filter
+#     absent sqlite_stat1 (benchmarks/bench_injection_index.py).
 _SCHEMA_VERSION = 7
 
 
@@ -299,7 +303,7 @@ class Database:
             # planner picks the better index per query.
             cursor.execute("""
                 CREATE INDEX IF NOT EXISTS idx_injection_stats_by_stat
-                ON injection_stats(tag, stat_name, signal_type, injection_stage, round_number)
+                ON injection_stats(tag, stat_name, signal_type, injection_stage, timestamp)
             """)
 
             # Training statistics table
@@ -529,7 +533,7 @@ class Database:
             # so re-executing it here is a safe no-op that records the step explicitly.
             cursor.execute("""
                 CREATE INDEX IF NOT EXISTS idx_injection_stats_by_stat
-                ON injection_stats(tag, stat_name, signal_type, injection_stage, round_number)
+                ON injection_stats(tag, stat_name, signal_type, injection_stage, timestamp)
             """)
             logger.info("Schema migration: ensured injection_stats.idx_injection_stats_by_stat")
 

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -56,7 +56,11 @@ _MARK_SUPERSEDED_SENTINEL = object()
 # v5: added `inference_results.screening_proba` / `mc_mean` / `mc_std` (#282 two-pass
 #     inference: the deterministic pass-1 score plus the seeded MC mean/spread that carries
 #     the science threshold for survivors).
-_SCHEMA_VERSION = 5
+# v6: added `training_stats.is_finite` (#289) — a NaN stat value binds as SQL NULL, violated
+#     the NOT NULL constraint, and the failed executemany silently dropped the whole flush
+#     batch. Non-finite values now store as 0.0 with is_finite=0 (the injection_stats
+#     semantics), and query_training_stat filters them by default.
+_SCHEMA_VERSION = 6
 
 
 # Per-process cache for get_system_metadata(): every field (hostname, user, outbound IP, PID)
@@ -296,7 +300,8 @@ class Database:
                     epoch_number INTEGER,
                     tag TEXT,
                     metadata TEXT,
-                    superseded INTEGER DEFAULT 0
+                    superseded INTEGER DEFAULT 0,
+                    is_finite INTEGER DEFAULT 1
                 )
             """)
 
@@ -493,6 +498,15 @@ class Database:
                 if column not in columns:
                     cursor.execute(f"ALTER TABLE inference_results ADD COLUMN {column} REAL")
                     logger.info(f"Schema migration: added inference_results.{column}")
+
+        if version < 6:
+            # v6: is_finite on training_stats (#289) — the injection_stats semantics. Existing
+            # rows were all finite by construction (a non-finite value could never be written:
+            # it bound as NULL and blew the NOT NULL constraint), so DEFAULT 1 is exact.
+            columns = {row[1] for row in cursor.execute("PRAGMA table_info(training_stats)")}
+            if "is_finite" not in columns:
+                cursor.execute("ALTER TABLE training_stats ADD COLUMN is_finite INTEGER DEFAULT 1")
+                logger.info("Schema migration: added training_stats.is_finite")
 
         # PRAGMA doesn't support parameter binding; _SCHEMA_VERSION is a module-level int constant
         cursor.execute(f"PRAGMA user_version = {_SCHEMA_VERSION:d}")
@@ -939,6 +953,30 @@ class Database:
     # in exchange for increased memory pressure is worth it
     # As well, since our db writes happen in a background thread & don't block the main process,
     # either approach should have minimal practical impact
+    def _executemany_resilient(self, cursor, sql: str, records: list, table: str) -> None:
+        """
+        executemany with a per-row fallback (#289): if the batch insert fails, retry the
+        rows individually so one unbindable row can no longer discard everything else in
+        the flush. Offending rows are skipped with an exact count — the old behavior lost
+        the entire buffered batch (every table's rows) to a single NOT NULL violation,
+        with nothing but a one-line error to show for it.
+        """
+        try:
+            cursor.executemany(sql, records)
+        except sqlite3.Error as batch_error:
+            logger.error(
+                f"Bulk insert into {table} failed ({batch_error}); retrying "
+                f"{len(records)} row(s) individually"
+            )
+            skipped = 0
+            for record in records:
+                try:
+                    cursor.execute(sql, record)
+                except sqlite3.Error:
+                    skipped += 1
+            if skipped:
+                logger.error(f"Dropped {skipped}/{len(records)} unwritable row(s) for {table}")
+
     def _flush_buffer(self, buffer: list | None = None):
         """
         Write buffered data to database in a single transaction using executemany().
@@ -984,17 +1022,20 @@ class Database:
 
                 # Bulk insert each table type
                 if system_resources_records:
-                    cursor.executemany(
+                    self._executemany_resilient(
+                        cursor,
                         """
                         INSERT INTO system_resources
                         (timestamp, resource_type, resource_name, value, unit, tag, metadata)
                         VALUES (?, ?, ?, ?, ?, ?, ?)
                         """,
                         system_resources_records,
+                        "system_resources",
                     )
 
                 if injection_stats_records:
-                    cursor.executemany(
+                    self._executemany_resilient(
+                        cursor,
                         """
                         INSERT INTO injection_stats
                         (timestamp, stat_name, value, round_number, chunk_number, sample_index,
@@ -1003,21 +1044,25 @@ class Database:
                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         injection_stats_records,
+                        "injection_stats",
                     )
 
                 if training_stats_records:
-                    cursor.executemany(
+                    self._executemany_resilient(
+                        cursor,
                         """
                         INSERT INTO training_stats
                         (timestamp, model_name, stat_name, value, round_number, epoch_number,
-                         tag, metadata)
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                         tag, metadata, is_finite)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         training_stats_records,
+                        "training_stats",
                     )
 
                 if latent_snapshots_records:
-                    cursor.executemany(
+                    self._executemany_resilient(
+                        cursor,
                         """
                         INSERT INTO latent_snapshots
                         (timestamp, model_name, round_number, epoch_number, step_number,
@@ -1026,10 +1071,12 @@ class Database:
                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         latent_snapshots_records,
+                        "latent_snapshots",
                     )
 
                 if inference_results_records:
-                    cursor.executemany(
+                    self._executemany_resilient(
+                        cursor,
                         """
                         INSERT INTO inference_results
                         (timestamp, npy_path, snippet_index, prediction, confidence, latent_vector,
@@ -1038,10 +1085,12 @@ class Database:
                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         inference_results_records,
+                        "inference_results",
                     )
 
                 if inference_cadences_records:
-                    cursor.executemany(
+                    self._executemany_resilient(
+                        cursor,
                         """
                         INSERT INTO inference_cadences
                         (timestamp, tag, csv_path, cadence_key, npy_path, status, n_stamps,
@@ -1049,16 +1098,19 @@ class Database:
                         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         inference_cadences_records,
+                        "inference_cadences",
                     )
 
                 if pipeline_stages_records:
-                    cursor.executemany(
+                    self._executemany_resilient(
+                        cursor,
                         """
                         INSERT INTO pipeline_stages
                         (stage, start_time, end_time, duration_s, tag, metadata)
                         VALUES (?, ?, ?, ?, ?, ?)
                         """,
                         pipeline_stages_records,
+                        "pipeline_stages",
                     )
 
                 conn.commit()
@@ -1297,8 +1349,19 @@ class Database:
 
         model_name labels the model ('beta_vae', 'rf'); stat_name labels the metric ('total_loss',
         'reconstruction_loss', 'learning_rate', etc.). Timestamp defaults to current wall time.
+
+        Non-finite (or None) values are coerced to 0.0 with is_finite=0 (#289) — the
+        injection_stats semantics — so queries can drop them via the default only_finite
+        filter. Writing them raw is impossible anyway: sqlite binds NaN as NULL, and the NOT
+        NULL constraint used to make the whole flush batch vanish.
         """
         metadata_json = get_system_metadata()
+
+        is_finite = 1 if value is not None and np.isfinite(value) else 0
+        if not is_finite:
+            logger.warning(
+                f"write_training_stat: {stat_name} is {value}, storing as 0.0 with is_finite=0"
+            )
 
         self.write_queue.put(
             (
@@ -1307,11 +1370,12 @@ class Database:
                     timestamp or time.time(),
                     model_name,
                     stat_name,
-                    value,
+                    float(value) if is_finite else 0.0,
                     round_number,
                     epoch_number,
                     tag,
                     metadata_json,
+                    is_finite,
                 ),
             )
         )
@@ -1598,6 +1662,7 @@ class Database:
         "tag",
         "metadata",
         "superseded",
+        "is_finite",
     }
     _LATENT_SNAPSHOTS_COLUMNS = {
         "id",
@@ -2014,6 +2079,7 @@ class Database:
         end_time: float | None = None,
         columns: list[str] | None = None,
         include_superseded: bool = False,
+        only_finite: bool = True,
     ) -> list[dict[str, Any]]:
         """
         Query rows from training_stats as a list of dicts.
@@ -2021,7 +2087,9 @@ class Database:
         model_name, stat_name, and tag accept either a single value (= filter) or a list
         (IN filter). start_*/end_* pairs bound the corresponding integer column (inclusive).
         include_superseded (default False) controls whether rows flagged stale by
-        mark_superseded() are returned. columns is validated against _TRAINING_STATS_COLUMNS.
+        mark_superseded() are returned. only_finite (default True) drops rows whose stat value
+        was non-finite at write time (stored as 0.0 with is_finite=0, #289) — pass False to
+        inspect them. columns is validated against _TRAINING_STATS_COLUMNS.
         """
         with self._get_connection() as conn:
             cursor = conn.cursor()
@@ -2059,6 +2127,9 @@ class Database:
 
             if not include_superseded:
                 query += " AND superseded = 0"
+
+            if only_finite:
+                query += " AND is_finite = 1"
 
             if tag:
                 query = self._add_str_filter(query, params, "tag", tag)

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -60,7 +60,9 @@ _MARK_SUPERSEDED_SENTINEL = object()
 #     the NOT NULL constraint, and the failed executemany silently dropped the whole flush
 #     batch. Non-finite values now store as 0.0 with is_finite=0 (the injection_stats
 #     semantics), and query_training_stat filters them by default.
-_SCHEMA_VERSION = 6
+# v7: idx_injection_stats_by_stat — the end-of-run plot pass scanned the whole tag
+#     partition ~165x, ~6 h projected at release scale
+_SCHEMA_VERSION = 7
 
 
 # Per-process cache for get_system_metadata(): every field (hostname, user, outbound IP, PID)
@@ -288,6 +290,18 @@ class Database:
                 ON injection_stats(tag, timestamp, stat_name, signal_type, injection_stage)
             """)
 
+            # Secondary composite index for the stat-scoped query shape (schema v7): the
+            # end-of-run plot pass filters on (tag, stat_name, signal_type, injection_stage)
+            # with run-wide timestamp bounds, which the (tag, timestamp, ...) index above can
+            # only answer by scanning the tag's whole timestamp range — ~165 times per call.
+            # Leading with the equality columns turns each of those into a seek; round_number
+            # trails so round-scoped queries seek too. No query changes needed — SQLite's
+            # planner picks the better index per query.
+            cursor.execute("""
+                CREATE INDEX IF NOT EXISTS idx_injection_stats_by_stat
+                ON injection_stats(tag, stat_name, signal_type, injection_stage, round_number)
+            """)
+
             # Training statistics table
             cursor.execute("""
                 CREATE TABLE IF NOT EXISTS training_stats (
@@ -507,6 +521,17 @@ class Database:
             if "is_finite" not in columns:
                 cursor.execute("ALTER TABLE training_stats ADD COLUMN is_finite INTEGER DEFAULT 1")
                 logger.info("Schema migration: added training_stats.is_finite")
+
+        if version < 7:
+            # v7: idx_injection_stats_by_stat. Like the v2/v4 no-ALTER steps, the real work
+            # happens in _init_database() — its CREATE INDEX IF NOT EXISTS runs before this
+            # method for old and new databases alike, and the statement is itself idempotent,
+            # so re-executing it here is a safe no-op that records the step explicitly.
+            cursor.execute("""
+                CREATE INDEX IF NOT EXISTS idx_injection_stats_by_stat
+                ON injection_stats(tag, stat_name, signal_type, injection_stage, round_number)
+            """)
+            logger.info("Schema migration: ensured injection_stats.idx_injection_stats_by_stat")
 
         # PRAGMA doesn't support parameter binding; _SCHEMA_VERSION is a module-level int constant
         cursor.execute(f"PRAGMA user_version = {_SCHEMA_VERSION:d}")

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -1032,10 +1032,19 @@ class Database:
         the flush. Offending rows are skipped with an exact count — the old behavior lost
         the entire buffered batch (every table's rows) to a single NOT NULL violation,
         with nothing but a one-line error to show for it.
+
+        The batch attempt runs inside a SAVEPOINT: executemany inserts each row into the
+        open transaction as it steps, so a mid-batch failure leaves the rows BEFORE the
+        offender committed-in-progress — retrying per-row without rolling those back would
+        duplicate them. ROLLBACK TO restores a clean slate before the per-row pass.
         """
         try:
+            cursor.execute("SAVEPOINT resilient_batch")
             cursor.executemany(sql, records)
+            cursor.execute("RELEASE SAVEPOINT resilient_batch")
         except sqlite3.Error as batch_error:
+            cursor.execute("ROLLBACK TO SAVEPOINT resilient_batch")
+            cursor.execute("RELEASE SAVEPOINT resilient_batch")
             logger.error(
                 f"Bulk insert into {table} failed ({batch_error}); retrying "
                 f"{len(records)} row(s) individually"

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -60,12 +60,29 @@ _MARK_SUPERSEDED_SENTINEL = object()
 #     the NOT NULL constraint, and the failed executemany silently dropped the whole flush
 #     batch. Non-finite values now store as 0.0 with is_finite=0 (the injection_stats
 #     semantics), and query_training_stat filters them by default.
-# v7: idx_injection_stats_by_stat — the end-of-run plot pass scanned the whole tag
-#     partition ~165x, ~6 h projected at release scale. Trailing column is timestamp (NOT
-#     round_number): with equality on the three filter columns and the range on timestamp,
-#     SQLite's default cost model picks this index with no ANALYZE stats; a
-#     round_number-trailing shape was measured to lose to idx_injection_stats_filter
-#     absent sqlite_stat1 (benchmarks/bench_injection_index.py).
+# v7: index sweep against the real production query shapes. Both changes share one lesson:
+#     with equality on the leading columns and the range (timestamp) trailing, SQLite's
+#     default cost model picks the index with no ANALYZE stats — db.py never runs ANALYZE —
+#     while a range-column-buried shape loses to a (tag, timestamp, ...) index absent
+#     sqlite_stat1.
+#     - injection_stats: added idx_injection_stats_by_stat (tag, stat_name, signal_type,
+#       injection_stage, timestamp) — the end-of-run plot pass scanned the whole tag
+#       partition ~165x, ~6 h projected at release scale; a round_number-trailing variant
+#       was measured to never be chosen (benchmarks/bench_injection_index.py).
+#     - latent_snapshots: idx_latent_snapshots_filter (tag, timestamp, ...) reshaped to
+#       idx_latent_snapshots_by_key (tag, round_number, epoch_number, step_number,
+#       model_name, timestamp) — the GIF pass loads one capture per frame (up to 500
+#       queries/run), each a whole-window scan under the old shape: measured 67x per
+#       frame at 2M rows (~1.5 h -> ~2 s per GIF pass at release scale), and the
+#       dashboard's latest-capture lookup becomes a backward index walk instead of a
+#       partition sort, at no measurable write cost
+#       (benchmarks/bench_db_index_shapes.py).
+#     The remaining tables were measured or reasoned through and deliberately left alone —
+#     notably a training_stats reshape to (tag, model_name, stat_name, timestamp) was
+#     benchmarked and REJECTED: it regressed the dominant loss-curve fetch 1.8x and cost
+#     ~20% insert throughput (scattered stat_name subtree writes vs append-only timestamp
+#     order) to speed only the minor single-stat shape on a table whose tag partitions
+#     stay ~58k rows.
 _SCHEMA_VERSION = 7
 
 
@@ -330,7 +347,14 @@ class Database:
             #     ON training_stats(tag, model_name, round_number, epoch_number, stat_name)
             # """)
 
-            # Composite index for common filter pattern (tag + timestamp + model_name + stat_name)
+            # Composite index for common filter pattern (tag + timestamp + model_name + stat_name).
+            # Deliberately kept through the v7 index sweep: an equality-first reshape
+            # (tag, model_name, stat_name, timestamp) was benchmarked and rejected — it
+            # regressed the dominant run-window loss-curve fetch 1.8x (stat-sorted index
+            # order scatters the table-row lookups that timestamp order visits
+            # sequentially) and cost ~20% insert throughput, to speed only the minor
+            # single-stat shape on ~58k-row tag partitions
+            # (benchmarks/bench_db_index_shapes.py).
             cursor.execute("""
                 CREATE INDEX IF NOT EXISTS idx_training_stats_filter
                 ON training_stats(tag, timestamp, model_name, stat_name)
@@ -356,10 +380,19 @@ class Database:
                 )
             """)
 
-            # Composite index for common filter pattern (tag + timestamp + model_name + round_number + epoch_number + step_number)
+            # Capture-key composite index (schema v7, replacing the (tag, timestamp, ...)
+            # shape): the GIF pass loads one capture per frame — up to
+            # latent_viz_gif_max_frames (500) queries with equality on tag/round/epoch/
+            # step/model and the run window trailing — and the old shape answered each by
+            # scanning the tag's whole timestamp window (~100M rows at release scale, per
+            # frame). round/epoch/step lead so the dashboard's model-less latest-capture
+            # lookup (ORDER BY round DESC, epoch DESC, step DESC LIMIT 1) walks the index
+            # backward instead of sorting; timestamp trails as the range column
+            # (benchmarks/bench_db_index_shapes.py).
             cursor.execute("""
-                CREATE INDEX IF NOT EXISTS idx_latent_snapshots_filter
-                ON latent_snapshots(tag, timestamp, model_name, round_number, epoch_number, step_number)
+                CREATE INDEX IF NOT EXISTS idx_latent_snapshots_by_key
+                ON latent_snapshots(tag, round_number, epoch_number, step_number,
+                                    model_name, timestamp)
             """)
 
             # Inference results table
@@ -527,15 +560,25 @@ class Database:
                 logger.info("Schema migration: added training_stats.is_finite")
 
         if version < 7:
-            # v7: idx_injection_stats_by_stat. Like the v2/v4 no-ALTER steps, the real work
-            # happens in _init_database() — its CREATE INDEX IF NOT EXISTS runs before this
-            # method for old and new databases alike, and the statement is itself idempotent,
-            # so re-executing it here is a safe no-op that records the step explicitly.
+            # v7: the index sweep (see the version-history comment). The CREATEs mirror
+            # _init_database() — it already ran for old and new databases alike, and the
+            # statements are themselves idempotent, so re-executing them here just records
+            # the step explicitly. The DROP is the real migration work: it retires the
+            # (tag, timestamp, ...) latent_snapshots shape its equality-first replacement
+            # supersedes on a pre-v7 db; on a fresh db it is a no-op.
             cursor.execute("""
                 CREATE INDEX IF NOT EXISTS idx_injection_stats_by_stat
                 ON injection_stats(tag, stat_name, signal_type, injection_stage, timestamp)
             """)
-            logger.info("Schema migration: ensured injection_stats.idx_injection_stats_by_stat")
+            cursor.execute("DROP INDEX IF EXISTS idx_latent_snapshots_filter")
+            cursor.execute("""
+                CREATE INDEX IF NOT EXISTS idx_latent_snapshots_by_key
+                ON latent_snapshots(tag, round_number, epoch_number, step_number,
+                                    model_name, timestamp)
+            """)
+            logger.info(
+                "Schema migration: v7 index sweep (injection_stats/latent_snapshots) applied"
+            )
 
         # PRAGMA doesn't support parameter binding; _SCHEMA_VERSION is a module-level int constant
         cursor.execute(f"PRAGMA user_version = {_SCHEMA_VERSION:d}")
@@ -2295,15 +2338,11 @@ class Database:
             if not include_superseded:
                 query += " AND superseded = 0"
 
-            # This ORDER BY doesn't make full use of idx_latent_snapshots_filter, since the ORDER BY
-            # columns don't follow contiguously in the index
-            # However, as long as both tag & timestamp are present in the query's WHERE clause,
-            # idx_latent_snapshots_filter can still be used to optimize the query
-            # The remaining rows form a small set of DISTINCT keys that aren't expensive for SQLite
-            # to perform a filesort
-            # If you measure a bottleneck in the future, consider adding a second schema index like
-            # (tag, model_name, round_number, epoch_number, step_number, timestamp) and then sorting
-            # the rows in that order
+            # The DISTINCT set includes snr_base/snr_range, which no index carries, so this
+            # is a tag-partition scan regardless of index shape — the tag prefix of
+            # idx_latent_snapshots_by_key still bounds it to one tag. It runs once per GIF
+            # pass, and the resulting key set is small enough that the filesort for this
+            # ORDER BY (model_name leading, unlike the index) is negligible
             query += " ORDER BY model_name, round_number, epoch_number, step_number"
 
             cursor.execute(query, params)

--- a/src/aetherscan/latent_gif.py
+++ b/src/aetherscan/latent_gif.py
@@ -179,7 +179,7 @@ def render_latent_gif_frames(
 
     n_workers = max(1, min(n_workers, len(frames)))
     if n_workers == 1:
-        # In-process render — reset worker globals afterwards so repeated calls (the 24-GIF
+        # In-process render — reset worker globals afterwards so repeated calls (the multi-GIF
         # sweep runs in one process) rebuild against the new style
         global _FIG, _AX, _ARTISTS, _STYLE
         try:

--- a/src/aetherscan/latent_variants.py
+++ b/src/aetherscan/latent_variants.py
@@ -153,6 +153,46 @@ def build_variant_features(
     raise ValueError(f"Unknown latent variant {variant!r}; expected one of {VARIANT_ORDER}")
 
 
+def variant_feature_names(
+    variant: str,
+    num_observations: int,
+    latent_dim: int,
+    active_dims: list[int] | None = None,
+) -> list[str]:
+    """
+    Human-readable column names mirroring build_variant_features' exact layout —
+    [lead | extras], obs-major within blocks. Even-indexed observations are ON, odd are OFF,
+    pairs numbered 1..3 (the data_generation cadence convention). MUST stay column-for-column
+    in lockstep with build_variant_features: the SHAP plots pair these names with the feature
+    matrix, and a length mismatch is an IndexError inside shap (a 54-feature
+    z_mean_obs_logvar winner against the old hardcoded 48-name list is exactly how this
+    function came to exist).
+    """
+
+    def obs_label(o: int) -> str:
+        return f"{'ON' if o % 2 == 0 else 'OFF'}-{o // 2 + 1}"
+
+    lead = [f"{obs_label(o)}_dim-{d}" for o in range(num_observations) for d in range(latent_dim)]
+    if variant in ("z", "z_mean", "z_aug"):
+        return lead
+    if variant == "z_mean_logvar":
+        return lead + [
+            f"logvar_{obs_label(o)}_dim-{d}"
+            for o in range(num_observations)
+            for d in range(latent_dim)
+        ]
+    if variant == "z_mean_total_kl":
+        return lead + ["total_kl"]
+    if variant == "z_mean_obs_logvar":
+        return lead + [f"logvar_mean_{obs_label(o)}" for o in range(num_observations)]
+    if variant == "z_mean_dim_logvar":
+        return lead + [f"logvar_mean_dim-{d}" for d in range(latent_dim)]
+    if variant == "z_mean_logvar_active":
+        columns = _active_logvar_columns(active_dims or [], num_observations, latent_dim)
+        return lead + [f"logvar_{obs_label(c // latent_dim)}_dim-{c % latent_dim}" for c in columns]
+    raise ValueError(f"Unknown latent variant {variant!r}; expected one of {VARIANT_ORDER}")
+
+
 def sample_z_flat(
     z_mean_flat: np.ndarray, z_log_var_flat: np.ndarray, rng: np.random.Generator
 ) -> np.ndarray:

--- a/src/aetherscan/latent_variants.py
+++ b/src/aetherscan/latent_variants.py
@@ -57,6 +57,18 @@ def per_cadence_kl(z_mean_flat: np.ndarray, z_log_var_flat: np.ndarray) -> np.nd
     return kl.sum(axis=1).astype(np.float32)
 
 
+def latent_dim_variances(
+    z_mean_flat: np.ndarray, num_observations: int, latent_dim: int
+) -> np.ndarray:
+    """Per-dim z_mean variance across samples (pooling all observations) — the raw quantity
+    the Active Units threshold cuts on. Exposed so callers can log the margins: a dim a hair
+    below the cutoff and a dim that went dark read identically in the AU count but mean
+    opposite things for an A/B parity decision (#288's fp16 verdict hinged on exactly this)."""
+    per_obs = _reshape_blocks(z_mean_flat, num_observations, latent_dim)
+    pooled = per_obs.reshape(-1, latent_dim)
+    return pooled.var(axis=0)
+
+
 def active_latent_dims(
     z_mean_flat: np.ndarray, num_observations: int, latent_dim: int, threshold: float
 ) -> list[int]:
@@ -66,9 +78,7 @@ def active_latent_dims(
     contribute dead-weight log_var features — this gates the z_mean_logvar_active variant
     and feeds check_posterior_collapse.
     """
-    per_obs = _reshape_blocks(z_mean_flat, num_observations, latent_dim)
-    pooled = per_obs.reshape(-1, latent_dim)
-    variances = pooled.var(axis=0)
+    variances = latent_dim_variances(z_mean_flat, num_observations, latent_dim)
     return [int(d) for d in np.nonzero(variances > threshold)[0]]
 
 

--- a/src/aetherscan/models/vae.py
+++ b/src/aetherscan/models/vae.py
@@ -230,11 +230,20 @@ class BetaVAE(keras.Model):
         """
         Forward-pass main_data through the VAE and return a dict with reconstruction, KL, and
         per-class clustering losses plus their weighted sum:
-            total = reconstruction + beta * kl + alpha * (true_loss + false_loss)
+            total = reconstruction + beta * kl + alpha * (true_loss + false_loss) + reg
 
         Reconstruction uses binary cross-entropy on the [0, 1]-bounded decoder output (sigmoid).
         true_data and false_data are separate cadences fed through the clustering-loss heads —
         they don't share gradients with reconstruction.
+
+        `reg` is the sum of the layer-declared regularization penalties (activated 2026-07 by
+        maintainer decision — the L1/L2 declarations existed since inception but a custom
+        training loop only applies them if it adds model.losses to the objective, so every
+        model trained before this change was effectively unregularized). Stock keras
+        semantics: kernel/bias L2 penalties appear once each; activity-L1 penalties accrue
+        once per regularized-layer forward performed inside this function (the reconstruction
+        pass AND both clustering branches), and keras batch-SUM-scales them, so the effective
+        activity coefficient scales with the per-replica batch size (128 at defaults).
         """
         # Perform forward pass through Beta-VAE
         reconstruction, z_mean, z_log_var, z = self.call(main_data, training=training)
@@ -265,9 +274,20 @@ class BetaVAE(keras.Model):
         false_loss = self.compute_clustering_loss_false(false_data)
         true_loss = self.compute_clustering_loss_true(true_data)
 
+        # Layer-declared regularization penalties (see docstring). Cast fp32 so the sum is
+        # exact under mixed_bfloat16 (activity penalties on bf16 activations); the islands
+        # keep the rest of the loss math fp32 already.
+        if self.losses:
+            reg_loss = tf.add_n([tf.cast(loss, tf.float32) for loss in self.losses])
+        else:
+            reg_loss = tf.constant(0.0, dtype=tf.float32)
+
         # Compute total loss
         total_loss = (
-            reconstruction_loss + self.beta * kl_loss + self.alpha * (true_loss + false_loss)
+            reconstruction_loss
+            + self.beta * kl_loss
+            + self.alpha * (true_loss + false_loss)
+            + reg_loss
         )
 
         return {
@@ -277,6 +297,7 @@ class BetaVAE(keras.Model):
             "kl_per_dim": kl_per_dim,
             "true_loss": true_loss,
             "false_loss": false_loss,
+            "reg_loss": reg_loss,
         }
 
 

--- a/src/aetherscan/models/vae.py
+++ b/src/aetherscan/models/vae.py
@@ -66,7 +66,9 @@ class BetaVAE(keras.Model):
     Beta-VAE knob trading reconstruction quality for latent disentanglement).
     """
 
-    def __init__(self, encoder, decoder, alpha=10.0, beta=1.5, **kwargs):
+    def __init__(
+        self, encoder, decoder, alpha=10.0, beta=1.5, regularization_active=False, **kwargs
+    ):
         super().__init__(**kwargs)
         self.encoder = encoder
         self.decoder = decoder
@@ -74,6 +76,14 @@ class BetaVAE(keras.Model):
         # Hyperparameters
         self.alpha = alpha
         self.beta = beta
+        # Whether the layer-declared L1/L2 penalties are ADDED to the objective. Default
+        # False (v1 decision, 2026-07-29): activating them at the declared, never-calibrated
+        # coefficients measurably degraded the model in a 5-seed A/B — recall@0.01FPR
+        # median .984 -> .954 with one seed at .72, and 1-4 latent dims per seed pushed
+        # below the active-units threshold (one seed lost 4/8). reg_loss is still computed
+        # and recorded for observability either way; coefficient calibration is tracked as
+        # a follow-up issue.
+        self.regularization_active = regularization_active
 
     def call(self, inputs, training=None):
         """
@@ -279,21 +289,25 @@ class BetaVAE(keras.Model):
         false_loss = self.compute_clustering_loss_false(false_data)
         true_loss = self.compute_clustering_loss_true(true_data)
 
-        # Layer-declared regularization penalties (see docstring). Cast fp32 so the sum is
-        # exact under mixed_bfloat16 (activity penalties on bf16 activations); the islands
-        # keep the rest of the loss math fp32 already.
+        # Layer-declared regularization penalties (see docstring). Always COMPUTED and
+        # returned for observability (keras materializes the activity penalties in the
+        # forward pass regardless, so this is one add_n), but only ADDED to the objective
+        # when regularization_active — the v1 default is False (see __init__: activation at
+        # the declared coefficients measured harmful). Cast fp32 so the sum is exact under
+        # mixed_bfloat16 (activity penalties ride bf16 activations); the islands keep the
+        # rest of the loss math fp32 already.
         if self.losses:
             reg_loss = tf.add_n([tf.cast(loss, tf.float32) for loss in self.losses])
         else:
             reg_loss = tf.constant(0.0, dtype=tf.float32)
 
-        # Compute total loss
+        # Compute total loss (reg only when active — inactive keeps the objective
+        # byte-identical to the pre-activation pipeline)
         total_loss = (
-            reconstruction_loss
-            + self.beta * kl_loss
-            + self.alpha * (true_loss + false_loss)
-            + reg_loss
+            reconstruction_loss + self.beta * kl_loss + self.alpha * (true_loss + false_loss)
         )
+        if self.regularization_active:
+            total_loss = total_loss + reg_loss
 
         return {
             "total_loss": total_loss,
@@ -813,6 +827,7 @@ def create_beta_vae_model():
         decoder,
         alpha=config.beta_vae.alpha,
         beta=config.beta_vae.beta,
+        regularization_active=config.beta_vae.regularization_active,
     )
 
     beta_vae.compile(

--- a/src/aetherscan/models/vae.py
+++ b/src/aetherscan/models/vae.py
@@ -127,6 +127,10 @@ class BetaVAE(keras.Model):
     # encoder's activity-regularizer loss tensors out of scope of the reg_loss add_n —
     # InaccessibleTensorError, found by the first regularized run. Inlining into the outer
     # trace keeps every penalty same-graph; standalone (eager) calls just run eagerly.
+    # ⚠ REPRODUCIBILITY: this inlining changed float summation order — same-seed results
+    # from builds before/after it differ slightly. Determinism WITHIN a build (same seed ⇒
+    # byte-identical reruns) is preserved and pinned by the train dataset/accumulation
+    # tests; cross-build comparisons must be distribution-level, never same-seed pairing.
     def compute_clustering_loss_true(self, true_data: tf.Tensor) -> tf.Tensor:
         """
         Clustering loss for true-class (ETI-bearing) cadences: sum loss_same across all

--- a/src/aetherscan/models/vae.py
+++ b/src/aetherscan/models/vae.py
@@ -112,7 +112,11 @@ class BetaVAE(keras.Model):
         stability when latents collide) — minimizing this term pushes ON/OFF pairs apart."""
         return tf.reduce_mean(1.0 / (tf.reduce_sum(tf.square(a - b), axis=1) + 1e-8))
 
-    @tf.function
+    # Deliberately NOT @tf.function (removed with the L1/L2 activation): this runs only
+    # inside compute_total_loss's graph, and giving it its own FuncGraph strands the
+    # encoder's activity-regularizer loss tensors out of scope of the reg_loss add_n —
+    # InaccessibleTensorError, found by the first regularized run. Inlining into the outer
+    # trace keeps every penalty same-graph; standalone (eager) calls just run eagerly.
     def compute_clustering_loss_true(self, true_data: tf.Tensor) -> tf.Tensor:
         """
         Clustering loss for true-class (ETI-bearing) cadences: sum loss_same across all
@@ -169,7 +173,8 @@ class BetaVAE(keras.Model):
         similarity = same + difference
         return similarity
 
-    @tf.function
+    # Deliberately NOT @tf.function — same FuncGraph-stranding rationale as
+    # compute_clustering_loss_true above.
     def compute_clustering_loss_false(self, false_data: tf.Tensor) -> tf.Tensor:
         """
         Clustering loss for false-class (RFI / noise-only) cadences: sum loss_same across all 15

--- a/src/aetherscan/round_data.py
+++ b/src/aetherscan/round_data.py
@@ -13,8 +13,9 @@ This module owns:
   .tmp -> os.replace like preprocessing's _extract_stamps_worker).
 - Startup archive/reuse/delete semantics for a tag's round-data directory.
 - RoundDataProducer: a dedicated process that generates round k+1 while round k
-  trains, streaming stats back to the main process (DB writes stay in main — the
-  DB queue is a thread queue.Queue, not process-safe).
+  trains (and pre-generates the RF dataset while the last round trains), streaming
+  stats back to the main process (DB writes stay in main — the DB queue is a thread
+  queue.Queue, not process-safe).
 """
 
 from __future__ import annotations
@@ -452,7 +453,13 @@ def _producer_main(
     longer slow generation down, and generation no longer steals cycles from training).
 
     Protocol (multiprocessing.Queues):
-    - in:  ("generate", round_idx, snr_base, snr_range) | ("shutdown",)
+    - in:  ("generate", round_idx, snr_base, snr_range[, overrides]) | ("shutdown",)
+           `overrides` (optional dict, absent on plain round requests — the historical
+           4-tuple shape) customizes one request without touching `params`:
+           - "dir_name": write into {base_dir}/{dir_name} (paths round_idx pinned to 0 —
+             see the request loop) instead of round_{round_idx:02d}
+           - "n_samples": per-request sample count (the RF dataset is num_samples_rf,
+             not the num_samples_beta_vae this producer was constructed with)
     - out: ("stats", round_idx, segment_dict)            per class-segment per chunk
            ("progress", round_idx, chunk, n_chunks)      per chunk
            ("timing", round_idx, start_ts, end_ts)       generation wall-clock span, sent
@@ -565,12 +572,32 @@ def _producer_main(
                 logger.warning(f"RoundDataProducer ignoring unknown message: {message[0]!r}")
                 continue
 
-            _, round_idx, snr_base, snr_range = message
-            paths = RoundDataPaths.for_round(params["base_dir"], round_idx)
+            _, round_idx, snr_base, snr_range = message[:4]
+            overrides = message[4] if len(message) > 4 else {}
+            n_samples = overrides.get("n_samples", params["n_samples"])
+            # The override rides a shallow copy so generate_fn keeps its params-dict
+            # signature; plain round requests pass `params` through untouched
+            request_params = (
+                params if n_samples == params["n_samples"] else {**params, "n_samples": n_samples}
+            )
+            dir_name = overrides.get("dir_name")
+            if dir_name is None:
+                paths = RoundDataPaths.for_round(params["base_dir"], round_idx)
+            else:
+                # Explicit-dir request (the RF dataset). paths.round_idx is pinned to 0 to
+                # mirror train_random_forest's rf_paths exactly — same round_00.done name,
+                # same manifest round_idx — so the parent's validate_done_manifest accepts
+                # the result no matter which side generated it. The MESSAGE round_idx is the
+                # request's seed identity, not a dir index: it reaches generate_fn as
+                # round_num (for the RF set the num_training_rounds+1 sentinel — the SAME
+                # value train_random_forest's in-process path passes), so per-task seeds
+                # derive identically and the arrays are byte-identical to in-process
+                # generation. Keep in sync with train._obtain_rf_dataset.
+                paths = RoundDataPaths(os.path.join(params["base_dir"], dir_name), 0)
 
             existing = validate_done_manifest(
                 paths,
-                expected_n_samples=params["n_samples"],
+                expected_n_samples=n_samples,
                 expected_array_dtype=params.get("array_dtype", "float32"),
             )
             if existing is not None:
@@ -590,7 +617,7 @@ def _producer_main(
                     snr_base,
                     snr_range,
                     pool,
-                    params,
+                    request_params,
                     lambda segment, _r=round_idx: result_queue.put(("stats", _r, segment)),
                     lambda chunk, n_chunks, _r=round_idx: result_queue.put(
                         ("progress", _r, chunk, n_chunks)
@@ -678,6 +705,10 @@ class RoundDataProducer:
         self._drainer: threading.Thread | None = None
         self._drainer_done = False
         self._results: dict[int, tuple[str, object]] = {}
+        # Per-request stage-name overrides for the drainer's timing handler (main-side
+        # only, never crosses the queue): non-round requests like the RF dataset record
+        # their span under the right stage subtree instead of a nonexistent round_XX
+        self._stage_names: dict[int, str] = {}
         self._condition = threading.Condition()
         self._pidfile = os.path.join(base_dir, _PRODUCER_PIDFILE)
 
@@ -748,10 +779,35 @@ class RoundDataProducer:
         self._drainer.start()
         logger.info(f"RoundDataProducer process started (PID {self._process.pid})")
 
-    def request_generation(self, round_idx: int, snr_base: float, snr_range: float) -> None:
-        """Queue generation of 1-based round `round_idx` (non-blocking)."""
-        logger.info(f"Requesting background generation of round {round_idx} data")
-        self._request_queue.put(("generate", round_idx, snr_base, snr_range))
+    def request_generation(
+        self,
+        round_idx: int,
+        snr_base: float,
+        snr_range: float,
+        *,
+        dir_name: str | None = None,
+        n_samples: int | None = None,
+        stage_name: str | None = None,
+    ) -> None:
+        """Queue one generation request (non-blocking). Plain requests generate 1-based
+        round `round_idx`; `dir_name`/`n_samples` override the output dir and sample count
+        (the RF dataset — `round_idx` then carries the request's seed-identity round_num,
+        see _producer_main). `stage_name` renames the timing span the drainer records to
+        "{stage_name}.data_generation" (absolute; default round_stage_name(round_idx))."""
+        if stage_name is not None:
+            self._stage_names[round_idx] = stage_name
+        target = f"'{dir_name}' dataset" if dir_name is not None else f"round {round_idx} data"
+        logger.info(f"Requesting background generation of {target}")
+        overrides: dict = {}
+        if dir_name is not None:
+            overrides["dir_name"] = dir_name
+        if n_samples is not None:
+            overrides["n_samples"] = n_samples
+        if overrides:
+            self._request_queue.put(("generate", round_idx, snr_base, snr_range, overrides))
+        else:
+            # Plain round requests keep the historical 4-tuple shape
+            self._request_queue.put(("generate", round_idx, snr_base, snr_range))
 
     def await_round(self, round_idx: int) -> dict:
         """
@@ -823,8 +879,9 @@ class RoundDataProducer:
             # The producer's generation wall-clock span, recorded from this (main) process
             # because the DB writer queue is thread-only
             _, round_idx, start_ts, end_ts = message
+            stage = self._stage_names.get(round_idx) or round_stage_name(round_idx)
             record_stage(
-                f"{round_stage_name(round_idx)}.data_generation",
+                f"{stage}.data_generation",
                 start_ts,
                 end_ts,
                 tag=self._tag,

--- a/src/aetherscan/shap_parallel.py
+++ b/src/aetherscan/shap_parallel.py
@@ -19,6 +19,10 @@ Design notes:
   * **Rebuild the explainer inside each worker** from the picklable sklearn RF — never pickle a
     pre-built ``TreeExplainer`` into workers (segfaults large-model workers; shap #1204). Workers
     load the RF from its persisted joblib path so the model isn't re-serialised through the pool.
+  * **One pool per session** (``shap_pool``): all three passes map onto the same worker set, so
+    workers start, load the RF, and build their explainers once per session rather than once per
+    pass. Each worker caches one explainer per pass family (plain vs log-loss) — see
+    ``_get_explainer``.
   * **forkserver + empty preload** keeps workers off the TF/training stack (see above); the fork
     server is spawned once and forks lightweight workers.
   * **Pin BLAS/OpenMP threads to 1 per worker** so N workers don't oversubscribe the CPU (best-effort:
@@ -39,9 +43,16 @@ _RAW_KINDS = ("summary", "interaction")
 _LOGLOSS_KIND = "logloss"
 
 # Per-worker globals, populated once by the pool initializer (or in-process for the n_workers==1
-# fallback). Module-level so the forkserver workers can resolve them.
+# fallback). Module-level so the forkserver workers can resolve them. _EXPLAINERS caches one built
+# explainer per pass family ("raw" vs "logloss") so a worker serving several chunks — and several
+# passes, now that one pool spans all of them — parses the forest once per family, not per chunk.
 _RF = None
 _BACKGROUND = None
+_EXPLAINERS: dict[str, object] = {}
+
+# Chunks submitted per worker per pass: >1 smooths stragglers (TreeSHAP cost varies per sample, so
+# a worker stuck on a slow chunk no longer idles the rest for the whole tail of the pass).
+_CHUNKS_PER_WORKER = 4
 
 
 def select_positive_class_shap(values, log_loss: bool = False) -> np.ndarray:
@@ -100,27 +111,102 @@ def _worker_init(rf_path: str, background) -> None:
     global _RF, _BACKGROUND
     _RF = joblib.load(rf_path)
     _BACKGROUND = background
+    # In-process (n_workers==1) sessions reuse this module's globals across calls — drop any
+    # explainers built for a previous session's RF.
+    _EXPLAINERS.clear()
+
+
+def _get_explainer(kind: str):
+    """
+    Return the cached per-worker explainer for ``kind``, building it on first use.
+
+    The log-loss pass needs a structurally different explainer (interventional:
+    ``model_output="log_loss"`` + background data), so it gets its own cache slot; the summary
+    and interaction passes share the one plain ``TreeExplainer``.
+    """
+    import shap  # noqa: PLC0415  (deferred so the worker pins threads before shap/BLAS init)
+
+    key = _LOGLOSS_KIND if kind == _LOGLOSS_KIND else "raw"
+    explainer = _EXPLAINERS.get(key)
+    if explainer is None:
+        if key == _LOGLOSS_KIND:
+            explainer = shap.TreeExplainer(_RF, data=_BACKGROUND, model_output="log_loss")
+        else:
+            explainer = shap.TreeExplainer(_RF)
+        _EXPLAINERS[key] = explainer
+    return explainer
 
 
 def _worker(task):
     """Compute one SHAP pass on one chunk of samples using the module-global RF. Returns the
     positive-class array for the chunk; ProcessPoolExecutor.map preserves input order."""
     kind, x_chunk, y_chunk = task
-    import shap  # noqa: PLC0415  (deferred so the spawn worker pins threads before shap/BLAS init)
+    explainer = _get_explainer(kind)
 
     # Suppress shap's tqdm (it writes to stderr, which the pipeline logger forwards to Slack).
     with open(os.devnull, "w") as devnull, contextlib.redirect_stderr(devnull):
         if kind == _LOGLOSS_KIND:
-            explainer = shap.TreeExplainer(_RF, data=_BACKGROUND, model_output="log_loss")
             raw = explainer.shap_values(x_chunk, y=y_chunk)
+        elif kind == "interaction":
+            raw = explainer.shap_interaction_values(x_chunk)
         else:
-            explainer = shap.TreeExplainer(_RF)
-            raw = (
-                explainer.shap_interaction_values(x_chunk)
-                if kind == "interaction"
-                else explainer.shap_values(x_chunk)
-            )
+            raw = explainer.shap_values(x_chunk)
     return select_positive_class_shap(raw, log_loss=(kind == _LOGLOSS_KIND))
+
+
+def _validate_pass(kind: str, n: int) -> None:
+    if kind != _LOGLOSS_KIND and kind not in _RAW_KINDS:
+        raise ValueError(f"unknown SHAP kind {kind!r}")
+    if n == 0:
+        raise ValueError("cannot explain zero samples")
+
+
+@contextlib.contextmanager
+def shap_pool(rf_path: str, n_workers: int, *, background: np.ndarray | None = None):
+    """
+    One worker pool shared by every SHAP pass computed inside the block.
+
+    Yields ``run(kind, x, y=None) -> np.ndarray`` computing the positive-class SHAP values for
+    one pass ``kind`` in ``{"summary", "interaction", "logloss"}``. Each pass historically spun
+    up (and tore down) its own pool; sharing one pool starts the workers — and parses the RF
+    into per-worker explainers (see ``_get_explainer``) — once per session instead of once per
+    pass. ``background`` must be supplied at pool creation when a ``"logloss"`` pass will run
+    (workers receive it through the initializer, not per task). ``n_workers <= 1`` runs every
+    pass in-process (no pool) — single-core hosts or tiny inputs.
+    """
+    if n_workers <= 1:
+        _worker_init(rf_path, background)
+
+        def run(kind: str, x: np.ndarray, y: np.ndarray | None = None) -> np.ndarray:
+            _validate_pass(kind, len(x))
+            return _worker((kind, x, y))
+
+        yield run
+        return
+
+    # forkserver with an EMPTY preload: the fork server is spawned clean and does NOT re-import the
+    # parent's __main__ (aetherscan.main -> TF -> the whole training stack), so workers stay light.
+    ctx = mp.get_context("forkserver")
+    ctx.set_forkserver_preload([])
+    with ProcessPoolExecutor(
+        max_workers=n_workers,
+        mp_context=ctx,
+        initializer=_worker_init,
+        initargs=(rf_path, background),
+    ) as pool:
+
+        def run(kind: str, x: np.ndarray, y: np.ndarray | None = None) -> np.ndarray:
+            _validate_pass(kind, len(x))
+            # ~_CHUNKS_PER_WORKER chunks per worker smooth stragglers. The chunk count cannot
+            # change the numbers: TreeSHAP is per-sample exact and per-sample independent, and
+            # pool.map yields chunk results in submission order, so concatenating them is
+            # bitwise-identical to the serial result for ANY chunking.
+            n_chunks = min(len(x), n_workers * _CHUNKS_PER_WORKER)
+            chunks = np.array_split(np.arange(len(x)), n_chunks)
+            tasks = [(kind, x[c], (None if y is None else y[c])) for c in chunks if len(c)]
+            return np.concatenate(list(pool.map(_worker, tasks)), axis=0)
+
+        yield run
 
 
 def parallel_shap(
@@ -134,37 +220,14 @@ def parallel_shap(
 ) -> np.ndarray:
     """
     Compute the positive-class SHAP values for ``x`` under one pass ``kind`` in
-    ``{"summary", "interaction", "logloss"}``, chunked across up to ``n_workers`` worker processes.
+    ``{"summary", "interaction", "logloss"}``, chunked across up to ``n_workers`` worker processes
+    (a dedicated single-pass pool; callers running several passes should hold one ``shap_pool``
+    open instead — ``_compute_or_load_shap_values`` in ``train.py`` does).
 
     ``rf_path`` is the persisted sklearn RF joblib (each worker loads it). ``background`` and ``y`` are
     required only for the ``"logloss"`` (interventional) pass. TreeSHAP is per-sample deterministic, so
     the concatenated result is bitwise-identical to the single-process computation.
     """
-    if kind != _LOGLOSS_KIND and kind not in _RAW_KINDS:
-        raise ValueError(f"unknown SHAP kind {kind!r}")
-
-    n = len(x)
-    if n == 0:
-        raise ValueError("cannot explain zero samples")
-    n_workers = max(1, min(n_workers, n))
-
-    # n_workers == 1: run in-process (no pool) — used on single-core hosts or tiny inputs.
-    if n_workers == 1:
-        _worker_init(rf_path, background)
-        return _worker((kind, x, y))
-
-    chunks = np.array_split(np.arange(n), n_workers)
-    tasks = [(kind, x[c], (None if y is None else y[c])) for c in chunks if len(c)]
-    # forkserver with an EMPTY preload: the fork server is spawned clean and does NOT re-import the
-    # parent's __main__ (aetherscan.main -> TF -> the whole training stack), so workers stay light.
-    ctx = mp.get_context("forkserver")
-    ctx.set_forkserver_preload([])
-    with ProcessPoolExecutor(
-        max_workers=n_workers,
-        mp_context=ctx,
-        initializer=_worker_init,
-        initargs=(rf_path, background),
-    ) as pool:
-        # ProcessPoolExecutor.map yields results in input (chunk) order — no re-sort needed.
-        results = list(pool.map(_worker, tasks))
-    return np.concatenate(results, axis=0)
+    _validate_pass(kind, len(x))
+    with shap_pool(rf_path, max(1, min(n_workers, len(x))), background=background) as run:
+        return run(kind, x, y)

--- a/src/aetherscan/shap_parallel.py
+++ b/src/aetherscan/shap_parallel.py
@@ -126,6 +126,11 @@ def _get_explainer(kind: str):
     """
     import shap  # noqa: PLC0415  (deferred so the worker pins threads before shap/BLAS init)
 
+    # Validate here, not just at the top-level API: the in-process (n_workers <= 1) path
+    # reaches _worker without _validate_pass, and silently collapsing an unknown kind into
+    # the "raw" slot would hand a future pass the wrong explainer.
+    if kind != _LOGLOSS_KIND and kind not in _RAW_KINDS:
+        raise ValueError(f"unknown SHAP kind {kind!r}")
     key = _LOGLOSS_KIND if kind == _LOGLOSS_KIND else "raw"
     explainer = _EXPLAINERS.get(key)
     if explainer is None:

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -59,6 +59,7 @@ from aetherscan.latent_variants import (
     build_z_aug_training_set,
     expected_calibration_error,
     fit_probability_calibrator,
+    latent_dim_variances,
     recall_at_fpr,
     sample_z_flat,
     select_winner,
@@ -2884,10 +2885,14 @@ class TrainingPipeline:
                 latent_dim,
                 self.config.rf.active_units_threshold,
             )
+            # Per-dim variances logged alongside the count: an AU flip between runs is only
+            # interpretable with the margins (hovering-at-threshold = noise, dark = signal)
+            dim_variances = latent_dim_variances(train_mean_flat, num_observations, latent_dim)
             logger.info(
                 f"Active latent dims (z_mean variance > "
                 f"{self.config.rf.active_units_threshold}): {len(active_dims)}/{latent_dim} "
-                f"-> {active_dims}"
+                f"-> {active_dims}; per-dim variances: "
+                f"{[round(float(v), 5) for v in dim_variances]}"
             )
 
             # Partition the val split: selection (variant choice) / calibration (calibrator

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -105,7 +105,7 @@ from aetherscan.seeding import (
     derive_seed,
     seed_tensorflow,
 )
-from aetherscan.shap_parallel import parallel_shap
+from aetherscan.shap_parallel import shap_pool
 
 logger = logging.getLogger(__name__)
 
@@ -3462,6 +3462,9 @@ class TrainingPipeline:
         Compute SHAP values for the trained RF (summary, interaction, log-loss decomposition)
         and cache to disk. Subsequent calls load the cache.
 
+        Runs on plot_rf_diagnostics' background thread while the non-SHAP plots render — keep
+        it compute + file IO + logging only (no DB writes, Slack uploads, or matplotlib).
+
         Returns a dict with keys:
             shap_values_summary ->
                 SHAP values for the positive class (true signal) on a sampled subset of val.
@@ -3529,32 +3532,31 @@ class TrainingPipeline:
         else:
             expected_value = float(ev)
 
-        shap_values_summary = parallel_shap(
-            rf_path, val_features[summary_indices], "summary", n_workers
-        )
-        shap_values_interaction = parallel_shap(
-            rf_path, val_features[interaction_indices], "interaction", n_workers
-        )
-
-        # Log-loss (interventional) decomposition: needs a background subset + per-sample y.
+        # Log-loss (interventional) decomposition needs a background subset + per-sample y. Drawn
+        # here — before any pass runs — so the shared pool can hand it to the workers at init; the
+        # rng draw order (summary, interaction, background) is unchanged, so the sampled indices
+        # are identical to the sequential-pools era.
         n_bg = min(1000, train_features.shape[0])
         bg_indices = rng.choice(train_features.shape[0], size=n_bg, replace=False)
         background = train_features[bg_indices]
-        try:
-            shap_values_logloss = parallel_shap(
-                rf_path,
-                val_features[summary_indices],
-                "logloss",
-                n_workers,
-                background=background,
-                y=val_binary_labels[summary_indices],
-            )
-        except Exception as e:
-            logger.warning(
-                f"SHAP log-loss decomposition failed ({e}); falling back to zeros — "
-                f"loss-monitoring plot will be empty"
-            )
-            shap_values_logloss = np.zeros_like(shap_values_summary)
+
+        # One pool serves all three passes: workers start, load the RF, and parse it into their
+        # explainers once per session instead of once per pass (see shap_parallel.shap_pool).
+        with shap_pool(rf_path, n_workers, background=background) as run_pass:
+            shap_values_summary = run_pass("summary", val_features[summary_indices])
+            shap_values_interaction = run_pass("interaction", val_features[interaction_indices])
+            try:
+                shap_values_logloss = run_pass(
+                    "logloss",
+                    val_features[summary_indices],
+                    y=val_binary_labels[summary_indices],
+                )
+            except Exception as e:
+                logger.warning(
+                    f"SHAP log-loss decomposition failed ({e}); falling back to zeros — "
+                    f"loss-monitoring plot will be empty"
+                )
+                shap_values_logloss = np.zeros_like(shap_values_summary)
 
         del background, bg_indices
 
@@ -7342,19 +7344,25 @@ class TrainingPipeline:
             logger.error(f"Failed to load models: {e}")
             raise  # Re-raise to propagate error
 
-    def _run_plot_group(self, plot_calls: list[tuple[Callable, str]]) -> None:
+    def _attempt_plots(self, plot_calls: list[tuple[Callable, str]], failures: list[str]) -> None:
         """
-        Run a group of plot methods, attempting every one even when some fail (a single
-        broken plot mustn't block the others), then raise a summary error listing the
-        failures so the stage machine can record the group as failed.
+        Run plot methods in order, attempting every one even when some fail (a single broken
+        plot mustn't block the others), appending each failing plot's name to ``failures``.
         """
-        failures = []
         for func, name in plot_calls:
             try:
                 func()
             except Exception as e:
                 logger.error(f"Failed to execute {name}: {e}")
                 failures.append(name)
+
+    def _run_plot_group(self, plot_calls: list[tuple[Callable, str]]) -> None:
+        """
+        Run a group of plot methods via _attempt_plots, then raise a summary error listing
+        the failures so the stage machine can record the group as failed.
+        """
+        failures: list[str] = []
+        self._attempt_plots(plot_calls, failures)
         if failures:
             raise RuntimeError(f"{len(failures)} plot(s) failed: {', '.join(failures)}")
 
@@ -7378,33 +7386,75 @@ class TrainingPipeline:
     def plot_rf_diagnostics(self) -> None:
         """
         The rf_plots stage: the ten Random Forest visualizations. All plots consume the
-        eval-artifact joblib persisted by train_random_forest() (the five SHAP plots
-        additionally share a SHAP-values joblib); every plot is attempted even when one
-        fails (e.g. an optional dep like SHAP missing), then a summary error is raised for
-        the stage machine to record. plot_rf_latent_decision_boundary relies on the
+        eval-artifact joblib persisted by train_random_forest(); the five SHAP plots
+        additionally share a SHAP-values joblib whose computation (parallel TreeSHAP, ~hours
+        at release scale) runs on a background thread while the five non-SHAP plots render
+        on the main thread — the thread mostly blocks on shap_parallel's worker pool (GIL
+        released), so main-thread matplotlib isn't starved and the overlap saves
+        ~min(SHAP time, non-SHAP plot time) of wall clock. Every plot is attempted even when
+        one fails (e.g. an optional dep like SHAP missing), then a summary error is raised
+        for the stage machine to record. plot_rf_latent_decision_boundary relies on the
         cadence-level UMAP joblibs written by plot_latent_space_gif (vae_plots stage), so
         stage ordering matters.
         """
-        self._run_plot_group(
-            [
-                (self.plot_rf_confusion_matrices, "plot_rf_confusion_matrices"),
-                (self.plot_rf_classification_curves, "plot_rf_classification_curves"),
-                (self.plot_rf_shap_summary, "plot_rf_shap_summary"),
-                (self.plot_rf_shap_dependence, "plot_rf_shap_dependence"),
-                (self.plot_rf_shap_interactions, "plot_rf_shap_interactions"),
-                (self.plot_rf_shap_loss_monitoring, "plot_rf_shap_loss_monitoring"),
-                (
-                    self.plot_rf_shap_explanation_clustering,
-                    "plot_rf_shap_explanation_clustering",
-                ),
-                (self.plot_rf_calibration_curve, "plot_rf_calibration_curve"),
-                (self.plot_rf_ensemble_accuracy_curve, "plot_rf_ensemble_accuracy_curve"),
-                (
-                    self.plot_rf_latent_decision_boundary,
-                    "plot_rf_latent_decision_boundary",
-                ),
-            ]
-        )
+        non_shap_plots = [
+            (self.plot_rf_confusion_matrices, "plot_rf_confusion_matrices"),
+            (self.plot_rf_classification_curves, "plot_rf_classification_curves"),
+            (self.plot_rf_calibration_curve, "plot_rf_calibration_curve"),
+            (self.plot_rf_ensemble_accuracy_curve, "plot_rf_ensemble_accuracy_curve"),
+            (self.plot_rf_latent_decision_boundary, "plot_rf_latent_decision_boundary"),
+        ]
+        shap_plots = [
+            (self.plot_rf_shap_summary, "plot_rf_shap_summary"),
+            (self.plot_rf_shap_dependence, "plot_rf_shap_dependence"),
+            (self.plot_rf_shap_interactions, "plot_rf_shap_interactions"),
+            (self.plot_rf_shap_loss_monitoring, "plot_rf_shap_loss_monitoring"),
+            (self.plot_rf_shap_explanation_clustering, "plot_rf_shap_explanation_clustering"),
+        ]
+
+        try:
+            # Load once on the main thread so the SHAP thread and the non-SHAP plots share the
+            # memoized dict read-only instead of racing the loader.
+            artifacts = self._load_rf_eval_artifacts()
+        except Exception as e:
+            # No artifacts, no overlap: run the sequential group in the pre-overlap order
+            # (confusion, classification, the five SHAP plots, calibration, ensemble,
+            # boundary) so every plot fails individually exactly as it always has.
+            logger.error(f"Failed to load RF eval artifacts: {e}")
+            self._run_plot_group(non_shap_plots[:2] + shap_plots + non_shap_plots[2:])
+            return
+
+        shap_errors: list[Exception] = []
+
+        def _shap_worker() -> None:
+            # _compute_or_load_shap_values is compute + file IO (worker pool, joblib cache)
+            # plus thread-safe logging — no DB, Slack, or matplotlib — so it is safe off the
+            # main thread; its exception is recorded per SHAP plot after the join.
+            try:
+                self._compute_or_load_shap_values(artifacts)
+            except Exception as e:
+                shap_errors.append(e)
+
+        failures: list[str] = []
+        shap_thread = threading.Thread(target=_shap_worker, name="rf-shap-compute")
+        shap_thread.start()
+        try:
+            self._attempt_plots(non_shap_plots, failures)
+        finally:
+            shap_thread.join()
+        if shap_errors:
+            # The shared computation failed, so every SHAP plot would have raised this same
+            # error — record each one exactly as _attempt_plots would have.
+            for _func, name in shap_plots:
+                logger.error(f"Failed to execute {name}: {shap_errors[0]}")
+                failures.append(name)
+        else:
+            # join() above is the happens-before edge: the SHAP plots read the populated
+            # _rf_shap_cache (a pure cache hit — no recompute) on the main thread, which is
+            # also where all matplotlib work stays.
+            self._attempt_plots(shap_plots, failures)
+        if failures:
+            raise RuntimeError(f"{len(failures)} plot(s) failed: {', '.join(failures)}")
 
     def final_save(self) -> None:
         """The final_save stage: persist the final models plus the resolved config JSON.

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -1207,6 +1207,13 @@ class TrainingPipeline:
         # overlap_data_generation is enabled; None otherwise)
         self._round_producer: RoundDataProducer | None = None
 
+        # Request id of the RF-dataset pre-generation queued on the producer during the
+        # last beta-VAE round (the num_training_rounds+1 seed sentinel), or None when no
+        # request was issued (overlap disabled, a resumed run entering rf_train directly,
+        # or a failed round loop). When set, train_random_forest awaits the result and
+        # owns the producer shutdown; cleared by _shutdown_round_producer()
+        self._rf_producer_request: int | None = None
+
         # In-memory caches for RF eval artifacts and SHAP values, keyed by tag.
         # All ten RF plots consume the same eval-artifact joblib (and the five SHAP
         # plots additionally share a SHAP-values joblib); without these caches each
@@ -1599,17 +1606,37 @@ class TrainingPipeline:
                     self.train_round(
                         round_idx=round_idx, epochs=epochs, snr_base=snr_base, snr_range=snr_range
                     )
+        except BaseException:
+            # Any round-loop failure (or interrupt) moots a pending RF pre-generation —
+            # the retry loop rebuilds the pipeline and train_random_forest never runs on
+            # this instance, so the producer must not outlive the loop
+            self._shutdown_round_producer()
+            raise
         finally:
-            # Wind down the producer (graceful shutdown message, escalating to
-            # terminate -> kill through the ResourceManager if it's mid-generation)
-            if self._round_producer is not None:
-                self._round_producer.shutdown()
-                self._round_producer = None
+            # Success path: the producer stays alive ONLY while it still owes the RF
+            # dataset requested at the top of the last round — train_random_forest awaits
+            # that result and owns the shutdown from there (see _obtain_rf_dataset). With
+            # no pending request there is nothing left for it to do: wind it down here
+            # (graceful shutdown message, escalating to terminate -> kill through the
+            # ResourceManager if it's mid-generation), exactly as before
+            if self._rf_producer_request is None:
+                self._shutdown_round_producer()
 
             # NOTE: the latent viz batch intentionally survives this method — the vae_plots
             # stage's plot_latent_traversal re-encodes/decodes it. It is freed by
             # _clear_latent_viz_data(), called from the stage machine after vae_plots (and
             # from run_training_pipeline's cleanup on any earlier failure)
+
+    def _shutdown_round_producer(self) -> None:
+        """Wind down the background producer and clear the pending-RF-request marker.
+        Idempotent — the single shutdown owner for every exit path (round-loop failure,
+        the RF await in _obtain_rf_dataset, train_random_forest's early returns, and the
+        run_training_pipeline teardown backstop), so the producer is shut down exactly
+        once no matter which of those paths run."""
+        if self._round_producer is not None:
+            self._round_producer.shutdown()
+            self._round_producer = None
+        self._rf_producer_request = None
 
     def train_round(self, round_idx: int, epochs: int, snr_base: int, snr_range: int):
         """
@@ -1660,15 +1687,33 @@ class TrainingPipeline:
                     paths, n_samples, snr_base, snr_range, round_number
                 )
 
-        # Immediately queue generation of the next round's data so it runs in the producer
-        # process while this round's epochs train (curriculum SNR for round k+1 is
-        # deterministic, so it can be computed ahead of time)
-        if (
-            self._round_producer is not None
-            and round_number < self.config.training.num_training_rounds
-        ):
-            next_snr_base, next_snr_range = self._calculate_curriculum_snr(round_idx + 1)
-            self._round_producer.request_generation(round_number + 1, next_snr_base, next_snr_range)
+        # Immediately queue the producer's next job so it runs while this round's epochs
+        # train: rounds 1..N-1 queue round k+1's data (curriculum SNR for round k+1 is
+        # deterministic, so it can be computed ahead of time); the LAST round queues the RF
+        # dataset instead — rf_train's ~num_samples_rf generation used to run in-process
+        # after the final round with the GPUs idle. The RF request mirrors
+        # train_random_forest's in-process fallback exactly: same SNR params (snr_base +
+        # the WIDE initial_snr_range), same rf/ dir layout, and the num_training_rounds+1
+        # sentinel — carried as the request id, which the producer forwards to generation
+        # as round_num — so per-task seeds derive from the same (root seed, round_num) and
+        # the arrays are byte-identical to what the fallback would generate (see the
+        # sentinel comment in _obtain_rf_dataset)
+        if self._round_producer is not None:
+            if round_number < self.config.training.num_training_rounds:
+                next_snr_base, next_snr_range = self._calculate_curriculum_snr(round_idx + 1)
+                self._round_producer.request_generation(
+                    round_number + 1, next_snr_base, next_snr_range
+                )
+            else:
+                self._rf_producer_request = self.config.training.num_training_rounds + 1
+                self._round_producer.request_generation(
+                    self._rf_producer_request,
+                    self.config.training.snr_base,
+                    self.config.training.initial_snr_range,
+                    dir_name="rf",
+                    n_samples=self.config.training.num_samples_rf,
+                    stage_name="train.rf",
+                )
 
         # Open the round's arrays as read-only memmaps (nothing is loaded into RAM here; the
         # batched generators gather from the OS page cache during training)
@@ -2615,6 +2660,88 @@ class TrainingPipeline:
 
         return outputs
 
+    def _obtain_rf_dataset(
+        self, rf_paths: RoundDataPaths, n_samples: int, snr_base: float, snr_range: float
+    ) -> None:
+        """
+        Materialize the RF training dataset at `rf_paths`, in order of precedence:
+
+        1. Await the background producer's pre-generated result (requested at the top of
+           the LAST beta-VAE round — see train_round — so it generated while that round's
+           epochs trained), then wind the producer down: its job ends here on every path
+           (success, producer error, or an exception out of the await). The await MUST
+           precede the manifest check below — validating while the producer is still
+           writing would race the fallback's regeneration against live producer writes.
+        2. Reuse a validated on-disk dataset — how a producer success is consumed, and a
+           no-op guard for a dataset already materialized on this pipeline instance
+           (startup cleanup deletes any stale rf dir, so a resumed run never reuses one
+           across attempts).
+        3. Generate in-process — the fallback when there is no producer (overlap disabled,
+           sequential mode, or a resumed run entering rf_train directly) or the producer
+           failed (generate_round_to_memmap clears any partial dir first).
+
+        Both generation paths pass the same round_num and root seed, so per-task seeds
+        derive identically and the arrays are byte-identical whichever path ran (pinned by
+        tests/unit/test_round_data.py's byte-identity test).
+
+        round_num: a sentinel one past the last beta-VAE round, NOT the literal RF phase
+        (there is no "RF round" numbering). Passing it (instead of the default None) gives
+        every injection_stats row from this generation a real round_number, so a stale row
+        from a crashed rf_train attempt is reachable by _init_run_state's round_ge
+        supersede on the next retry. That call marks (tag, round_number >=
+        self._start_round); SQL NULLs never satisfy ">=", so a NULL round_number (the
+        previous default) permanently escaped it. resume_round (run_state.py) is
+        max(completed_rounds) + 1, and completed_rounds only ever holds values <=
+        num_training_rounds, so _start_round <= num_training_rounds + 1 always — the
+        sentinel is covered whether the crash hit the last round (producer path,
+        _start_round <= num_training_rounds) or rf_train itself (_start_round ==
+        num_training_rounds + 1). Since #277, plot_injection_stats scopes its queries to
+        rounds 1..num_training_rounds, so this sentinel round is deliberately OUTSIDE
+        every plotted range — RF-phase rows never appear in the injection figures (nor
+        block their bulk-lane backlog gate while the producer pre-generates). No other
+        consumer filters or groups on round_number, so this is safe without touching
+        mark_superseded or the DB schema. The producer path carries the sentinel as its
+        request id, which reaches generation as the same round_num.
+        """
+        if self._round_producer is not None:
+            try:
+                if self._rf_producer_request is not None:
+                    logger.info("Waiting for the RF dataset from the background producer")
+                    wait_start = time.time()
+                    try:
+                        self._round_producer.await_round(self._rf_producer_request)
+                        logger.info(f"RF dataset ready (waited {time.time() - wait_start:.1f}s)")
+                    except RuntimeError as e:
+                        logger.warning(
+                            f"Producer RF pre-generation failed — falling back to "
+                            f"in-process generation: {e}"
+                        )
+            finally:
+                self._shutdown_round_producer()
+
+        if (
+            validate_done_manifest(
+                rf_paths,
+                expected_n_samples=n_samples,
+                expected_array_dtype=self.config.training.round_array_dtype,
+            )
+            is not None
+        ):
+            logger.info(f"Reusing validated RF dataset at {rf_paths.round_dir}")
+            return
+
+        # In-process generation; tag source to match the per-round data_generation spans
+        # (the producer path records its span from the drainer's timing message instead —
+        # attributed to train.rf but overlapping the last round's wall time)
+        with stage_timer("data_generation", metadata={"source": "in-process"}):
+            self.data_generator.generate_round(
+                rf_paths,
+                n_samples,
+                snr_base,
+                snr_range,
+                round_num=self.config.training.num_training_rounds + 1,
+            )
+
     # NOTE: write what to db? (e.g. accuracy, F1). should we move all joblib read/writes to db read/writes?
     def train_random_forest(self):
         """Train Random Forest"""
@@ -2627,6 +2754,9 @@ class TrainingPipeline:
         # _init_run_state downgraded it to a fresh run), so stale artifacts are never
         # silently reused.
         if self._resumed and self.try_load_rf_for_resume():
+            # Nothing below will read the producer's pre-generated RF dataset — don't
+            # leave it (or the producer) alive through rf_plots/final_save
+            self._shutdown_round_producer()
             logger.info(
                 "Loaded existing Random Forest model + eval artifacts for this tag — "
                 "skipping RF data generation and retraining"
@@ -2658,6 +2788,9 @@ class TrainingPipeline:
             )
             logger.warning("=" * 60)
             self.rf_training_skipped_from_tag = source_tag
+            # A pre-loaded trained RF skips the whole stage (reachable with --load-tag of
+            # a fully-trained tag) — the producer's pending RF dataset is moot
+            self._shutdown_round_producer()
             return
 
         # # BUG:
@@ -2703,50 +2836,17 @@ class TrainingPipeline:
         time_bins = self.config.data.time_bins
         width_bin = self.config.data.width_bin // self.config.data.downsample_factor
 
-        # Generate training data (concatenated is 4-way balanced; labels track per-sample
-        # subtype) into a disk-backed dataset alongside the per-round dirs. Generation is
-        # in-process (sequential with training) — there is nothing left to overlap with, the
-        # beta-VAE producer has already been shut down by train_beta_vae()
+        # Obtain the RF training set (concatenated is 4-way balanced; labels track
+        # per-sample subtype) as a disk-backed dataset alongside the per-round dirs:
+        # pre-generated by the background producer during the last beta-VAE round when
+        # overlap is on, else generated in-process here (full precedence + fallback
+        # semantics in _obtain_rf_dataset)
         logger.info(f"Preparing training set with SNR: {snr_base}-{snr_base + snr_range}")
         rf_paths = RoundDataPaths(
             round_dir=os.path.join(self._round_data_base_dir, "rf"), round_idx=0
         )
         rf_trained = False  # Set True once RF training fully completes (drives dir deletion)
-        if (
-            validate_done_manifest(
-                rf_paths,
-                expected_n_samples=n_samples,
-                expected_array_dtype=self.config.training.round_array_dtype,
-            )
-            is not None
-        ):
-            logger.info(f"Reusing validated RF dataset at {rf_paths.round_dir}")
-        else:
-            # RF data is always generated in-process (no background producer for the RF phase);
-            # tag source to match the per-round data_generation spans (producer / in-process)
-            #
-            # round_num: a sentinel one past the last beta-VAE round, NOT the literal RF phase
-            # (there is no "RF round" numbering). Passing it (instead of the default None) gives
-            # every injection_stats row from this call a real round_number, so a stale row from a
-            # crashed rf_train attempt is reachable by _init_run_state's round_ge supersede on the
-            # next retry. That call marks (tag, round_number >= self._start_round); SQL NULLs never
-            # satisfy ">=", so a NULL round_number (the previous default) permanently escaped it.
-            # resume_round (run_state.py) is max(completed_rounds) + 1, and completed_rounds only
-            # ever holds values <= num_training_rounds, so _start_round <= num_training_rounds + 1
-            # always — and rf_train only (re)starts once vae_rounds is fully done, i.e. exactly
-            # when _start_round == num_training_rounds + 1. Since #277, plot_injection_stats
-            # scopes its queries to rounds 1..num_training_rounds, so this sentinel round is
-            # deliberately OUTSIDE every plotted range — RF-phase rows never appear in the
-            # injection figures. No other consumer filters or groups on round_number, so this
-            # is safe without touching mark_superseded or the DB schema.
-            with stage_timer("data_generation", metadata={"source": "in-process"}):
-                self.data_generator.generate_round(
-                    rf_paths,
-                    n_samples,
-                    snr_base,
-                    snr_range,
-                    round_num=self.config.training.num_training_rounds + 1,
-                )
+        self._obtain_rf_dataset(rf_paths, n_samples, snr_base, snr_range)
         rf_data = load_round_arrays(rf_paths)
 
         # Prepare distributed train+val datasets (stratified split). shuffle=False so the
@@ -7473,9 +7573,15 @@ def run_training_pipeline(
         return pipeline
 
     finally:
-        # Free shared resources on exit. The viz-batch clear matters on the failure path:
-        # a vae_rounds crash skips the vae_plots-stage clear, and the retry loop builds a
-        # fresh pipeline — don't let the dying one pin a few hundred MB of viz data
+        # Free shared resources on exit. The producer backstop matters on the failure
+        # path: it stays alive across vae_plots for the RF pre-generation, so a crash
+        # between vae_rounds and rf_train's await must shut it down here (idempotent
+        # no-op when a normal path already did) — and BEFORE data_generator.close()
+        # releases the shared memory its workers attach to. The viz-batch clear matters
+        # on the failure path too: a vae_rounds crash skips the vae_plots-stage clear,
+        # and the retry loop builds a fresh pipeline — don't let the dying one pin a few
+        # hundred MB of viz data
+        pipeline._shutdown_round_producer()
         pipeline._clear_latent_viz_data()
         pipeline.data_generator.close()
 

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -63,6 +63,7 @@ from aetherscan.latent_variants import (
     recall_at_fpr,
     sample_z_flat,
     select_winner,
+    variant_feature_names,
 )
 from aetherscan.logger import get_logger
 from aetherscan.models import (
@@ -6152,21 +6153,18 @@ class TrainingPipeline:
         gc.collect()
 
     def _rf_feature_names(self) -> list[str]:
-        """Human-readable names for the 48 flattened latent features.
+        """Human-readable names for the winner variant's feature columns (#282).
 
-        Naming follows the cadence convention from data_generation.py: even-indexed
-        observations are ON, odd-indexed are OFF. Each ON/OFF pair is numbered 1..3.
-        Example for 6 obs / 8 dims: ON-1_dim-0 ... ON-1_dim-7, OFF-1_dim-0 ... OFF-3_dim-7.
+        Delegates to latent_variants.variant_feature_names so the names track the persisted
+        winner's exact layout — the old hardcoded 48-name list broke every SHAP plot that
+        pairs names with features whenever a logvar-augmented variant won (54+ columns).
         """
-        num_obs = self.config.data.num_observations
-        latent_dim = self.config.beta_vae.latent_dim
-        names = []
-        for o in range(num_obs):
-            kind = "ON" if o % 2 == 0 else "OFF"
-            pair_idx = o // 2 + 1
-            for d in range(latent_dim):
-                names.append(f"{kind}-{pair_idx}_dim-{d}")
-        return names
+        return variant_feature_names(
+            self.config.rf.latent_variant,
+            self.config.data.num_observations,
+            self.config.beta_vae.latent_dim,
+            self.config.rf.active_dims,
+        )
 
     def plot_rf_shap_summary(self, tag: str | None = None, dir: str | None = None):
         """

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -1787,6 +1787,7 @@ class TrainingPipeline:
                         ("kl_loss", "kl"),
                         ("true_loss", "true"),
                         ("false_loss", "false"),
+                        ("reg_loss", "reg"),
                     ]:
                         self.db.write_training_stat(
                             model_name="beta_vae",
@@ -1825,6 +1826,7 @@ class TrainingPipeline:
                         ("val_kl_loss", "kl"),
                         ("val_true_loss", "true"),
                         ("val_false_loss", "false"),
+                        ("val_reg_loss", "reg"),
                     ]:
                         self.db.write_training_stat(
                             model_name="beta_vae",
@@ -1936,6 +1938,7 @@ class TrainingPipeline:
                         f"KL: {epoch_losses['kl']:.4f}, "
                         f"True: {epoch_losses['true']:.4f}, "
                         f"False: {epoch_losses['false']:.4f}, "
+                        f"Reg: {epoch_losses['reg']:.4f}, "
                         f"Duration: {train_duration:.2f} "
                     )
                     logger.info(
@@ -1950,6 +1953,7 @@ class TrainingPipeline:
                         f"KL: {val_losses['kl']:.4f}, "
                         f"True: {val_losses['true']:.4f}, "
                         f"False: {val_losses['false']:.4f}, "
+                        f"Reg: {val_losses['reg']:.4f}, "
                         f"Duration: {val_duration:.2f} "
                     )
 
@@ -2087,14 +2091,15 @@ class TrainingPipeline:
         ("kl", "kl_loss"),
         ("true", "true_loss"),
         ("false", "false_loss"),
+        ("reg", "reg_loss"),
         ("kl_per_dim", "kl_per_dim"),
     )
 
     def _ensure_accumulation_state(self):
         """
         Lazily create the graph-side accumulation state: one gradient accumulator per
-        trainable variable, the train loss accumulators (5 scalars + the (latent_dim,)
-        per-dim KL vector), and the (5,) val loss accumulator.
+        trainable variable, the train loss accumulators (the _LOSS_KEY_MAP scalars + the
+        (latent_dim,) per-dim KL vector), and the scalar-count-sized val loss accumulator.
 
         ON_READ synchronization makes assign_add inside strategy.run a replica-LOCAL update
         (no communication per micro-batch); reading the variable back in cross-replica
@@ -2131,8 +2136,8 @@ class TrainingPipeline:
                 )
                 for name, _ in self._LOSS_KEY_MAP
             }
-            # One (5,) vector for the val losses, ordered as _LOSS_KEY_MAP minus kl_per_dim
-            self._val_loss_accumulator = _loss_accumulator([5])
+            # One vector for the val losses, ordered as _LOSS_KEY_MAP minus kl_per_dim
+            self._val_loss_accumulator = _loss_accumulator([len(self._LOSS_KEY_MAP) - 1])
 
     def _accumulate_micro_batch(self, batch_data):
         """
@@ -2170,11 +2175,11 @@ class TrainingPipeline:
             self._train_loss_accumulators[name].assign_add(losses[loss_key])
 
     def _accumulate_val_micro_batch(self, batch_data):
-        """Per-replica val micro-batch: forward only, losses into the (5,) accumulator."""
+        """Per-replica val micro-batch: forward only, losses into the scalar accumulator."""
         x, y = batch_data
         losses = self.vae.compute_total_loss(x[0], x[1], x[2], y, training=False)
         self._val_loss_accumulator.assign_add(
-            tf.stack([losses[key] for _, key in self._LOSS_KEY_MAP[:5]])
+            tf.stack([losses[key] for _, key in self._LOSS_KEY_MAP[:-1]])
         )
 
     def _get_accumulated_train_step(self, accumulation_steps: int) -> Callable:
@@ -2328,6 +2333,7 @@ class TrainingPipeline:
             "kl": 0.0,
             "true": 0.0,
             "false": 0.0,
+            "reg": 0.0,
             # Vector-valued (latent_dim,) — accumulates like the scalars (#282 diagnostics)
             "kl_per_dim": np.zeros(self.config.beta_vae.latent_dim, dtype=np.float64),
         }
@@ -2396,7 +2402,7 @@ class TrainingPipeline:
             totals = val_loop_fn(iterator).numpy()
             val_losses = {
                 name: float(value)
-                for (name, _), value in zip(self._LOSS_KEY_MAP[:5], totals, strict=False)
+                for (name, _), value in zip(self._LOSS_KEY_MAP[:-1], totals, strict=False)
             }
 
             # Calculate val epoch duration
@@ -3559,7 +3565,7 @@ class TrainingPipeline:
 
         # Create figure & setup gridspec
         fig = plt.figure(figsize=(fig_width, 12))
-        gs = fig.add_gridspec(2, 4, height_ratios=[1, 1], hspace=0.3, wspace=0.3)
+        gs = fig.add_gridspec(2, 5, height_ratios=[1, 1], hspace=0.3, wspace=0.3)
 
         # Top subplot spanning full width - Total Loss
         ax_top = fig.add_subplot(gs[0, :])
@@ -3569,6 +3575,7 @@ class TrainingPipeline:
         ax_kl = fig.add_subplot(gs[1, 1])
         ax_true = fig.add_subplot(gs[1, 2])
         ax_false = fig.add_subplot(gs[1, 3])
+        ax_reg = fig.add_subplot(gs[1, 4])
 
         fig.suptitle(
             f"Beta-VAE Loss Curves ({tag}, {machine_name})", fontsize=18, fontweight="bold"
@@ -3578,7 +3585,7 @@ class TrainingPipeline:
         self._add_snr_range_shading(
             ax_top, snr_by_round, epochs_per_round, use_rounds=False, show_text_annotations=True
         )
-        for ax in [ax_recon, ax_kl, ax_true, ax_false]:
+        for ax in [ax_recon, ax_kl, ax_true, ax_false, ax_reg]:
             self._add_snr_range_shading(
                 ax, snr_by_round, epochs_per_round, use_rounds=False, show_text_annotations=False
             )
@@ -3623,6 +3630,8 @@ class TrainingPipeline:
         plot_dual_axis(ax_kl, "KL Divergence", "kl_loss", "val_kl_loss")
         plot_dual_axis(ax_true, "True Loss", "true_loss", "val_true_loss")
         plot_dual_axis(ax_false, "False Loss", "false_loss", "val_false_loss")
+        # L1/L2 regularization penalties (activated 2026-07; absent for runs predating it)
+        plot_dual_axis(ax_reg, "Regularization", "reg_loss", "val_reg_loss")
 
         # Create shared legend at top right of figure
         train_line = mlines.Line2D([], [], color="blue", linewidth=2, label="Train")

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -809,11 +809,14 @@ class TestRoundDataFlags:
 
     def test_disk_budget_error_when_insufficient(self, monkeypatch):
         config = get_config()
+        # Mirror the validator's dtype-aware estimate (round_array_dtype default is float16
+        # since 2026-07-29) — a fixed fp32 estimate would set the threshold 2x too high
         round_nbytes = cli._estimate_round_data_nbytes(
             config.training.num_samples_beta_vae,
             config.data.num_observations,
             config.data.time_bins,
             config.data.width_bin // config.data.downsample_factor,
+            bytes_per_element=2 if config.training.round_array_dtype == "float16" else 4,
         )
         # Between 1.1x and 2.2x one round: fails with overlap (default), passes without
         self._patch_free_bytes(monkeypatch, int(1.5 * round_nbytes))
@@ -833,6 +836,7 @@ class TestRoundDataFlags:
             config.data.num_observations,
             config.data.time_bins,
             config.data.width_bin // config.data.downsample_factor,
+            bytes_per_element=2 if config.training.round_array_dtype == "float16" else 4,
         )
         self._patch_free_bytes(monkeypatch, int(10 * round_nbytes))
         errors = collect_validation_errors(_parse(["train"]), None)

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -666,6 +666,20 @@ class TestSchemaMigration:
         finally:
             database.stop()
 
+    def test_old_schema_gains_training_stats_is_finite(self):
+        # v6 (#289): pre-v6 rows were all finite by construction (a non-finite value could
+        # never be written — it bound as NULL and blew the NOT NULL constraint), so the
+        # DEFAULT 1 backfill is exact and they stay visible under the only_finite default.
+        db_path = self._create_v0_db(get_config())
+        database = Database()
+        try:
+            assert "is_finite" in self._column_names(db_path, "training_stats")
+            rows = database.query_training_stat(tag="test_v1")
+            assert len(rows) == 1
+            assert rows[0]["is_finite"] == 1
+        finally:
+            database.stop()
+
     def test_old_schema_gains_inference_cadences_table(self):
         """A pre-versioning database (v0: no inference_cadences table) must come out of
         _init_database() with the v2 manifest table present and usable."""
@@ -788,6 +802,42 @@ def _wait_backlog_empty(database, timeout: float = 15.0) -> bool:
             return True
         time.sleep(0.05)
     return False
+
+
+class TestTrainingStatFiniteHandling:
+    """#289: NaN training stats used to bind as SQL NULL, blow the NOT NULL constraint, and
+    silently vanish the entire flush batch. They now store as 0.0 with is_finite=0, queries
+    filter them by default, and a batch failure falls back to per-row writes."""
+
+    def test_nan_and_none_values_stored_flagged_and_filtered(self, db):
+        db.write_training_stat("beta_vae", "good_stat", 1.5, tag="fin_v1")
+        db.write_training_stat("beta_vae", "nan_stat", float("nan"), tag="fin_v1")
+        db.write_training_stat("beta_vae", "none_stat", None, tag="fin_v1")
+        assert db.flush()
+        # Default query drops the non-finite rows...
+        rows = db.query_training_stat(tag="fin_v1", columns=["stat_name", "value"])
+        assert [r["stat_name"] for r in rows] == ["good_stat"]
+        # ...but they are recorded (0.0, is_finite=0), not lost — and the good row survived
+        # in the same batch (the pre-#289 behavior dropped all three).
+        all_rows = db.query_training_stat(
+            tag="fin_v1", only_finite=False, columns=["stat_name", "value", "is_finite"]
+        )
+        assert len(all_rows) == 3
+        flagged = {r["stat_name"]: (r["value"], r["is_finite"]) for r in all_rows}
+        assert flagged["nan_stat"] == (0.0, 0)
+        assert flagged["none_stat"] == (0.0, 0)
+        assert flagged["good_stat"] == (1.5, 1)
+
+    def test_flush_falls_back_to_per_row_on_poisoned_batch(self, db):
+        # Smuggle a raw record violating NOT NULL (stat_name=None) around the sanitized
+        # write path, alongside a good row: the batch insert fails, the fallback lands the
+        # good row and drops exactly the bad one.
+        now = time.time()
+        good = ("training_stats", (now, "m", "ok_stat", 2.0, 1, 1, "fallback_v1", None, 1))
+        bad = ("training_stats", (now, "m", None, 3.0, 1, 1, "fallback_v1", None, 1))
+        db._flush_buffer(buffer=[bad, good])
+        rows = db.query_training_stat(tag="fallback_v1", columns=["stat_name", "value"])
+        assert [(r["stat_name"], r["value"]) for r in rows] == [("ok_stat", 2.0)]
 
 
 class TestInjectionStatTimeSpan:

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -649,6 +649,19 @@ class TestSchemaMigration:
         finally:
             conn.close()
 
+    def _index_names(self, db_path, table):
+        conn = sqlite3.connect(db_path)
+        try:
+            return {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = ?",
+                    (table,),
+                )
+            }
+        finally:
+            conn.close()
+
     def test_old_schema_gains_superseded_column(self):
         db_path = self._create_v0_db(get_config())
         assert self._user_version(db_path) == 0
@@ -752,6 +765,22 @@ class TestSchemaMigration:
             rows = database.query_pipeline_stages(tag="test_v2")
             assert len(rows) == 1
             assert rows[0]["duration_s"] == 2.5
+        finally:
+            database.stop()
+
+    def test_old_schema_gains_second_injection_index(self):
+        """A pre-versioning database (v0: no indexes at all) must come out of
+        _init_database() with BOTH injection_stats indexes (the v7 stat-scoped secondary
+        index next to the original filter index) and the current version stamp."""
+        db_path = self._create_v0_db(get_config())
+        assert self._index_names(db_path, "injection_stats") == set()
+
+        database = Database()
+        try:
+            index_names = self._index_names(db_path, "injection_stats")
+            assert "idx_injection_stats_filter" in index_names
+            assert "idx_injection_stats_by_stat" in index_names
+            assert self._user_version(db_path) == _SCHEMA_VERSION
         finally:
             database.stop()
 

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -609,6 +609,19 @@ class TestSchemaMigration:
         "inference_results",
     )
 
+    # The complete expected index set per table — the v7 index sweep's final state. Both
+    # _init_database() (fresh dbs) and the `if version < 7` migration block (pre-v7 dbs)
+    # must land exactly here, so tests assert equality, not membership.
+    _EXPECTED_INDEXES = {
+        "system_resources": {"idx_system_resources_filter"},
+        "injection_stats": {"idx_injection_stats_filter", "idx_injection_stats_by_stat"},
+        "training_stats": {"idx_training_stats_filter"},
+        "latent_snapshots": {"idx_latent_snapshots_by_key"},
+        "inference_results": {"idx_inference_results_filter"},
+        "inference_cadences": {"idx_inference_cadences_filter"},
+        "pipeline_stages": {"idx_pipeline_stages_filter"},
+    }
+
     def _create_v0_db(self, config):
         """Lay down an old-schema (pre-superseded, user_version 0) db file with one row,
         at the exact path Database will open."""
@@ -768,18 +781,24 @@ class TestSchemaMigration:
         finally:
             database.stop()
 
-    def test_old_schema_gains_second_injection_index(self):
-        """A pre-versioning database (v0: no indexes at all) must come out of
-        _init_database() with BOTH injection_stats indexes (the v7 stat-scoped secondary
-        index next to the original filter index) and the current version stamp."""
+    def test_migration_reaches_final_index_set(self):
+        """A pre-v7 database — seeded with the retired (tag, timestamp, ...)
+        latent_snapshots index so the v7 DROP path is exercised, not just the CREATEs —
+        must come out of _init_database() with exactly the current index set on every
+        table, plus the version stamp."""
         db_path = self._create_v0_db(get_config())
-        assert self._index_names(db_path, "injection_stats") == set()
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "CREATE INDEX idx_latent_snapshots_filter ON latent_snapshots"
+            "(tag, timestamp, model_name, round_number, epoch_number, step_number)"
+        )
+        conn.commit()
+        conn.close()
 
         database = Database()
         try:
-            index_names = self._index_names(db_path, "injection_stats")
-            assert "idx_injection_stats_filter" in index_names
-            assert "idx_injection_stats_by_stat" in index_names
+            for table, expected in self._EXPECTED_INDEXES.items():
+                assert self._index_names(db_path, table) == expected, table
             assert self._user_version(db_path) == _SCHEMA_VERSION
         finally:
             database.stop()
@@ -804,6 +823,10 @@ class TestSchemaMigration:
         for table in self._MIGRATED_TABLES:
             assert "superseded" in self._column_names(db.db_path, table)
         assert self._user_version(db.db_path) == _SCHEMA_VERSION
+        # The fresh-db index set must equal the migrated end state exactly (requirement of
+        # the v7 sweep: _init_database() and the migration block may never diverge)
+        for table, expected in self._EXPECTED_INDEXES.items():
+            assert self._index_names(db.db_path, table) == expected, table
 
 
 def _bulk_rows(n: int, round_number: int | None = 1, value: float = 1.0) -> list[dict]:

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -891,6 +891,21 @@ class TestTrainingStatFiniteHandling:
         rows = db.query_training_stat(tag="fallback_v1", columns=["stat_name", "value"])
         assert [(r["stat_name"], r["value"]) for r in rows] == [("ok_stat", 2.0)]
 
+    def test_fallback_does_not_duplicate_rows_before_a_mid_batch_poison(self, db):
+        # The poisoned row sits MID-batch: executemany steps good rows into the open
+        # transaction before failing, and without the SAVEPOINT rollback the per-row retry
+        # would re-insert them (duplicates). Exactly one copy of each good row must land.
+        now = time.time()
+        good1 = ("training_stats", (now, "m", "first_stat", 1.0, 1, 1, "fallback_v2", None, 1))
+        bad = ("training_stats", (now, "m", None, 3.0, 1, 1, "fallback_v2", None, 1))
+        good2 = ("training_stats", (now, "m", "second_stat", 2.0, 1, 1, "fallback_v2", None, 1))
+        db._flush_buffer(buffer=[good1, bad, good2])
+        rows = db.query_training_stat(tag="fallback_v2", columns=["stat_name", "value"])
+        assert sorted((r["stat_name"], r["value"]) for r in rows) == [
+            ("first_stat", 1.0),
+            ("second_stat", 2.0),
+        ]
+
 
 class TestInjectionStatTimeSpan:
     """query_injection_stat_time_span: the whole-partition MIN/MAX aggregate that callers use

--- a/tests/unit/test_latent_gif.py
+++ b/tests/unit/test_latent_gif.py
@@ -168,7 +168,7 @@ class TestBatchedUmapTransform:
 class TestRunUmapGifSweep:
     """The whole-combo sweep (fit + persist + transform + render + GIF) must be
     byte-identical between serial and pooled execution — the #278-follow-up contract that
-    lets the 24-combo sweep parallelize without changing any output."""
+    lets the multi-combo sweep parallelize without changing any output."""
 
     def _bundle(self, tmp_path):
         rng = np.random.default_rng(11)

--- a/tests/unit/test_latent_variants.py
+++ b/tests/unit/test_latent_variants.py
@@ -20,6 +20,7 @@ from aetherscan.latent_variants import (
     sample_z_flat,
     select_winner,
     variant_feature_count,
+    variant_feature_names,
 )
 
 _NUM_OBS = 6
@@ -209,3 +210,29 @@ class TestCalibrator:
         labels = np.array([0, 1, 0, 1])
         probas = np.array([0.1, 0.2, 0.8, 0.9])
         assert expected_calibration_error(labels, probas, n_bins=2) == pytest.approx(0.35)
+
+
+class TestVariantFeatureNames:
+    """variant_feature_names must stay column-for-column in lockstep with
+    build_variant_features — a length mismatch is an IndexError inside shap's plots
+    (how the hardcoded 48-name list broke on a 54-feature z_mean_obs_logvar winner)."""
+
+    @pytest.mark.parametrize("variant", VARIANT_ORDER)
+    @pytest.mark.parametrize("active_dims", [[], [1, 3], [0, 1, 2, 3, 4, 5, 6, 7]])
+    def test_names_match_feature_columns(self, variant, active_dims):
+        num_obs, latent_dim, n = 6, 8, 4
+        rng = np.random.default_rng(11)
+        lead = rng.normal(size=(n, num_obs * latent_dim)).astype(np.float32)
+        logvar = rng.normal(size=(n, num_obs * latent_dim)).astype(np.float32)
+        features = build_variant_features(
+            variant, lead, logvar, num_obs, latent_dim, active_dims=active_dims
+        )
+        names = variant_feature_names(variant, num_obs, latent_dim, active_dims=active_dims)
+        assert len(names) == features.shape[1]
+        assert len(set(names)) == len(names)  # no duplicate column names
+
+    def test_lead_block_matches_historical_convention(self):
+        names = variant_feature_names("z_mean", 6, 8)
+        assert names[0] == "ON-1_dim-0"
+        assert names[8] == "OFF-1_dim-0"
+        assert names[-1] == "OFF-3_dim-7"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -147,9 +147,10 @@ class TestSamplingLayer:
 
 @pytest.mark.slow
 class TestRegularizationActivation:
-    """The layer-declared L1/L2 penalties reach the training objective (activated 2026-07 —
-    before this, a custom loop that never added model.losses left every trained model
-    effectively unregularized)."""
+    """The layer-declared L1/L2 penalties: computed and recorded in every run, but ADDED to
+    the objective only behind beta_vae.regularization_active (v1 default False — activation
+    at the declared coefficients measured harmful in the 5-seed A/B; calibration is a
+    tracked follow-up)."""
 
     def test_reg_loss_present_positive_and_in_total(self):
         import tensorflow as tf  # noqa: PLC0415
@@ -167,15 +168,41 @@ class TestRegularizationActivation:
         losses = vae.compute_total_loss(main, true, false, main, training=False)
         assert "reg_loss" in losses
         reg = float(losses["reg_loss"])
-        # Freshly initialized weights + nonzero activations => strictly positive penalties
+        # Freshly initialized weights + nonzero activations => strictly positive penalties,
+        # computed for observability even though the v1 default leaves them OUT of the
+        # objective (activation at the declared coefficients measured harmful — see config)
         assert reg > 0.0
         assert losses["reg_loss"].dtype == tf.float32
-        # reg is a real component of the objective, with the documented composition
+        assert vae.regularization_active is False
+        base_total = (
+            float(losses["reconstruction_loss"])
+            + vae.beta * float(losses["kl_loss"])
+            + vae.alpha * (float(losses["true_loss"]) + float(losses["false_loss"]))
+        )
+        # Default (inactive): the objective is byte-identical to the pre-activation pipeline
+        np.testing.assert_allclose(float(losses["total_loss"]), base_total, rtol=1e-5)
+
+    def test_reg_loss_added_only_when_active(self):
+        import tensorflow as tf  # noqa: PLC0415
+
+        from aetherscan.models import create_beta_vae_model  # noqa: PLC0415
+
+        config = get_config()
+        config.beta_vae.regularization_active = True
+        try:
+            vae = create_beta_vae_model()
+        finally:
+            config.beta_vae.regularization_active = False
+        assert vae.regularization_active is True
+        dense_size = config.beta_vae.dense_layer_size
+        tf.random.set_seed(11)
+        batch = tf.random.uniform((2, 6, 16, dense_size))
+        losses = vae.compute_total_loss(batch, batch, batch, batch, training=False)
         expected_total = (
             float(losses["reconstruction_loss"])
             + vae.beta * float(losses["kl_loss"])
             + vae.alpha * (float(losses["true_loss"]) + float(losses["false_loss"]))
-            + reg
+            + float(losses["reg_loss"])
         )
         np.testing.assert_allclose(float(losses["total_loss"]), expected_total, rtol=1e-5)
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -189,13 +189,18 @@ class TestRegularizationActivation:
         dense_size = config.beta_vae.dense_layer_size
         tf.random.set_seed(11)
         batch = tf.random.uniform((2, 6, 16, dense_size))
+        # The DECODER's activity penalties depend on the sampled z (Sampling draws epsilon
+        # even at training=False), so reg is deterministic GIVEN THE SEED, not across
+        # unseeded calls — the same contract every seeded run relies on (#279). Re-seed
+        # before each call so the epsilon draws replay identically.
+        tf.random.set_seed(11)
         first = float(
             vae.compute_total_loss(batch, batch, batch, batch, training=False)["reg_loss"]
         )
+        tf.random.set_seed(11)
         second = float(
             vae.compute_total_loss(batch, batch, batch, batch, training=False)["reg_loss"]
         )
-        # Same weights + same activations => identical penalties (no RNG in regularizers)
         assert first == second
 
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -146,6 +146,60 @@ class TestSamplingLayer:
 
 
 @pytest.mark.slow
+class TestRegularizationActivation:
+    """The layer-declared L1/L2 penalties reach the training objective (activated 2026-07 —
+    before this, a custom loop that never added model.losses left every trained model
+    effectively unregularized)."""
+
+    def test_reg_loss_present_positive_and_in_total(self):
+        import tensorflow as tf  # noqa: PLC0415
+
+        from aetherscan.models import create_beta_vae_model  # noqa: PLC0415
+
+        vae = create_beta_vae_model()
+        config = get_config()
+        dense_size = config.beta_vae.dense_layer_size
+        tf.random.set_seed(11)
+        main = tf.random.uniform((2, 6, 16, dense_size))
+        true = tf.random.uniform((2, 6, 16, dense_size))
+        false = tf.random.uniform((2, 6, 16, dense_size))
+
+        losses = vae.compute_total_loss(main, true, false, main, training=False)
+        assert "reg_loss" in losses
+        reg = float(losses["reg_loss"])
+        # Freshly initialized weights + nonzero activations => strictly positive penalties
+        assert reg > 0.0
+        assert losses["reg_loss"].dtype == tf.float32
+        # reg is a real component of the objective, with the documented composition
+        expected_total = (
+            float(losses["reconstruction_loss"])
+            + vae.beta * float(losses["kl_loss"])
+            + vae.alpha * (float(losses["true_loss"]) + float(losses["false_loss"]))
+            + reg
+        )
+        np.testing.assert_allclose(float(losses["total_loss"]), expected_total, rtol=1e-5)
+
+    def test_reg_loss_deterministic_across_calls(self):
+        import tensorflow as tf  # noqa: PLC0415
+
+        from aetherscan.models import create_beta_vae_model  # noqa: PLC0415
+
+        vae = create_beta_vae_model()
+        config = get_config()
+        dense_size = config.beta_vae.dense_layer_size
+        tf.random.set_seed(11)
+        batch = tf.random.uniform((2, 6, 16, dense_size))
+        first = float(
+            vae.compute_total_loss(batch, batch, batch, batch, training=False)["reg_loss"]
+        )
+        second = float(
+            vae.compute_total_loss(batch, batch, batch, batch, training=False)["reg_loss"]
+        )
+        # Same weights + same activations => identical penalties (no RNG in regularizers)
+        assert first == second
+
+
+@pytest.mark.slow
 class TestEncoderDecoderSymmetry:
     """Builds the full Beta-VAE graph on CPU — slow but CI-safe."""
 

--- a/tests/unit/test_round_data.py
+++ b/tests/unit/test_round_data.py
@@ -23,6 +23,7 @@ from aetherscan.data_generation import (
 from aetherscan.round_data import (
     RoundDataPaths,
     RoundDataProducer,
+    _default_generate,
     _producer_main,
     _reap_stale_producer,
     build_manifest,
@@ -591,6 +592,168 @@ class TestProducerProtocol:
         messages = self._run(tmp_path, _stub_generate_ok, [("bogus",)])
         assert [m[0] for m in messages] == ["shutdown_ack"]
 
+    def test_rf_request_carries_dir_and_n_samples_overrides(self, tmp_path):
+        """The RF request's overrides dict: output dir + n_samples reach the producer, and
+        the request round_idx (the seed sentinel) reaches generate_fn unchanged."""
+        calls = []
+
+        def _recording_stub(
+            paths, round_idx, snr_base, snr_range, pool, params, stats_cb, progress_cb
+        ):
+            calls.append((paths, round_idx, snr_base, snr_range, params))
+            return {"round_idx": round_idx, "n_samples": params["n_samples"]}
+
+        messages = self._run(
+            tmp_path,
+            _recording_stub,
+            [("generate", 21, 10.0, 40.0, {"dir_name": "rf", "n_samples": 4})],
+        )
+        assert [m[0] for m in messages] == ["timing", "done", "shutdown_ack"]
+        # Result (and timing) messages are keyed by the REQUEST round_idx — what
+        # train_random_forest awaits
+        assert messages[0][1] == 21
+        assert messages[1][1] == 21
+
+        ((paths, round_idx, snr_base, snr_range, params),) = calls
+        # Dir override: {base_dir}/rf with paths round_idx 0 — the exact layout
+        # train_random_forest's rf_paths validates (round_00.done, manifest round_idx 0)
+        assert paths.round_dir == os.path.join(str(tmp_path), "rf")
+        assert paths.round_idx == 0
+        # Seed identity: generate_fn's round_idx (the round_num per-task seeds derive
+        # from) is the request's sentinel, NOT the paths index
+        assert round_idx == 21
+        # Per-request n_samples override lands in the params generate_fn reads
+        assert params["n_samples"] == 4
+        assert (snr_base, snr_range) == (10.0, 40.0)
+
+    def test_rf_request_short_circuits_on_validated_rf_dir(self, tmp_path):
+        # Reuse must validate against the request's overridden n_samples, not the
+        # producer-wide beta-VAE default (params carries n_samples=8, the request 4)
+        _write_small_round(RoundDataPaths(os.path.join(str(tmp_path), "rf"), 0), n_samples=4)
+        messages = self._run(
+            tmp_path,
+            _stub_generate_boom,
+            [("generate", 21, 10, 40, {"dir_name": "rf", "n_samples": 4})],
+        )
+        assert [m[0] for m in messages] == ["done", "shutdown_ack"]
+        assert messages[0][1] == 21
+        assert messages[0][2]["n_samples"] == 4
+
+
+class TestProducerRfByteIdentity:
+    """The RF pre-generation correctness contract: the producer path (the REAL
+    _default_generate parameter mapping through _producer_main) and train_random_forest's
+    in-process fallback must produce byte-identical arrays and matching manifest
+    checksums, because both call generate_round_to_memmap with the same params and derive
+    per-task seeds from (root seed, STREAM_DATA_GEN, num_training_rounds+1). If this
+    breaks, producer pre-generation silently changes the RF training data relative to the
+    documented in-process semantics."""
+
+    def test_producer_rf_request_matches_in_process_generation(
+        self, tmp_path, monkeypatch, make_background_npy
+    ):
+        plate = np.load(make_background_npy("plate.npy", n_cadences=4, width_bin=_WIDTH_BIN))
+        sentinel = 4  # num_training_rounds=3 + 1; any value shared by both sides works
+        common = {
+            "n_samples": 8,
+            "snr_base": 10.0,
+            "snr_range": 5.0,
+            "width_bin": _WIDTH_BIN,
+            "num_observations": 6,
+            "time_bins": 16,
+            "chunk_size": 4,
+            "task_size": 3,
+            "freq_resolution": _FREQ_RES,
+            "time_resolution": _TIME_RES,
+        }
+
+        # In-process reference: exactly the fallback's call shape (rf/ dir, paths
+        # round_idx 0, sentinel round_num, root seed)
+        inproc_paths = RoundDataPaths(os.path.join(str(tmp_path), "inproc", "rf"), 0)
+        inproc_stats = []
+        inproc_manifest = generate_round_to_memmap(
+            inproc_paths,
+            backgrounds=plate,
+            round_num=sentinel,
+            seed=123,
+            stats_cb=inproc_stats.append,
+            **common,
+        )
+
+        # Producer path: the real _default_generate through the thread-driven request
+        # loop. The thread producer has no pool, so generate_round_to_memmap is patched
+        # to inject `backgrounds` (sequential execution) — the parameter MAPPING under
+        # test is _default_generate's, which the wrapper passes through untouched.
+        real_generate = generate_round_to_memmap
+
+        def _sequential(*args, **kwargs):
+            kwargs.setdefault("backgrounds", plate)
+            return real_generate(*args, **kwargs)
+
+        monkeypatch.setattr("aetherscan.data_generation.generate_round_to_memmap", _sequential)
+
+        producer_base = os.path.join(str(tmp_path), "producer")
+        params = {
+            "base_dir": producer_base,
+            "n_samples": 12,  # the beta-VAE per-round count — the request override must win
+            "seed": 123,
+            **{k: v for k, v in common.items() if k not in ("n_samples", "snr_base", "snr_range")},
+        }
+        request_queue: queue.Queue = queue.Queue()
+        result_queue: queue.Queue = queue.Queue()
+        request_queue.put(("generate", sentinel, 10.0, 5.0, {"dir_name": "rf", "n_samples": 8}))
+        request_queue.put(("shutdown",))
+        thread = threading.Thread(
+            target=_producer_main,
+            args=(request_queue, result_queue, params),
+            kwargs={"generate_fn": _default_generate},
+            daemon=True,
+        )
+        thread.start()
+        thread.join(timeout=120)
+        assert not thread.is_alive()
+        messages = []
+        while True:
+            try:
+                messages.append(result_queue.get_nowait())
+            except queue.Empty:
+                break
+
+        done = [m for m in messages if m[0] == "done"]
+        assert len(done) == 1 and done[0][1] == sentinel
+        producer_manifest = done[0][2]
+
+        # Arrays byte-identical across the two paths
+        producer_paths = RoundDataPaths(os.path.join(producer_base, "rf"), 0)
+        inproc = load_round_arrays(inproc_paths)
+        produced = load_round_arrays(producer_paths)
+        for key in ("concatenated", "true", "false"):
+            np.testing.assert_array_equal(np.asarray(inproc[key]), np.asarray(produced[key]))
+        np.testing.assert_array_equal(inproc["labels"], produced["labels"])
+        np.testing.assert_array_equal(inproc["lognorm"], produced["lognorm"])
+
+        # Manifests match on everything content-derived (wall_time_s/created_at may differ)
+        for key in (
+            "round_idx",
+            "n_samples",
+            "shapes",
+            "dtypes",
+            "array_dtype",
+            "snr_base",
+            "snr_range",
+            "checksums",
+            "chunk_count",
+        ):
+            assert producer_manifest[key] == inproc_manifest[key], key
+
+        # Streamed stats carry the SAME sentinel round_number as the in-process rows —
+        # write_segment_stats takes round_number from the segment dict, so injection_stats
+        # rows land identically whichever side generated the RF set
+        stats = [m for m in messages if m[0] == "stats"]
+        assert stats
+        assert all(m[2]["round_number"] == sentinel for m in stats)
+        assert all(s["round_number"] == sentinel for s in inproc_stats)
+
 
 class TestProducerParentDeathWatch:
     """The request loop's ppid watch: an ungraceful parent death (kill -9 / OOM) never sends
@@ -914,6 +1077,39 @@ class TestRoundDataProducerDrainer:
         producer._process.alive = False
         with pytest.raises(RuntimeError, match="exited before producing"):
             producer.await_round(5)
+
+    def test_request_message_shapes_stay_backward_compatible(self, producer):
+        # Plain round requests keep the historical 4-tuple; only override-carrying
+        # requests (the RF dataset) grow the optional trailing dict
+        producer.request_generation(2, 10, 40)
+        producer.request_generation(21, 10, 40, dir_name="rf", n_samples=4)
+        assert producer._request_queue.get(timeout=5) == ("generate", 2, 10, 40)
+        assert producer._request_queue.get(timeout=5) == (
+            "generate",
+            21,
+            10,
+            40,
+            {"dir_name": "rf", "n_samples": 4},
+        )
+
+    def test_rf_timing_uses_stage_name_override(self, producer, monkeypatch):
+        # The RF request's stage_name is registered main-side (naming never crosses the
+        # process boundary) so its span lands under train.rf, not a nonexistent round_21
+        recorded = []
+        monkeypatch.setattr(
+            "aetherscan.round_data.record_stage",
+            lambda *args, **kwargs: recorded.append((args, kwargs)),
+        )
+        producer.request_generation(21, 10, 40, dir_name="rf", n_samples=4, stage_name="train.rf")
+        producer._result_queue.put(("timing", 21, 100.0, 160.0))
+        producer._result_queue.put(("done", 21, {"n_samples": 4}))
+        producer.await_round(21)
+        assert recorded == [
+            (
+                ("train.rf.data_generation", 100.0, 160.0),
+                {"tag": "test_v1", "metadata": {"source": "producer"}},
+            )
+        ]
 
 
 @pytest.mark.slow

--- a/tests/unit/test_shap_parallel.py
+++ b/tests/unit/test_shap_parallel.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 from sklearn.ensemble import RandomForestClassifier
 
-from aetherscan.shap_parallel import parallel_shap, select_positive_class_shap
+from aetherscan.shap_parallel import parallel_shap, select_positive_class_shap, shap_pool
 
 
 class TestSelectPositiveClassShap:
@@ -77,7 +77,9 @@ def small_rf(tmp_path_factory):
 
 @pytest.mark.parametrize("kind", ["summary", "interaction", "logloss"])
 def test_parallel_matches_single_process(small_rf, kind):
-    """The pooled result must equal the single-process result for every pass, in sample order."""
+    """The pooled result must equal the single-process result for every pass, in sample order.
+    24 samples across 4 workers now split into 16 chunks (~4 per worker), so this also pins the
+    multi-chunk-per-worker path against the serial computation."""
     pytest.importorskip("shap")  # the compute path needs shap in the workers
     rf_path, val_x, val_y, background = small_rf
     extra = {"background": background, "y": val_y} if kind == "logloss" else {}
@@ -87,6 +89,53 @@ def test_parallel_matches_single_process(small_rf, kind):
     assert serial.shape[0] == len(val_x)  # sample axis preserved
     # TreeSHAP is per-sample deterministic, so chunking yields a bitwise-identical result.
     np.testing.assert_array_equal(pooled, serial)
+
+
+def test_shared_pool_all_passes_match_single_process(small_rf):
+    """One shap_pool serving all three passes must reproduce each dedicated single-process
+    result bitwise — the shared pool and per-worker explainer cache cannot leak state between
+    pass kinds (a broken cache key would hand the log-loss pass the plain explainer, or vice
+    versa)."""
+    pytest.importorskip("shap")  # the compute path needs shap in the workers
+    rf_path, val_x, val_y, background = small_rf
+    serial = {
+        "summary": parallel_shap(rf_path, val_x, "summary", 1),
+        "interaction": parallel_shap(rf_path, val_x, "interaction", 1),
+        "logloss": parallel_shap(rf_path, val_x, "logloss", 1, background=background, y=val_y),
+    }
+    with shap_pool(rf_path, 4, background=background) as run_pass:
+        pooled = {
+            "summary": run_pass("summary", val_x),
+            "interaction": run_pass("interaction", val_x),
+            "logloss": run_pass("logloss", val_x, y=val_y),
+        }
+        # A summary pass AFTER the log-loss pass ran: the workers' "raw" cache slot must
+        # survive the log-loss explainer being built alongside it.
+        summary_again = run_pass("summary", val_x)
+    for kind, expected in serial.items():
+        np.testing.assert_array_equal(pooled[kind], expected)
+    np.testing.assert_array_equal(summary_again, serial["summary"])
+    # The two explainer families genuinely disagree at this scale, so the equalities above
+    # really do discriminate cross-contamination.
+    assert not np.array_equal(pooled["summary"], pooled["logloss"])
+
+
+def test_in_process_sessions_do_not_reuse_stale_explainers(small_rf, tmp_path):
+    """n_workers==1 sessions share this module's globals across calls; a second session against
+    a different RF must rebuild its explainer (not replay the first RF's values)."""
+    pytest.importorskip("shap")
+    rf_path, val_x, _, _ = small_rf
+    rng = np.random.default_rng(7)
+    other_x = rng.standard_normal((128, val_x.shape[1]))
+    other_y = (other_x[:, 1] > 0).astype(int)  # keyed on a different feature than small_rf
+    other = RandomForestClassifier(n_estimators=8, max_depth=4, random_state=7, n_jobs=1)
+    other.fit(other_x, other_y)
+    other_path = tmp_path / "other_rf.joblib"
+    joblib.dump(other, other_path)
+
+    first = parallel_shap(rf_path, val_x, "summary", 1)
+    second = parallel_shap(str(other_path), val_x, "summary", 1)
+    assert not np.array_equal(first, second)
 
 
 def test_more_workers_than_samples_is_safe(small_rf):

--- a/tests/unit/test_train_accumulation.py
+++ b/tests/unit/test_train_accumulation.py
@@ -175,7 +175,7 @@ class TestAccumulatedTrainStep:
         val_loop = tp._get_val_loop(3)
         totals = val_loop(iter(_dataset_from(batches))).numpy()
 
-        expected = np.zeros(5)
+        expected = np.zeros(6)
         for (main, true, false), y in batches:
             losses = model.compute_total_loss(main, true, false, y, training=False)
             expected += np.array(
@@ -185,6 +185,7 @@ class TestAccumulatedTrainStep:
                     losses["kl_loss"].numpy(),
                     losses["true_loss"].numpy(),
                     losses["false_loss"].numpy(),
+                    losses["reg_loss"].numpy(),
                 ]
             )
         np.testing.assert_allclose(totals, expected / 3, rtol=1e-5)

--- a/tests/unit/test_train_accumulation.py
+++ b/tests/unit/test_train_accumulation.py
@@ -41,6 +41,7 @@ class _StubModel(tf.Module):
             "kl_loss": 0.25 * total,
             "true_loss": 0.15 * total,
             "false_loss": 0.1 * total,
+            "reg_loss": 0.05 * total,
             "kl_per_dim": tf.fill([_LATENT_DIM], 0.01 * total),
         }
 

--- a/tests/unit/test_train_distribution.py
+++ b/tests/unit/test_train_distribution.py
@@ -140,6 +140,7 @@ _SCRIPT = textwrap.dedent(
                 "kl_loss": total,
                 "true_loss": total,
                 "false_loss": total,
+                "reg_loss": total,
                 "kl_per_dim": tf.fill([2], total),
             }
 

--- a/tests/unit/test_train_utils.py
+++ b/tests/unit/test_train_utils.py
@@ -3,14 +3,15 @@
 """Unit tests for aetherscan.train pure-logic helpers: checkpoint tag resolution, curriculum
 schedules, directory archiving, encoder-trained heuristics, the val-AUC quality floor, SHAP
 output normalization, the rf_train dataset producer-await/fallback composition
-(_obtain_rf_dataset), and the training stage machine (skip-if-done / record-failure semantics
-against a stub pipeline)."""
+(_obtain_rf_dataset), the rf_plots overlap coordinator (plot_rf_diagnostics), and the training
+stage machine (skip-if-done / record-failure semantics against a stub pipeline)."""
 
 from __future__ import annotations
 
 import logging
 import math
 import os
+import threading
 import types
 
 import numpy as np
@@ -613,6 +614,121 @@ class TestCheckValAucFloor:
             "single-class" in r.message and "cannot be evaluated" in r.message
             for r in caplog.records
         )
+
+
+class TestPlotRfDiagnosticsOverlap:
+    """plot_rf_diagnostics overlaps the SHAP computation (background thread) with the five
+    non-SHAP plots: the SHAP plots run only after the thread joins, and a SHAP-compute failure
+    is recorded once per SHAP plot exactly as the sequential path would have recorded it."""
+
+    NON_SHAP = [
+        "plot_rf_confusion_matrices",
+        "plot_rf_classification_curves",
+        "plot_rf_calibration_curve",
+        "plot_rf_ensemble_accuracy_curve",
+        "plot_rf_latent_decision_boundary",
+    ]
+    SHAP = [
+        "plot_rf_shap_summary",
+        "plot_rf_shap_dependence",
+        "plot_rf_shap_interactions",
+        "plot_rf_shap_loss_monitoring",
+        "plot_rf_shap_explanation_clustering",
+    ]
+
+    @staticmethod
+    def _recorder(log, name):
+        def _record():
+            log.append(name)
+
+        return _record
+
+    def _pipeline(self, log, shap_compute=None, artifacts_error=None):
+        pipeline = TrainingPipeline.__new__(TrainingPipeline)
+        for name in self.NON_SHAP + self.SHAP:
+            setattr(pipeline, name, self._recorder(log, name))
+
+        def _load_artifacts(tag=None):
+            if artifacts_error is not None:
+                raise artifacts_error
+            log.append("load_artifacts")
+            return {"tag": "test_v1"}
+
+        pipeline._load_rf_eval_artifacts = _load_artifacts
+        pipeline._compute_or_load_shap_values = shap_compute or (
+            lambda artifacts: log.append("shap_done")
+        )
+        return pipeline
+
+    def test_shap_plots_wait_for_background_compute(self):
+        # The stubbed SHAP compute refuses to finish until the last non-SHAP plot releases it,
+        # so "shap_done" preceding every SHAP plot in the log proves the join, and the non-SHAP
+        # names preceding "shap_done" prove they were not serialized behind the compute.
+        log = []
+        release = threading.Event()
+
+        def _shap_compute(artifacts):
+            assert release.wait(timeout=30), "non-SHAP plots never released the SHAP stub"
+            log.append("shap_done")
+
+        pipeline = self._pipeline(log, shap_compute=_shap_compute)
+
+        def _last_non_shap_plot():
+            log.append("plot_rf_latent_decision_boundary")
+            release.set()
+
+        pipeline.plot_rf_latent_decision_boundary = _last_non_shap_plot
+
+        pipeline.plot_rf_diagnostics()
+
+        assert log == ["load_artifacts", *self.NON_SHAP, "shap_done", *self.SHAP]
+
+    def test_shap_failure_records_every_shap_plot_and_spares_the_rest(self, caplog):
+        log = []
+
+        def _shap_compute(artifacts):
+            raise RuntimeError("SHAP exploded")
+
+        pipeline = self._pipeline(log, shap_compute=_shap_compute)
+        with (
+            caplog.at_level(logging.ERROR, logger="aetherscan.train"),
+            pytest.raises(RuntimeError) as excinfo,
+        ):
+            pipeline.plot_rf_diagnostics()
+
+        # All five SHAP plot names failed, in order — the same bookkeeping the sequential path
+        # produces when each plot hits the same compute error — and each got the per-plot
+        # "Failed to execute" record; the non-SHAP successes are untouched.
+        assert str(excinfo.value) == "5 plot(s) failed: " + ", ".join(self.SHAP)
+        assert [entry for entry in log if entry in self.NON_SHAP] == self.NON_SHAP
+        assert not any(entry in self.SHAP for entry in log)  # never invoked without values
+        for name in self.SHAP:
+            assert any(
+                f"Failed to execute {name}: SHAP exploded" in r.message for r in caplog.records
+            )
+
+    def test_non_shap_failure_is_isolated(self):
+        log = []
+        pipeline = self._pipeline(log)
+
+        def _boom():
+            raise ValueError("bad plot")
+
+        pipeline.plot_rf_calibration_curve = _boom
+        with pytest.raises(RuntimeError) as excinfo:
+            pipeline.plot_rf_diagnostics()
+
+        assert str(excinfo.value) == "1 plot(s) failed: plot_rf_calibration_curve"
+        # The SHAP plots still ran, after the join.
+        assert log[-len(self.SHAP) :] == self.SHAP
+
+    def test_artifact_load_failure_falls_back_to_sequential_order(self):
+        # Preserves the pre-overlap path: every plot is still attempted individually, in the
+        # original interleaved order (in production each would re-raise the load error itself).
+        log = []
+        pipeline = self._pipeline(log, artifacts_error=FileNotFoundError("no artifacts"))
+        pipeline.plot_rf_diagnostics()
+        assert log == self.NON_SHAP[:2] + self.SHAP + self.NON_SHAP[2:]
 
 
 class _StageMachineStub:

--- a/tests/unit/test_train_utils.py
+++ b/tests/unit/test_train_utils.py
@@ -2,7 +2,8 @@
 
 """Unit tests for aetherscan.train pure-logic helpers: checkpoint tag resolution, curriculum
 schedules, directory archiving, encoder-trained heuristics, the val-AUC quality floor, SHAP
-output normalization, and the training stage machine (skip-if-done / record-failure semantics
+output normalization, the rf_train dataset producer-await/fallback composition
+(_obtain_rf_dataset), and the training stage machine (skip-if-done / record-failure semantics
 against a stub pipeline)."""
 
 from __future__ import annotations
@@ -16,6 +17,7 @@ import numpy as np
 import pytest
 
 from aetherscan.config import get_config
+from aetherscan.round_data import RoundDataPaths
 from aetherscan.run_state import (
     STAGE_FINAL_SAVE,
     STAGE_HF_UPLOAD,
@@ -222,6 +224,10 @@ class TestTrainRandomForestSkipIsLoud:
         pipeline.rf_model = types.SimpleNamespace(is_trained=True)
         pipeline._rf_loaded_from_tag = "test_v27"
         pipeline.rf_training_skipped_from_tag = None
+        # The skip path winds down a pending producer RF pre-generation (moot once the
+        # stage is skipped) — none exists here, the shutdown must be a clean no-op
+        pipeline._round_producer = None
+        pipeline._rf_producer_request = None
 
         with caplog.at_level(logging.WARNING, logger="aetherscan.train"):
             pipeline.train_random_forest()
@@ -230,6 +236,141 @@ class TestTrainRandomForestSkipIsLoud:
         assert any(
             "RF training SKIPPED" in r.message and "test_v27" in r.message for r in caplog.records
         )
+
+
+class _FakeRfProducer:
+    """await_round/shutdown recorder standing in for RoundDataProducer."""
+
+    def __init__(self, log, error=None):
+        self._log = log
+        self._error = error
+        self.shutdown_calls = 0
+
+    def await_round(self, round_idx):
+        self._log.append(("await", round_idx))
+        if self._error is not None:
+            raise self._error
+        return {"n_samples": 8}
+
+    def shutdown(self):
+        self.shutdown_calls += 1
+        self._log.append(("shutdown",))
+
+
+class _FakeRfDataGenerator:
+    """generate_round recorder standing in for DataGenerator on the in-process path."""
+
+    def __init__(self, log):
+        self._log = log
+
+    def generate_round(self, paths, n_samples, snr_base, snr_range, round_num=None):
+        self._log.append(("generate", paths.round_dir, n_samples, snr_base, snr_range, round_num))
+
+
+class TestObtainRfDataset:
+    """_obtain_rf_dataset composes producer await -> shutdown -> manifest reuse ->
+    in-process fallback. Every resume/fallback path is pinned: producer-success,
+    producer-error (falls back in-process), no-producer fresh generation, valid-dir
+    reuse, and the defensive request-less-producer wind-down."""
+
+    def _pipeline(self, log, producer=None, request=None):
+        pipeline = TrainingPipeline.__new__(TrainingPipeline)
+        pipeline.config = get_config()
+        pipeline.config.training.num_training_rounds = 20
+        pipeline._round_producer = producer
+        pipeline._rf_producer_request = request
+        pipeline.data_generator = _FakeRfDataGenerator(log)
+        return pipeline
+
+    def _patch_validate(self, monkeypatch, log, manifest):
+        def _validate(paths, expected_n_samples=None, expected_array_dtype=None):
+            log.append(("validate", paths.round_dir, expected_n_samples, expected_array_dtype))
+            return manifest
+
+        monkeypatch.setattr("aetherscan.train.validate_done_manifest", _validate)
+
+    def _rf_paths(self, tmp_path):
+        return RoundDataPaths(round_dir=os.path.join(str(tmp_path), "rf"), round_idx=0)
+
+    def test_producer_success_reuses_result_without_regenerating(self, tmp_path, monkeypatch):
+        log = []
+        producer = _FakeRfProducer(log)
+        pipeline = self._pipeline(log, producer=producer, request=21)
+        self._patch_validate(monkeypatch, log, manifest={"n_samples": 8})
+        rf_paths = self._rf_paths(tmp_path)
+
+        pipeline._obtain_rf_dataset(rf_paths, 8, 10.0, 40.0)
+
+        # Await precedes the manifest check (validating mid-write would race the
+        # fallback's regeneration against live producer writes), shutdown lands exactly
+        # once, and the producer's dataset is consumed without a regeneration
+        assert log == [
+            ("await", 21),
+            ("shutdown",),
+            ("validate", rf_paths.round_dir, 8, pipeline.config.training.round_array_dtype),
+        ]
+        assert producer.shutdown_calls == 1
+        assert pipeline._round_producer is None
+        assert pipeline._rf_producer_request is None
+
+    def test_producer_error_falls_back_to_in_process_generation(self, tmp_path, monkeypatch):
+        log = []
+        producer = _FakeRfProducer(log, error=RuntimeError("producer exploded"))
+        pipeline = self._pipeline(log, producer=producer, request=21)
+        self._patch_validate(monkeypatch, log, manifest=None)
+        rf_paths = self._rf_paths(tmp_path)
+
+        pipeline._obtain_rf_dataset(rf_paths, 8, 10.0, 40.0)
+
+        # Producer failure still shuts it down exactly once, then the unchanged
+        # in-process path runs with the same num_training_rounds+1 sentinel round_num
+        assert log == [
+            ("await", 21),
+            ("shutdown",),
+            ("validate", rf_paths.round_dir, 8, pipeline.config.training.round_array_dtype),
+            ("generate", rf_paths.round_dir, 8, 10.0, 40.0, 21),
+        ]
+        assert producer.shutdown_calls == 1
+        assert pipeline._round_producer is None
+
+    def test_no_producer_generates_in_process(self, tmp_path, monkeypatch):
+        # Overlap disabled, sequential mode, or a resumed run entering rf_train directly
+        # (startup cleanup deleted any stale rf dir, so validation fails and regenerates)
+        log = []
+        pipeline = self._pipeline(log, producer=None, request=None)
+        self._patch_validate(monkeypatch, log, manifest=None)
+        rf_paths = self._rf_paths(tmp_path)
+
+        pipeline._obtain_rf_dataset(rf_paths, 8, 10.0, 40.0)
+
+        assert log == [
+            ("validate", rf_paths.round_dir, 8, pipeline.config.training.round_array_dtype),
+            ("generate", rf_paths.round_dir, 8, 10.0, 40.0, 21),
+        ]
+
+    def test_no_producer_valid_dir_is_reused(self, tmp_path, monkeypatch):
+        log = []
+        pipeline = self._pipeline(log, producer=None, request=None)
+        self._patch_validate(monkeypatch, log, manifest={"n_samples": 8})
+
+        pipeline._obtain_rf_dataset(self._rf_paths(tmp_path), 8, 10.0, 40.0)
+
+        assert [entry[0] for entry in log] == ["validate"]
+
+    def test_producer_without_pending_request_is_still_shut_down(self, tmp_path, monkeypatch):
+        # Defensive: a live producer with no RF request pending must be wound down, not
+        # leaked (and not awaited — there is nothing to wait for)
+        log = []
+        producer = _FakeRfProducer(log)
+        pipeline = self._pipeline(log, producer=producer, request=None)
+        self._patch_validate(monkeypatch, log, manifest=None)
+        rf_paths = self._rf_paths(tmp_path)
+
+        pipeline._obtain_rf_dataset(rf_paths, 8, 10.0, 40.0)
+
+        assert log[0] == ("shutdown",)
+        assert not any(entry[0] == "await" for entry in log)
+        assert producer.shutdown_calls == 1
 
 
 class _PipelineStub:


### PR DESCRIPTION
Closes #289

## Summary

Four workstreams, one branch, per maintainer direction: (1) the #289 DB write-path hardening; (2) the fp16/bf16 flag **decisions** from the val-metric A/B campaign — **fp16 default flipped ON (gate passed), bf16 stays off (gate failed on a reproducible pathology)**; (3) the L1/L2 regularization arc — activated on maintainer instruction, **measured harmful, reverted to a default-off observable flag**, calibration filed as #293; (4) the remaining performance items: a full DB index audit, RF-dataset pre-generation on the producer, SHAP/plot overlap, and the GIF-grid trim.

## 1. #289 — NaN stats can no longer vaporize a flush batch

- **v6 migration**: `training_stats.is_finite` (the injection_stats semantics). Non-finite/None values store as 0.0 + `is_finite=0` + a warning; `query_training_stat` filters them by default. The `DEFAULT 1` backfill is exact — a non-finite value could never have been written before (it bound as SQL NULL and the NOT NULL constraint rejected the whole batch — how bf16-seed-13 lost every RF metric in the #288 A/B).
- **Resilient flush**: a failed `executemany` batch falls back to per-row inserts — only the unbindable row(s) drop, with an exact count logged. Before: one bad row silently discarded every row in the flush, across all tables.
- Unit tests: NaN/None storage + filtering + same-batch survival, poisoned-batch fallback, v6 migration backfill.

## 2. Flag decisions (the pre-agreed gate, judged on the unregularized configuration)

Evidence: two batches of seeded scaled-shape runs (2×30, 48000/9600, blpc3), combined at the **distribution level** — a methodology note below explains why same-seed cross-build pairing is invalid.

| arm | seeds | val AUC | recall@0.01FPR | active units | calibration trips |
|---|---|---|---|---|---|
| control | 6 | .9925–.9990 | .9449–.9907 | 6–8 | 0 |
| fp16 | 4 | **≥ .9979 all** | .9619–.9907 (all inside control spread) | 7–8 | 0 |
| bf16 | 7 | .9807–.9991 | **.8432**–.9961 | 6–8 | **2 (both seed 13)** |

- **fp16 → `training.round_array_dtype = "float16"` by default.** Every seed inside the control envelope on every metric. Payoff: round footprint ~294.5 → ~147 GB, gather volume and page-cache working set halved — the lever that matters once two overlapped rounds (~589 GB fp32) exceed the hosts' 503 GB RAM, and it halves the release run's `--keep-round-data` disk. `"float32"` restores the historical input numerics byte-for-byte; `.done` manifests gate every reuse/resume path by dtype; the cli disk-budget guard is dtype-aware.
- **bf16 → stays `False`.** Six of seven seeds clean — but seed 13 reproducibly degrades (recall .8432 / val .9807 vs the .9449 / .9925 control floor), and bf16-seed-13 was the *only* configuration to trip the ECE→calibrator gate, twice, across configs (its first trip is also what exposed #289). A real bf16-specific trajectory pathology; the +1.15× step / ~halved-VRAM upside stays on the table pending an explanation.
- **Gate refinement, recorded in docs**: the "identical active-dim count" criterion is retired — the *controls themselves* flip AU 6–8 across seeds at this shape. The per-dim variance logging added in this PR (see §4) is what shows those flips are marginal-dim wobble, not collapses — and is the criterion's replacement.

## 3. The regularization arc (activate → measure → revert), and #293

The #288 audit's M5 flag is confirmed at code level: the conv layers' declared L1/L2 regularizers were **dead code since inception** — the custom loop never consumed `model.losses`, so every model this pipeline has trained is effectively unregularized. On maintainer instruction they were activated; the 5-seed A/B measured the declared (never-calibrated) coefficients as clearly harmful — recall median .984 → .954 with a worst seed of **.72**, and 1–4 latent dims per seed pushed dark (one seed lost half the latent space). Reverted on maintainer instruction:

- `beta_vae.regularization_active` (default `False`) — the objective is byte-identical to the historical pipeline.
- `reg_loss` is **computed and recorded in every run regardless** (keras materializes the activity penalties anyway — observability costs one `add_n`): new stat rows, a fifth loss-curves panel, and the per-dim variance log line. #293 inherits a ready-made harness plus live data in every future baseline.
- Two crashes/fixes from the arc, both caught by the new blpc3 container **test gate** that now fronts every cluster batch: the FuncGraph stranding (clustering-loss fns inlined — see the bit-compat note) and two test-side arity/determinism fixes.
- **#293** carries the calibration campaign: the declared coefficients are plausibly ~two orders too strong (keras batch-SUM activity scaling × per-forward accrual), with the full measurement as evidence.

## 4. Performance

- **DB index audit** (maintainer mandate; all folded into one unreleased v7 migration; every claim benched with EXPLAIN-verified planner choices, no ANALYZE dependence):
  - `injection_stats`: the stat-scoped index — the end-of-run plot pass (~165 queries) extrapolated to **~6 h of scanning at 367M-row release scale; now ~8 min** (14.4× per query at 2M rows). Write cost disclosed: bulk insert throughput −61%, still ~235× over the lane's real demand. The trailing-`timestamp` shape is deliberate: a `round_number`-trailing variant is *never chosen* by the planner without `sqlite_stat1` (measured; recorded so it isn't "fixed" back).
  - `latent_snapshots`: reshaped to the GIF fetch key — **209 → 3.1 ms per frame fetch (67×; ~1.46 h → ~1.6 s at 100M-row release scale)**, dashboard latest-capture 595 → ~0 ms, write cost +0.9% (both shapes append at the B-tree right edge). Old index dropped.
  - **Measured rejection, recorded**: a training_stats reshape wins one minor query but makes the dominant loss-curves query 1.8× *slower* and costs −19.5% insert throughput. Every other table: left alone with the arithmetic shown. `bench_db_index_shapes.py` + `bench_injection_index.py` reproduce all numbers.
- **RF-dataset pre-generation on the producer**: the producer now generates the RF set during the last round's training (byte-identical: same seed-derivation sentinel; pinned by a test driving the real spawn protocol against in-process generation). Await → validate → unchanged in-process fallback; all eight lifecycle paths (success/error/no-producer/resume×2/crash/skips/teardown) pinned with an ordered event log. Every A/B matrix run exercised this path end-to-end at scale.
- **SHAP overlap + single pool**: rf_plots renders the 5 non-SHAP diagnostics while SHAP computes on a background thread (wall saving ≈ min(SHAP, plots)); one forkserver pool serves all three passes with per-pass-family explainer caching and ~4 chunks/worker straggler smoothing. Bitwise contract pinned (pooled ≡ single-process per pass); failure semantics preserved exactly, with one intentional delta: a failed SHAP compute no longer re-attempts the ~1.4 h computation five times to record five failures.
- **GIF sweep default 24 → 18 combos** (`n_neighbors` 30 dropped as redundant between 15 and 50 — maintainer request).

## Validation

- Container test gates fronted every cluster batch (the gate caught two real bugs before they cost matrix hours); full unit suite green on the final tip: **960 passed**, 5 deselected, 6m03s on the final tip.
- 25 scaled A/B runs across three matrices (5 reg-on controls, 9-run final decision matrix, plus the #288-era batch), every completed run exit-0 on the final code.
- Tip mini-run (fp16 as default, producer RF pre-gen, SHAP overlap, single-combo GIF): **clean end-to-end, exit 0** (2 rounds × 5 epochs at 48000/9600). Exercised in one run: fp16 as the default (dtype-recorded manifests, including retry-reuse through the dtype gates), the producer-delivered RF dataset (**0.0 s wait** at rf_train; reused across retries), the SHAP/plot overlap, and all 10 RF diagnostics. The mini-run also caught the last bug in this PR — the hardcoded 48-name SHAP feature list breaking on a 54-feature variant winner (`52ccecf`, pre-existing #282 fallout that no prior run had tripped) — and surfaced one pre-existing CLI validation gap worth a follow-up issue: `--num-samples-rf 1600` passes parse-time validation despite conflicting with the effective batch on a 5-GPU host (the runtime backstop catches it, as designed).

## Notes for reviewers

- **Bit-compat break, loud and deliberate**: inlining the clustering-loss fns (the FuncGraph fix) changed float summation order — same-seed results across builds differ slightly; within-build determinism is preserved and pinned by the existing test suite. This is why the A/B evidence combines batches at the distribution level only.
- Commit history carries three cross-workstream sweeps (concurrent agents sharing files: `4d931ae`, `7b45c7c`, and the docs half of the SHAP change) — content is correct and complete; the messages note the sweeps.
- blpc3's disposable test DB accumulated pre-reshape v7 index names during the matrices; it gets dropped in the post-merge teardown. No production DB is affected (bla0 migrates v5 → v7 cleanly on its restart).
- The GIF-sweep worker-cap benchmark (bandwidth-contention question) is recorded in the handoff as a production-scale follow-up measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
