### PR TITLE
Round-2 inference optimizations: catalog-scale survivability, stamp-cache pruning, saved-config allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -924,10 +924,12 @@ options:
                         background (0 disables)
   --prefetch-depth PREFETCH_DEPTH
                         Cadences preprocessed+loaded ahead of the GPU stage in
-                        the streaming loop (>= 1). Depth 2 overlaps one
-                        cadence's energy-detection reads with the previous
-                        one's stamp extraction, costing one extra in-flight
-                        cadence of RAM; outputs are identical at any depth
+                        the streaming loop (>= 1). Each unit of depth overlaps
+                        energy-detection reads with stamp extraction and the
+                        serial per-cadence sections, costing one in-flight
+                        cadence of RAM (up to ~65 GB for RFI-dense C-band
+                        cadences); outputs are identical at any depth
+                        (default: 3 per the on-cluster A/B)
   --cadence-group-by-cols CADENCE_GROUP_BY_COLS [CADENCE_GROUP_BY_COLS ...]
                         Space-separated list of CSV column names whose joint
                         value defines cadence membership (e.g., Target Session

--- a/README.md
+++ b/README.md
@@ -414,9 +414,9 @@ The Aetherscan training pipeline exposes the following CLI flags to the user. Re
 ```
 usage: train [-h] [--seed SEED] [--unseeded]
              [--tf-deterministic-ops | --no-tf-deterministic-ops]
-             [--data-path DATA_PATH] [--model-path MODEL_PATH]
-             [--output-path OUTPUT_PATH] [--dashboard | --no-dashboard]
-             [--dashboard-port DASHBOARD_PORT]
+             [--n-processes N_PROCESSES] [--data-path DATA_PATH]
+             [--model-path MODEL_PATH] [--output-path OUTPUT_PATH]
+             [--dashboard | --no-dashboard] [--dashboard-port DASHBOARD_PORT]
              [--benchmark-report | --no-benchmark-report]
              [--vae-latent-dim VAE_LATENT_DIM]
              [--vae-dense-layer-size VAE_DENSE_LAYER_SIZE]
@@ -498,6 +498,13 @@ options:
                         Default: enabled — without it, cuDNN autotune noise
                         can flip near-threshold candidates between identical
                         runs; opt out with --no-tf-deterministic-ops
+  --n-processes N_PROCESSES
+                        Worker-process count for the multiprocessing pools
+                        (energy detection + stamp extraction at inference;
+                        data generation at training). Default: all cores. Host
+                        tuning: never layered from a saved --config-path, so a
+                        config recorded on a bigger host cannot oversubscribe
+                        this one (must be >= 1)
   --data-path DATA_PATH
                         Path to data directory (overrides AETHERSCAN_DATA_PATH
                         environment variable)
@@ -768,8 +775,9 @@ The Aetherscan inference pipeline exposes the following CLI flags to the user. R
 ```
 usage: inference [-h] [--seed SEED] [--unseeded]
                  [--tf-deterministic-ops | --no-tf-deterministic-ops]
-                 [--data-path DATA_PATH] [--model-path MODEL_PATH]
-                 [--output-path OUTPUT_PATH] [--dashboard | --no-dashboard]
+                 [--n-processes N_PROCESSES] [--data-path DATA_PATH]
+                 [--model-path MODEL_PATH] [--output-path OUTPUT_PATH]
+                 [--dashboard | --no-dashboard]
                  [--dashboard-port DASHBOARD_PORT]
                  [--benchmark-report | --no-benchmark-report]
                  [--num-replicas NUM_REPLICAS]
@@ -801,7 +809,9 @@ usage: inference [-h] [--seed SEED] [--unseeded]
                  [--overlap-search | --no-overlap-search]
                  [--overlap-fraction OVERLAP_FRACTION]
                  [--preprocess-output-dir PREPROCESS_OUTPUT_DIR]
+                 [--prune-stamps | --no-prune-stamps]
                  [--inference-viz | --no-inference-viz]
+                 [--inference-viz-scope {full,new}]
                  [--stamp-gallery-top-k STAMP_GALLERY_TOP_K]
                  [--max-candidate-plots MAX_CANDIDATE_PLOTS]
                  [--max-retries MAX_RETRIES] [--retry-delay RETRY_DELAY]
@@ -828,6 +838,13 @@ options:
                         Default: enabled — without it, cuDNN autotune noise
                         can flip near-threshold candidates between identical
                         runs; opt out with --no-tf-deterministic-ops
+  --n-processes N_PROCESSES
+                        Worker-process count for the multiprocessing pools
+                        (energy detection + stamp extraction at inference;
+                        data generation at training). Default: all cores. Host
+                        tuning: never layered from a saved --config-path, so a
+                        config recorded on a bigger host cannot oversubscribe
+                        this one (must be >= 1)
   --data-path DATA_PATH
                         Path to data directory (overrides AETHERSCAN_DATA_PATH
                         environment variable)
@@ -925,10 +942,12 @@ options:
                         Number of fine channels per coarse channel (default:
                         1048576)
   --coarse-channel-log-interval COARSE_CHANNEL_LOG_INTERVAL
-                        Progress-logging chunk size for energy detection, in
-                        coarse channels per log line (default: the number of
-                        worker processes). Parallelism itself comes from the
-                        persistent worker pool, not this knob.
+                        Progress-logging cadence for energy detection, in
+                        coarse channels per log line. Default: ~25% milestone
+                        lines per ON file (the per-channel lines were 62% of a
+                        run's Slack-bound log volume); pass an explicit N to
+                        restore every-N-channels lines. Parallelism itself
+                        comes from the persistent worker pool, not this knob.
   --bandpass-method BANDPASS_METHOD
                         Bandpass flattening method for energy detection: 'pfb'
                         (default) divides each coarse channel by the
@@ -985,6 +1004,18 @@ options:
                         directory. Pass a directory explicitly to pin/share
                         one location (reuse is still guarded by the sidecar's
                         recorded h5 paths and ED fingerprint)
+  --prune-stamps, --no-prune-stamps
+                        Delete each cadence's stamp .npy right after its
+                        'inferred' manifest row lands, keeping the metadata
+                        .json plus a ~196 KB snippet sidecar per candidate —
+                        resume rides the DB row, and only stamps this run
+                        freshly extracted are ever pruned. Without pruning a
+                        full catalog writes ~30-90 TB of stamps. Default: AUTO
+                        — enabled for the fingerprint-scoped default cache
+                        directory, disabled when --preprocess-output-dir is
+                        set explicitly. Pass --no-prune-stamps to keep every
+                        stamp (slice-scale runs wanting the cross-run rerun
+                        cache).
   --inference-viz, --no-inference-viz
                         Render the inference visualization suite (energy
                         detection distributions, hit spectrum, bandpass
@@ -994,6 +1025,15 @@ options:
                         plots/inference/{save_tag}/ and uploaded to Slack
                         (default: enabled). Pass --no-inference-viz to
                         disable.
+  --inference-viz-scope {full,new}
+                        Which cadences the metadata-driven viz figures cover:
+                        'full' (default) renders the whole accumulated tag
+                        every successful pass; 'new' renders only cadences
+                        inferred this pass — recommended for resumed multi-
+                        pass catalog campaigns, where 'full' re-pays the
+                        entire catalog's viz tail on every pass. DB-sourced
+                        candidate figures always cover the full tag either
+                        way.
   --stamp-gallery-top-k STAMP_GALLERY_TOP_K
                         Number of top-statistic stamps shown in the stamp
                         gallery figure, each as a 6-observation waterfall grid

--- a/docs/CONFIG_AND_CLI.md
+++ b/docs/CONFIG_AND_CLI.md
@@ -37,7 +37,9 @@ parse_args()                       ── argparse picks the specified subparser
    ▼
 apply_saved_config(config_path)    ── only runs on args.command == inference and args.config_path
    │                                  is not None:
-   │                                  overrides the singleton defaults at runtime with a saved JSON
+   │                                  layers the saved JSON's allowlisted model-contract fields
+   │                                  onto the singleton defaults (#303); every other saved field
+   │                                  is ignored (logged when it differs from the resolved value)
    │
    ▼
 validate_args(args)                ── raises ValueError on any failure (no mutation)
@@ -53,11 +55,28 @@ apply_args_to_config(args)         ── writes non-None args onto the Config s
 train_command() / inference_command()
 ```
 
-Priority order:
+Priority order, for the fields a saved config is allowed to layer:
 
 ```
 runtime defaults  <  loaded config  <  CLI args
 ```
+
+`apply_saved_config` is **allowlist-only** (#303): a saved training config layers exactly
+the model-contract / result-affecting fields — the whole `beta_vae` section, the RF's
+deployed-representation contract (`latent_variant` / `active_dims` / `calibration_active` /
+`calibration_method` — not `n_jobs`, not seeds), the data geometry keys, and precisely the
+inference fields the resume fingerprints hash minus the artifact paths. Everything else —
+paths (in nested or legacy flat form), `gpu`, `manager`, `db` / `logger` / `monitor`, `hf`,
+`training`, `checkpoint`, and `reproducibility` — always comes from env + defaults + CLI,
+and every ignored saved field whose value differs from the resolved one is logged as a
+startup diff line, so nothing disappears silently. The old inverse design (apply everything
+minus a skip-list) left every host-scoped field unsafe by default — the live footgun being
+`manager.n_processes`: a config saved on a 96-core host silently 3×-oversubscribed a
+32-core host's worker pool, with no CLI rescue before `--n-processes` existed. The
+allowlist is **derived from `run_state.py`'s fingerprint key sets** and pinned by a drift
+test, so `cli.py` and `run_state.py` can never silently disagree about what is
+result-affecting: a new result-affecting field defaults to layering, a new host field
+defaults to ignored — both fail-safe.
 
 ## The configuration singleton
 
@@ -144,9 +163,9 @@ The `_add_*_flags_to(parser)` indirection exists so utility scripts (e.g.
 `utils/find_optimal_configs.py`) can expose the exact same flag surface against an
 arbitrary parser — they import the helper and call it on their own parser without
 re-declaring every argument. Both helpers additionally call
-`_add_reproducibility_flags_to(parser)` first, registering the shared `--seed` /
-`--tf-deterministic-ops` flags (#279) through one function so the train and inference
-surfaces cannot drift.
+`_add_reproducibility_flags_to(parser)` and `_add_runtime_flags_to(parser)` first,
+registering the shared `--seed` / `--tf-deterministic-ops` (#279) and `--n-processes`
+(#303) flags through one function each so the train and inference surfaces cannot drift.
 
 ### Flag categories
 
@@ -167,7 +186,8 @@ if hasattr(args, "num_samples_beta_vae") and args.num_samples_beta_vae is not No
 ```
 
 Examples: most flags (`--num-samples-beta-vae`, `--curriculum-schedule`,
-`--encoder-path`, `--screening-threshold`, `--mc-draws`, `--overlap-fraction`, ...). The
+`--encoder-path`, `--screening-threshold`, `--mc-draws`, `--overlap-fraction`,
+`--prune-stamps`, `--inference-viz-scope`, ...). The
 `hasattr` check is what gives the
 guarantee — argparse simply doesn't add inference-only attributes to a train namespace
 (and vice versa), so `hasattr` is False for any other mode.
@@ -203,6 +223,7 @@ Current Pattern B flags:
 - `--benchmark-report` / `--no-benchmark-report` (`BooleanOptionalAction`) → `config.monitor.benchmark_report_enabled`
 - `--seed` / `--unseeded` → `config.reproducibility.seed` (registered via `_add_reproducibility_flags_to`; `--unseeded` sets it to None, mutually exclusive with `--seed`)
 - `--tf-deterministic-ops` (`BooleanOptionalAction`) → `config.reproducibility.tf_deterministic_ops` (same helper)
+- `--n-processes` → `config.manager.n_processes` (registered via the shared `_add_runtime_flags_to` helper, #303; validated `>= 1` — the operator override for worker-pool sizing, which is never layered from a saved `--config-path`)
 
 #### Pattern C — shared flag, divergent destination
 
@@ -261,7 +282,8 @@ effective value the pipeline would use even when a flag is omitted.
 In `inference` mode, `apply_saved_config(args.config_path)` runs immediately
 after `parse_args` and before `validate_args` — so by the time validation kicks in,
 the singleton's defaults at runtime have already been overridden by the saved JSON's
-fields, allowing `_resolve` to return the correct value.
+allowlisted fields (#303 — see the layering rules above), allowing `_resolve` to return
+the correct value.
 
 Three things to know:
 
@@ -272,7 +294,14 @@ Three things to know:
    `_solve_cross_param_constraints`, `_check_cross_constraints`) to append a
    `Suggested fixes:` block to the error message. The standalone
    [`utils/find_optimal_configs.py`](#diagnosing-config-issues-with-find_optimal_configspy) script exercises the same proposer for ad-hoc
-   "what config would work on N GPUs?" queries.
+   "what config would work on N GPUs?" queries. The cross-parameter checks include, since
+   #297, the RF train-split floor —
+   `num_samples_rf * train_val_split >= effective_batch_size`, a `>=` floor only
+   (deliberately not divisibility: the runtime split trims to a multiple of the effective
+   batch, and the defaults rely on the trim) — because below one full batch the split
+   trims to zero and the run dies at `rf_train` *after* the beta-VAE rounds already
+   trained; the same floor is mirrored in `_check_cross_constraints` so the suggested-fix
+   solver can never propose a config that dies there.
 
 2. **`num_replicas` is resolved ahead of time** by `_resolve_num_replicas(args)`, in
    priority order: `args.num_replicas` if the user passed `--num-replicas`, else
@@ -415,7 +444,8 @@ mode && /^ *"--/{
 The second command lists every shared flag (those appearing in both subparsers); each
 should match either a single Pattern B `apply_args` block or a pair of Pattern C blocks
 with a `command` discriminator. Note the awk only sees flags registered lexically inside
-the two `_add_*_flags_to` bodies — `--seed` / `--tf-deterministic-ops` live in the shared
-`_add_reproducibility_flags_to` helper (called by both) and must be counted by hand. As of
-this writing the command yields 15 flags; with the two helper-registered ones the shared
-surface is 17 — 14 Pattern B + 3 Pattern C.
+the two `_add_*_flags_to` bodies — `--seed` / `--tf-deterministic-ops` / `--n-processes`
+live in the shared `_add_reproducibility_flags_to` / `_add_runtime_flags_to` helpers
+(called by both) and must be counted by hand. As of this writing the command yields 15
+flags; with the three helper-registered ones the shared surface is 18 — 15 Pattern B +
+3 Pattern C.

--- a/docs/CONFIG_AND_CLI.md
+++ b/docs/CONFIG_AND_CLI.md
@@ -73,10 +73,16 @@ startup diff line, so nothing disappears silently. The old inverse design (apply
 minus a skip-list) left every host-scoped field unsafe by default — the live footgun being
 `manager.n_processes`: a config saved on a 96-core host silently 3×-oversubscribed a
 32-core host's worker pool, with no CLI rescue before `--n-processes` existed. The
-allowlist is **derived from `run_state.py`'s fingerprint key sets** and pinned by a drift
-test, so `cli.py` and `run_state.py` can never silently disagree about what is
-result-affecting: a new result-affecting field defaults to layering, a new host field
-defaults to ignored — both fail-safe.
+inference and data sub-allowlists are **derived from `run_state.py`'s fingerprint key
+sets** and pinned by a drift test, so `cli.py` and `run_state.py` can never silently
+disagree about which inference/data fields are result-affecting; the `rf` field allowlist
+and the `beta_vae` section allowlist are literal (`rf` is in no fingerprint) and pinned by
+their own equality test. One trap this design does **not** remove: a *new* field added to
+`InferenceConfig` defaults **into** the allowlist (it is `fields(InferenceConfig)` minus the
+exclude set) and — once mirrored into `to_dict` — into both fingerprints, so a new
+host-tuning knob on `InferenceConfig` must be added to the run_state denylists explicitly,
+exactly as `prune_stamps`/`inference_viz_scope` were. Only a field added to a
+non-allowlisted section (`manager`, `gpu`, `db`, …) is ignored by default.
 
 ## The configuration singleton
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -14,7 +14,7 @@ high-volume injection-stat chunks (#277) — drained by **one background writer 
 batches rows and commits with `executemany()`; reads open short-lived connections directly.
 Failed-attempt rows are never deleted — they're flagged `superseded = 1`, and every query
 filters them out by default. Schema evolution is a minimal `PRAGMA user_version` gate
-(currently version 7).
+(currently version 8).
 
 > [!IMPORTANT]
 > The write queue is a **thread** queue, not process-safe. Worker *processes* must never call
@@ -258,7 +258,12 @@ per-cadence aggregates that summaries need live in the manifest table instead.
 | `screening_proba` | REAL | Deterministic pass-1 score of the #282 two-pass cascade (v5) |
 | `mc_mean`, `mc_std` | REAL | Seeded MC mean/spread for pass-2 survivors — the mean carries the science threshold; NULL for snippets that never reached pass 2 (v5) |
 
-Index: `(tag, timestamp, confidence, prediction)`.
+Indexes: `(tag, timestamp, confidence, prediction)` plus, since v8, the partial
+`idx_inference_results_supersede` on `(tag, npy_path) WHERE superseded = 0` — matching
+`_execute_mark_superseded`'s exact predicate. The once-per-cadence supersede UPDATE blocks
+the inference thread via the writer-queue sentinel, and the timestamp-led index only
+narrowed it to the tag partition — a quadratic-in-catalog term on RFI-dense 6k-cadence
+runs (#301).
 
 ### `inference_cadences` (run manifest, schema v2)
 
@@ -300,7 +305,7 @@ attempt, each with its own span.
 ## Schema migration
 
 `_migrate_schema()` runs on every startup, gated on `PRAGMA user_version`
-(`_SCHEMA_VERSION = 7`). The stamp maps to schema features as:
+(`_SCHEMA_VERSION = 8`). The stamp maps to schema features as:
 
 | `user_version` | What it added | Migration work |
 | --- | --- | --- |
@@ -312,6 +317,7 @@ attempt, each with its own span.
 | v5 | `screening_proba` / `mc_mean` / `mc_std` on `inference_results` (#282 two-pass inference) | additive `ALTER TABLE ... ADD COLUMN` |
 | v6 | `is_finite INTEGER DEFAULT 1` on `training_stats` (#289 NaN-write hardening) | additive `ALTER TABLE ... ADD COLUMN` |
 | v7 | the index sweep: the `idx_injection_stats_by_stat` secondary index on `injection_stats`; `latent_snapshots`' index reshaped to `idx_latent_snapshots_by_key` | `DROP INDEX IF EXISTS idx_latent_snapshots_filter` in the migration block; the CREATEs run in `_init_database()` and are re-executed there |
+| v8 | the `idx_inference_results_supersede` partial index on `inference_results` (`(tag, npy_path) WHERE superseded = 0`, #301) | the `if version < 8` block creates it — deliberately NOT `_init_database()`: the partial predicate needs the `superseded` column the v1 ALTER adds, so an init-time CREATE would fail on a pre-v1 file. Fresh databases reach the block too (version 0 → current) |
 
 - **v0 → v1**: `ALTER TABLE ... ADD COLUMN superseded INTEGER DEFAULT 0` on the four tables
   above — the only in-place change SQLite supports is additive `ADD COLUMN`, which is exactly
@@ -355,8 +361,16 @@ attempt, each with its own span.
   Like v2/v4, `_init_database()` does the CREATE work — `CREATE INDEX IF NOT EXISTS` runs
   for old and new databases alike before migration; the `if version < 7` block re-executes
   the (themselves idempotent) statements, performs the DROP, and advances the stamp.
+- **v7 → v8** (`idx_inference_results_supersede`, #301): the supersede partial index on
+  `inference_results` — see [that table's index note](#inference_results). Unlike v7, the
+  `CREATE INDEX IF NOT EXISTS` lives **only** in the `if version < 8` block, never in
+  `_init_database()`: its `WHERE superseded = 0` predicate needs the column the v1 ALTER
+  adds, so an init-time CREATE would precede the ALTER and fail on a pre-v1 file. Fresh
+  databases reach the block too (version 0 → current), so both paths land the same final
+  index set.
 
-Fresh databases get the full current schema from the CREATE statements and are just stamped.
+Fresh databases get the full current schema from the CREATE statements and are just stamped
+(the one v8 exception above lands via the migration block either way).
 The pattern to follow for future changes: bump `_SCHEMA_VERSION`, add a
 `if version < N:` block with additive, idempotent statements, and rely on
 `CREATE TABLE IF NOT EXISTS` for whole new tables.
@@ -364,10 +378,10 @@ The pattern to follow for future changes: bump `_SCHEMA_VERSION`, add a
 ## Query API
 
 Each table has a `query_*` method returning `list[dict]`
-(`query_system_resource`, `query_injection_stat`, `query_injection_stat_stability`,
-`query_training_stat`, `query_latent_snapshots`, `query_latent_snapshot_keys`,
-`query_inference_result`, `query_inference_cadences`, `query_pipeline_stages`). Shared
-conventions:
+(`query_system_resource`, `query_system_resource_decimated`, `query_injection_stat`,
+`query_injection_stat_stability`, `query_training_stat`, `query_latent_snapshots`,
+`query_latent_snapshot_keys`, `query_inference_result`, `query_inference_cadences`,
+`query_pipeline_stages`). Shared conventions:
 
 - **String filters** (`tag`, `stat_name`, `status`, ...) accept a single value (`=`) or a
   list (`IN`); **range filters** come as `start_*`/`end_*` pairs (inclusive);
@@ -396,8 +410,22 @@ quadratic over a campaign as history accumulates) — `plot_injection_stats` iss
 queries per call and now pays this one aggregate up front, tightening every window to the
 plotted rounds' actual span (±1 s).
 
+**`query_system_resource_decimated(tag, start_time, end_time, max_points_per_series)`**
+(#301) returns a per-series uniformly-strided subset of `system_resources` rows (same dict
+shape as `query_system_resource`): a
+`ROW_NUMBER() OVER (PARTITION BY resource_type, resource_name ORDER BY timestamp)` window
+keeps at most `max_points_per_series` uniformly-spaced points per
+`(resource_type, resource_name)` line, with the stride computed from the largest series
+(stride 1 degenerates to the plain query). It exists for the monitor's teardown resource
+plot ([`RUNTIME_SERVICES.md`](RUNTIME_SERVICES.md)): a multi-week catalog run accumulates
+tens of millions of samples while the plot renders ~2 k px wide, so materializing every row
+cost a multi-GB teardown RAM spike for invisible detail.
+
 `get_db_stats()` returns row counts per table, the covered time range, and the database file
-size — logged at startup.
+size — **on-demand diagnostics only** since #301: its per-table `COUNT(*)` full scans
+measured ~13 min per cold-cache launch on the 80 GB production DB (re-paid on every
+retry-loop relaunch), so `Database.__init__` no longer calls it and startup logs only the
+O(1) `db_size_bytes` pragma.
 
 ## Growth expectations
 

--- a/docs/INFERENCE_PIPELINE.md
+++ b/docs/INFERENCE_PIPELINE.md
@@ -232,17 +232,27 @@ training tags and, under `--hf-upload`, checks the Hub for the tag at startup ra
    `--no-prune-stamps` override), each cadence's multi-GB stamp `.npy` is deleted right
    after its `'inferred'` manifest row lands and viz collection ran — without pruning a
    full catalog writes ~30–90 TB of stamps. The metadata `.json` always stays (provenance,
-   viz, resume guard), resume rides the DB row, and only stamps **this run freshly
-   extracted** are ever pruned (`CadenceResult.freshly_extracted`) — a resumed run never
-   deletes a cache it was handed. Before deletion each candidate's snippet (~196 KB) is
-   snapshotted into an atomic `.candidates.npz` sidecar and the viz collector pools the
-   global top-K stamp pixels (~2.4 MB), so candidate figures and the stamp gallery survive
-   pruning; `'failed'` cadences keep their stamps until they succeed. Best-effort: any
-   pruning failure keeps the stamps and the run continues. Both `prune_stamps` and
+   viz, resume guard), resume rides the DB row, and only stamps **this run extracted** are
+   ever pruned — tracked by an in-process set on the preprocessor, so a genuinely handed
+   cache (extracted by another process/operator) is never deleted, while a cadence *this*
+   run extracted then failed-and-retried IS pruned on success (a per-attempt
+   `freshly_extracted` flag alone would leak it forever, #305). Before deletion each
+   candidate's snippet (~196 KB) is snapshotted into an atomic `.candidates.npz` sidecar and
+   the viz collector pools the global top-K stamp pixels (~2.4 MB, persisted across the
+   in-process retry attempts), so candidate figures and the stamp gallery survive pruning;
+   `'failed'` cadences keep their stamps until they succeed. Best-effort: any pruning
+   failure keeps the stamps and the run continues. Both `prune_stamps` and
    `inference_viz_scope` sit in `run_state.py`'s fingerprint denylists, so fingerprints —
    and hence resume rows and cache directories — are unchanged. The trade: cross-run
    re-scoring under a new tag re-pays extraction for pruned cadences; same-run resume/retry
-   is unaffected.
+   is science-unaffected. **Limitations** (viz-only, graceful): a cross-*process* relaunch
+   can't recover an earlier process's pruned pixels, so the stamp gallery may show blank
+   columns for earlier-run cadences; and two runs sharing the default cache dir with pruning
+   ON can race (one deletes/overwrites a `.npy` or `.candidates.npz` another is mid-read of —
+   contained, self-heals via retry). Run concurrently in one dir only with a per-run
+   `--preprocess-output-dir` or `--no-prune-stamps` (a deliberate design choice — cross-
+   process file locking was deferred as disproportionate for a self-healing, science-neutral
+   race).
 7. **Failure containment.** A cadence whose inference stage throws is logged, recorded as
    `status='failed'` in the manifest, and the loop moves on — one bad cadence never aborts
    the catalog. After the loop, the pass raises so the retry loop re-attempts, and the
@@ -464,7 +474,7 @@ cadences).
 | `ed_stat_distributions_{tag}.png` | Log-log histogram of the D'Agostino–Pearson k² statistic over **all** windows (not just hits), per-ON-file overlay + total, threshold line. | The bulk should be a compact low-k² mass (noise ≈ χ², df=2) with a long RFI tail. The threshold should sit far into the tail: if the noise bulk crosses it, the stamp count explodes; if one ON file's curve is shifted, that file has a bandpass/level problem. |
 | `ed_hit_spectrum_{tag}.png` | Hit density vs frequency (MHz), pre- vs post-deduplication — rendered by rebinning each cadence's fine pre-binned `hit_spectrum_hist` (≥ 40× finer than the figure's bins) onto one global axis (#301): visually identical to histogramming the raw hit lists, which the sidecars no longer store. | Instantly shows RFI comb structure (regular spikes) and band edges. Dedup should collapse combs dramatically; a band where post-dedup density is still high dominates your stamp budget. |
 | `bandpass_flattening_{tag}.png` | Raw vs flattened integrated spectrum for a few sampled coarse channels, with the removed model (scaled PFB response H or spline fit) overlaid. Rendered from the sidecar's stored `bandpass_envelopes` when present (#301 — zero `.h5` reads at viz time); legacy sidecars keep the live-read path. | The flattened spectrum should be level across the channel. Residual scalloping under PFB means the static response doesn't match the recording — check `--pfb-taps-per-channel` or fall back to `--bandpass-method spline` (the log's edge/mid-ratio warning fires on the same condition). |
-| `stamp_gallery_{tag}.png` | Top-K stamps by detection statistic (`stamp_gallery_top_k`, default 12), each a 6-observation waterfall strip; overlap-offset copies collapsed first. Cadences pruned this run render from the collector's pooled pixels (#302); cadences pruned by an earlier pass degrade to blank columns. | The cadence layout scientists actually inspect: a real technosignature shows in ONs (rows 0/2/4) and vanishes in OFFs; the top of this gallery is virtually always bright RFI present in all six — that's expected. |
+| `stamp_gallery_{tag}.png` | Top-K stamps by detection statistic (`stamp_gallery_top_k`, default 12), each a 6-observation waterfall strip; overlap-offset copies collapsed first. Cadences pruned in this run (incl. across its in-process retries) render from the collector's pooled pixels (#302); cadences pruned by an earlier *process* (a relaunch-resume) degrade to blank columns. | The cadence layout scientists actually inspect: a real technosignature shows in ONs (rows 0/2/4) and vanishes in OFFs; the top of this gallery is virtually always bright RFI present in all six — that's expected. |
 | `preproc_funnel_{tag}.png` | Per-cadence bar funnel: raw hits → merged hits → stamps (incl. overlap copies) → snippets inferred, plus storage per cadence. Past 120 cadences the strongest (by raw hits) keep individual bars and the rest aggregate into one summary bar (#301 — the unbounded figure exceeded Agg's 2¹⁶-px canvas limit past 242 cadences and was silently lost). | Where the volume goes. A weak merge step (raw ≈ merged) means hits are spread out rather than comb-like; snippets ≪ stamps indicates load-time validity rejections. |
 | `confidence_distribution_{tag}.png` | P(true) histogram over all snippets inferred this pass (log-y), threshold line, per-cadence overlay when ≤ 10 cadences. | Mass should hug 0 with a thin bridge toward 1. Any mass just *below* threshold is worth manual inspection; a large mass above it usually means model/data mismatch (e.g. wrong config JSON) rather than a sky full of signals. |
 | `candidate_gallery_{tag}.png` + `candidate_{i}_{tag}.png` | Gallery of top candidates by confidence + up to `max_candidate_plots` (50) per-candidate figures: 6-panel waterfall annotated with confidence, frequency, target/session/band, and the latent bar chart. Sourced from `inference_results`, so resumed cadences are included. | The human veto stage. Check the ON/OFF pattern by eye, the frequency against known RFI allocations, and whether the latent vector resembles the true-class latents from training. |

--- a/docs/INFERENCE_PIPELINE.md
+++ b/docs/INFERENCE_PIPELINE.md
@@ -139,10 +139,21 @@ paths:
 - `--config-path` → the training run's `config_{tag}.json`, layered onto the singleton by
   `cli.apply_saved_config()` **before validation** so shape-critical fields
   (`width_bin`, `stamp_width`, `latent_dim`, `dense_layer_size`, ...) match what the encoder
-  was trained with. The saved `checkpoint` section is deliberately skipped — most damagingly
-  `save_tag`: without the skip, an inference run would masquerade under the training run's
-  tag, corrupting DB provenance and output paths. This run's resolved save_tag (the
-  `{command}_{datetime}` tag set once in `main()`) stays authoritative.
+  was trained with. Layering is **allowlist-only** (#303): exactly the
+  model-contract / result-affecting fields layer — the whole `beta_vae` section, the RF's
+  deployed-representation contract (`latent_variant` / `active_dims` / `calibration_active`
+  / `calibration_method`), the data geometry keys, and precisely the inference fields the
+  resume fingerprints hash (thresholds, `mc_draws`, ED params) minus the artifact paths.
+  Everything else — paths, `gpu`, `manager`, `db`/`logger`/`monitor`, `hf`, `training`,
+  `reproducibility`, and `checkpoint` (most damagingly `save_tag`: layering it would make an
+  inference run masquerade under the training run's tag, corrupting DB provenance and
+  output paths) — never layers, so a config saved on a bigger host can no longer import its
+  pool sizing or batching; every ignored saved field whose value differs from the resolved
+  one is logged as a startup diff line. The allowlist is derived from `run_state.py`'s
+  fingerprint key sets and test-pinned, so `cli.py` and `run_state.py` can never silently
+  disagree about what is result-affecting (see [`CONFIG_AND_CLI.md`](CONFIG_AND_CLI.md)).
+  This run's resolved save_tag (the `{command}_{datetime}` tag set once in `main()`) stays
+  authoritative.
 
 `collect_validation_errors` enforces the trio all-or-none (a partial set is the error above);
 every path that *is* set must exist on disk. The three artifacts should carry the same training
@@ -212,13 +223,30 @@ training tags and, under `--hf-upload`, checks the Hub for the tag at startup ra
      dead attempt are retired *before* fresh rows land;
    - `run_inference()` (below), then a superseding `inference_cadences` row with
      `status='inferred'` carrying the aggregate stats.
-6. **Failure containment.** A cadence whose inference stage throws is logged, recorded as
+6. **Stamp-cache pruning (#302).** With `inference.prune_stamps` resolved ON (the `None`
+   default is AUTO: ON for the fingerprint-scoped default cache directory, OFF when
+   `--preprocess-output-dir` pins an operator-curated one; `--prune-stamps` /
+   `--no-prune-stamps` override), each cadence's multi-GB stamp `.npy` is deleted right
+   after its `'inferred'` manifest row lands and viz collection ran — without pruning a
+   full catalog writes ~30–90 TB of stamps. The metadata `.json` always stays (provenance,
+   viz, resume guard), resume rides the DB row, and only stamps **this run freshly
+   extracted** are ever pruned (`CadenceResult.freshly_extracted`) — a resumed run never
+   deletes a cache it was handed. Before deletion each candidate's snippet (~196 KB) is
+   snapshotted into an atomic `.candidates.npz` sidecar and the viz collector pools the
+   global top-K stamp pixels (~2.4 MB), so candidate figures and the stamp gallery survive
+   pruning; `'failed'` cadences keep their stamps until they succeed. Best-effort: any
+   pruning failure keeps the stamps and the run continues. Both `prune_stamps` and
+   `inference_viz_scope` sit in `run_state.py`'s fingerprint denylists, so fingerprints —
+   and hence resume rows and cache directories — are unchanged. The trade: cross-run
+   re-scoring under a new tag re-pays extraction for pruned cadences; same-run resume/retry
+   is unaffected.
+7. **Failure containment.** A cadence whose inference stage throws is logged, recorded as
    `status='failed'` in the manifest, and the loop moves on — one bad cadence never aborts
    the catalog. After the loop, the pass raises so the retry loop re-attempts, and the
    manifest skip means **only the failed cadences re-run**. Permanent conditions (no work
    units from the CSVs, no cadence produced stamps) raise `NonRetryableInferenceError`, which
    fails fast instead of burning retries.
-7. **Finalization.** On a fully successful pass, the reference cloud is MC-scored and
+8. **Finalization.** On a fully successful pass, the reference cloud is MC-scored and
    persisted (`finalize_reference_cloud()`, best-effort — see below), then (with
    `inference.inference_viz_enabled`) `render_inference_visualizations()` draws the whole
    suite, every figure individually exception-guarded.
@@ -243,11 +271,20 @@ For one cadence's snippet array `(n, 6, 16, 512)`:
    from the cadence front so the remainder is **encoded rather than silently dropped**, and
    the padded outputs never leave the encode (only real rows are written out). Order is
    preserved (no shuffle), and the traced-shape count is bounded by the bucket ladder for
-   any catalog.
+   any catalog. The loop is a **one-step-deep software pipeline** (#301): step k+1 is
+   dispatched (eager TF enqueues its h2d + kernels asynchronously) *before* step k's
+   results are harvested, so the host-side d2h + numpy writes overlap the next step's
+   device work instead of serializing against it — same tensors, same step geometry, same
+   write order; peak memory grows by one step of latent outputs.
 2. Each snippet's 6 observations go through the encoder as independent `(16, 512, 1)`
    inputs and come back as the **deterministic posterior parameters** `z_mean` /
    `z_log_var` (#282 — no stochastic `z` ever crosses the GPU boundary; the MC draws below
-   are reparameterized in NumPy from these, seeded per cadence). Per-replica results are
+   are reparameterized in NumPy from these, seeded per cadence). The step runs an
+   **encode-only submodel** `init_models` slices from the loaded encoder's first two
+   outputs (#301): the discarded `Sampling` draw is a stateful op graph pruning must
+   retain, so it used to execute per step per replica for nothing — excluding the sampling
+   branch from the traced graph leaves `z_mean` / `z_log_var` as the very same graph nodes
+   (a non-functional encoder falls back to the full model). Per-replica results are
    gathered with `experimental_local_results` + `np.concatenate` (cheaper than an NCCL
    gather for the tiny latent payload).
 3. **Two-pass cascade** (#282). Features are rebuilt per the saved config's winning
@@ -354,7 +391,8 @@ flagged while later writes stay live (`Database.mark_superseded`).
 
 | Artifact | Where | Notes |
 | --- | --- | --- |
-| Stamp arrays + metadata | `{data_path}/inference/preprocessed/<csv_stem>_ed<hash12>/*.npy` + `.json` | Shared across runs with the same ED config (#298). The `.json` carries hit provenance: stamp starts/frequencies/statistics/p-values, ED statistic histograms, raw/merged hit lists, the `.h5` header, and the `ed_config_fingerprint` the resume guard checks. |
+| Stamp arrays + metadata | `{data_path}/inference/preprocessed/<csv_stem>_ed<hash12>/*.npy` + `.json` | Shared across runs with the same ED config (#298) — though with pruning ON (#302, the default for this directory) each `.npy` is deleted once its cadence is scored, leaving the `.json`. The `.json` carries hit provenance: stamp starts/frequencies/statistics/p-values, ED statistic histograms, the pre-binned `hit_spectrum_hist` + merged hit list and stored `bandpass_envelopes` (#301 — the raw per-hit frequency list is no longer stored; see [`PREPROCESSING.md`](PREPROCESSING.md)), the `.h5` header, and the `ed_config_fingerprint` the resume guard checks. |
+| Candidate snippet sidecars | same directory, `*.candidates.npz` | Written by the pruning step (#302): each pruned cadence's candidate snippets (~196 KB each), atomically published; `load_display_cadence` falls back to it when the stamp `.npy` is gone, so candidate figures and galleries survive pruning. |
 | Candidate rows | `inference_results` table | Positives only, with latents + provenance + the two-pass scores (`screening_proba`/`mc_mean`/`mc_std`, schema v5). |
 | Run manifest | `inference_cadences` table | Per-cadence stages, aggregates, durations. |
 | Reference cloud | `{output_path}/inference_reference_cloud_{tag}.npz` | MC scores for the seeded uniform reservoir of pass-1 rejects — the survey background of the candidate uncertainty figure (regenerable without re-running inference). |
@@ -393,23 +431,38 @@ coarse, `C` = coarse-channel count, `T` = `pfb_taps_per_channel`.
 
 [`inference_viz.py`](../src/aetherscan/inference_viz.py) renders at end of run from three
 sources: the bounded in-memory `InferenceVizCollector` (per-cadence aggregates + a
-reservoir-sampled latent pool, memory O(#cadences), candidates always kept), the durable
-per-cadence metadata JSONs, and the DB tables — so figures also cover cadences that were
-skipped by the resume. Every figure is wrapped in `_viz_safe` (log-and-swallow): a plot bug
-can never kill a science run. Slack uploads go through a single-worker FIFO background
+reservoir-sampled latent pool, memory O(#cadences), candidates always kept — plus, under
+pruning, the bounded top-K stamp-pixel pool, #302), the durable per-cadence metadata JSONs,
+and the DB tables — so figures also cover cadences that were skipped by the resume. The
+sidecars are **stream-reduced** (#301): each JSON is parsed once, reduced to a bounded ~KB
+`CadenceVizSummary` (hit counts, pre-binned histograms, stored bandpass envelopes,
+per-cadence top-K stamp representatives), and dropped — the suite used to hold every
+cadence's fully parsed JSON (up to ~19 MB each on RFI-dense cadences) for the whole render,
+an OOM-class heap at catalog scale; legacy sidecars' raw hit lists are binned at load, so
+RAM stays bounded for old catalogs too. `inference.inference_viz_scope`
+(`--inference-viz-scope`, default `full`) controls coverage: `new` renders the
+metadata-driven figures only for cadences inferred **this pass** — recommended for resumed
+multi-pass catalog campaigns, where `full` re-pays the entire catalog's viz tail on every
+pass; the DB-sourced candidate figures always cover the whole tag either way. Every figure
+is wrapped in `_viz_safe` (log-and-swallow): a plot bug can never kill a science run — and
+each figure records its own `pipeline_stages` sub-span, alongside `load_metadata` and
+`upload_drain` spans (#301), so the suite's wall is attributable instead of one opaque
+`inference.viz` span. Slack uploads go through a single-worker FIFO background
 uploader (#298 — figure ordering and API rate unchanged; drained before teardown), and the
 per-candidate figures render across a forkserver process pool in the TF-free
 [`candidate_figures.py`](../src/aetherscan/candidate_figures.py) (empty preload — the
 `shap_parallel`/`latent_gif` isolation pattern; per-figure failures degrade the suite
-exactly like `_viz_safe`).
+exactly like `_viz_safe`; its metadata-sidecar reads are memoized through a small
+`lru_cache`, #301 — sidecars are immutable once published, and candidates cluster on few
+cadences).
 
 | File | Contents | What to look for |
 | --- | --- | --- |
 | `ed_stat_distributions_{tag}.png` | Log-log histogram of the D'Agostino–Pearson k² statistic over **all** windows (not just hits), per-ON-file overlay + total, threshold line. | The bulk should be a compact low-k² mass (noise ≈ χ², df=2) with a long RFI tail. The threshold should sit far into the tail: if the noise bulk crosses it, the stamp count explodes; if one ON file's curve is shifted, that file has a bandpass/level problem. |
-| `ed_hit_spectrum_{tag}.png` | Hit density vs frequency (MHz), pre- vs post-deduplication. | Instantly shows RFI comb structure (regular spikes) and band edges. Dedup should collapse combs dramatically; a band where post-dedup density is still high dominates your stamp budget. |
-| `bandpass_flattening_{tag}.png` | Raw vs flattened integrated spectrum for a few sampled coarse channels, with the removed model (scaled PFB response H or spline fit) overlaid. | The flattened spectrum should be level across the channel. Residual scalloping under PFB means the static response doesn't match the recording — check `--pfb-taps-per-channel` or fall back to `--bandpass-method spline` (the log's edge/mid-ratio warning fires on the same condition). |
-| `stamp_gallery_{tag}.png` | Top-K stamps by detection statistic (`stamp_gallery_top_k`, default 12), each a 6-observation waterfall strip; overlap-offset copies collapsed first. | The cadence layout scientists actually inspect: a real technosignature shows in ONs (rows 0/2/4) and vanishes in OFFs; the top of this gallery is virtually always bright RFI present in all six — that's expected. |
-| `preproc_funnel_{tag}.png` | Per-cadence bar funnel: raw hits → merged hits → stamps (incl. overlap copies) → snippets inferred, plus storage per cadence. | Where the volume goes. A weak merge step (raw ≈ merged) means hits are spread out rather than comb-like; snippets ≪ stamps indicates load-time validity rejections. |
+| `ed_hit_spectrum_{tag}.png` | Hit density vs frequency (MHz), pre- vs post-deduplication — rendered by rebinning each cadence's fine pre-binned `hit_spectrum_hist` (≥ 40× finer than the figure's bins) onto one global axis (#301): visually identical to histogramming the raw hit lists, which the sidecars no longer store. | Instantly shows RFI comb structure (regular spikes) and band edges. Dedup should collapse combs dramatically; a band where post-dedup density is still high dominates your stamp budget. |
+| `bandpass_flattening_{tag}.png` | Raw vs flattened integrated spectrum for a few sampled coarse channels, with the removed model (scaled PFB response H or spline fit) overlaid. Rendered from the sidecar's stored `bandpass_envelopes` when present (#301 — zero `.h5` reads at viz time); legacy sidecars keep the live-read path. | The flattened spectrum should be level across the channel. Residual scalloping under PFB means the static response doesn't match the recording — check `--pfb-taps-per-channel` or fall back to `--bandpass-method spline` (the log's edge/mid-ratio warning fires on the same condition). |
+| `stamp_gallery_{tag}.png` | Top-K stamps by detection statistic (`stamp_gallery_top_k`, default 12), each a 6-observation waterfall strip; overlap-offset copies collapsed first. Cadences pruned this run render from the collector's pooled pixels (#302); cadences pruned by an earlier pass degrade to blank columns. | The cadence layout scientists actually inspect: a real technosignature shows in ONs (rows 0/2/4) and vanishes in OFFs; the top of this gallery is virtually always bright RFI present in all six — that's expected. |
+| `preproc_funnel_{tag}.png` | Per-cadence bar funnel: raw hits → merged hits → stamps (incl. overlap copies) → snippets inferred, plus storage per cadence. Past 120 cadences the strongest (by raw hits) keep individual bars and the rest aggregate into one summary bar (#301 — the unbounded figure exceeded Agg's 2¹⁶-px canvas limit past 242 cadences and was silently lost). | Where the volume goes. A weak merge step (raw ≈ merged) means hits are spread out rather than comb-like; snippets ≪ stamps indicates load-time validity rejections. |
 | `confidence_distribution_{tag}.png` | P(true) histogram over all snippets inferred this pass (log-y), threshold line, per-cadence overlay when ≤ 10 cadences. | Mass should hug 0 with a thin bridge toward 1. Any mass just *below* threshold is worth manual inspection; a large mass above it usually means model/data mismatch (e.g. wrong config JSON) rather than a sky full of signals. |
 | `candidate_gallery_{tag}.png` + `candidate_{i}_{tag}.png` | Gallery of top candidates by confidence + up to `max_candidate_plots` (50) per-candidate figures: 6-panel waterfall annotated with confidence, frequency, target/session/band, and the latent bar chart. Sourced from `inference_results`, so resumed cadences are included. | The human veto stage. Check the ON/OFF pattern by eye, the frequency against known RFI allocations, and whether the latent vector resembles the true-class latents from training. |
 | `candidate_uncertainty_{tag}.png` | Each candidate (red star) at x = final RF probability (MC mean), y = MC spread, over a hexbin density background of the reference cloud (the survey's pass-1 rejects), with the science threshold as a vertical line. | Population context is the whole point: "p = 0.97, spread = 0.05" is only interpretable against where the survey sits. The dangerous quadrant is **high p + high spread** — a mean that looks confident while draws swing — exactly what `p` alone cannot flag (see the interpretation table above). Candidates hugging the survey cloud are threshold noise. |
@@ -437,6 +490,6 @@ Inference-specific fields live on `InferenceConfig`
 | Streaming | `prefetch_depth` |
 | Cadence grouping | `cadence_group_by_cols`, `cadence_h5_path_col`, `cadence_expected_obs` |
 | Energy detection | `coarse_channel_width`, `coarse_channel_log_interval`, `bandpass_method`, `pfb_taps_per_channel`, `bandpass_debug_plot`, `spline_order`, `detection_window_size`, `detection_step_size`, `stat_threshold` |
-| Stamps | `stamp_width`, `store_downsampled_stamps`, `overlap_search`, `overlap_fraction`, `preprocess_output_dir` |
-| Visualization | `inference_viz_enabled`, `stamp_gallery_top_k`, `max_candidate_plots` |
+| Stamps | `stamp_width`, `store_downsampled_stamps`, `overlap_search`, `overlap_fraction`, `preprocess_output_dir`, `prune_stamps` |
+| Visualization | `inference_viz_enabled`, `inference_viz_scope`, `stamp_gallery_top_k`, `max_candidate_plots` |
 | Fault tolerance | `max_retries`, `retry_delay` |

--- a/docs/INFERENCE_PIPELINE.md
+++ b/docs/INFERENCE_PIPELINE.md
@@ -203,15 +203,18 @@ training tags and, under `--hf-upload`, checks the Hub for the tag at startup ra
    under the first cadence's energy detection. The distributed encode step is a
    lazily-built, cached `tf.function` — repeated `run_inference` calls reuse a bounded set
    of traces (one per batch-shape bucket) instead of retracing per cadence.
-4. **Prefetch depth = `inference.prefetch_depth`** (#298, default 2 — measured ~16%
-   lower end-to-end wall vs depth 1 on fresh /datag cadences, identical candidates). A
+4. **Prefetch depth = `inference.prefetch_depth`** (default 3 — the #301 A/B on the same
+   8 fresh /datag cadences as #298's depth-1→2 measurement: depth 3 = 4,071 s vs depth 2
+   = 5,118 s wall, ~10–20% honest win after the run-order warmth caveat, identical
+   candidates with 0.0 score deltas). A
    `ThreadPoolExecutor` keeps that many `_prefetch_cadence` futures in flight — each
    preprocesses AND loads/log-norms its cadence (`load_inference_data(parallel=False)`:
    the sequential vectorized branch, since the persistent energy-detection pool already
    owns the CPU) — consumed strictly in catalog order, so results, manifest ordering, and
-   per-cadence seeding are identical at any depth. Depth 2 overlaps one cadence's
-   disk-bound energy detection with the previous one's decompression-bound extraction, at
-   the cost of one extra in-flight cadence of RAM. A prefetch-side load failure degrades to
+   per-cadence seeding are identical at any depth. Each unit of depth overlaps disk-bound
+   energy detection with decompression-bound extraction and the serial per-cadence
+   sections, at the cost of one in-flight cadence of RAM (up to ~65 GB for RFI-dense
+   C-band cadences). A prefetch-side load failure degrades to
    loading on the inference thread under the per-cadence containment below.
 5. **Per-cadence inference** (`main.py:_infer_cadence`):
    - provenance derived from the group key + metadata JSON

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -202,7 +202,9 @@ latent-space *visualizations* always use the deterministic `z_mean` regardless o
 
 `RandomForestClassifier(n_estimators=1000, bootstrap=True, max_features="sqrt",
 random_state=<derived from the root seed>, n_jobs=-1)`, fit on binary labels (`true_*`
-subtypes = 1). Prediction surfaces:
+subtypes = 1). `n_jobs` is a predict-time execution knob: `RandomForestModel.load()`
+re-pins it from the **runtime** config (#301) — the pickled artifact otherwise carried the
+training host's value wholesale. Prediction surfaces:
 
 - `predict_proba` → `(n, 2)` columns `[P(false), P(true)]`. With 1000 bootstrap trees the
   probability resolution is fine enough for a 0.99 operating point to be meaningful.

--- a/docs/PREPROCESSING.md
+++ b/docs/PREPROCESSING.md
@@ -30,10 +30,15 @@ aggregate hits → deduplicate → build stamp centers (± overlap offsets)
 
 One **persistent worker pool** (started once per run by `start_energy_detection_pool()`)
 serves every channel of every file of every cadence, and the extraction stage reuses it. Each
-task returns only a small hit list plus a fixed-size statistic histogram — the bulky
+task returns only a small hit list plus a fixed-size statistic histogram — and, for the few
+sampled channels of the primary ON file, the despiked channel's time-integrated spectrum
+(the `want_spectrum` task flag, #301: the parent turns those into the persisted bandpass
+envelopes below at zero extra `.h5` reads) — the bulky
 `(time_bins, coarse_channel_width)` intermediates never leave the worker, so there is no
 shared memory and no block-sized array in the parent at all
-(`_energy_detect_channel_worker`).
+(`_energy_detect_channel_worker`). Progress logs default to ~25 % milestones per ON file
+(#301 — the per-channel lines measured 62 % of a run's total, Slack-bound, log volume); an
+explicit `--coarse-channel-log-interval N` restores the historical every-N-channels lines.
 
 ### Coarse channels and the DC spike
 
@@ -198,7 +203,10 @@ opened with an HDF5 chunk cache **sized from the file's actual chunk layout** (#
 `_chunk_cache_kwargs` — h5py's 1 MiB default cannot hold one decompressed BL-scale
 bitshuffle chunk, so every stamp used to re-decompress its full ~16-chunk stripe; with the
 sized cache, sequential start order makes each chunk decompress once per task, the reuse
-the sort was always meant to buy).
+the sort was always meant to buy). The sizing is computed **once per obs file in the
+parent** and shipped in the task args (#301 — each task used to re-open the file just to
+inspect its chunk layout, ~2 redundant network-FS open/inspect cycles × ~132 tasks per
+cadence; the same hoist the PFB-check tasks already used).
 
 ### Stamp extraction and storage math
 
@@ -210,6 +218,16 @@ oversubscription keeps the stage's final wave to a fraction of one task, drained
 per-run-unique `.tmp` → `os.replace` atomicity — the resume path treats the `.npy`'s
 existence as proof of a complete write, and abandoned tmps are age-swept (see the guarded
 cross-run stamp cache in [`INFERENCE_PIPELINE.md`](INFERENCE_PIPELINE.md)).
+
+Within a task, overlapping or abutting stamp windows (the overlap_search triplets abut at
+`stamp_width // 2`) are **coalesced into one wide h5 read** and sliced per stamp
+(`_coalesce_stamp_groups`, #301) — byte-identical values, ~one read instead of three across
+an RFI comb, the wide buffer bounded by `_COALESCE_MAX_BINS` (~64 MiB per worker); disjoint
+windows stay singleton groups, i.e. exactly the historical per-stamp read pattern. The
+per-task memmap `flush()` is also gone (#301): `flush()` `msync(MS_SYNC)`s the *entire*
+multi-GB mapping once per task, serializing writeback into worker time — read coherence is
+the unified page cache either way, and crash durability is unchanged (the `os.replace`
+publication never fsynced data pages; an unpublished tmp re-extracts by design).
 
 **Downsample-at-extraction** (`store_downsampled_stamps`, default on): each stamp is reduced
 along frequency with `skimage.transform.downscale_local_mean(stamp, (1, downsample_factor))`
@@ -228,11 +246,22 @@ self-describes, and the loader handles both layouts (below). Disable to archive 
 stamps.
 
 The metadata JSON also carries the full ED provenance for the visualization suite —
-per-stamp starts/frequencies/statistics/p-values, raw and merged hit frequency lists, the
-per-ON-file statistic histograms, and the `.h5` header — plus the `ed_config_fingerprint`
-the stamp-cache resume guard verifies (#298). It is written with compact separators (the
-old `indent=2` pretty-printing cost ~0.5–1.5 s per RFI-dense cadence on the prefetch
-critical path).
+per-stamp starts/frequencies/statistics/p-values, the per-ON-file statistic histograms, and
+the `.h5` header — plus the `ed_config_fingerprint` the stamp-cache resume guard verifies
+(#298). Hit frequencies are stored **pre-binned** since #301: `hit_spectrum_hist` (8,192
+bins spanning the file band — `freq_lo`/`freq_hi`/`n_bins`, raw + merged counts, and the
+exact raw-hit min/max so the figure reproduces the historical axis bounds) replaces the raw
+per-hit frequency list, which ran ~19 MB of JSON on an RFI-dense cadence and had exactly
+one consumer — the hit-spectrum figure, which now rebins the histogram instead; the small
+post-dedup `merged_hit_frequencies_mhz` list stays. The sidecar also persists
+`bandpass_envelopes` (#301): per sampled coarse channel of the primary ON file, decimated
+raw / flattened / overlay integrated-spectrum lines (`{idx, values}` each, plus the channel
+and overlay label) — computed in the parent from the despiked spectra the ED workers return,
+exact w.r.t. the figure's own math (the PFB divide and the spline subtraction both commute
+with the time mean) — so the bandpass-flattening figure renders from ~KB of stored points
+instead of re-reading cold coarse channels at viz time. The JSON is written with compact
+separators (the old `indent=2` pretty-printing cost ~0.5–1.5 s per RFI-dense cadence on the
+prefetch critical path).
 
 ## Loading paths
 
@@ -251,10 +280,15 @@ the stored width: files already at `width_bin // downsample_factor` (512 — wri
 downsample-at-extraction) need only per-cadence log-norm, run vectorized in the workers
 (`_lognorm_worker`); legacy full-width files (4096) keep the historical
 downsample-then-log-norm path. Any other width is an error (skipped with a log). The loaded
-array must survive strict [0, 1] / NaN / Inf checks before inference proceeds.
+array must survive strict [0, 1] / NaN / Inf checks before inference proceeds (leaner since
+#301: NaN detection rides the min reduction — NaN propagates — with branch outcomes and
+messages unchanged for every input, and the two full-array boolean passes gone).
 `parallel=False` forces the sequential in-process branch (no chunk pool / SHM) — the
 streaming per-cadence path uses it so the loader never competes with the persistent
-energy-detection pool for cores.
+energy-detection pool for cores. On that branch an already-downsampled file loads as **one
+chunk** (#301): the chunking bounds the SHM block on the pooled path and RAM on legacy
+full-width loads, but here it only split one cadence's stamps into blocks that then paid a
+full-array `np.concatenate` re-copy — peak transient is ~2× the array either way.
 
 **Log-normalization** (`data_generation.log_norm`): `y = log(x + 10⁻¹⁰)` shifted by its
 minimum and scaled by its range into [0, 1], per observation. With `return_params=True` it

--- a/docs/RUNTIME_SERVICES.md
+++ b/docs/RUNTIME_SERVICES.md
@@ -183,7 +183,11 @@ core count, so 100 % means "all cores busy".
 
 ### The shutdown plot
 
-When the monitor stops (during cleanup), `_save_plot()` queries the run's samples and renders
+When the monitor stops (during cleanup), `_save_plot()` queries the run's samples —
+decimated per series since #301 (`db.query_system_resource_decimated`, ≤ 4,096
+uniformly-strided points per `(resource_type, resource_name)` line: a multi-week run holds
+tens of millions of rows while the plot renders ~2 k px wide, and materializing them all
+cost a multi-GB teardown RAM spike; see [`DATABASE.md`](DATABASE.md)) — and renders
 `plots/resource_utilization_{tag}.png` — three stacked, time-aligned panels:
 
 1. **CPU** — Aetherscan process tree (filled) vs system total.

--- a/src/aetherscan/candidate_figures.py
+++ b/src/aetherscan/candidate_figures.py
@@ -20,6 +20,7 @@ index order from the returned paths.
 
 from __future__ import annotations
 
+import functools
 import json
 import logging
 import multiprocessing as mp
@@ -124,14 +125,29 @@ def candidate_annotation(row: dict) -> str:
     return "\n".join(lines)
 
 
+@functools.lru_cache(maxsize=4)
+def _load_sidecar_cached(metadata_path: str) -> dict | None:
+    """Small parent-side LRU over parsed metadata sidecars (#301): candidates cluster on
+    few cadences, and the gallery/task-build path parsed the SAME multi-MB JSON once per
+    candidate row (~15-20 s serial before the render pool even started). Sidecars are
+    immutable once published (atomic tmp -> os.replace), so a cached parse can never go
+    stale; maxsize bounds the held dicts."""
+    try:
+        with open(metadata_path) as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
 def candidate_frequency_range_mhz(row: dict) -> tuple[float, float] | None:
     """Best-effort frequency span for one candidate row: read its cadence's metadata
-    sidecar (derived from npy_path) and look up the stamp's range. None on any failure —
-    the figure keeps its generic axis label."""
+    sidecar (derived from npy_path, cached across rows) and look up the stamp's range.
+    None on any failure — the figure keeps its generic axis label."""
     try:
-        with open(cadence_metadata_path(str(row["npy_path"]))) as f:
-            metadata = json.load(f)
-    except (OSError, json.JSONDecodeError, KeyError):
+        metadata = _load_sidecar_cached(cadence_metadata_path(str(row["npy_path"])))
+    except KeyError:
+        return None
+    if metadata is None:
         return None
     return stamp_frequency_range_mhz(metadata, int(row["snippet_index"]))
 

--- a/src/aetherscan/candidate_figures.py
+++ b/src/aetherscan/candidate_figures.py
@@ -173,7 +173,11 @@ def _load_sidecar_cached(metadata_path: str) -> dict | None:
     few cadences, and the gallery/task-build path parsed the SAME multi-MB JSON once per
     candidate row (~15-20 s serial before the render pool even started). Sidecars are
     immutable once published (atomic tmp -> os.replace), so a cached parse can never go
-    stale; maxsize bounds the held dicts."""
+    stale; maxsize bounds the held dicts.
+
+    CONTRACT: the returned dict is the CACHED object, aliased across every caller —
+    treat it as immutable (a mutation would silently poison all later readers of the
+    same sidecar; a copy here would defeat the memory bound)."""
     try:
         with open(metadata_path) as f:
             return json.load(f)

--- a/src/aetherscan/candidate_figures.py
+++ b/src/aetherscan/candidate_figures.py
@@ -25,6 +25,7 @@ import json
 import logging
 import multiprocessing as mp
 import os
+import uuid
 from concurrent.futures import ProcessPoolExecutor
 
 import numpy as np
@@ -45,12 +46,53 @@ _MAX_RENDER_WORKERS = 8
 _MIN_ROWS_FOR_POOL = 4
 
 
-def load_display_cadence(npy_path: str, snippet_index: int) -> np.ndarray:
-    """Load one snippet's (num_obs, time_bins, width) stamp from its .npy and log-normalize
-    it for display (the same transform the model input path applies)."""
+def candidate_sidecar_path(npy_path: str) -> str:
+    """Sibling .candidates.npz path for a cadence's pruned candidate snippets (#302)."""
+    return os.path.splitext(npy_path)[0] + ".candidates.npz"
+
+
+def write_candidate_snippet_sidecar(npy_path: str, snippet_indices) -> str:
+    """Snapshot the candidate snippets (~196 KB each) of a cadence into an atomic
+    .candidates.npz sidecar next to its metadata (#302): stamp-cache pruning deletes the
+    multi-GB stamp .npy after scoring, and the candidate figures re-read their snippets
+    from this sidecar instead. Raw (pre-log-norm) values, exactly as stored in the .npy,
+    so load_display_cadence's fallback applies the identical display transform."""
     stamps = np.load(npy_path, mmap_mode="r")
-    snippet = np.array(stamps[snippet_index], dtype=np.float32)
+    indices = np.asarray(sorted({int(i) for i in snippet_indices}), dtype=np.int64)
+    rows = np.array(stamps[indices], dtype=np.float32)
     del stamps
+    path = candidate_sidecar_path(npy_path)
+    tmp_path = f"{path}.{os.getpid()}.{uuid.uuid4().hex}.tmp"
+    with open(tmp_path, "wb") as f:
+        np.savez(f, snippet_indices=indices, stamps=rows)
+    os.replace(tmp_path, path)
+    return path
+
+
+def _load_snippet_from_sidecar(npy_path: str, snippet_index: int) -> np.ndarray:
+    """Read one candidate snippet from the pruned cadence's sidecar; raises KeyError when
+    the snippet was not a candidate (non-candidate pixels are gone by design, #302)."""
+    with np.load(candidate_sidecar_path(npy_path)) as sidecar:
+        match = np.nonzero(sidecar["snippet_indices"] == int(snippet_index))[0]
+        if not len(match):
+            raise KeyError(
+                f"snippet {snippet_index} is not in the candidate sidecar for {npy_path} "
+                f"(its stamp .npy was pruned and only candidate snippets were kept)"
+            )
+        return np.array(sidecar["stamps"][int(match[0])], dtype=np.float32)
+
+
+def load_display_cadence(npy_path: str, snippet_index: int) -> np.ndarray:
+    """Load one snippet's (num_obs, time_bins, width) stamp from its .npy — falling back
+    to the candidate snippet sidecar when the .npy was pruned (#302) — and log-normalize
+    it for display (the same transform the model input path applies)."""
+    try:
+        stamps = np.load(npy_path, mmap_mode="r")
+    except OSError:
+        snippet = _load_snippet_from_sidecar(npy_path, snippet_index)
+    else:
+        snippet = np.array(stamps[snippet_index], dtype=np.float32)
+        del stamps
     return log_norm(snippet)
 
 

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -914,7 +914,7 @@ def _add_inference_flags_to(parser):
         "--prefetch-depth",
         type=int,
         default=None,
-        help="Cadences preprocessed+loaded ahead of the GPU stage in the streaming loop (>= 1). Depth 2 overlaps one cadence's energy-detection reads with the previous one's stamp extraction, costing one extra in-flight cadence of RAM; outputs are identical at any depth",
+        help="Cadences preprocessed+loaded ahead of the GPU stage in the streaming loop (>= 1). Each unit of depth overlaps energy-detection reads with stamp extraction and the serial per-cadence sections, costing one in-flight cadence of RAM (up to ~65 GB for RFI-dense C-band cadences); outputs are identical at any depth (default: 3 per the on-cluster A/B)",
     )
 
     # Energy detection preprocessing

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -2069,6 +2069,22 @@ def collect_validation_errors(
                             fix_kind="cross_param",
                         )
                     )
+                # The RF's TRAIN split is trimmed to a multiple of effective_batch_size at
+                # runtime (create_train_val_split); below one full batch it trims to ZERO
+                # and the run dies at rf_train with "train_steps < 1" — after the beta-VAE
+                # rounds already trained (#297). Divisibility is deliberately NOT required:
+                # the defaults themselves rely on the trim (79,872 % 7,680 != 0); only the
+                # >= one-effective-batch floor is a hard constraint.
+                rf_train_samples = round(nsr * tvs)
+                if eb > rf_train_samples:
+                    errors.append(
+                        ValidationError(
+                            field="training.num_samples_rf",
+                            current=nsr,
+                            message=f"num_samples_rf * train_val_split ({nsr} * {tvs:.4f} = {rf_train_samples}) must be >= --effective-batch-size ({eb}) — the RF train split trims to a multiple of the effective batch, so below one batch it trims to zero and rf_train fails at runtime",
+                            fix_kind="cross_param",
+                        )
+                    )
                 if latent_total > val_samples:
                     errors.append(
                         ValidationError(
@@ -2675,6 +2691,11 @@ def _check_cross_constraints(
         if gval > num_samples_beta_vae * (1 - train_val_split):
             return False
         if gval > num_samples_rf:
+            return False
+        # RF train-split floor (#297): mirrors collect_validation_errors — the RF stage
+        # trims its train split to a multiple of the effective batch, so it needs at
+        # least one full effective batch after the split.
+        if effective_batch_size > round(num_samples_rf * train_val_split):
             return False
         if effective_batch_size % gtrain != 0:
             return False

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -11,11 +11,16 @@ import os
 import re
 import shutil
 from dataclasses import dataclass, field, is_dataclass
+from dataclasses import fields as dataclass_fields
 from datetime import datetime
 from math import gcd, lcm
 from typing import Any
 
-from aetherscan.config import get_config
+from aetherscan.config import InferenceConfig, get_config
+from aetherscan.run_state import (
+    _INFERENCE_FINGERPRINT_DATA_KEYS,
+    _INFERENCE_FINGERPRINT_EXCLUDE_INFERENCE_KEYS,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -261,14 +266,28 @@ def _add_reproducibility_flags_to(parser):
     )
 
 
+def _add_runtime_flags_to(parser):
+    """
+    Add the shared host-runtime flags — registered on BOTH subparsers via one helper so
+    the train and inference surfaces cannot drift (#303).
+    """
+    parser.add_argument(
+        "--n-processes",
+        type=int,
+        default=None,
+        help="Worker-process count for the multiprocessing pools (energy detection + stamp extraction at inference; data generation at training). Default: all cores. Host tuning: never layered from a saved --config-path, so a config recorded on a bigger host cannot oversubscribe this one (must be >= 1)",
+    )
+
+
 def _add_train_flags_to(parser):
     """
     Add all training-mode CLI flags to `parser`. Defined separately from the subparser wrapper
     so that utility scripts (e.g. utils/find_optimal_configs.py) can expose the same flag
     surface without re-declaring every argument.
     """
-    # Shared reproducibility flags (#279) — one helper, both subparsers
+    # Shared reproducibility + host-runtime flags — one helper each, both subparsers
     _add_reproducibility_flags_to(parser)
+    _add_runtime_flags_to(parser)
 
     # Path arguments (overrides environment variables)
     parser.add_argument(
@@ -764,8 +783,9 @@ def _add_inference_flags_to(parser):
     so that utility scripts (e.g. utils/find_optimal_configs.py) can expose the same flag
     surface without re-declaring every argument.
     """
-    # Shared reproducibility flags (#279) — one helper, both subparsers
+    # Shared reproducibility + host-runtime flags — one helper each, both subparsers
     _add_reproducibility_flags_to(parser)
+    _add_runtime_flags_to(parser)
 
     # Path arguments
     parser.add_argument(
@@ -1077,20 +1097,38 @@ def _add_inference_flags_to(parser):
     )
 
 
-# NOTE: come back to this later
-# Per-section fields apply_saved_config never layers from a saved config (#298): these are
-# RUN-SCOPED knobs, not model provenance — a config saved by an older training run would
-# otherwise silently re-impose its values on every future inference run.
-# - inference batching/prefetch are host tuning (a pre-#298 config would re-impose
-#   per_replica_batch_size 2048 over the corrected 256 default); both are provably
-#   result-invariant (they sit in run_state's inference-fingerprint denylist).
-# - reproducibility is the RUN'S OWN contract: determinism defaults ON and opting out must
-#   be an explicit CLI act (--no-tf-deterministic-ops / --unseeded), never a side effect of
-#   loading a training config recorded before the default flipped.
-# Current defaults + CLI flags stay authoritative for all of these.
-_SAVED_CONFIG_SKIP_FIELDS: dict[str, frozenset[str]] = {
-    "inference": frozenset({"per_replica_batch_size", "prefetch_depth"}),
-    "reproducibility": frozenset({"seed", "tf_deterministic_ops"}),
+# Saved-config ALLOWLIST (#303): apply_saved_config layers ONLY these fields from a saved
+# training config; everything else always comes from env + defaults + CLI. The old design
+# was the inverse — apply everything minus a skip-list — which left every host-scoped
+# field unsafe by default and needed a new amendment each time one bit (checkpoint, then
+# inference batching/prefetch, then reproducibility). The live footgun: a config saved on
+# 96-core bla0 carries manager.n_processes=96 and silently 3x-oversubscribed 32-core
+# blpc3's ED pool, with no CLI rescue before --n-processes existed.
+#
+# The allowlist is DERIVED from run_state.py's result-fingerprint key sets so the two can
+# never drift (test-pinned): every field the fingerprints treat as result-affecting keeps
+# layering — de-layering one would silently change science relative to the artifact's
+# validation, and would also stale the resume fingerprints — while host/runtime fields
+# (gpu, manager, db, logger, monitor, paths, hf, training, checkpoint, reproducibility)
+# never layer. An allowlist can only under-layer (visible in the startup diff log below,
+# fixable via CLI); the old shape could silently import a foreign host's tuning.
+# - beta_vae: whole section — model contract (latent_dim drives the scoring feature
+#   layout; dense_layer_size/kernel_size feed shape validation; loss/precision fields are
+#   inert at inference because the encoder is loaded whole from the .keras file).
+# - rf: the deployed-representation contract only — NOT n_jobs (host tuning, re-pinned
+#   from the runtime config at load) and NOT seeds (run-scoped, #279).
+# - inference: exactly the fields inference_config_fingerprint hashes (thresholds,
+#   mc_draws, ED params — training certifies the threshold cascade against this specific
+#   model, so the artifact carrying its own science params is correct provenance) minus
+#   the artifact paths (host-local; CLI/HF-resolved).
+# - data: the stamp/encoder geometry keys the fingerprints use.
+_SAVED_CONFIG_SECTION_ALLOWLIST = frozenset({"beta_vae"})
+_SAVED_CONFIG_FIELD_ALLOWLIST: dict[str, frozenset[str]] = {
+    "data": frozenset(_INFERENCE_FINGERPRINT_DATA_KEYS),
+    "inference": frozenset(f.name for f in dataclass_fields(InferenceConfig))
+    - _INFERENCE_FINGERPRINT_EXCLUDE_INFERENCE_KEYS
+    - frozenset({"encoder_path", "rf_path", "config_path"}),
+    "rf": frozenset({"latent_variant", "active_dims", "calibration_active", "calibration_method"}),
 }
 
 
@@ -1102,21 +1140,18 @@ def apply_saved_config(config_path: str) -> None:
     `_resolve`, and any CLI flags the user also passes will override them in the
     subsequent `apply_args_to_config` call.
 
-    Priority order ends up as:
+    Priority order for ALLOWLISTED fields ends up as:
 
         defaults  <  saved config  <  CLI args
 
-    For each top-level key in the JSON the corresponding sub-dataclass on the
-    singleton is located by name (`data`, `inference`, `gpu`, ...) and the saved
-    fields are written via setattr. Unknown keys/fields are skipped to stay
-    forward-compat with newer/older saved configs. Top-level scalar entries
-    (`data_path`, `model_path`, `output_path`) are applied directly.
-
-    The `checkpoint` section is skipped entirely: a saved *training* config's
-    checkpoint fields (most damagingly `save_tag`) are never what an inference run
-    wants — layering them would make this run masquerade under the training run's
-    tag, corrupting DB provenance and output paths. This run's resolved save_tag
-    (set once in main() by resolve_save_tag) stays authoritative.
+    Only the model-contract / result-affecting fields in _SAVED_CONFIG_FIELD_ALLOWLIST /
+    _SAVED_CONFIG_SECTION_ALLOWLIST layer (#303); every other saved field — paths, gpu,
+    manager, db/logger/monitor, hf, training, checkpoint (most damagingly save_tag, which
+    would make this run masquerade under the training run's tag), reproducibility (the
+    run's own contract: opting out of determinism is an explicit CLI act) — is ignored,
+    with every ignored field whose saved value differs from the resolved one logged as a
+    startup diff line so nothing disappears silently. Unknown keys/fields are skipped to
+    stay forward-compat with newer/older saved configs.
 
     Raises `ValueError` if the file is missing or malformed — caught by main.py's
     wrapper alongside `validate_args` failures.
@@ -1133,22 +1168,38 @@ def apply_saved_config(config_path: str) -> None:
     if config is None:
         raise ValueError("get_config() returned None")
 
+    ignored_diffs: list[str] = []
     for key, value in saved.items():
-        if key == "checkpoint":
-            # Never layer a saved training run's checkpoint section (save_tag/load_tag/
-            # load_dir/start_round) under CLI flags — see docstring.
-            continue
         target = getattr(config, key, None)
-        if target is None:
+        if not (is_dataclass(target) and isinstance(value, dict)):
+            # Top-level scalars (a legacy flat config's data_path/model_path/...) and
+            # unknown sections never layer: paths and host layout always come from
+            # env + defaults + CLI (#303; current-format configs nest paths under a
+            # "paths" key that was never applied anyway — this formalizes that).
+            if not isinstance(value, dict) and value != target:
+                ignored_diffs.append(f"{key}: saved={value!r} ignored")
             continue
-        if is_dataclass(target) and isinstance(value, dict):
-            skipped = _SAVED_CONFIG_SKIP_FIELDS.get(key, frozenset())
-            for sub_key, sub_val in value.items():
-                if sub_key not in skipped and hasattr(target, sub_key):
-                    setattr(target, sub_key, sub_val)
+        if key in _SAVED_CONFIG_SECTION_ALLOWLIST:
+            allowed = {f.name for f in dataclass_fields(target)}
         else:
-            # Top-level scalar (data_path, model_path, output_path, ...).
-            setattr(config, key, value)
+            allowed = _SAVED_CONFIG_FIELD_ALLOWLIST.get(key, frozenset())
+        for sub_key, sub_val in value.items():
+            if not hasattr(target, sub_key):
+                continue
+            if sub_key in allowed:
+                setattr(target, sub_key, sub_val)
+            else:
+                current = getattr(target, sub_key)
+                if current != sub_val:
+                    ignored_diffs.append(
+                        f"{key}.{sub_key}: saved={sub_val!r} ignored, using {current!r}"
+                    )
+    if ignored_diffs:
+        logger.info(
+            f"Saved-config fields NOT layered ({len(ignored_diffs)} host/run-scoped "
+            f"difference(s); the #303 allowlist keeps paths and host tuning with "
+            f"env+defaults+CLI): {'; '.join(ignored_diffs)}"
+        )
 
 
 def apply_args_to_config(args: argparse.Namespace) -> None:
@@ -1158,6 +1209,11 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
     config = get_config()
     if config is None:
         raise ValueError("get_config() returned None")
+
+    # Host-runtime overrides (#303): the only way to size the worker pools besides the
+    # cpu_count() default — never layered from a saved config
+    if hasattr(args, "n_processes") and args.n_processes is not None:
+        config.manager.n_processes = args.n_processes
 
     # Path overrides (must be done first as they affect file loading)
     if hasattr(args, "data_path") and args.data_path is not None:
@@ -1522,6 +1578,19 @@ def collect_validation_errors(
 
     cmd = getattr(args, "command", None)
     errors: list[ValidationError] = []
+
+    # Shared host-runtime flags (#303) — both subcommands
+    nproc = _resolve(args, "n_processes", config.manager.n_processes)
+    if nproc is not None and nproc < 1:
+        errors.append(
+            ValidationError(
+                field="manager.n_processes",
+                current=nproc,
+                message=f"--n-processes must be >= 1, got {nproc}",
+                fix_kind="clamp_low",
+                min_val=1,
+            )
+        )
 
     # --num-replicas validation (>= 1 and <= available GPUs) is performed upstream
     # by _resolve_num_replicas(), which validate_args() calls before

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -947,7 +947,7 @@ def _add_inference_flags_to(parser):
         "--coarse-channel-log-interval",
         type=int,
         default=None,
-        help="Progress-logging chunk size for energy detection, in coarse channels per log line (default: the number of worker processes). Parallelism itself comes from the persistent worker pool, not this knob.",
+        help="Progress-logging cadence for energy detection, in coarse channels per log line. Default: ~25%% milestone lines per ON file (the per-channel lines were 62%% of a run's Slack-bound log volume); pass an explicit N to restore every-N-channels lines. Parallelism itself comes from the persistent worker pool, not this knob.",
     )
     parser.add_argument(
         "--bandpass-method",

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -1010,6 +1010,13 @@ def _add_inference_flags_to(parser):
         help="Render the inference visualization suite (energy detection distributions, hit spectrum, bandpass overlay, stamp/candidate galleries, confidence distribution, latent projection, summary card) at the end of a CSV inference run, saved under plots/inference/{save_tag}/ and uploaded to Slack (default: enabled). Pass --no-inference-viz to disable.",
     )
     parser.add_argument(
+        "--inference-viz-scope",
+        type=str,
+        choices=["full", "new"],
+        default=None,
+        help="Which cadences the metadata-driven viz figures cover: 'full' (default) renders the whole accumulated tag every successful pass; 'new' renders only cadences inferred this pass — recommended for resumed multi-pass catalog campaigns, where 'full' re-pays the entire catalog's viz tail on every pass. DB-sourced candidate figures always cover the full tag either way.",
+    )
+    parser.add_argument(
         "--stamp-gallery-top-k",
         type=int,
         default=None,
@@ -1466,6 +1473,8 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
     # "force off" (--no-inference-viz)
     if hasattr(args, "inference_viz") and args.inference_viz is not None:
         config.inference.inference_viz_enabled = args.inference_viz
+    if hasattr(args, "inference_viz_scope") and args.inference_viz_scope is not None:
+        config.inference.inference_viz_scope = args.inference_viz_scope
     if hasattr(args, "stamp_gallery_top_k") and args.stamp_gallery_top_k is not None:
         config.inference.stamp_gallery_top_k = args.stamp_gallery_top_k
     if hasattr(args, "max_candidate_plots") and args.max_candidate_plots is not None:

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -2164,8 +2164,13 @@ def collect_validation_errors(
                 # and the run dies at rf_train with "train_steps < 1" — after the beta-VAE
                 # rounds already trained (#297). Divisibility is deliberately NOT required:
                 # the defaults themselves rely on the trim (79,872 % 7,680 != 0); only the
-                # >= one-effective-batch floor is a hard constraint.
-                rf_train_samples = round(nsr * tvs)
+                # >= one-effective-batch floor is a hard constraint. int(), not round():
+                # the runtime split truncates PER LABEL (sum of int(count_l * tvs)), so
+                # round()'s upward half could pass a config the runtime kills. Truncating
+                # the total still over-estimates the per-label sum by at most
+                # (n_labels - 1) samples — negligible against a multi-thousand-row batch
+                # and covered by the runtime backstop for exact-floor pathologies.
+                rf_train_samples = int(nsr * tvs)
                 if eb > rf_train_samples:
                     errors.append(
                         ValidationError(
@@ -2447,6 +2452,20 @@ def collect_validation_errors(
                     message=f"--prefetch-depth must be a positive integer, got {prefetch_depth}",
                     fix_kind="clamp_low",
                     min_val=1,
+                )
+            )
+
+        # The CLI enforces choices=["full", "new"], but the config field can be set
+        # programmatically (or by a hand-edited config file passed through a future
+        # surface) — a typo would otherwise silently render full-scope (#301 review note)
+        viz_scope = _resolve(args, "inference_viz_scope", config.inference.inference_viz_scope)
+        if viz_scope not in (None, "full", "new"):
+            errors.append(
+                ValidationError(
+                    field="inference.inference_viz_scope",
+                    current=viz_scope,
+                    message=f"--inference-viz-scope must be 'full' or 'new', got {viz_scope!r}",
+                    fix_kind="format",
                 )
             )
 
@@ -2784,8 +2803,9 @@ def _check_cross_constraints(
             return False
         # RF train-split floor (#297): mirrors collect_validation_errors — the RF stage
         # trims its train split to a multiple of the effective batch, so it needs at
-        # least one full effective batch after the split.
-        if effective_batch_size > round(num_samples_rf * train_val_split):
+        # least one full effective batch after the split. int() matches the validator
+        # (the runtime truncates per label; see the comment there).
+        if effective_batch_size > int(num_samples_rf * train_val_split):
             return False
         if effective_batch_size % gtrain != 0:
             return False

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -1002,6 +1002,13 @@ def _add_inference_flags_to(parser):
         help="Directory for per-cadence .npy outputs from preprocessing. Default: a per-CSV directory {data_path}/inference/preprocessed/<csv_stem>_ed<hash>/ keyed on the energy-detection config fingerprint — runs sharing an ED config reuse each other's stamps automatically, and any ED-config change resolves to a fresh directory. Pass a directory explicitly to pin/share one location (reuse is still guarded by the sidecar's recorded h5 paths and ED fingerprint)",
     )
 
+    parser.add_argument(
+        "--prune-stamps",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Delete each cadence's stamp .npy right after its 'inferred' manifest row lands, keeping the metadata .json plus a ~196 KB snippet sidecar per candidate — resume rides the DB row, and only stamps this run freshly extracted are ever pruned. Without pruning a full catalog writes ~30-90 TB of stamps. Default: AUTO — enabled for the fingerprint-scoped default cache directory, disabled when --preprocess-output-dir is set explicitly. Pass --no-prune-stamps to keep every stamp (slice-scale runs wanting the cross-run rerun cache).",
+    )
+
     # Visualization suite
     parser.add_argument(
         "--inference-viz",
@@ -1471,6 +1478,11 @@ def apply_args_to_config(args: argparse.Namespace) -> None:
     # inference_viz uses argparse.BooleanOptionalAction with default=None so that the CLI
     # can express "leave the config default" (omit), "force on" (--inference-viz), and
     # "force off" (--no-inference-viz)
+    # prune_stamps uses BooleanOptionalAction with default=None, where None means AUTO
+    # (on for the fingerprint-default cache dir, off for an explicit one) — resolved at
+    # run time by main._resolve_prune_stamps, so only explicit flags land here
+    if hasattr(args, "prune_stamps") and args.prune_stamps is not None:
+        config.inference.prune_stamps = args.prune_stamps
     if hasattr(args, "inference_viz") and args.inference_viz is not None:
         config.inference.inference_viz_enabled = args.inference_viz
     if hasattr(args, "inference_viz_scope") and args.inference_viz_scope is not None:

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -487,15 +487,18 @@ class InferenceConfig:
     # disables the cloud (and the plot's background).
     reference_cloud_size: int = 10000
     # Streaming-loop prefetch depth (#298 N2): cadences preprocessed+loaded concurrently
-    # ahead of the GPU stage. Depth 2 overlaps one cadence's disk-bound energy detection
-    # with the previous one's decompression-bound extraction and fills the worker pool
-    # during per-cadence serial sections, at the cost of one extra in-flight cadence of
-    # RAM (stamps + loaded array, up to ~10-20 GB each). Default 2 per the on-cluster A/B
-    # (8 fresh /datag cadences: ~16% lower end-to-end wall vs depth 1, identical
-    # candidates). Per-cadence outputs are identical at any depth (results are consumed
-    # in catalog order and seeding keys on the catalog index); depth 1 restores the
-    # historical serial behavior.
-    prefetch_depth: int = 2
+    # ahead of the GPU stage, overlapping disk-bound energy detection with
+    # decompression-bound extraction and the per-cadence serial sections, at the cost of
+    # one in-flight cadence of RAM per unit of depth (stamps + loaded array — up to
+    # ~65 GB each for RFI-dense C-band cadences, so depth 3 budgets ~4 in-flight worst
+    # case ≈ 260 GB on a 503 GB host). Default 3 per the #301 on-cluster A/B (the same 8
+    # fresh /datag cadences as the #298 depth-1→2 A/B: depth 3 = 4,071 s vs depth 2 =
+    # 5,118 s wall, ~-20%, identical candidates with 0.0 score deltas; caveat: the
+    # depth-3 leg ran last and warmest, so treat the honest win as ~10-20% — same
+    # confound structure the 1→2 flip carried). Per-cadence outputs are identical at any
+    # depth (results are consumed in catalog order and seeding keys on the catalog
+    # index); depth 1 restores the historical serial behavior.
+    prefetch_depth: int = 3
 
     # NOTE: come back to this later (is this the optimal grouping?)
     # Energy detection preprocessing

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -507,9 +507,11 @@ class InferenceConfig:
 
     # NOTE: come back to this later (are these params correct?)
     coarse_channel_width: int = 1048576
-    # Progress-logging chunk size for energy detection (coarse channels per log line).
-    # None -> use manager.n_processes. Parallelism itself comes from the persistent worker
-    # pool (one fused task per coarse channel), not from this knob.
+    # Progress-logging cadence for energy detection. None (default) logs ~25% milestones
+    # per ON file (#301 — the per-channel lines were 62% of a run's log volume, all
+    # Slack-bound); an explicit N restores the historical every-N-channels lines.
+    # Parallelism itself comes from the persistent worker pool (one fused task per coarse
+    # channel), not from this knob.
     coarse_channel_log_interval: int | None = None
     # Bandpass flattening method for energy detection: "pfb" divides each coarse channel by
     # the instrument's static polyphase-filterbank response (computed once per run); "spline"

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -557,6 +557,11 @@ class InferenceConfig:
     # to Slack. Every figure is individually exception-guarded — a plot bug can never kill
     # a science run.
     inference_viz_enabled: bool = True
+    # Which cadences the metadata-driven figures cover: "full" (default) renders the whole
+    # accumulated tag every successful pass; "new" renders only cadences inferred THIS
+    # pass (#301 — a resumed catalog campaign re-paid the full O(catalog) viz tail on
+    # every pass). DB-sourced candidate figures always cover the full tag either way.
+    inference_viz_scope: str = "full"
     # Number of top-statistic stamps shown in the stamp gallery (6-obs waterfall grids).
     stamp_gallery_top_k: int = 12
     # Cap on per-candidate figures (candidate_{i}_{tag}.png), highest confidence first.

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -551,6 +551,18 @@ class InferenceConfig:
     # to pin one directory across runs and CSVs (the resume guard still verifies each
     # sidecar's h5_paths and recorded fingerprint before reuse).
     preprocess_output_dir: str | None = None
+    # Stamp-cache pruning (#302): delete a cadence's stamp .npy right after its 'inferred'
+    # manifest row lands (metadata .json always kept; resume rides the DB row; each
+    # candidate's snippet is snapshotted into a ~196 KB .candidates.npz sidecar and a
+    # bounded in-memory pixel pool keeps the stamp gallery whole). Without pruning a full
+    # catalog writes ~30-90 TB of stamps vs ~2.7 TB free on /datax — the run dies on disk
+    # after a few hundred cadences. None (default) = AUTO: ON for the fingerprint-scoped
+    # default cache dir, OFF when preprocess_output_dir is explicitly set (an
+    # operator-curated cache is never destroyed implicitly). Only stamps THIS run freshly
+    # extracted are ever pruned — a resumed run never deletes a cache it was handed.
+    # Trade: pruning forfeits the cross-run stamp-reuse rerun win for pruned cadences
+    # (re-extraction ~5-15 min each); same-run resume/retry is unaffected.
+    prune_stamps: bool | None = None
 
     # Visualization suite (aetherscan.inference_viz): rendered at the end of a streaming
     # CSV inference run, saved under {output_path}/plots/inference/{save_tag}/ and uploaded
@@ -937,7 +949,12 @@ class Config:
                 "discard_side_channels": self.inference.discard_side_channels,
                 "side_channel_count": self.inference.side_channel_count,
                 "preprocess_output_dir": self.inference.preprocess_output_dir,
+                # NOTE: any key added here also enters BOTH inference fingerprints unless
+                # it joins the run_state.py denylists — prune_stamps and
+                # inference_viz_scope are excluded there (#301/#302: retention/viz only)
+                "prune_stamps": self.inference.prune_stamps,
                 "inference_viz_enabled": self.inference.inference_viz_enabled,
+                "inference_viz_scope": self.inference.inference_viz_scope,
                 "stamp_gallery_top_k": self.inference.stamp_gallery_top_k,
                 "max_candidate_plots": self.inference.max_candidate_plots,
                 "max_retries": self.inference.max_retries,

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -556,15 +556,22 @@ class InferenceConfig:
     preprocess_output_dir: str | None = None
     # Stamp-cache pruning (#302): delete a cadence's stamp .npy right after its 'inferred'
     # manifest row lands (metadata .json always kept; resume rides the DB row; each
-    # candidate's snippet is snapshotted into a ~196 KB .candidates.npz sidecar and a
-    # bounded in-memory pixel pool keeps the stamp gallery whole). Without pruning a full
-    # catalog writes ~30-90 TB of stamps vs ~2.7 TB free on /datax — the run dies on disk
-    # after a few hundred cadences. None (default) = AUTO: ON for the fingerprint-scoped
-    # default cache dir, OFF when preprocess_output_dir is explicitly set (an
-    # operator-curated cache is never destroyed implicitly). Only stamps THIS run freshly
-    # extracted are ever pruned — a resumed run never deletes a cache it was handed.
-    # Trade: pruning forfeits the cross-run stamp-reuse rerun win for pruned cadences
-    # (re-extraction ~5-15 min each); same-run resume/retry is unaffected.
+    # candidate's snippet is snapshotted into a ~196 KB .candidates.npz sidecar so the
+    # candidate figures survive, and a bounded top-K pixel pool — persisted across the
+    # in-process retry attempts, #305 — keeps the stamp gallery whole within one run).
+    # Without pruning a full catalog writes ~30-90 TB of stamps vs ~2.7 TB free on /datax —
+    # the run dies on disk after a few hundred cadences. None (default) = AUTO: ON for the
+    # fingerprint-scoped default cache dir, OFF when preprocess_output_dir is explicitly set
+    # (an operator-curated cache is never destroyed implicitly). Only stamps THIS run
+    # extracted are pruned (a resumed run never deletes a handed cache; a failed-then-retried
+    # cadence of the same run IS pruned). Same-run resume/retry is science-unaffected.
+    # Known limitations (viz-only, graceful): a cross-PROCESS relaunch cannot recover an
+    # earlier process's pruned pixels, so its stamp gallery may show blank columns for
+    # earlier-run cadences; and concurrent runs sharing the default cache dir with pruning
+    # ON can race (one deletes/overwrites a .npy or .candidates.npz another is mid-read of —
+    # self-heals via retry). Use a per-run --preprocess-output-dir or --no-prune-stamps to
+    # run concurrently in one dir. Trade: pruning forfeits the cross-run stamp-reuse rerun
+    # win for pruned cadences (re-extraction ~5-15 min each).
     prune_stamps: bool | None = None
 
     # Visualization suite (aetherscan.inference_viz): rendered at the end of a streaming

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -1945,6 +1945,54 @@ class Database:
             # Pair column names with values and return to user as a dict
             return [dict(zip(result_columns, row, strict=False)) for row in cursor.fetchall()]
 
+    def query_system_resource_decimated(
+        self,
+        tag: str,
+        start_time: float,
+        end_time: float,
+        max_points_per_series: int,
+    ) -> list[dict[str, Any]]:
+        """
+        Per-series uniformly-strided subset of system_resources rows for the teardown
+        resource plot (#301): a multi-week catalog run accumulates tens of millions of
+        rows while the plot renders ~2k px wide, so materializing every row cost a
+        multi-GB teardown RAM spike for invisible detail. The stride is computed from the
+        LARGEST series so every (resource_type, resource_name) line keeps up to
+        max_points_per_series uniformly-spaced points; stride 1 degenerates to the full
+        query. Returns the same dict shape as query_system_resource.
+        """
+        with self._get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT MAX(cnt) FROM (SELECT COUNT(*) AS cnt FROM system_resources"
+                " WHERE tag = ? AND timestamp >= ? AND timestamp <= ?"
+                " GROUP BY resource_type, resource_name)",
+                (tag, start_time, end_time),
+            )
+            max_series = cursor.fetchone()[0] or 0
+            stride = max(1, -(-max_series // max_points_per_series))  # ceil div
+            if stride == 1:
+                # Small run: identical to the unstrided query (window overhead skipped)
+                return self.query_system_resource(tag=tag, start_time=start_time, end_time=end_time)
+            cursor.execute(
+                "SELECT * FROM ("
+                " SELECT *, ROW_NUMBER() OVER ("
+                "   PARTITION BY resource_type, resource_name ORDER BY timestamp"
+                " ) AS _rn FROM system_resources"
+                " WHERE tag = ? AND timestamp >= ? AND timestamp <= ?"
+                ") WHERE (_rn - 1) % ? = 0",
+                (tag, start_time, end_time, stride),
+            )
+            result_columns = [desc[0] for desc in cursor.description]
+            rows = [dict(zip(result_columns, row, strict=False)) for row in cursor.fetchall()]
+            for row in rows:
+                row.pop("_rn", None)
+            logger.info(
+                f"Resource-plot query decimated by stride {stride} "
+                f"(largest series {max_series} rows -> <= {max_points_per_series}/series)"
+            )
+            return rows
+
     def query_injection_stat_time_span(
         self,
         tag: str,

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -438,14 +438,12 @@ class Database:
                 ON inference_results(tag, timestamp, confidence, prediction)
             """)
 
-            # Partial index matching _execute_mark_superseded's predicate exactly (v8):
-            # the per-cadence supersede UPDATE blocks the inference thread, and without
-            # this the (tag, timestamp, ...) index above only narrows to the tag
-            # partition — a whole-partition visit per cadence at catalog scale (#301)
-            cursor.execute("""
-                CREATE INDEX IF NOT EXISTS idx_inference_results_supersede
-                ON inference_results(tag, npy_path) WHERE superseded = 0
-            """)
+            # v8's idx_inference_results_supersede is created ONLY in _migrate_schema
+            # (unlike the indexes here): its partial-index predicate references the
+            # superseded column, which a pre-v1 database gains from the v1 ALTER — a
+            # CREATE here would run before that ALTER and fail with "no such column"
+            # on any legacy file. Fresh databases still get it at init because
+            # _migrate_schema always runs (version 0 -> current).
 
             # Inference cadence manifest table (schema v2): one row per (cadence, stage
             # transition) — status 'preprocessed' when the stamp .npy lands, a superseding
@@ -601,9 +599,12 @@ class Database:
             )
 
         if version < 8:
-            # v8: the supersede partial index (see the version-history comment). Like v7,
-            # the CREATE mirrors _init_database() — already executed for old and new
-            # databases alike and idempotent; re-executing records the step explicitly.
+            # v8: the supersede partial index (see the version-history comment). UNLIKE
+            # v7, this CREATE lives only here and deliberately NOT in _init_database():
+            # its WHERE superseded = 0 predicate needs the column the v1 block above
+            # adds, so on a pre-v1 file an init-time CREATE would precede the ALTER and
+            # fail. Fresh databases reach this block too (version 0 -> current), so both
+            # paths land the same final index set.
             cursor.execute("""
                 CREATE INDEX IF NOT EXISTS idx_inference_results_supersede
                 ON inference_results(tag, npy_path) WHERE superseded = 0

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -83,7 +83,12 @@ _MARK_SUPERSEDED_SENTINEL = object()
 #     ~20% insert throughput (scattered stat_name subtree writes vs append-only timestamp
 #     order) to speed only the minor single-stat shape on a table whose tag partitions
 #     stay ~58k rows.
-_SCHEMA_VERSION = 7
+# v8: added idx_inference_results_supersede — a partial index on (tag, npy_path) WHERE
+#     superseded = 0, matching _execute_mark_superseded's exact predicate. The only prior
+#     index led with (tag, timestamp, ...), so the once-per-cadence supersede UPDATE (which
+#     BLOCKS the inference thread via the writer-queue sentinel) visited every live row of
+#     the tag partition — a quadratic-in-catalog term on RFI-dense 6k-cadence runs (#301).
+_SCHEMA_VERSION = 8
 
 
 # Per-process cache for get_system_metadata(): every field (hostname, user, outbound IP, PID)
@@ -218,9 +223,15 @@ class Database:
         self._init_database()
 
         logger.info(f"Database initialized at: {self.db_path}")
-        db_stats = self.get_db_stats()
-        for name, value in db_stats.items():
-            logger.info(f"  {name}: {value}")
+        # Startup logs only O(1) facts. The per-table COUNT(*) summary that used to print
+        # here (get_db_stats) cost a measured ~13 min per cold-cache process launch on a
+        # catalog-scale DB (80 GB, ~190M injection_stats rows) and was re-paid on every
+        # retry-loop relaunch (#301); get_db_stats() remains for on-demand diagnostics.
+        with self._get_connection() as conn:
+            db_size_bytes = conn.execute(
+                "SELECT page_count * page_size FROM pragma_page_count(), pragma_page_size()"
+            ).fetchone()[0]
+        logger.info(f"  db_size_bytes: {db_size_bytes}")
         logger.info(f"Write interval: {self.write_interval} seconds")
         logger.info(f"Max buffer size: {self.write_buffer_max_size} records")
 
@@ -427,6 +438,15 @@ class Database:
                 ON inference_results(tag, timestamp, confidence, prediction)
             """)
 
+            # Partial index matching _execute_mark_superseded's predicate exactly (v8):
+            # the per-cadence supersede UPDATE blocks the inference thread, and without
+            # this the (tag, timestamp, ...) index above only narrows to the tag
+            # partition — a whole-partition visit per cadence at catalog scale (#301)
+            cursor.execute("""
+                CREATE INDEX IF NOT EXISTS idx_inference_results_supersede
+                ON inference_results(tag, npy_path) WHERE superseded = 0
+            """)
+
             # Inference cadence manifest table (schema v2): one row per (cadence, stage
             # transition) — status 'preprocessed' when the stamp .npy lands, a superseding
             # 'inferred' row (with aggregate stats) when inference completes, and 'failed'
@@ -579,6 +599,16 @@ class Database:
             logger.info(
                 "Schema migration: v7 index sweep (injection_stats/latent_snapshots) applied"
             )
+
+        if version < 8:
+            # v8: the supersede partial index (see the version-history comment). Like v7,
+            # the CREATE mirrors _init_database() — already executed for old and new
+            # databases alike and idempotent; re-executing records the step explicitly.
+            cursor.execute("""
+                CREATE INDEX IF NOT EXISTS idx_inference_results_supersede
+                ON inference_results(tag, npy_path) WHERE superseded = 0
+            """)
+            logger.info("Schema migration: v8 supersede partial index applied")
 
         # PRAGMA doesn't support parameter binding; _SCHEMA_VERSION is a module-level int constant
         cursor.execute(f"PRAGMA user_version = {_SCHEMA_VERSION:d}")
@@ -2610,7 +2640,10 @@ class Database:
 
     # NOTE: this call gets expensive as db grows. create a separate schema to track num_rows_added per pipeline run. then count & update as part of db cleanup routine? or use SQLite's dbstat virtual table or periodic ANALYZE?
     def get_db_stats(self) -> dict[str, Any]:
-        """Get summary statistics for the database"""
+        """Get summary statistics for the database.
+
+        On-demand diagnostics only — deliberately NOT called at init: the per-table
+        COUNT(*) scans cost ~13 min on a cold-cache catalog-scale DB (#301)."""
         with self._get_connection() as conn:
             cursor = conn.cursor()
 

--- a/src/aetherscan/inference.py
+++ b/src/aetherscan/inference.py
@@ -183,6 +183,42 @@ class ReferenceCloudReservoir:
         )
 
 
+def _derive_encode_model(encoder):
+    """Encode-only view of the VAE encoder (#301): inference consumes z_mean/z_log_var and
+    discards the sampled z, but the Sampling layer's tf.random draw is a STATEFUL op that
+    graph pruning must retain — it executed per step per replica for nothing. Slicing the
+    functional encoder's first two outputs excludes the sampling branch from the traced
+    graph (the z_mean/z_log_var tensors are the same graph nodes, so outputs are unchanged).
+
+    Must be called inside strategy.scope() (its Model wraps the encoder's mirrored
+    variables). Returns the full encoder unchanged as a graceful fallback when the submodel
+    can't be built.
+
+    Shape contract the traced encode step relies on: the encoder is
+    keras.Model(inputs, [z_mean, z_log_var, z]) (vae.py — 3 heads). The guard checks the
+    SOURCE encoder's head COUNT (not the derived model's, which is always <= 2 by
+    construction, #305 pass-2 note): a future encoder that adds or drops a head falls back
+    loudly instead of the [:2] slice silently taking the wrong two tensors. A head REORDER
+    at the same count is still vae.py's construction contract (unguardable by shape alone).
+    """
+    import tensorflow as tf  # noqa: PLC0415  (module already imports it; local keeps the helper self-contained)
+
+    try:
+        if len(encoder.outputs) != 3:
+            raise ValueError(
+                f"encoder has {len(encoder.outputs)} outputs, expected 3 "
+                f"(z_mean, z_log_var, z); refusing to build a potentially mis-sliced "
+                f"encode submodel"
+            )
+        return tf.keras.Model(encoder.inputs, encoder.outputs[:2])
+    except Exception as e:
+        logger.warning(
+            f"Encode-only submodel derivation failed ({e}); using the full encoder "
+            f"(the discarded sampling op will run per step)"
+        )
+        return encoder
+
+
 class InferencePipeline:
     """Inference pipeline"""
 
@@ -271,25 +307,7 @@ class InferencePipeline:
                 # replica for nothing. Slicing the functional model's first two outputs
                 # excludes the sampling branch from the traced graph entirely; z_mean /
                 # z_log_var tensors are the same graph nodes, so outputs are unchanged.
-                try:
-                    self._encode_model = tf.keras.Model(
-                        self.encoder.inputs, self.encoder.outputs[:2]
-                    )
-                    # Shape contract the traced encode step relies on (outputs[0] =
-                    # z_mean, outputs[1] = z_log_var — vae.py's head order): a future
-                    # encoder with a different head count must land in the fallback
-                    # below loudly, not mis-slice silently (#305 review note)
-                    if len(self._encode_model.outputs) != 2:
-                        raise ValueError(
-                            f"encode submodel has {len(self._encode_model.outputs)} "
-                            f"outputs, expected 2 (z_mean, z_log_var)"
-                        )
-                except Exception as e:
-                    logger.warning(
-                        f"Encode-only submodel derivation failed ({e}); using the full "
-                        f"encoder (the discarded sampling op will run per step)"
-                    )
-                    self._encode_model = self.encoder
+                self._encode_model = _derive_encode_model(self.encoder)
             logger.info("Encoder loaded successfully")
         except Exception as e:
             logger.error(f"Error loading encoder: {e}")

--- a/src/aetherscan/inference.py
+++ b/src/aetherscan/inference.py
@@ -111,8 +111,13 @@ def _batched_mc_scores(
         )
         for _ in range(mc_draws)
     ]
+    stacked_features = np.vstack(draw_features)
+    # Release the per-draw list before the forest runs: holding it across predict_proba
+    # doubled the MC transient (mc_draws x n_rows x n_features, twice) for no reason —
+    # the stacked copy is the only thing the predict needs (#301)
+    del draw_features
     stacked_scores = apply_probability_calibrator(
-        calibrator, rf_model.model.predict_proba(np.vstack(draw_features))[:, 1]
+        calibrator, rf_model.model.predict_proba(stacked_features)[:, 1]
     )
     return stacked_scores.reshape(mc_draws, -1)
 

--- a/src/aetherscan/inference.py
+++ b/src/aetherscan/inference.py
@@ -265,6 +265,22 @@ class InferencePipeline:
             logger.info(f"Loading encoder from {encoder_path} within strategy scope")
             with self.strategy.scope():
                 self.encoder = tf.keras.models.load_model(encoder_path)
+                # Encode-only view (#301): inference consumes z_mean/z_log_var and
+                # discards the sampled z, but the Sampling layer's tf.random draw is a
+                # STATEFUL op that graph pruning must retain — it executed per step per
+                # replica for nothing. Slicing the functional model's first two outputs
+                # excludes the sampling branch from the traced graph entirely; z_mean /
+                # z_log_var tensors are the same graph nodes, so outputs are unchanged.
+                try:
+                    self._encode_model = tf.keras.Model(
+                        self.encoder.inputs, self.encoder.outputs[:2]
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"Encode-only submodel derivation failed ({e}); using the full "
+                        f"encoder (the discarded sampling op will run per step)"
+                    )
+                    self._encode_model = self.encoder
             logger.info("Encoder loaded successfully")
         except Exception as e:
             logger.error(f"Error loading encoder: {e}")
@@ -557,6 +573,10 @@ class InferencePipeline:
             # Cache dimensions for tf.function
             time_bins = self.config.data.time_bins
             width_bin = self.config.data.width_bin // self.config.data.downsample_factor
+            # The encode-only submodel when init_models derived one (#301: skips the
+            # discarded sampling draw); a bare stub/full encoder still works — the first
+            # two outputs are z_mean/z_log_var either way
+            encode_model = getattr(self, "_encode_model", None) or self.encoder
 
             @tf.function
             def encode_step(batch_data):
@@ -564,9 +584,8 @@ class InferencePipeline:
                     """Per-replica encoding step"""
                     # Reshape for encoder: (batch, 6, 16, 512) -> (batch * 6, 16, 512, 1)
                     reshaped = tf.reshape(data, [-1, time_bins, width_bin, 1])
-                    # Encode (returns mean, log_var, z) — keep the posterior parameters
-                    z_mean, z_log_var, _ = self.encoder(reshaped, training=False)
-                    return z_mean, z_log_var
+                    outputs = encode_model(reshaped, training=False)
+                    return outputs[0], outputs[1]  # z_mean, z_log_var
 
                 # Run encoding on all replicas
                 return self.strategy.run(encode_fn, args=(batch_data,))
@@ -574,6 +593,32 @@ class InferencePipeline:
             self._encode_step = encode_step
 
         encode_step = self._encode_step
+
+        def _harvest(entry) -> None:
+            # Extract results from each replica and concatenate (cheaper than an NCCL
+            # gather for the small latent payload). The .numpy() calls block until the
+            # step's kernels finish — which, in the pipelined loop below, overlaps the
+            # NEXT step's device work instead of serializing against it.
+            per_replica_mean, per_replica_log_var, out_rows, write_idx = entry
+            batch_mean = np.concatenate(
+                [r.numpy() for r in self.strategy.experimental_local_results(per_replica_mean)],
+                axis=0,
+            )
+            batch_log_var = np.concatenate(
+                [r.numpy() for r in self.strategy.experimental_local_results(per_replica_log_var)],
+                axis=0,
+            )
+            # Only the real rows land in the outputs (obs-major: out_rows snippet rows)
+            z_mean_out[write_idx : write_idx + out_rows] = batch_mean[:out_rows]
+            z_log_var_out[write_idx : write_idx + out_rows] = batch_log_var[:out_rows]
+
+        # One-step-deep software pipeline (#301): dispatch step k+1 (h2d + kernels are
+        # enqueued asynchronously by eager TF) BEFORE harvesting step k, so the host-side
+        # d2h + numpy writes of step k run while step k+1 computes on the GPUs. The old
+        # loop harvested immediately, fully serializing convert -> compute -> sync per
+        # step (~2% of benched encode throughput). Numerics are untouched: same tensors,
+        # same step geometry, same write order — only the harvest timing moves.
+        pending = None
         n_steps = 0
         out_idx = 0
         start = 0
@@ -591,7 +636,7 @@ class InferencePipeline:
             else:
                 # Pad the final step with duplicate rows cycled from the cadence start
                 # (deterministic, same semantics as the retired dataset padding); their
-                # encoded outputs are sliced off below and never leave this method
+                # encoded outputs are sliced off in _harvest and never leave this method
                 pad_indices = np.arange(global_rows - remaining) % n_samples
                 step_slice = np.concatenate([data[start:], data[pad_indices]], axis=0)
                 real_rows = remaining
@@ -603,21 +648,11 @@ class InferencePipeline:
             per_replica_batch = self.strategy.experimental_distribute_values_from_function(value_fn)
             per_replica_mean, per_replica_log_var = encode_step(per_replica_batch)
 
-            # Extract results from each replica and concatenate
-            # This avoids the inefficient gather operation with NCCL
-            batch_mean = np.concatenate(
-                [r.numpy() for r in self.strategy.experimental_local_results(per_replica_mean)],
-                axis=0,
-            )
-            batch_log_var = np.concatenate(
-                [r.numpy() for r in self.strategy.experimental_local_results(per_replica_log_var)],
-                axis=0,
-            )
+            if pending is not None:
+                _harvest(pending)
 
-            # Only the real rows land in the outputs (obs-major: real_rows snippets)
             out_rows = real_rows * self.num_observations
-            z_mean_out[out_idx : out_idx + out_rows] = batch_mean[:out_rows]
-            z_log_var_out[out_idx : out_idx + out_rows] = batch_log_var[:out_rows]
+            pending = (per_replica_mean, per_replica_log_var, out_rows, out_idx)
 
             out_idx += out_rows
             start += real_rows
@@ -625,10 +660,14 @@ class InferencePipeline:
             if n_steps % 10 == 0 or start >= n_samples:
                 logger.info(f"Encoded {start}/{n_samples} snippets ({n_steps} steps)")
 
-            # Refcount-managed numpy arrays and eager tensors: freed on del. The full
-            # gc.collect() that used to run here EVERY STEP (~0.3 s each with TF
-            # loaded, GIL held) reclaimed nothing cyclic (#298 I7).
-            del per_replica_mean, per_replica_log_var, batch_mean, batch_log_var
+            # Refcount-managed numpy arrays and eager tensors: freed on del/rebind. The
+            # full gc.collect() that used to run here EVERY STEP (~0.3 s each with TF
+            # loaded, GIL held) reclaimed nothing cyclic (#298 I7). At most one extra
+            # step of outputs stays live (the pipeline depth).
+            del per_replica_mean, per_replica_log_var
+
+        if pending is not None:
+            _harvest(pending)
 
         return z_mean_out, z_log_var_out
 

--- a/src/aetherscan/inference.py
+++ b/src/aetherscan/inference.py
@@ -275,6 +275,15 @@ class InferencePipeline:
                     self._encode_model = tf.keras.Model(
                         self.encoder.inputs, self.encoder.outputs[:2]
                     )
+                    # Shape contract the traced encode step relies on (outputs[0] =
+                    # z_mean, outputs[1] = z_log_var — vae.py's head order): a future
+                    # encoder with a different head count must land in the fallback
+                    # below loudly, not mis-slice silently (#305 review note)
+                    if len(self._encode_model.outputs) != 2:
+                        raise ValueError(
+                            f"encode submodel has {len(self._encode_model.outputs)} "
+                            f"outputs, expected 2 (z_mean, z_log_var)"
+                        )
                 except Exception as e:
                     logger.warning(
                         f"Encode-only submodel derivation failed ({e}); using the full "

--- a/src/aetherscan/inference_viz.py
+++ b/src/aetherscan/inference_viz.py
@@ -51,6 +51,7 @@ from aetherscan.candidate_figures import (
     stamp_frequency_range_mhz,
 )
 from aetherscan.config import get_config
+from aetherscan.data_generation import log_norm
 from aetherscan.db import get_db
 from aetherscan.logger import get_logger
 from aetherscan.pfb import gen_coarse_channel_response
@@ -192,6 +193,11 @@ class InferenceVizCollector:
         config = get_config()
         root_seed = config.reproducibility.seed if config is not None else None
         self._rng = derive_rng(root_seed, STREAM_INFERENCE_VIZ)
+        # Bounded top-K stamp-pixel pool (#302): raw pixels of the strongest stamps seen
+        # so far, captured just before pruning deletes a cadence's .npy, so the stamp
+        # gallery stays whole (~196 KB x top_k ≈ 2.4 MB at defaults)
+        self._gallery_top_k = config.inference.stamp_gallery_top_k if config is not None else 12
+        self._gallery_pixel_pool: list[tuple[float, str, int, np.ndarray]] = []
 
     def record_skipped(
         self, key: tuple, npy_path: str, metadata_path: str, manifest_row: dict
@@ -276,6 +282,36 @@ class InferenceVizCollector:
         if not self._latent_chunks:
             return np.empty((0, 0), dtype=np.float32), np.empty(0, dtype=bool)
         return np.concatenate(self._latent_chunks), np.concatenate(self._candidate_chunks)
+
+    def pool_gallery_pixels(self, metadata_path: str, npy_path: str) -> None:
+        """Capture this cadence's top-K stamp pixels into the bounded global pool (#302):
+        called by the pruning step just before it deletes the stamp .npy. The global
+        top-K is a subset of the per-cadence top-Ks, so pooling per-cadence top-K and
+        truncating globally preserves exactly the stamps plot_stamp_gallery will select.
+        Best-effort — a failure degrades the gallery, never the run."""
+        try:
+            with open(metadata_path) as f:
+                metadata = json.load(f)
+            representatives = _cadence_top_stamps(metadata, self._gallery_top_k)
+            if not representatives:
+                return
+            stamps = np.load(npy_path, mmap_mode="r")
+            for stat, idx, _freq, _freq_range in representatives:
+                self._gallery_pixel_pool.append(
+                    (stat, npy_path, int(idx), np.array(stamps[int(idx)], dtype=np.float32))
+                )
+            del stamps
+            self._gallery_pixel_pool.sort(key=lambda entry: entry[0], reverse=True)
+            del self._gallery_pixel_pool[self._gallery_top_k :]
+        except Exception as e:
+            logger.warning(
+                f"Gallery pixel pooling failed for {npy_path} ({e}); the stamp gallery "
+                f"may show blank columns for this cadence"
+            )
+
+    def gallery_pixels(self) -> dict[tuple[str, int], np.ndarray]:
+        """(npy_path, snippet_index) -> raw stamp pixels for the pooled top-K stamps."""
+        return {(path, idx): pixels for _, path, idx, pixels in self._gallery_pixel_pool}
 
 
 # ---------------------------------------------------------------------------
@@ -783,10 +819,14 @@ def _select_top_stamps(
 
 
 def plot_stamp_gallery(
-    records: list[CadenceVizRecord], summaries: dict[str, CadenceVizSummary]
+    records: list[CadenceVizRecord],
+    summaries: dict[str, CadenceVizSummary],
+    pixel_pool: dict[tuple[str, int], np.ndarray] | None = None,
 ) -> str | None:
     """Top-K stamps by detection statistic, each rendered as the 6-observation cadence
-    waterfall grid scientists actually inspect (ON/OFF rows, one stamp per column)."""
+    waterfall grid scientists actually inspect (ON/OFF rows, one stamp per column).
+    pixel_pool carries raw pixels the collector captured before pruning deleted their
+    .npy (#302) — the fallback when the direct load fails."""
     config = get_config()
     tag = config.checkpoint.save_tag
     top_k = config.inference.stamp_gallery_top_k
@@ -805,10 +845,14 @@ def plot_stamp_gallery(
         try:
             snippet = load_display_cadence(record.npy_path, idx)
         except Exception as e:
-            logger.warning(f"Viz: failed to load stamp {idx} from {record.npy_path}: {e}")
-            for row in range(n_rows):
-                axes[row][col].set_axis_off()
-            continue
+            pooled = (pixel_pool or {}).get((record.npy_path, idx))
+            if pooled is None:
+                logger.warning(f"Viz: failed to load stamp {idx} from {record.npy_path}: {e}")
+                for row in range(n_rows):
+                    axes[row][col].set_axis_off()
+                continue
+            # Same display transform load_display_cadence applies to the raw stamp
+            snippet = log_norm(np.array(pooled, dtype=np.float32))
         draw_cadence_strip(
             [axes[row][col] for row in range(n_rows)],
             snippet,
@@ -1370,7 +1414,9 @@ def render_inference_visualizations(
         _viz_safe("ed_stat_distributions", plot_ed_stat_distributions, records, summaries)
         _viz_safe("ed_hit_spectrum", plot_ed_hit_spectrum, records, summaries)
         _viz_safe("bandpass_flattening", plot_bandpass_flattening, preprocessor, records, summaries)
-        _viz_safe("stamp_gallery", plot_stamp_gallery, records, summaries)
+        _viz_safe(
+            "stamp_gallery", plot_stamp_gallery, records, summaries, collector.gallery_pixels()
+        )
         _viz_safe("preproc_funnel", plot_preproc_funnel, records, summaries)
         _viz_safe("confidence_distribution", plot_confidence_distribution, records)
         _viz_safe("candidate_gallery", plot_candidate_gallery)

--- a/src/aetherscan/inference_viz.py
+++ b/src/aetherscan/inference_viz.py
@@ -40,6 +40,7 @@ import h5py
 import numpy as np
 from matplotlib.figure import Figure
 
+from aetherscan.benchmark import stage_timer
 from aetherscan.candidate_figures import (
     OBS_ROW_LABELS,
     candidate_frequency_range_mhz,
@@ -68,6 +69,18 @@ _MAX_LATENT_POINTS = 20_000
 
 # Frequency-axis bins for the hit spectrum figure.
 _HIT_SPECTRUM_BINS = 200
+
+# Fine-grid bin count used when a LEGACY sidecar's raw hit-frequency lists are reduced to
+# a bounded per-cadence histogram at metadata-load time (#301) — new sidecars arrive
+# pre-binned by preprocessing (_HIT_HIST_BINS, same value).
+_LEGACY_HIT_HIST_BINS = 8192
+
+# Cap on individually-drawn cadences in the preprocessing funnel (#301): at 270 px per
+# cadence (1.8 in x 150 dpi) the figure exceeds Agg's hard 2^16-px canvas limit past 242
+# cadences — the render then raises and _viz_safe swallowed it, so every catalog-scale
+# pass silently LOST the funnel. Beyond the cap, the highest-raw-hit cadences are drawn
+# individually and the remainder is aggregated into one summary bar.
+_FUNNEL_MAX_CADENCES = 120
 
 # Candidate gallery shows at most this many top-confidence candidates (per-candidate figures
 # are governed separately by config.inference.max_candidate_plots).
@@ -272,9 +285,12 @@ class InferenceVizCollector:
 
 def _viz_safe(name: str, fn: Callable, *args, **kwargs):
     """Run one figure function, log-and-swallow any exception: a plot bug must never kill a
-    science run (mirrors train.py's _safe_call, with viz-specific logging)."""
+    science run (mirrors train.py's _safe_call, with viz-specific logging). Each figure
+    records its own pipeline_stages sub-span (#301) — the suite used to be one opaque
+    'inference.viz' span covering 73% of a cached rerun's wall."""
     try:
-        return fn(*args, **kwargs)
+        with stage_timer(name):
+            return fn(*args, **kwargs)
     except Exception as e:
         logger.error(f"Inference viz '{name}' failed (run continues without it): {e}")
         return None
@@ -314,6 +330,129 @@ def _load_metadata(record: CadenceVizRecord) -> dict | None:
         return None
 
 
+@dataclass
+class CadenceVizSummary:
+    """Bounded per-cadence reduction of the metadata sidecar (#301). The suite used to
+    hold every cadence's fully parsed JSON (up to ~19 MB each on RFI-dense cadences —
+    an OOM-class hundreds of GB at 6,093-cadence catalog scale) for the whole render;
+    each figure now reads these ~KB summaries and the parsed dict is dropped as soon as
+    its cadence is reduced."""
+
+    n_raw_hits: int = 0
+    n_merged_hits: int = 0
+    n_stamp_rows: int = 0
+    npy_size_bytes: float = float("nan")
+    ed_hist_edges: np.ndarray | None = None
+    ed_hist_counts: np.ndarray | None = None  # (n_on_files, n_bins) int64
+    # {raw_counts, merged_counts, freq_lo, freq_hi, raw_freq_min, raw_freq_max} — fine
+    # per-cadence histograms rebinned onto the figure's global axis at render time
+    hit_hist: dict | None = None
+    h5_path: str | None = None
+    nchans: int = 0
+    bandpass_envelopes: list | None = None
+    # Per-cadence top-K stamp representatives: (statistic, snippet_idx, freq, freq_range)
+    gallery_reps: list = field(default_factory=list)
+
+
+def _reduce_hit_hist(metadata: dict) -> dict | None:
+    """Normalize a cadence's hit-frequency data to a bounded fine histogram: new sidecars
+    carry hit_spectrum_hist pre-binned by preprocessing; legacy sidecars' raw float lists
+    are binned HERE, once, on their own span — so RAM stays bounded for old and new
+    catalogs alike (#301)."""
+    hist = metadata.get("hit_spectrum_hist")
+    if hist:
+        return {
+            "raw_counts": np.asarray(hist["raw_counts"], dtype=np.int64),
+            "merged_counts": np.asarray(hist["merged_counts"], dtype=np.int64),
+            "freq_lo": float(hist["freq_lo"]),
+            "freq_hi": float(hist["freq_hi"]),
+            "raw_freq_min": float(hist["raw_freq_min"]),
+            "raw_freq_max": float(hist["raw_freq_max"]),
+        }
+    raw = metadata.get("raw_hit_frequencies_mhz") or []
+    if not raw:
+        return None
+    merged = metadata.get("merged_hit_frequencies_mhz") or []
+    lo, hi = float(np.min(raw)), float(np.max(raw))
+    span_lo, span_hi = (lo, hi) if lo < hi else (lo - 0.5, hi + 0.5)
+    edges = np.linspace(span_lo, span_hi, _LEGACY_HIT_HIST_BINS + 1)
+    return {
+        "raw_counts": np.histogram(raw, bins=edges)[0],
+        "merged_counts": np.histogram(merged, bins=edges)[0],
+        "freq_lo": span_lo,
+        "freq_hi": span_hi,
+        "raw_freq_min": lo,
+        "raw_freq_max": hi,
+    }
+
+
+def _cadence_top_stamps(metadata: dict, top_k: int) -> list[tuple[float, int, float, tuple | None]]:
+    """This cadence's top-K stamp representatives by detection statistic, overlap-offset
+    copies collapsed first (the per-cadence half of the old _select_top_stamps): stamps
+    sharing one exact statistic are one hit's offset copies — represented by the
+    median-start stamp (the offset-0 center for a full triplet). Keeping only the
+    per-cadence top-K preserves the global top-K exactly (each cadence can contribute at
+    most K entries to it) while bounding the reduction (#301)."""
+    stats_list = metadata.get("stamp_statistics") or []
+    freqs = metadata.get("stamp_frequencies_mhz") or []
+    starts = metadata.get("stamp_starts") or []
+
+    by_stat: dict[float, list[tuple[int, int]]] = {}
+    for idx, stat in enumerate(stats_list):
+        start = int(starts[idx]) if idx < len(starts) else 0
+        by_stat.setdefault(float(stat), []).append((start, idx))
+
+    representatives: list[tuple[float, int, float, tuple | None]] = []
+    for stat, members in by_stat.items():
+        members.sort()  # by start; median = offset-0 center for a full triplet
+        _, idx = members[len(members) // 2]
+        freq = float(freqs[idx]) if idx < len(freqs) else float("nan")
+        representatives.append((stat, idx, freq, stamp_frequency_range_mhz(metadata, idx)))
+
+    # Distinct stats per cadence (offset copies collapsed), so this sort has no ties and
+    # cross-cadence tie order stays the stable record order the old global sort had
+    representatives.sort(key=lambda r: r[0], reverse=True)
+    return representatives[:top_k]
+
+
+def _reduce_metadata(
+    record: CadenceVizRecord, metadata: dict, gallery_top_k: int
+) -> CadenceVizSummary:
+    """Reduce one cadence's parsed metadata to the bounded summary the figures consume."""
+    summary = CadenceVizSummary()
+    summary.n_raw_hits = int(metadata.get("n_raw_hits") or 0)
+    summary.n_merged_hits = int(metadata.get("n_merged_hits") or 0)
+    summary.n_stamp_rows = len(metadata.get("stamp_starts") or []) or record.n_stamps
+    with contextlib.suppress(OSError):
+        summary.npy_size_bytes = float(os.path.getsize(record.npy_path))
+    ed_hist = metadata.get("ed_stat_hist")
+    if ed_hist:
+        summary.ed_hist_edges = np.asarray(ed_hist["bin_edges"], dtype=np.float64)
+        summary.ed_hist_counts = np.asarray(ed_hist["counts_per_on_file"], dtype=np.int64)
+    summary.hit_hist = _reduce_hit_hist(metadata)
+    h5_paths = metadata.get("h5_paths") or []
+    if h5_paths:
+        summary.h5_path = h5_paths[0]
+        summary.nchans = int((metadata.get("header") or {}).get("nchans", 0) or 0)
+    summary.bandpass_envelopes = metadata.get("bandpass_envelopes") or None
+    summary.gallery_reps = _cadence_top_stamps(metadata, gallery_top_k)
+    return summary
+
+
+def _build_summaries(
+    records: list[CadenceVizRecord], gallery_top_k: int
+) -> dict[str, CadenceVizSummary]:
+    """One pass over the records' metadata sidecars: parse, reduce, drop — the only place
+    the suite touches the raw JSONs (#301)."""
+    summaries: dict[str, CadenceVizSummary] = {}
+    for record in records:
+        metadata = _load_metadata(record)
+        if metadata is not None:
+            summaries[record.npy_path] = _reduce_metadata(record, metadata, gallery_top_k)
+        del metadata
+    return summaries
+
+
 # _load_display_cadence and _draw_cadence_strip moved to the TF-free candidate_figures
 # module (#298 I9) so forkserver render workers can import them without pulling TF;
 # the suite uses them via the load_display_cadence / draw_cadence_strip imports above.
@@ -330,7 +469,7 @@ def _key_label(key: tuple, max_len: int = 28) -> str:
 
 
 def plot_ed_stat_distributions(
-    records: list[CadenceVizRecord], metadatas: dict[str, dict]
+    records: list[CadenceVizRecord], summaries: dict[str, CadenceVizSummary]
 ) -> str | None:
     """Histogram of the D'Agostino-Pearson k2 statistic over all finite windows (not just
     hits — the ED workers histogram only finite k2 values), log-log, per-ON-file overlay +
@@ -344,12 +483,11 @@ def plot_ed_stat_distributions(
     per_on_totals: np.ndarray | None = None
     contributing: set[str] = set()  # npy_paths whose histograms actually landed in the totals
     for record in records:
-        metadata = metadatas.get(record.npy_path)
-        ed_hist = (metadata or {}).get("ed_stat_hist")
-        if not ed_hist:
+        summary = summaries.get(record.npy_path)
+        if summary is None or summary.ed_hist_edges is None:
             continue
-        cadence_edges = np.asarray(ed_hist["bin_edges"], dtype=np.float64)
-        counts = np.asarray(ed_hist["counts_per_on_file"], dtype=np.int64)
+        cadence_edges = summary.ed_hist_edges
+        counts = summary.ed_hist_counts
         if edges is None:
             edges = cadence_edges
             per_on_totals = np.zeros_like(counts)
@@ -388,7 +526,7 @@ def plot_ed_stat_distributions(
     # so the threshold generally falls inside a bin — summing bins would be approximate).
     # Summed over the SAME cadence subset that built the histogram, so the above/total pair
     # stays consistent when a mismatched-bins/shape cadence was dropped above.
-    above = sum(int(metadatas[p].get("n_raw_hits") or 0) for p in contributing)
+    above = sum(summaries[p].n_raw_hits for p in contributing)
     total = int(per_on_totals.sum())
     ax.set_xscale("log")
     ax.set_yscale("log")
@@ -405,42 +543,54 @@ def plot_ed_stat_distributions(
     return _save_and_upload(fig, f"ed_stat_distributions_{tag}.png", "ED Statistic Distribution")
 
 
-def plot_ed_hit_spectrum(records: list[CadenceVizRecord], metadatas: dict[str, dict]) -> str | None:
+def plot_ed_hit_spectrum(
+    records: list[CadenceVizRecord], summaries: dict[str, CadenceVizSummary]
+) -> str | None:
     """Hit density vs frequency (MHz) across the band, pre- vs post-deduplication — RFI comb
-    structure shows up immediately as spikes/picket-fences."""
+    structure shows up immediately as spikes/picket-fences. Rendered by rebinning each
+    cadence's bounded fine histogram (pre-binned by preprocessing, or reduced from a legacy
+    sidecar's raw lists at load — #301) onto one global axis: the fine bins are ≥40x finer
+    than the figure's, so the result is visually identical to histogramming the raw floats
+    while never holding the catalog's hit lists in RAM."""
     tag = get_config().checkpoint.save_tag
 
-    # NOTE: unlike the pre-binned ED stat histograms, hit frequencies are accumulated raw
-    # across every cadence before the histogram call — an asymmetry that is bounded at
-    # current catalog scale (~1e5-1e6 floats) but would warrant pre-binning in the
-    # metadata (fixed frequency grid, like ed_stat_hist) if catalogs grow to hundreds of
-    # RFI-dense cadences.
-    raw_freqs: list[float] = []
-    merged_freqs: list[float] = []
-    for record in records:
-        metadata = metadatas.get(record.npy_path) or {}
-        raw_freqs.extend(metadata.get("raw_hit_frequencies_mhz") or [])
-        merged_freqs.extend(metadata.get("merged_hit_frequencies_mhz") or [])
-
-    if not raw_freqs:
+    with_hits = [
+        summaries[record.npy_path]
+        for record in records
+        if summaries.get(record.npy_path) and summaries[record.npy_path].hit_hist
+    ]
+    if not with_hits:
         logger.info("Viz: no hit frequencies available; skipping ed_hit_spectrum")
         return None
 
-    lo, hi = float(np.min(raw_freqs)), float(np.max(raw_freqs))
+    lo = min(s.hit_hist["raw_freq_min"] for s in with_hits)
+    hi = max(s.hit_hist["raw_freq_max"] for s in with_hits)
     if lo == hi:  # single-frequency degenerate range: give the histogram some width
         lo, hi = lo - 0.5, hi + 0.5
     bins = np.linspace(lo, hi, _HIT_SPECTRUM_BINS + 1)
 
+    raw_total = np.zeros(_HIT_SPECTRUM_BINS, dtype=np.float64)
+    merged_total = np.zeros(_HIT_SPECTRUM_BINS, dtype=np.float64)
+    for s in with_hits:
+        h = s.hit_hist
+        fine_edges = np.linspace(h["freq_lo"], h["freq_hi"], len(h["raw_counts"]) + 1)
+        # Clip centers into the global range: a boundary hit's fine bin can center just
+        # outside [lo, hi] — its count belongs in the edge bin, exactly where the raw
+        # float would have landed
+        centers = np.clip((fine_edges[:-1] + fine_edges[1:]) / 2, lo, hi)
+        raw_total += np.histogram(centers, bins=bins, weights=h["raw_counts"])[0]
+        merged_total += np.histogram(centers, bins=bins, weights=h["merged_counts"])[0]
+
     fig = Figure(figsize=(12, 5))
     ax = fig.subplots()
-    ax.hist(raw_freqs, bins=bins, histtype="stepfilled", alpha=0.35, label="raw hits (pre-dedup)")
-    ax.hist(merged_freqs, bins=bins, histtype="step", lw=1.4, color="crimson", label="merged hits")
+    ax.stairs(raw_total, bins, fill=True, alpha=0.35, label="raw hits (pre-dedup)")
+    ax.stairs(merged_total, bins, lw=1.4, color="crimson", label="merged hits")
     ax.set_yscale("log")
     ax.set_xlabel("frequency (MHz)")
     ax.set_ylabel("hit count")
     ax.set_title(
         f"Energy-detection hit spectrum ({tag})\n"
-        f"{len(raw_freqs):,} raw → {len(merged_freqs):,} merged hits"
+        f"{int(raw_total.sum()):,} raw → {int(merged_total.sum()):,} merged hits"
     )
     ax.legend(fontsize=9)
     ax.grid(True, alpha=0.2)
@@ -448,13 +598,65 @@ def plot_ed_hit_spectrum(records: list[CadenceVizRecord], metadatas: dict[str, d
     return _save_and_upload(fig, f"ed_hit_spectrum_{tag}.png", "ED Hit Spectrum")
 
 
+def _plot_bandpass_from_envelopes(
+    envelopes: list[dict], h5_path: str | None, tag: str
+) -> str | None:
+    """Render the bandpass-flattening figure from the decimated envelope lines persisted
+    in a cadence's metadata sidecar (#301): the same three lines per sampled channel the
+    live path draws, computed by preprocessing while the channels were resident — no h5
+    reads at viz time (they measured 114 s of cold /datag reads = 74% of a cached rerun's
+    viz span)."""
+    fig = Figure(figsize=(14, 3.2 * len(envelopes)))
+    axes = fig.subplots(len(envelopes), 2, squeeze=False)
+    overlay_label = "removed model"
+    for row, entry in enumerate(envelopes):
+        ax_raw, ax_flat = axes[row]
+        overlay_label = entry.get("overlay_label") or overlay_label
+        ax_raw.plot(
+            entry["raw"]["idx"],
+            entry["raw"]["values"],
+            lw=0.6,
+            color="tab:blue",
+            label="raw integrated spectrum",
+        )
+        ax_raw.plot(
+            entry["overlay"]["idx"],
+            entry["overlay"]["values"],
+            lw=1.2,
+            ls="--",
+            color="tab:orange",
+            label=overlay_label,
+        )
+        ax_raw.set_ylabel(f"coarse channel {entry.get('channel', '?')}\nintegrated power")
+        ax_flat.plot(
+            entry["flat"]["idx"],
+            entry["flat"]["values"],
+            lw=0.6,
+            color="tab:green",
+            label="flattened integrated spectrum",
+        )
+        if row == 0:
+            ax_raw.legend(loc="upper right", fontsize=8)
+            ax_flat.legend(loc="upper right", fontsize=8)
+        if row == len(envelopes) - 1:
+            ax_raw.set_xlabel("fine channel (within coarse channel)")
+            ax_flat.set_xlabel("fine channel (within coarse channel)")
+
+    method = "pfb" if "PFB" in overlay_label else "spline"
+    source = os.path.basename(h5_path) if h5_path else "stored envelopes"
+    fig.suptitle(f"Bandpass flattening ({method}, {tag}): {source}")
+    fig.tight_layout()
+    return _save_and_upload(fig, f"bandpass_flattening_{tag}.png", "Bandpass Flattening")
+
+
 def plot_bandpass_flattening(
-    preprocessor, records: list[CadenceVizRecord], metadatas: dict[str, dict]
+    preprocessor, records: list[CadenceVizRecord], summaries: dict[str, CadenceVizSummary]
 ) -> str | None:
     """Integrated spectrum raw vs flattened for a few coarse channels sampled across the
     band of the first cadence's primary ON file, with the removed model (scaled PFB response
     H or spline fit) overlaid — formalizes PR-07's opt-in debug artifact as a standard
-    per-run figure."""
+    per-run figure. Rendered from the envelopes persisted at preprocess time when a sidecar
+    carries them (#301); legacy sidecars keep the historical live-read path below."""
     # NOTE: reaches into DataPreprocessor's private helpers on purpose — they are the
     # single source of truth for how a channel is read/despiked/flattened, and duplicating
     # that here would let the figure drift from what detection actually does.
@@ -468,13 +670,18 @@ def plot_bandpass_flattening(
     tag = config.checkpoint.save_tag
     width = config.inference.coarse_channel_width
 
-    h5_path = None
     for record in records:
-        metadata = metadatas.get(record.npy_path) or {}
-        h5_paths = metadata.get("h5_paths") or []
-        if h5_paths and os.path.exists(h5_paths[0]):
-            h5_path = h5_paths[0]
-            n_chans = int((metadata.get("header") or {}).get("nchans", 0))
+        summary = summaries.get(record.npy_path)
+        if summary is not None and summary.bandpass_envelopes:
+            return _plot_bandpass_from_envelopes(summary.bandpass_envelopes, summary.h5_path, tag)
+
+    h5_path = None
+    n_chans = 0
+    for record in records:
+        summary = summaries.get(record.npy_path)
+        if summary is not None and summary.h5_path and os.path.exists(summary.h5_path):
+            h5_path = summary.h5_path
+            n_chans = summary.nchans
             break
     if h5_path is None:
         logger.info("Viz: no readable ON-source .h5 available; skipping bandpass_flattening")
@@ -552,48 +759,39 @@ def plot_bandpass_flattening(
 
 
 def _select_top_stamps(
-    records: list[CadenceVizRecord], metadatas: dict[str, dict], top_k: int
-) -> list[tuple[CadenceVizRecord, int, float, float]]:
-    """Pick the top_k stamps by detection statistic across all cadences, collapsing
-    overlap-search offset copies first: with overlap_search each hit yields up to three
-    stamps (at -offset/0/+offset) that all carry the hit's statistic, so a plain top-K
-    would show the same hit up to three times. Copies are grouped by their (exact) shared
-    statistic per cadence and represented by the median-start stamp — the offset-0 center
-    for a full triplet. Returns (record, snippet_index, statistic, frequency_mhz) tuples,
-    strongest first."""
-    representatives: list[tuple[float, CadenceVizRecord, int, float]] = []
+    records: list[CadenceVizRecord], summaries: dict[str, CadenceVizSummary], top_k: int
+) -> list[tuple[CadenceVizRecord, int, float, float, tuple | None]]:
+    """Pick the top_k stamps by detection statistic across all cadences, from the
+    per-cadence top-K representatives the reduce pass computed (_cadence_top_stamps —
+    overlap-offset copies already collapsed there). Selecting the global top-K from the
+    per-cadence top-Ks is exact: each cadence can contribute at most K entries. Returns
+    (record, snippet_index, statistic, frequency_mhz, freq_range) tuples, strongest
+    first."""
+    representatives: list[tuple[float, CadenceVizRecord, int, float, tuple | None]] = []
     for record in records:
-        metadata = metadatas.get(record.npy_path) or {}
-        stats_list = metadata.get("stamp_statistics") or []
-        freqs = metadata.get("stamp_frequencies_mhz") or []
-        starts = metadata.get("stamp_starts") or []
-
-        # Group this cadence's stamps by exact statistic value (offset copies of one hit
-        # share the same float64 statistic; distinct hits colliding on the exact value is
-        # vanishingly unlikely, and for a gallery a collision merely hides a duplicate look)
-        by_stat: dict[float, list[tuple[int, int]]] = {}
-        for idx, stat in enumerate(stats_list):
-            start = int(starts[idx]) if idx < len(starts) else 0
-            by_stat.setdefault(float(stat), []).append((start, idx))
-
-        for stat, members in by_stat.items():
-            members.sort()  # by start; median = offset-0 center for a full triplet
-            _, idx = members[len(members) // 2]
-            freq = float(freqs[idx]) if idx < len(freqs) else float("nan")
-            representatives.append((stat, record, idx, freq))
+        summary = summaries.get(record.npy_path)
+        if summary is None:
+            continue
+        for stat, idx, freq, freq_range in summary.gallery_reps:
+            representatives.append((stat, record, idx, freq, freq_range))
 
     representatives.sort(key=lambda c: c[0], reverse=True)
-    return [(record, idx, stat, freq) for stat, record, idx, freq in representatives[:top_k]]
+    return [
+        (record, idx, stat, freq, freq_range)
+        for stat, record, idx, freq, freq_range in representatives[:top_k]
+    ]
 
 
-def plot_stamp_gallery(records: list[CadenceVizRecord], metadatas: dict[str, dict]) -> str | None:
+def plot_stamp_gallery(
+    records: list[CadenceVizRecord], summaries: dict[str, CadenceVizSummary]
+) -> str | None:
     """Top-K stamps by detection statistic, each rendered as the 6-observation cadence
     waterfall grid scientists actually inspect (ON/OFF rows, one stamp per column)."""
     config = get_config()
     tag = config.checkpoint.save_tag
     top_k = config.inference.stamp_gallery_top_k
 
-    selected = _select_top_stamps(records, metadatas, top_k)
+    selected = _select_top_stamps(records, summaries, top_k)
     if not selected:
         logger.info("Viz: no stamps available; skipping stamp_gallery")
         return None
@@ -603,7 +801,7 @@ def plot_stamp_gallery(records: list[CadenceVizRecord], metadatas: dict[str, dic
     fig = Figure(figsize=(1.9 * n_cols + 1.2, 1.1 * n_rows + 1.6))
     axes = fig.subplots(n_rows, n_cols, squeeze=False)
 
-    for col, (record, idx, stat, freq) in enumerate(selected):
+    for col, (record, idx, stat, freq, freq_range) in enumerate(selected):
         try:
             snippet = load_display_cadence(record.npy_path, idx)
         except Exception as e:
@@ -615,7 +813,7 @@ def plot_stamp_gallery(records: list[CadenceVizRecord], metadatas: dict[str, dic
             [axes[row][col] for row in range(n_rows)],
             snippet,
             label_rows=col == 0,
-            freq_range_mhz=stamp_frequency_range_mhz(metadatas.get(record.npy_path) or {}, idx),
+            freq_range_mhz=freq_range,
         )
         axes[0][col].set_title(
             f"$k^2$={stat:.3g}\n{freq:.4f} MHz\n{_key_label(record.key, 20)}", fontsize=7
@@ -626,29 +824,47 @@ def plot_stamp_gallery(records: list[CadenceVizRecord], metadatas: dict[str, dic
     return _save_and_upload(fig, f"stamp_gallery_{tag}.png", "Stamp Gallery")
 
 
-def plot_preproc_funnel(records: list[CadenceVizRecord], metadatas: dict[str, dict]) -> str | None:
+def plot_preproc_funnel(
+    records: list[CadenceVizRecord], summaries: dict[str, CadenceVizSummary]
+) -> str | None:
     """Per-cadence preprocessing funnel: raw hits → merged hits → stamps (incl. overlap
-    offsets) → snippets inferred, plus per-cadence stamp storage annotated on top."""
+    offsets) → snippets inferred, plus per-cadence stamp storage annotated on top. Past
+    _FUNNEL_MAX_CADENCES the strongest cadences (by raw hits) keep individual bars and
+    the rest aggregate into one summary bar (#301 — at 270 px/cadence the unbounded
+    figure exceeded Agg's 2^16-px canvas limit past 242 cadences, so every catalog-scale
+    render burned the artist work and then silently lost the figure)."""
     tag = get_config().checkpoint.save_tag
 
     labels: list[str] = []
     stage_counts: list[tuple[int, int, int, int]] = []
     storage_gb: list[float] = []
     for record in records:
-        metadata = metadatas.get(record.npy_path) or {}
-        n_raw = int(metadata.get("n_raw_hits") or 0)
-        n_merged = int(metadata.get("n_merged_hits") or 0)
-        n_stamps = len(metadata.get("stamp_starts") or []) or record.n_stamps
+        summary = summaries.get(record.npy_path)
+        n_raw = summary.n_raw_hits if summary else 0
+        n_merged = summary.n_merged_hits if summary else 0
+        n_stamps = (summary.n_stamp_rows if summary else 0) or record.n_stamps
         labels.append(_key_label(record.key))
         stage_counts.append((n_raw, n_merged, n_stamps, record.n_stamps))
-        try:
-            storage_gb.append(os.path.getsize(record.npy_path) / 1e9)
-        except OSError:
-            storage_gb.append(float("nan"))
+        size = summary.npy_size_bytes if summary else float("nan")
+        storage_gb.append(size / 1e9 if np.isfinite(size) else float("nan"))
 
     if not stage_counts:
         logger.info("Viz: no cadences recorded; skipping preproc_funnel")
         return None
+
+    aggregated_note = ""
+    if len(stage_counts) > _FUNNEL_MAX_CADENCES:
+        order = np.argsort([c[0] for c in stage_counts])[::-1]
+        keep = set(order[:_FUNNEL_MAX_CADENCES].tolist())
+        rest = [i for i in range(len(stage_counts)) if i not in keep]
+        agg_counts = tuple(int(sum(stage_counts[i][j] for i in rest)) for j in range(4))
+        agg_storage = float(np.nansum([storage_gb[i] for i in rest]))
+        # Kept cadences stay in catalog order; the aggregate bar closes the figure
+        kept = sorted(keep)
+        labels = [labels[i] for i in kept] + [f"+{len(rest)} more (aggregated)"]
+        stage_counts = [stage_counts[i] for i in kept] + [agg_counts]
+        storage_gb = [storage_gb[i] for i in kept] + [agg_storage]
+        aggregated_note = f" — top {_FUNNEL_MAX_CADENCES} by raw hits, {len(rest)} aggregated"
 
     stages = ("raw hits", "merged hits", "stamps (+overlap)", "snippets inferred")
     counts = np.asarray(stage_counts, dtype=np.float64)  # (n_cadences, 4)
@@ -679,7 +895,9 @@ def plot_preproc_funnel(records: list[CadenceVizRecord], metadatas: dict[str, di
     ax.set_xticks(x)
     ax.set_xticklabels(labels, rotation=20, ha="right", fontsize=8)
     ax.set_ylabel("count")
-    ax.set_title(f"Preprocessing funnel per cadence ({tag}) — stamp storage annotated")
+    ax.set_title(
+        f"Preprocessing funnel per cadence ({tag}) — stamp storage annotated{aggregated_note}"
+    )
     ax.legend(fontsize=8)
     ax.grid(True, axis="y", alpha=0.2)
 
@@ -1029,7 +1247,7 @@ def plot_inference_latent_projection(collector: InferenceVizCollector) -> str | 
 
 
 def plot_inference_summary(
-    records: list[CadenceVizRecord], metadatas: dict[str, dict], totals: dict
+    records: list[CadenceVizRecord], summaries: dict[str, CadenceVizSummary], totals: dict
 ) -> str | None:
     """Table-style run summary card: cadence/snippet/candidate counts, per-stage durations
     and throughput from the inference_cadences manifest, and per-target/band candidate
@@ -1055,12 +1273,12 @@ def plot_inference_summary(
                 inference_duration += duration
 
     n_snippets = int(totals.get("n_cadence_snippets", 0))
-    n_raw_hits = sum(int((m or {}).get("n_raw_hits") or 0) for m in metadatas.values())
-    n_merged_hits = sum(int((m or {}).get("n_merged_hits") or 0) for m in metadatas.values())
-    storage_gb = 0.0
-    for record in records:
-        with contextlib.suppress(OSError):
-            storage_gb += os.path.getsize(record.npy_path) / 1e9
+    n_raw_hits = sum(s.n_raw_hits for s in summaries.values())
+    n_merged_hits = sum(s.n_merged_hits for s in summaries.values())
+    # File sizes were stat()ed once by the reduce pass — no second walk over the catalog
+    storage_gb = float(
+        np.nansum([s.npy_size_bytes for s in summaries.values()]) / 1e9 if summaries else 0.0
+    )
 
     summary_rows = [
         ("run tag", tag),
@@ -1133,27 +1351,37 @@ def render_inference_visualizations(
     logger.info(f"Rendering inference visualization suite under plots/inference/{tag}/")
 
     records = collector.records
-    metadatas: dict[str, dict] = {}
-    for record in records:
-        metadata = _load_metadata(record)
-        if metadata is not None:
-            metadatas[record.npy_path] = metadata
+    if config.inference.inference_viz_scope == "new":
+        # Scope 'new' (#301): resumed passes on an accumulating tag re-rendered the FULL
+        # catalog's figures every pass. This renders only cadences inferred THIS pass;
+        # the DB-sourced candidate figures below still cover the whole tag, and the final
+        # pass can render everything with the 'full' default.
+        n_before = len(records)
+        records = [record for record in records if not record.skipped]
+        logger.info(
+            f"Viz scope 'new': rendering {len(records)} of {n_before} recorded cadence(s) "
+            f"(resumed cadences excluded; candidate figures still cover the full tag)"
+        )
+
+    with stage_timer("load_metadata"):
+        summaries = _build_summaries(records, config.inference.stamp_gallery_top_k)
 
     try:
-        _viz_safe("ed_stat_distributions", plot_ed_stat_distributions, records, metadatas)
-        _viz_safe("ed_hit_spectrum", plot_ed_hit_spectrum, records, metadatas)
-        _viz_safe("bandpass_flattening", plot_bandpass_flattening, preprocessor, records, metadatas)
-        _viz_safe("stamp_gallery", plot_stamp_gallery, records, metadatas)
-        _viz_safe("preproc_funnel", plot_preproc_funnel, records, metadatas)
+        _viz_safe("ed_stat_distributions", plot_ed_stat_distributions, records, summaries)
+        _viz_safe("ed_hit_spectrum", plot_ed_hit_spectrum, records, summaries)
+        _viz_safe("bandpass_flattening", plot_bandpass_flattening, preprocessor, records, summaries)
+        _viz_safe("stamp_gallery", plot_stamp_gallery, records, summaries)
+        _viz_safe("preproc_funnel", plot_preproc_funnel, records, summaries)
         _viz_safe("confidence_distribution", plot_confidence_distribution, records)
         _viz_safe("candidate_gallery", plot_candidate_gallery)
         _viz_safe("candidate_uncertainty", plot_candidate_uncertainty)
         _viz_safe("inference_latent_projection", plot_inference_latent_projection, collector)
-        _viz_safe("inference_summary", plot_inference_summary, records, metadatas, totals)
+        _viz_safe("inference_summary", plot_inference_summary, records, summaries, totals)
     finally:
         # The async uploader must be empty before the caller reaches logger teardown
         # (#298 I9) — uploads queued by any figure above are flushed here even when a
         # figure raised through _viz_safe's own guard
-        _uploader.drain()
+        with stage_timer("upload_drain"):
+            _uploader.drain()
 
     logger.info("Inference visualization suite complete")

--- a/src/aetherscan/inference_viz.py
+++ b/src/aetherscan/inference_viz.py
@@ -24,7 +24,6 @@ background threads, and pyplot's global figure registry is not thread-safe.
 
 from __future__ import annotations
 
-import contextlib
 import json
 import logging
 import os
@@ -184,7 +183,11 @@ class InferenceVizCollector:
     subsampled against a global budget (candidates always kept).
     """
 
-    def __init__(self, max_latent_points: int = _MAX_LATENT_POINTS):
+    def __init__(
+        self,
+        max_latent_points: int = _MAX_LATENT_POINTS,
+        gallery_pool: list | None = None,
+    ):
         self.records: list[CadenceVizRecord] = []
         self._max_latent_points = max_latent_points
         self._latent_chunks: list[np.ndarray] = []  # (k, num_obs * latent_dim) each
@@ -195,9 +198,16 @@ class InferenceVizCollector:
         self._rng = derive_rng(root_seed, STREAM_INFERENCE_VIZ)
         # Bounded top-K stamp-pixel pool (#302): raw pixels of the strongest stamps seen
         # so far, captured just before pruning deletes a cadence's .npy, so the stamp
-        # gallery stays whole (~196 KB x top_k ≈ 2.4 MB at defaults)
+        # gallery stays whole (~196 KB x top_k ≈ 2.4 MB at defaults). A caller-supplied
+        # list persists it ACROSS the in-process retry attempts (#305 fix): each attempt
+        # builds a fresh collector, but a cadence pruned in an earlier attempt is
+        # resume-skipped (never re-pooled) in later ones, so a per-attempt pool would blank
+        # its gallery column on the retry render. Cross-PROCESS relaunch still can't recover
+        # those pixels (documented) — but a full-catalog run rarely relaunches.
         self._gallery_top_k = config.inference.stamp_gallery_top_k if config is not None else 12
-        self._gallery_pixel_pool: list[tuple[float, str, int, np.ndarray]] = []
+        self._gallery_pixel_pool: list[tuple[float, str, int, np.ndarray]] = (
+            gallery_pool if gallery_pool is not None else []
+        )
 
     def record_skipped(
         self, key: tuple, npy_path: str, metadata_path: str, manifest_row: dict
@@ -459,8 +469,21 @@ def _reduce_metadata(
     summary.n_raw_hits = int(metadata.get("n_raw_hits") or 0)
     summary.n_merged_hits = int(metadata.get("n_merged_hits") or 0)
     summary.n_stamp_rows = len(metadata.get("stamp_starts") or []) or record.n_stamps
-    with contextlib.suppress(OSError):
+    try:
         summary.npy_size_bytes = float(os.path.getsize(record.npy_path))
+    except OSError:
+        # The .npy was pruned after scoring (#302 default) — reconstruct the size the run
+        # transiently held from the stored geometry so the funnel/summary storage figures
+        # don't silently collapse to nan/0 on every default run. The .npy shape is
+        # (n_stamps, n_obs, time_bins, stored_width) float32 + a ~128-byte header.
+        config = get_config()
+        stored_width = metadata.get("stored_width")
+        time_bins = config.data.time_bins if config is not None else None
+        n_obs = len(metadata.get("h5_paths") or []) or 6
+        if stored_width and time_bins:
+            summary.npy_size_bytes = float(
+                summary.n_stamp_rows * n_obs * int(time_bins) * int(stored_width) * 4 + 128
+            )
     ed_hist = metadata.get("ed_stat_hist")
     if ed_hist:
         summary.ed_hist_edges = np.asarray(ed_hist["bin_edges"], dtype=np.float64)
@@ -579,14 +602,27 @@ def plot_ed_stat_distributions(
     return _save_and_upload(fig, f"ed_stat_distributions_{tag}.png", "ED Statistic Distribution")
 
 
+def _clamp_hit_spectrum_bins(
+    lo: float, hi: float, coarsest_fine_width: float, max_bins: int
+) -> int:
+    """Number of hit-spectrum figure bins over [lo, hi] that keeps each figure bin no finer
+    than the coarsest stored fine grid (>= one fine bin per figure bin), so the rebin can't
+    alias into a picket-fence (#305). Returns max_bins when the span is wide (the common
+    case) and fewer as the span narrows toward the fine-grid resolution."""
+    if coarsest_fine_width <= 0 or hi <= lo:
+        return max_bins
+    return max(1, min(max_bins, int((hi - lo) / coarsest_fine_width)))
+
+
 def plot_ed_hit_spectrum(
     records: list[CadenceVizRecord], summaries: dict[str, CadenceVizSummary]
 ) -> str | None:
     """Hit density vs frequency (MHz) across the band, pre- vs post-deduplication — RFI comb
     structure shows up immediately as spikes/picket-fences. Rendered by rebinning each
     cadence's bounded fine histogram (pre-binned by preprocessing, or reduced from a legacy
-    sidecar's raw lists at load — #301) onto one global axis: the fine bins are ≥40x finer
-    than the figure's, so the result is visually identical to histogramming the raw floats
+    sidecar's raw lists at load — #301) onto one global axis whose bin count is clamped so
+    the figure bins are never finer than the stored fine grid — so the result is visually
+    faithful to histogramming the raw floats (identical for the wide-span common case)
     while never holding the catalog's hit lists in RAM."""
     tag = get_config().checkpoint.save_tag
 
@@ -603,10 +639,21 @@ def plot_ed_hit_spectrum(
     hi = max(s.hit_hist["raw_freq_max"] for s in with_hits)
     if lo == hi:  # single-frequency degenerate range: give the histogram some width
         lo, hi = lo - 0.5, hi + 0.5
-    bins = np.linspace(lo, hi, _HIT_SPECTRUM_BINS + 1)
 
-    raw_total = np.zeros(_HIT_SPECTRUM_BINS, dtype=np.float64)
-    merged_total = np.zeros(_HIT_SPECTRUM_BINS, dtype=np.float64)
+    # Clamp the figure's bin count so its bins are never FINER than the stored fine grid
+    # over this span (#305 review): new sidecars pre-bin over the whole file band, so when
+    # the catalog-wide hit span is narrow (< ~band/41) the 200-bin figure axis would be
+    # finer than the fine bins and the center-weighted rebin below would draw a spurious
+    # picket-fence (empty bins between populated ones) not present in the data.
+    coarsest_fine_width = max(
+        (s.hit_hist["freq_hi"] - s.hit_hist["freq_lo"]) / max(1, len(s.hit_hist["raw_counts"]))
+        for s in with_hits
+    )
+    n_fig_bins = _clamp_hit_spectrum_bins(lo, hi, coarsest_fine_width, _HIT_SPECTRUM_BINS)
+    bins = np.linspace(lo, hi, n_fig_bins + 1)
+
+    raw_total = np.zeros(n_fig_bins, dtype=np.float64)
+    merged_total = np.zeros(n_fig_bins, dtype=np.float64)
     for s in with_hits:
         h = s.hit_hist
         fine_edges = np.linspace(h["freq_lo"], h["freq_hi"], len(h["raw_counts"]) + 1)

--- a/src/aetherscan/inference_viz.py
+++ b/src/aetherscan/inference_viz.py
@@ -52,7 +52,6 @@ from aetherscan.candidate_figures import (
 from aetherscan.config import get_config
 from aetherscan.db import get_db
 from aetherscan.logger import get_logger
-from aetherscan.models import prepare_latent_features
 from aetherscan.pfb import gen_coarse_channel_response
 from aetherscan.seeding import STREAM_INFERENCE_VIZ, derive_rng
 
@@ -234,11 +233,6 @@ class InferenceVizCollector:
         concatenated), candidates always kept; non-candidates fill whatever global budget
         remains, uniformly subsampled WITHIN this cadence when they'd overflow it (later
         cadences get nothing once the budget is spent)."""
-        config = get_config()
-        features = prepare_latent_features(
-            np.asarray(latents), config.data.num_observations
-        ).astype(np.float32)
-
         keep = np.nonzero(is_candidate)[0]
         budget = self._max_latent_points - self._latent_count - keep.size
         non_candidates = np.nonzero(~is_candidate)[0]
@@ -248,8 +242,18 @@ class InferenceVizCollector:
             keep = np.concatenate([keep, non_candidates])
 
         if keep.size == 0:
+            # Once the global budget is spent (a cadence or two into the catalog), every
+            # non-candidate cadence lands here — so nothing may be built before this
+            # return. The full-cadence feature matrix this method used to construct first
+            # (~190 MB float64 for a 330k-stamp cadence) was thrown away each time (#301).
             return
-        self._latent_chunks.append(features[keep])
+        # Cadence-level rows for the kept indices only. Value-identical to
+        # prepare_latent_features(latents)[keep].astype(np.float32): the helper's
+        # float32 -> float64 -> float32 round trip is exact, and the row-major
+        # reshape is the helper's own documented layout (fancy indexing yields a
+        # fresh array, so the chunk owns its memory).
+        features = np.asarray(latents, dtype=np.float32).reshape(len(is_candidate), -1)[keep]
+        self._latent_chunks.append(features)
         self._candidate_chunks.append(is_candidate[keep])
         self._latent_count += keep.size
 

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -6,6 +6,7 @@ Entry point for Aetherscan Pipeline
 
 from __future__ import annotations
 
+import contextlib
 import gc
 import importlib.util
 import json
@@ -22,6 +23,7 @@ import tensorflow as tf
 from dotenv import find_dotenv, load_dotenv
 
 from aetherscan.benchmark import stage_timer
+from aetherscan.candidate_figures import write_candidate_snippet_sidecar
 from aetherscan.cli import (
     apply_args_to_config,
     apply_saved_config,
@@ -459,6 +461,49 @@ def _prefetch_cadence(preprocessor: DataPreprocessor, unit: PendingCadence) -> t
     return cadence_result, cadence_data
 
 
+def _resolve_prune_stamps(config) -> bool:
+    """Resolve the stamp-cache pruning mode (#302): an explicit inference.prune_stamps
+    wins; the None default means AUTO — ON for the fingerprint-scoped default cache
+    directory, OFF when --preprocess-output-dir pins an operator-curated one (a handed
+    cache is never destroyed implicitly)."""
+    if config.inference.prune_stamps is not None:
+        return bool(config.inference.prune_stamps)
+    return config.inference.preprocess_output_dir is None
+
+
+def _prune_cadence_stamps(
+    cadence_result: CadenceResult, results: dict, collector: InferenceVizCollector | None
+) -> None:
+    """Delete one scored cadence's stamp .npy (#302), keeping everything the rest of the
+    run needs: the metadata .json (provenance + viz + resume guard), a ~196 KB
+    .candidates.npz snippet sidecar per candidate (the candidate figures' read path), and
+    the collector's bounded top-K pixel pool (the stamp gallery's). Runs strictly AFTER
+    the cadence's 'inferred' manifest row and viz collection — resume rides the DB row
+    and never touches the .npy. Best-effort: a pruning failure keeps the stamps and the
+    run continues (disk pressure is a slow failure; a science pass must not die for it)."""
+    npy_path = cadence_result.npy_path
+    try:
+        candidate_idx = np.nonzero(np.asarray(results["predictions"]) == 1)[0]
+        if len(candidate_idx):
+            write_candidate_snippet_sidecar(npy_path, candidate_idx)
+        if collector is not None:
+            collector.pool_gallery_pixels(cadence_result.metadata_path, npy_path)
+        size_gb = 0.0
+        with contextlib.suppress(OSError):
+            size_gb = os.path.getsize(npy_path) / 1e9
+        os.remove(npy_path)
+        logger.info(
+            f"Pruned stamp cache for cadence {cadence_result.key}: removed {npy_path} "
+            f"({size_gb:.2f} GB; metadata kept, {len(candidate_idx)} candidate snippet(s) "
+            f"sidecarred)"
+        )
+    except Exception as e:
+        logger.error(
+            f"Stamp pruning failed for cadence {cadence_result.key} ({e}); stamps kept; "
+            f"run continues"
+        )
+
+
 def _infer_cadence(
     pipeline: InferencePipeline,
     preprocessor: DataPreprocessor,
@@ -681,6 +726,13 @@ def _run_streaming_csv_inference(
         f"({totals['n_skipped']} already inferred, resumed from manifest)"
     )
 
+    prune_stamps = _resolve_prune_stamps(config)
+    logger.info(
+        f"Stamp-cache pruning: {'ON' if prune_stamps else 'OFF'} "
+        f"({'explicit' if config.inference.prune_stamps is not None else 'auto'}; "
+        f"{'default fingerprint-scoped cache dir' if config.inference.preprocess_output_dir is None else 'explicit --preprocess-output-dir'})"
+    )
+
     failed_keys: list[tuple] = []
     if pending:
         # Start the persistent energy-detection pool from the main thread BEFORE any
@@ -790,6 +842,13 @@ def _run_streaming_csv_inference(
                                 f"Viz collection failed for cadence {cadence_result.key} "
                                 f"({e}); plots will be degraded; run continues"
                             )
+
+                    # Stamp-cache pruning (#302): strictly after the 'inferred' manifest
+                    # row (inside _infer_cadence) and viz collection above, and only for
+                    # stamps THIS run freshly extracted — a resumed run never deletes a
+                    # cache it was handed
+                    if prune_stamps and cadence_result.freshly_extracted:
+                        _prune_cadence_stamps(cadence_result, results, collector)
 
                     logger.info(
                         f"Cadence {cadence_result.key} ({totals['n_cadences']} done, "

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -606,7 +606,9 @@ def _infer_cadence(
 
 
 def _run_streaming_csv_inference(
-    preprocessor: DataPreprocessor, strategy: tf.distribute.Strategy
+    preprocessor: DataPreprocessor,
+    strategy: tf.distribute.Strategy,
+    gallery_pool: list | None = None,
 ) -> dict:
     """
     Per-cadence streaming inference over the configured CSV catalogs, with stage-aware
@@ -659,7 +661,14 @@ def _run_streaming_csv_inference(
         "n_cadences": 0,
         "n_skipped": 0,
     }
-    collector = InferenceVizCollector() if config.inference.inference_viz_enabled else None
+    # gallery_pool (a run-scoped list from inference_command) persists the stamp-gallery
+    # pixel pool across the in-process retry attempts (#305): a fresh collector per attempt
+    # would otherwise blank the gallery for cadences an earlier attempt pruned.
+    collector = (
+        InferenceVizCollector(gallery_pool=gallery_pool)
+        if config.inference.inference_viz_enabled
+        else None
+    )
 
     # Stage-aware resume: a live 'inferred' manifest row for (tag, npy_path) means the cadence
     # completed on an earlier attempt — skip it and reuse its aggregates, but ONLY when it was
@@ -984,6 +993,11 @@ def inference_command():
     max_retries = config.inference.max_retries
     retry_delay = config.inference.retry_delay
     results = None
+    # Run-scoped stamp-gallery pixel pool: persists across the retry attempts below so a
+    # cadence pruned in an earlier attempt still renders in the final attempt's gallery
+    # (#305). Bounded to top-K pixels (~2.4 MB); the preprocessor likewise persists, so its
+    # freshly-extracted set survives too.
+    gallery_pool: list = []
 
     for attempt in range(max_retries):
         try:
@@ -994,7 +1008,7 @@ def inference_command():
                 # write, with models loaded once and inference.prefetch_depth cadences in
                 # flight (see _run_streaming_csv_inference). Memory stays independent of
                 # catalog size.
-                results = _run_streaming_csv_inference(preprocessor, strategy)
+                results = _run_streaming_csv_inference(preprocessor, strategy, gallery_pool)
             else:
                 if not config.data.test_files:
                     logger.error(

--- a/src/aetherscan/models/random_forest.py
+++ b/src/aetherscan/models/random_forest.py
@@ -40,16 +40,16 @@ def prepare_latent_features(latent_vectors: np.ndarray, num_observations: int = 
 
     # Target shape: (num_cadences, num_observations * latent_dim)
     # Where each element in the latent vector is treated as a feature by the Random Forest
-    # We flatten the observations so all 6 latents in a cadence are grouped together
-    features = np.zeros((num_cadences, num_observations * latent_dim))
-
-    for i in range(num_cadences):
-        # Flatten & concatenate the latent vectors according to the number of observations
-        features[i, :] = latent_vectors[
-            i * num_observations : (i + 1) * num_observations, :
-        ].ravel()
-
-    return features
+    # We flatten the observations so all 6 latents in a cadence are grouped together.
+    # A row-major reshape IS that flatten (row i = rows i*num_obs..(i+1)*num_obs-1
+    # raveled) — the per-row Python loop this replaces cost ~0.1-0.5 s per RFI-dense
+    # cadence at inference (#301). The float64 dtype is deliberate and load-bearing:
+    # the historical np.zeros default, and the training-side Active-Units gate computes
+    # .var() on this output, whose float32 accumulation differs in exactly the low bits
+    # that decide a hovering-at-threshold dim (#288's margin lesson).
+    return np.asarray(latent_vectors, dtype=np.float64).reshape(
+        num_cadences, num_observations * latent_dim
+    )
 
 
 class RandomForestModel:
@@ -149,5 +149,12 @@ class RandomForestModel:
             logger.warning("Overriding trained model")
 
         self.model = joblib.load(filepath)
+        # Predict-time parallelism must come from the RUNTIME config, not the training
+        # host's pickled value (#301): joblib.load replaces the estimator wholesale, so
+        # the constructor's rf.n_jobs was silently dead on every loaded model. n_jobs is
+        # a predict-time execution knob on a fitted forest — reassigning it cannot touch
+        # the trees. Default (-1) matches the deployed artifacts, so behavior only
+        # changes when an operator asks for it.
+        self.model.n_jobs = self.config.rf.n_jobs
         self.is_trained = True
         logger.info(f"Loaded Random Forest model from {filepath}")

--- a/src/aetherscan/monitor/monitor.py
+++ b/src/aetherscan/monitor/monitor.py
@@ -637,10 +637,14 @@ class ResourceMonitor:
         if self.db is None:
             raise RuntimeError("No database instance detected - cannot generate resource plot")
 
-        all_resources = self.db.query_system_resource(
+        # Decimated per series (#301): a multi-week run holds tens of millions of rows;
+        # the plot renders ~2k px wide, so >4k points/line is invisible and the full
+        # materialization cost a multi-GB teardown RAM spike.
+        all_resources = self.db.query_system_resource_decimated(
             tag=self.tag,
             start_time=self.start_time,
             end_time=current_time,
+            max_points_per_series=4096,
         )
 
         if not all_resources:

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -101,6 +101,16 @@ _STALE_TMP_MAX_AGE_S = 24 * 3600
 # wide float32 buffer at ~64 MiB per worker (16 time rows) even across an RFI comb whose
 # windows chain for a whole coarse channel.
 _COALESCE_MAX_BINS = 2**20
+# Fixed per-cadence bin count for the pre-binned hit-frequency histograms stored in the
+# metadata sidecar (#301): the raw per-hit frequency lists ran ~19 MB of JSON on an
+# RFI-dense cadence (~117 GB over the full catalog) and forced the viz suite to hold every
+# cadence's floats in RAM. 8192 bins over the file band keeps the rebinned hit-spectrum
+# figure visually identical (fine-bin width ≪ the figure's global bin width) at ~20-50 KB.
+_HIT_HIST_BINS = 8192
+# Decimation budget for the bandpass envelopes persisted per cadence (#301): the viz
+# figure renders ~2,100 px wide, so 1,024 min/max pairs per line lose nothing visually,
+# and the stored envelopes spare the figure its ~114 s of cold /datag channel re-reads.
+_ENVELOPE_MAX_POINTS = 1024
 
 
 def _chunk_cache_kwargs(h5_path: str, time_bins: int) -> dict:
@@ -663,21 +673,24 @@ def _cached_h5_file(h5_path: str):
     return handle
 
 
-def _energy_detect_channel_worker(args: tuple) -> tuple[list[tuple], np.ndarray]:
+def _energy_detect_channel_worker(args: tuple) -> tuple[list[tuple], np.ndarray, np.ndarray | None]:
     """
     Fused worker: run the complete energy-detection chain for one coarse channel — read the
     channel's h5 slice, remove the DC spike, flatten the bandpass, and threshold the vectorized
-    normality statistic. Returns (hits, stat_hist): hits is a small list of
+    normality statistic. Returns (hits, stat_hist, integrated): hits is a small list of
     (absolute_fine_channel_index, statistic, pvalue) tuples; stat_hist is the histogram of
     *all* finite window statistics (not just hits) over the fixed ED_STAT_HIST_EDGES bins, so
     the parent can cheaply accumulate the full per-file statistic distribution for the
-    visualization suite. The bulky (time_bins, coarse_channel_width) intermediates never leave
+    visualization suite; integrated is the despiked channel's time-integrated spectrum
+    (float64, only when want_spectrum — the parent turns the few sampled channels' spectra
+    into the persisted bandpass envelopes, #301, sparing the viz suite its cold h5 re-reads).
+    The bulky (time_bins, coarse_channel_width) intermediates never leave
     the worker, so no shared memory or per-block parent arrays are needed.
 
     args is (h5_path, channel_index, coarse_channel_width, time_bins, bandpass_flatten,
-    window_size, step_size, stat_threshold). bandpass_flatten is a picklable callable
-    (channel) -> residuals (see _spline_flatten_bandpass). Each worker opens its own h5py.File
-    since h5py file handles are fork-unsafe to share.
+    window_size, step_size, stat_threshold, want_spectrum). bandpass_flatten is a picklable
+    callable (channel) -> residuals (see _spline_flatten_bandpass). Each worker opens its own
+    h5py.File since h5py file handles are fork-unsafe to share.
     """
     (
         h5_path,
@@ -688,6 +701,7 @@ def _energy_detect_channel_worker(args: tuple) -> tuple[list[tuple], np.ndarray]
         window_size,
         step_size,
         stat_threshold,
+        want_spectrum,
     ) = args
 
     start = channel_index * coarse_channel_width
@@ -706,6 +720,10 @@ def _energy_detect_channel_worker(args: tuple) -> tuple[list[tuple], np.ndarray]
     # offsets can never cross a coarse-channel boundary.
     _remove_dc_spike(channel, coarse_channel_width, 1)
 
+    # float64 accumulation matches the viz path this replaces (_read_despiked_channel
+    # casts to float64 before integrating); one mean over the already-resident channel.
+    integrated = channel.mean(axis=0, dtype=np.float64) if want_spectrum else None
+
     residuals = bandpass_flatten(channel)
 
     k2 = _sliding_normality_k2(residuals, window_size, step_size)
@@ -720,7 +738,7 @@ def _energy_detect_channel_worker(args: tuple) -> tuple[list[tuple], np.ndarray]
 
     hit_windows = np.nonzero(k2 > stat_threshold)[0]
     if hit_windows.size == 0:
-        return [], stat_hist
+        return [], stat_hist, integrated
 
     # p-values are only stored in metadata, so chi2.sf runs on the (small) hit subset only
     pvalues = stats.chi2.sf(k2[hit_windows], 2)
@@ -728,7 +746,7 @@ def _energy_detect_channel_worker(args: tuple) -> tuple[list[tuple], np.ndarray]
         (start + int(j) * step_size, float(k2[j]), float(p))
         for j, p in zip(hit_windows, pvalues, strict=True)
     ]
-    return hits, stat_hist
+    return hits, stat_hist, integrated
 
 
 def _coalesce_stamp_groups(stamp_starts, stamp_width: int) -> list[list[int]]:
@@ -1980,6 +1998,11 @@ class DataPreprocessor:
                 else None
             )
 
+            # The few channels whose despiked integrated spectra feed the persisted
+            # bandpass envelopes (#301) — primary ON file only, same sampling as the
+            # figure this replaces; the spectra ride back with the ED results, so no
+            # extra h5 reads happen at all
+            envelope_channels = set(self._sample_channel_indices(n_coarse_total))
             tasks = [
                 (
                     on_h5,
@@ -1990,6 +2013,7 @@ class DataPreprocessor:
                     window_size,
                     step_size,
                     stat_threshold,
+                    on_h5 == primary_h5 and ch in envelope_channels,
                 )
                 for on_h5 in on_source_paths
                 for ch in range(n_coarse_total)
@@ -2007,11 +2031,14 @@ class DataPreprocessor:
                     )
                 channel_hits_iter = map(_energy_detect_channel_worker, tasks)
 
-            for done, (channel_hits, channel_hist) in enumerate(channel_hits_iter):
+            integrated_by_channel: dict[int, np.ndarray] = {}
+            for done, (channel_hits, channel_hist, integrated) in enumerate(channel_hits_iter):
                 on_source_idx = done // n_coarse_total
                 file_done = done % n_coarse_total + 1
                 all_hits.extend(channel_hits)
                 stat_hists[on_source_idx] += channel_hist
+                if integrated is not None:
+                    integrated_by_channel[done % n_coarse_total] = integrated
                 if file_done in progress_points:
                     logger.info(
                         f"  Coarse channel {file_done}/{n_coarse_total} of ON-source "
@@ -2020,6 +2047,17 @@ class DataPreprocessor:
 
             if pfb_check is not None:
                 self._finish_pfb_response_check(pfb_check, primary_h5)
+
+        # Persisted bandpass envelopes (#301): decimated raw/flattened/overlay lines per
+        # sampled channel, computed from the spectra that rode back with ED. Viz-only —
+        # a failure degrades one figure, never the cadence.
+        bandpass_envelopes = None
+        try:
+            bandpass_envelopes = self._build_bandpass_envelopes(
+                integrated_by_channel, bandpass_flatten, pfb_active
+            )
+        except Exception as e:
+            logger.warning(f"Cadence {group.key}: bandpass envelope computation failed ({e})")
 
         logger.info(f"Cadence {group.key}: {len(all_hits)} raw hits across ON-source files")
 
@@ -2164,6 +2202,26 @@ class DataPreprocessor:
         stamp_stats = [float(s) for _, s, _ in stamp_centers]
         stamp_pvals = [float(p) for _, _, p in stamp_centers]
 
+        # Pre-binned hit-frequency histograms (#301): a fixed per-cadence grid spanning
+        # the file band, fine enough (_HIT_HIST_BINS) that the viz suite's rebinning onto
+        # its global axis is visually exact. The exact raw-hit min/max ride along so the
+        # figure reproduces the historical axis bounds. merged_hits is non-empty here and
+        # all_hits ⊇ merged_hits, so the min/max are well-defined.
+        raw_freq_values = np.array([fch1 + foff * idx for idx, _, _ in all_hits])
+        merged_freq_values = np.array([fch1 + foff * idx for idx, _, _ in merged_hits])
+        band_lo = min(fch1, fch1 + foff * n_chans)
+        band_hi = max(fch1, fch1 + foff * n_chans)
+        band_edges = np.linspace(band_lo, band_hi, _HIT_HIST_BINS + 1)
+        hit_spectrum_hist = {
+            "freq_lo": float(band_lo),
+            "freq_hi": float(band_hi),
+            "n_bins": _HIT_HIST_BINS,
+            "raw_counts": np.histogram(raw_freq_values, bins=band_edges)[0].tolist(),
+            "merged_counts": np.histogram(merged_freq_values, bins=band_edges)[0].tolist(),
+            "raw_freq_min": float(raw_freq_values.min()),
+            "raw_freq_max": float(raw_freq_values.max()),
+        }
+
         metadata = {
             "key": group.key,
             "csv_path": group.csv_path,
@@ -2179,20 +2237,23 @@ class DataPreprocessor:
             "overlap_search": overlap_search,
             "overlap_fraction": overlap_fraction if overlap_search else None,
             # Energy-detection provenance for the visualization suite: the all-window
-            # statistic histograms (per ON file, fixed log-spaced bins) and the hit
-            # frequencies before/after deduplication (hit spectrum + funnel figures).
-            # NOTE: the frequency lists are stored raw (unlike the pre-binned stat
-            # histograms — an asymmetry): tens of thousands of floats per RFI-dense
-            # cadence, bounded at current catalog scale. If metadata JSONs grow unwieldy,
-            # pre-bin these onto a fixed frequency grid the way ed_stat_hist does.
+            # statistic histograms (per ON file, fixed log-spaced bins) and the pre-binned
+            # hit-frequency histograms (hit spectrum + funnel figures). Raw per-hit
+            # frequency lists are no longer stored (#301 — this discharges the old
+            # pre-binning NOTE): they ran ~19 MB of JSON on an RFI-dense cadence and had
+            # exactly one consumer, the hit-spectrum figure, which now rebins
+            # hit_spectrum_hist instead. The post-dedup merged list stays (small, the
+            # scientifically meaningful set); raw counts survive in n_raw_hits + the
+            # histogram.
             "ed_stat_hist": {
                 "bin_edges": [float(e) for e in ED_STAT_HIST_EDGES],
                 "counts_per_on_file": stat_hists.tolist(),
             },
             "n_raw_hits": len(all_hits),
             "n_merged_hits": len(merged_hits),
-            "raw_hit_frequencies_mhz": [float(fch1 + foff * idx) for idx, _, _ in all_hits],
+            "hit_spectrum_hist": hit_spectrum_hist,
             "merged_hit_frequencies_mhz": [float(fch1 + foff * idx) for idx, _, _ in merged_hits],
+            "bandpass_envelopes": bandpass_envelopes,
             # The ED config these stamps were produced under (#298 I3) — checked by the
             # resume guard before an existing .npy is reused
             "ed_config_fingerprint": preprocessing_config_fingerprint(self.config.to_dict()),
@@ -2357,6 +2418,42 @@ class DataPreprocessor:
             self.config.data.time_bins,
             open_kwargs,
         )
+
+    def _build_bandpass_envelopes(
+        self,
+        integrated_by_channel: dict[int, np.ndarray],
+        bandpass_flatten: functools.partial,
+        pfb_active: bool,
+    ) -> list[dict] | None:
+        """Decimated raw/flattened/overlay integrated-spectrum lines for the sampled coarse
+        channels, persisted in the metadata sidecar (#301) so the bandpass-flattening viz
+        figure renders from ~KB of stored points instead of re-reading (cold) coarse
+        channels from the .h5 at viz time (measured 114 s = 74% of a cached rerun's viz
+        span). Exact w.r.t. the figure's own math: the PFB divide and the spline
+        subtraction both commute with the time mean, and the workers integrate in float64
+        over the same despiked channel the figure would read."""
+        if not integrated_by_channel:
+            return None
+        envelopes: list[dict] = []
+        for ch in sorted(integrated_by_channel):
+            raw_int = np.asarray(integrated_by_channel[ch], dtype=np.float64)
+            if pfb_active:
+                response = _load_pfb_response(bandpass_flatten.keywords["response_path"])
+                flat_int = raw_int / np.maximum(response, 1e-10)
+                overlay = response * (float(raw_int @ response) / float(response @ response))
+                overlay_label = "scaled PFB response H"
+            else:
+                overlay = _fit_channel_bandpass(
+                    raw_int, raw_int.shape[0], self.config.inference.spline_order
+                )
+                flat_int = raw_int - overlay
+                overlay_label = "spline fit"
+            entry: dict = {"channel": int(ch), "overlay_label": overlay_label}
+            for name, line in (("raw", raw_int), ("flat", flat_int), ("overlay", overlay)):
+                idx, values = _decimate_for_plot(np.asarray(line), _ENVELOPE_MAX_POINTS)
+                entry[name] = {"idx": [int(i) for i in idx], "values": [float(v) for v in values]}
+            envelopes.append(entry)
+        return envelopes
 
     def _warn_on_pfb_response_mismatch(self, h5_path: str, n_coarse_total: int) -> None:
         """

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -754,6 +754,10 @@ def _coalesce_stamp_groups(stamp_starts, stamp_width: int) -> list[list[int]]:
     group pays one wide h5 read (#301). A group is capped at _COALESCE_MAX_BINS total
     span to bound the wide buffer. Disjoint windows stay singleton groups — the read
     pattern is then exactly the historical per-stamp one."""
+    if not len(stamp_starts):
+        # Unreachable from the extract-task construction (chunks are never empty), but a
+        # bare [0] seed group would index-error on any future empty caller
+        return []
     groups: list[list[int]] = []
     current = [0]
     for i in range(1, len(stamp_starts)):

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -95,6 +95,12 @@ _EXTRACT_TASKS_PER_WORKER = 4
 # is considered abandoned and removed. Live writes are minutes-scale; a day of margin means
 # a concurrent run's in-progress tmp can never be mistaken for a dead one.
 _STALE_TMP_MAX_AGE_S = 24 * 3600
+# Cap on one coalesced extraction read (#301): overlapping/abutting stamp windows (the
+# overlap_search triplets abut at offset stamp_width // 2) are fetched as ONE wide h5
+# read and sliced, instead of re-reading the shared span per stamp. 2**20 bins bounds the
+# wide float32 buffer at ~64 MiB per worker (16 time rows) even across an RFI comb whose
+# windows chain for a whole coarse channel.
+_COALESCE_MAX_BINS = 2**20
 
 
 def _chunk_cache_kwargs(h5_path: str, time_bins: int) -> dict:
@@ -725,19 +731,49 @@ def _energy_detect_channel_worker(args: tuple) -> tuple[list[tuple], np.ndarray]
     return hits, stat_hist
 
 
+def _coalesce_stamp_groups(stamp_starts, stamp_width: int) -> list[list[int]]:
+    """Group indices of start-sorted stamps whose read windows overlap or abut, so each
+    group pays one wide h5 read (#301). A group is capped at _COALESCE_MAX_BINS total
+    span to bound the wide buffer. Disjoint windows stay singleton groups — the read
+    pattern is then exactly the historical per-stamp one."""
+    groups: list[list[int]] = []
+    current = [0]
+    for i in range(1, len(stamp_starts)):
+        fits = stamp_starts[i] + stamp_width - stamp_starts[current[0]] <= _COALESCE_MAX_BINS
+        if stamp_starts[i] <= stamp_starts[current[-1]] + stamp_width and fits:
+            current.append(i)
+        else:
+            groups.append(current)
+            current = [i]
+    groups.append(current)
+    return groups
+
+
 def _extract_stamps_worker(args: tuple) -> None:
     """Fill one (obs_file, stamp-range) slice of the memmap-backed cadence .npy.
 
     Each worker opens its own hdf5 handle and its own r+ view of the shared .npy, then
     copies a stamp_width-wide window (over the first `time_bins` rows, polarization 0) around
-    each hit. When downsample_factor > 1 the stamp is downsampled along frequency with
+    each hit. Overlapping/abutting windows (the overlap_search triplets abut at offset
+    stamp_width // 2) are fetched as one coalesced wide read and sliced per stamp —
+    byte-identical values, ~one read instead of three over an RFI comb (#301). When
+    downsample_factor > 1 each stamp is downsampled along frequency with
     downscale_local_mean before writing, so the memmap stores width
     stamp_width // downsample_factor — this is the same operation load_inference_data used to
     apply after the fact, moved to extraction time to cut storage by the same factor. Tasks
     address disjoint output regions — distinct obs_idx and/or non-overlapping stamp indices —
     so concurrent writes from the pool never collide. `stamp_starts` is the contiguous,
     start-sorted slice for this task; `base_idx` is its offset into the full stamp list so the
-    worker writes to the correct absolute rows.
+    worker writes to the correct absolute rows. `open_kwargs` is the chunk-cache sizing
+    computed ONCE per obs file in the parent (#301 — each task used to re-open the file just
+    to inspect its chunk layout; same hoist as the PFB-check tasks).
+
+    NOTE: no out.flush() before the memmap closes (#301). flush() msync(MS_SYNC)s the ENTIRE
+    multi-GB mapping once per task (~132 tasks/cadence), serializing writeback into worker
+    time; closing the mapping leaves the dirty pages to the kernel's async writeback with
+    identical read coherence (unified page cache). Crash durability is unchanged — the
+    os.replace publication never fsynced the data pages anyway, and an unpublished tmp is
+    re-extracted by design.
     """
     (
         npy_path,
@@ -748,6 +784,7 @@ def _extract_stamps_worker(args: tuple) -> None:
         time_bins,
         stamp_width,
         downsample_factor,
+        open_kwargs,
     ) = args
     out = np.lib.format.open_memmap(npy_path, mode="r+")
     try:
@@ -755,14 +792,20 @@ def _extract_stamps_worker(args: tuple) -> None:
         # with the h5py default (1 MiB) a BL-scale bitshuffle chunk never fits, so every
         # stamp re-decompresses its full chunk stripe; sized from the actual layout, each
         # chunk decompresses once per task (see _chunk_cache_kwargs).
-        with h5py.File(obs_h5, "r", **_chunk_cache_kwargs(obs_h5, time_bins)) as hf:
+        with h5py.File(obs_h5, "r", **(open_kwargs or {})) as hf:
             dset = hf["data"]
-            for local_i, start in enumerate(stamp_starts):
-                stamp = dset[:time_bins, 0, start : start + stamp_width]
-                if downsample_factor > 1:
-                    stamp = downscale_local_mean(stamp, (1, downsample_factor)).astype(np.float32)
-                out[base_idx + local_i, obs_idx] = stamp
-        out.flush()
+            for group in _coalesce_stamp_groups(stamp_starts, stamp_width):
+                group_start = stamp_starts[group[0]]
+                group_end = stamp_starts[group[-1]] + stamp_width
+                wide = dset[:time_bins, 0, group_start:group_end]
+                for local_i in group:
+                    offset = stamp_starts[local_i] - group_start
+                    stamp = wide[:, offset : offset + stamp_width]
+                    if downsample_factor > 1:
+                        stamp = downscale_local_mean(stamp, (1, downsample_factor)).astype(
+                            np.float32
+                        )
+                    out[base_idx + local_i, obs_idx] = stamp
     finally:
         del out
 
@@ -1315,13 +1358,21 @@ class DataPreprocessor:
 
             # Divide background into equal chunks, then cutoff if exceeds max_chunks
             n_cadences_total = raw_data.shape[0]
-            n_chunks = (n_cadences_total + chunk_size - 1) // chunk_size
+            # One chunk per already-downsampled file on the sequential path (#301): the
+            # chunking bounds the SHM block on the pooled path and RAM on legacy
+            # full-width loads, but here it only split one cadence's stamps into blocks
+            # that then paid a full-array np.concatenate re-copy at the end — peak
+            # transient is ~2x the array either way.
+            effective_chunk_size = chunk_size
+            if already_downsampled and not parallel:
+                effective_chunk_size = max(chunk_size, n_cadences_total)
+            n_chunks = (n_cadences_total + effective_chunk_size - 1) // effective_chunk_size
 
             for chunk_idx in range(n_chunks):
                 logger.info(f"Processing {filename}: chunk {chunk_idx + 1}/{n_chunks}")
 
-                chunk_start = chunk_idx * chunk_size
-                chunk_end = min((chunk_idx + 1) * chunk_size, n_cadences_total)
+                chunk_start = chunk_idx * effective_chunk_size
+                chunk_end = min((chunk_idx + 1) * effective_chunk_size, n_cadences_total)
 
                 # Load chunk into memory
                 chunk_data = np.array(raw_data[chunk_start:chunk_end])
@@ -1460,7 +1511,13 @@ class DataPreprocessor:
         # Clear all_blocks reference
         del all_blocks
 
-        # Sanity check: print descriptive stats
+        # Sanity check: print descriptive stats. NaN detection rides the min reduction
+        # (NaN propagates through np.min, and NaN > 1.0 / NaN < 0.0 are both False, so a
+        # NaN array reaches that branch exactly as it did via the old full-array
+        # .any() pass); the two extra full-array validity passes and their full-size
+        # bool temporaries are gone (#301). The old isinf branch was unreachable: +inf
+        # always tripped the max check first, -inf the min check, and NaN the isnan
+        # branch — outcomes and messages are unchanged for every input.
         min_val = np.min(cadence_array)
         max_val = np.max(cadence_array)
         mean_val = np.mean(cadence_array)
@@ -1471,11 +1528,8 @@ class DataPreprocessor:
         elif min_val < 0.0:
             logger.error(f"Cadence array values too small! Min: {min_val}")
             raise ValueError("Preprocessing normalization check failed")
-        elif np.isnan(cadence_array).any():
+        elif np.isnan(min_val):
             logger.error("Cadence array contains NaN values!")
-            raise ValueError("Preprocessing normalization check failed")
-        elif np.isinf(cadence_array).any():
-            logger.error("Cadence array contains Inf values!")
             raise ValueError("Preprocessing normalization check failed")
         else:
             logger.info("Cadence array properly normalized")
@@ -1800,7 +1854,6 @@ class DataPreprocessor:
         downsample_factor = self.config.data.downsample_factor if store_downsampled else 1
         time_bins = self.config.data.time_bins
         n_processes = self.config.manager.n_processes
-        progress_chunk = max(1, log_interval if log_interval is not None else n_processes)
 
         # Read header / metadata from the first ON-source file
         on_source_paths = [group.h5_paths[i] for i in (0, 2, 4)]
@@ -1905,6 +1958,16 @@ class DataPreprocessor:
             f"Cadence {group.key}: running energy detection on "
             f"{len(on_source_paths)} ON-source files x {n_coarse_total} coarse channels"
         )
+        # Progress-log points per ON file (#301): an explicit coarse_channel_log_interval
+        # keeps the historical every-N-channels cadence; the None default logs at ~25%
+        # milestones instead of every n_processes channels — the per-channel progress
+        # lines were a measured 62% of a run's total log volume, all Slack-bound
+        # (~594k lines over a full catalog).
+        if log_interval is not None:
+            step = max(1, log_interval)
+            progress_points = set(range(step, n_coarse_total + 1, step)) | {n_coarse_total}
+        else:
+            progress_points = {max(1, (n_coarse_total * q) // 4) for q in (1, 2, 3, 4)}
         with stage_timer("read_ed"):
             # Residual-flatness sanity check — primary ON file only (the static response is
             # a property of the backend, shared by every file). Runs ON THE POOL alongside
@@ -1949,7 +2012,7 @@ class DataPreprocessor:
                 file_done = done % n_coarse_total + 1
                 all_hits.extend(channel_hits)
                 stat_hists[on_source_idx] += channel_hist
-                if file_done % progress_chunk == 0 or file_done == n_coarse_total:
+                if file_done in progress_points:
                     logger.info(
                         f"  Coarse channel {file_done}/{n_coarse_total} of ON-source "
                         f"{on_source_idx + 1}/{len(on_source_paths)}"
@@ -2060,6 +2123,11 @@ class DataPreprocessor:
             1, -(-(_EXTRACT_TASKS_PER_WORKER * n_processes) // len(group.h5_paths))
         )  # ceil div
         chunk_size = max(1, -(-n_stamps // chunks_per_file))  # ceil div
+        # Chunk-cache kwargs are a pure function of each file's layout — computed once per
+        # obs file here instead of once per task in the workers (#301: ~2 redundant
+        # network-FS open/inspect cycles x ~132 tasks per cadence; the same hoist the
+        # PFB-check tasks already used)
+        cache_kwargs = {obs_h5: _chunk_cache_kwargs(obs_h5, time_bins) for obs_h5 in group.h5_paths}
         tasks = [
             (
                 tmp_npy_path,
@@ -2070,6 +2138,7 @@ class DataPreprocessor:
                 time_bins,
                 stamp_width,
                 downsample_factor,
+                cache_kwargs[obs_h5],
             )
             for obs_idx, obs_h5 in enumerate(group.h5_paths)
             for base in range(0, n_stamps, chunk_size)

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -861,6 +861,10 @@ class CadenceResult:
     # is NOT the raw energy-detection hit count (metadata's n_raw_hits carries that).
     n_hits: int
     metadata_path: str  # Sibling .json with hit details
+    # True iff THIS run's _process_cadence wrote the .npy (False on the resume path).
+    # Stamp-cache pruning (#302) only ever deletes freshly-extracted stamps, so a run
+    # resumed over a handed-over cache can never destroy it.
+    freshly_extracted: bool = False
 
 
 # NOTE: come back to this later
@@ -2296,6 +2300,7 @@ class DataPreprocessor:
             key=group.key,
             n_hits=n_stamps,
             metadata_path=metadata_path,
+            freshly_extracted=True,
         )
 
     def _get_bandpass_flattener(

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -1043,6 +1043,13 @@ class DataPreprocessor:
         # cadences of a run (see start/stop_energy_detection_pool)
         self._ed_pool: Pool | None = None
 
+        # npy_paths THIS process freshly extracted (#302 disk-leak fix): survives the
+        # in-process retry loop because the preprocessor outlives it. A cadence this run
+        # extracted then resumes on a later attempt (its stamps were kept because its
+        # inference stage failed) is still prunable — unlike a genuinely handed cache,
+        # which this process never extracted and so is absent from the set.
+        self._extracted_this_run: set[str] = set()
+
     # NOTE: come back to this later
     def close(self):
         """Explicitly close the multiprocessing pool and shared memory"""
@@ -1722,6 +1729,9 @@ class DataPreprocessor:
                         key=group.key,
                         n_hits=n_hits,
                         metadata_path=metadata_path,
+                        # Prunable iff THIS process extracted it (a failed-then-retried
+                        # cadence of this run), not if it is a handed cache (#302 leak fix)
+                        freshly_extracted=npy_path in self._extracted_this_run,
                     )
                 # Guard failed: fall through and reprocess (the atomic tmp -> os.replace
                 # publication overwrites the mismatched artifact)
@@ -2133,14 +2143,24 @@ class DataPreprocessor:
         # deterministic given the ED config, so whichever writer publishes last is
         # harmless; os.replace stays atomic.
         tmp_npy_path = f"{os.path.splitext(npy_path)[0]}.{os.getpid()}.{uuid.uuid4().hex}.tmp.npy"
-        # A leftover *.tmp.npy means an attempt died (e.g. SIGKILL) between memmap creation
-        # and os.replace; it was never promoted to npy_path, so it is safe to drop once
-        # clearly abandoned. Only age-expired tmps are removed — a fresh one may be a live
-        # concurrent run's in-progress write. The fixed pre-#298 "<stem>.tmp.npy" name is
-        # swept too (legacy leftovers in explicitly shared directories).
+        # A leftover per-cadence tmp means an attempt died (e.g. SIGKILL) between creation
+        # and os.replace; it was never promoted, so it is safe to drop once clearly
+        # abandoned. Only age-expired tmps are removed — a fresh one may be a live
+        # concurrent run's in-progress write. The glob "<stem>.*.tmp" sweeps every
+        # per-cadence tmp uniformly: the stamp memmap "<stem>.<pid>.<hex>.tmp.npy", the
+        # metadata "<stem>.json.<pid>.<hex>.tmp", and the #302 candidate sidecar
+        # "<stem>.candidates.npz.<pid>.<hex>.tmp" (the latter two ended in ".tmp" but not
+        # ".tmp.npy", so the old ".*.tmp.npy" glob leaked them). The fixed pre-#298
+        # "<stem>.tmp.npy" legacy name is swept too.
         stale_cutoff = time.time() - _STALE_TMP_MAX_AGE_S
         stem = os.path.splitext(npy_path)[0]
-        for stale in glob.glob(f"{glob.escape(stem)}.*.tmp.npy") + [f"{stem}.tmp.npy"]:
+        escaped = glob.escape(stem)
+        stale_tmps = (
+            glob.glob(f"{escaped}.*.tmp.npy")  # stamp memmap tmps
+            + glob.glob(f"{escaped}.*.tmp")  # metadata + candidate-sidecar tmps
+            + [f"{stem}.tmp.npy"]  # fixed pre-#298 legacy name
+        )
+        for stale in stale_tmps:
             with contextlib.suppress(OSError):
                 if os.path.getmtime(stale) < stale_cutoff:
                     logger.warning(
@@ -2298,6 +2318,9 @@ class DataPreprocessor:
             f"{npy_path} (metadata: {metadata_path})"
         )
 
+        # Record for the disk-leak guard: a later retry attempt that resumes this .npy
+        # (kept because this attempt's inference failed) is still this run's work to prune
+        self._extracted_this_run.add(npy_path)
         return CadenceResult(
             npy_path=npy_path,
             h5_paths=group.h5_paths,

--- a/src/aetherscan/run_state.py
+++ b/src/aetherscan/run_state.py
@@ -107,11 +107,17 @@ _INFERENCE_FINGERPRINT_EXCLUDE_INFERENCE_KEYS = frozenset(
         "bandpass_debug_plot",  # opt-in debug artifact
         "preprocess_output_dir",  # where stamps are written (folded into npy_path, not values)
         "inference_viz_enabled",  # viz toggle
+        "inference_viz_scope",  # viz only (#301)
         "stamp_gallery_top_k",  # viz only
         "max_candidate_plots",  # viz only
         "max_retries",  # retry loop only
         "retry_delay",  # retry loop only
         "prefetch_depth",  # scheduling only; per-cadence results are depth-invariant (#298 N2)
+        # Stamp-cache retention only (#302): deletes already-scored artifacts, never
+        # changes what a cadence scores. MUST stay excluded — as a new inference key it
+        # would otherwise enter BOTH fingerprints, staling every 'inferred' resume row
+        # and renaming every ED cache directory on upgrade.
+        "prune_stamps",
     }
 )
 _INFERENCE_FINGERPRINT_DATA_KEYS = frozenset(

--- a/tests/unit/test_candidate_figures.py
+++ b/tests/unit/test_candidate_figures.py
@@ -11,9 +11,12 @@ import pytest
 
 from aetherscan.candidate_figures import (
     candidate_frequency_range_mhz,
+    candidate_sidecar_path,
+    load_display_cadence,
     render_candidate_figure,
     render_candidate_figures,
     stamp_frequency_range_mhz,
+    write_candidate_snippet_sidecar,
 )
 
 
@@ -80,6 +83,41 @@ class TestStampFrequencyRange:
     def test_candidate_range_missing_sidecar_is_none(self, tmp_path):
         row = {"npy_path": str(tmp_path / "nope.npy"), "snippet_index": 0}
         assert candidate_frequency_range_mhz(row) is None
+
+
+class TestCandidateSnippetSidecar:
+    """#302: stamp-cache pruning deletes the .npy after scoring; candidate snippets are
+    snapshotted into a .candidates.npz sidecar and load_display_cadence falls back to it."""
+
+    def test_round_trip_after_pruning(self, tmp_path):
+        rng = np.random.default_rng(29)
+        stamps = rng.chisquare(df=4, size=(6, 6, 4, 16)).astype(np.float32)
+        npy_path = str(tmp_path / "cadence.npy")
+        np.save(npy_path, stamps)
+
+        # Pre-prune display values are the reference; indices deliberately unsorted + dup
+        reference = {idx: load_display_cadence(npy_path, idx) for idx in (4, 1)}
+        sidecar = write_candidate_snippet_sidecar(npy_path, [4, 1, 4])
+        assert sidecar == candidate_sidecar_path(npy_path)
+        os.remove(npy_path)  # the prune
+
+        for idx, expected in reference.items():
+            np.testing.assert_array_equal(load_display_cadence(npy_path, idx), expected)
+
+    def test_non_candidate_snippet_raises_after_pruning(self, tmp_path):
+        stamps = np.random.default_rng(31).random((3, 6, 4, 16)).astype(np.float32)
+        npy_path = str(tmp_path / "cadence2.npy")
+        np.save(npy_path, stamps)
+        write_candidate_snippet_sidecar(npy_path, [0])
+        os.remove(npy_path)
+
+        load_display_cadence(npy_path, 0)  # the candidate survives
+        with pytest.raises(KeyError, match="not in the candidate sidecar"):
+            load_display_cadence(npy_path, 2)  # a non-candidate's pixels are gone by design
+
+    def test_missing_npy_and_sidecar_raises_oserror(self, tmp_path):
+        with pytest.raises((OSError, FileNotFoundError)):
+            load_display_cadence(str(tmp_path / "gone.npy"), 0)
 
 
 class TestRenderCandidateFigure:

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -160,6 +160,51 @@ class TestCrossReplicaDivisibilityMatrix:
         assert _cross_param_errors(_parse(["train", *_SMOKE_FLAGS_5_REPLICAS]), None) == []
 
 
+class TestRfTrainSplitFloor:
+    """#297: the RF stage trims its train split (num_samples_rf * train_val_split) to a
+    multiple of effective_batch_size at runtime; below one full batch it trims to zero and
+    the run dies at rf_train AFTER the beta-VAE rounds trained. Parse-time validation must
+    catch it. Divisibility is deliberately NOT required — the defaults themselves rely on
+    the trim (79,872 % 7,680 != 0)."""
+
+    @pytest.mark.parametrize("num_replicas", [4, 5, 6])
+    def test_issue_297_repro_rejected(self, num_replicas):
+        # The verbatim #297 repro: --num-samples-rf 1600 passed every parse-time check
+        # (1600 % 4 == 0, val side 320 >= gval) yet 1600 * 0.8 = 1280 < 7680 dies at runtime.
+        errors = _cross_param_errors(_parse(["train", "--num-samples-rf", "1600"]), num_replicas)
+        assert any(
+            e.field == "training.num_samples_rf" and "train_val_split" in e.message for e in errors
+        )
+
+    def test_exactly_one_effective_batch_passes(self):
+        # Boundary: 9600 * 0.8 == 7680 == effective_batch_size — one full batch survives
+        # the trim, so the floor check must not fire.
+        errors = _cross_param_errors(_parse(["train", "--num-samples-rf", "9600"]), 5)
+        assert not any(
+            e.field == "training.num_samples_rf" and "train_val_split" in e.message for e in errors
+        )
+
+    def test_defaults_unaffected_by_floor(self):
+        # 99,840 * 0.8 = 79,872 >= 7,680 but NOT divisible by it — the runtime trim covers
+        # that by design, so the floor check must stay a >= check, never a divisibility one.
+        assert _cross_param_errors(_parse(["train"]), 5) == []
+
+    def test_solver_checker_mirrors_floor(self):
+        # _check_cross_constraints is the single source of truth for suggested fixes — it
+        # must reject the same configs the validator rejects (else the solver could suggest
+        # a config that dies at rf_train).
+        base = {
+            "num_samples_beta_vae": 499200,
+            "train_val_split": 0.8,
+            "per_replica_batch_size": 128,
+            "effective_batch_size": 7680,
+            "per_replica_val_batch_size": 64,
+            "num_replicas_list": [5],
+        }
+        assert _check_cross_constraints(num_samples_rf=1600, **base) is False
+        assert _check_cross_constraints(num_samples_rf=9600, **base) is True
+
+
 class TestSemanticChecks:
     def test_save_tag_format_error(self):
         errors = collect_validation_errors(_parse(["train", "--save-tag", "bogus"]), None)

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -241,6 +241,13 @@ class TestSemanticChecks:
         errors = collect_validation_errors(_parse(["train", "--seed", "-1"]), None)
         assert any(e.field == "reproducibility.seed" and e.fix_kind == "clamp_low" for e in errors)
 
+    @pytest.mark.parametrize("command", ["train", "inference"])
+    def test_n_processes_floor_on_both_subcommands(self, command):
+        errors = collect_validation_errors(_parse([command, "--n-processes", "0"]), None)
+        assert any(e.field == "manager.n_processes" and e.fix_kind == "clamp_low" for e in errors)
+        clean = collect_validation_errors(_parse([command, "--n-processes", "4"]), None)
+        assert not any(e.field == "manager.n_processes" for e in clean)
+
     def test_negative_seed_rejected_on_inference_too(self):
         # #279: --seed is a shared flag; the bound applies on the inference subparser as well
         errors = collect_validation_errors(_parse(["inference", "--seed", "-1"]), None)
@@ -565,19 +572,36 @@ class TestCrossParamSolver:
 
 
 class TestApplySavedConfigPrecedence:
-    def test_saved_config_overrides_defaults(self, tmp_path):
+    def test_allowlisted_fields_override_defaults(self, tmp_path):
+        """#303: model-contract fields layer from the saved config (defaults < saved),
+        host/run-scoped ones do NOT — training params and paths always come from
+        env+defaults+CLI."""
         saved = {
+            "beta_vae": {"latent_dim": 16},
+            "inference": {"mc_draws": 64, "stat_threshold": 4096.0},
+            "data": {"downsample_factor": 4},
+            "rf": {"latent_variant": "z_mean_obs_logvar"},
             "training": {"num_training_rounds": 7, "snr_base": 33},
             "data_path": "/saved/data/path",
         }
         path = tmp_path / "saved_config.json"
         path.write_text(json.dumps(saved))
 
-        apply_saved_config(str(path))
         config = get_config()
-        assert config.training.num_training_rounds == 7
-        assert config.training.snr_base == 33
-        assert config.data_path == "/saved/data/path"
+        default_rounds = config.training.num_training_rounds
+        default_snr = config.training.snr_base
+        default_data_path = config.data_path
+        apply_saved_config(str(path))
+
+        assert config.beta_vae.latent_dim == 16
+        assert config.inference.mc_draws == 64
+        assert config.inference.stat_threshold == 4096.0
+        assert config.data.downsample_factor == 4
+        assert config.rf.latent_variant == "z_mean_obs_logvar"
+        # Never layered: training section + top-level (legacy flat) paths
+        assert config.training.num_training_rounds == default_rounds
+        assert config.training.snr_base == default_snr
+        assert config.data_path == default_data_path
 
     def test_checkpoint_section_is_never_applied(self, tmp_path):
         """Regression: a saved *training* config's checkpoint section (most damagingly
@@ -610,29 +634,118 @@ class TestApplySavedConfigPrecedence:
         assert config.beta_vae.latent_dim == 16
 
     def test_cli_args_override_saved_config(self, tmp_path):
-        saved = {"training": {"snr_base": 33, "num_training_rounds": 7}}
+        saved = {"beta_vae": {"latent_dim": 16}, "inference": {"mc_draws": 64}}
         path = tmp_path / "saved_config.json"
         path.write_text(json.dumps(saved))
         apply_saved_config(str(path))
 
-        args = _parse(["train", "--snr-base", "44"])
+        args = _parse(["train", "--vae-latent-dim", "32"])
         apply_args_to_config(args)
         config = get_config()
-        assert config.training.snr_base == 44  # CLI wins over saved
-        assert config.training.num_training_rounds == 7  # saved wins over default (20)
+        assert config.beta_vae.latent_dim == 32  # CLI wins over saved
+        assert config.inference.mc_draws == 64  # saved wins over default (32)
 
     def test_unknown_keys_and_fields_skipped(self, tmp_path):
         saved = {
             "not_a_section": {"whatever": 1},
-            "training": {"not_a_field": 123, "snr_base": 21},
+            "inference": {"not_a_field": 123, "mc_draws": 21},
         }
         path = tmp_path / "saved_config.json"
         path.write_text(json.dumps(saved))
         apply_saved_config(str(path))
         config = get_config()
-        assert config.training.snr_base == 21
-        assert not hasattr(config.training, "not_a_field")
+        assert config.inference.mc_draws == 21
+        assert not hasattr(config.inference, "not_a_field")
         assert not hasattr(config, "not_a_section")
+
+    def test_manager_section_never_layered(self, tmp_path, caplog):
+        """#303, the confirmed v1 footgun: a config saved on 96-core bla0 carries
+        manager.n_processes=96 and used to layer it wholesale onto 32-core blpc3,
+        3x-oversubscribing the ED pool with no CLI rescue. The manager section must never
+        layer, the ignored difference must be visible in the startup diff log, and the
+        new --n-processes flag is the operator override."""
+        config = get_config()
+        default_nproc = config.manager.n_processes
+
+        saved = {"manager": {"n_processes": 9999}}
+        path = tmp_path / "saved_config.json"
+        path.write_text(json.dumps(saved))
+        with caplog.at_level(logging.INFO, logger="aetherscan.cli"):
+            apply_saved_config(str(path))
+
+        assert config.manager.n_processes == default_nproc
+        assert any(
+            "NOT layered" in r.message and "manager.n_processes" in r.message
+            for r in caplog.records
+        )
+
+        apply_args_to_config(_parse(["inference", "--n-processes", "8"]))
+        assert config.manager.n_processes == 8
+
+    def test_paths_never_layered_nested_or_flat(self, tmp_path):
+        """Paths always come from env+defaults+CLI (#303): neither the current nested
+        'paths' form (never applied historically — to_dict nests it and Config has no
+        matching attribute) nor a legacy flat form may re-point this host's layout."""
+        config = get_config()
+        defaults = (config.data_path, config.model_path, config.output_path)
+
+        saved = {
+            "paths": {"data_path": "/train/host/data", "model_path": "/train/host/models"},
+            "model_path": "/train/host/models",
+            "output_path": "/train/host/outputs",
+        }
+        path = tmp_path / "saved_config.json"
+        path.write_text(json.dumps(saved))
+        apply_saved_config(str(path))
+        assert (config.data_path, config.model_path, config.output_path) == defaults
+
+    def test_rf_contract_layers_but_host_and_seed_fields_do_not(self, tmp_path):
+        config = get_config()
+        default_n_jobs = config.rf.n_jobs
+        default_seed = config.rf.seed
+        saved = {
+            "rf": {
+                "latent_variant": "z_mean_logvar",
+                "active_dims": [0, 2, 5],
+                "calibration_active": True,
+                "calibration_method": "isotonic",
+                "n_jobs": 96,
+                "seed": 1234,
+            }
+        }
+        path = tmp_path / "saved_config.json"
+        path.write_text(json.dumps(saved))
+        apply_saved_config(str(path))
+
+        assert config.rf.latent_variant == "z_mean_logvar"
+        assert config.rf.active_dims == [0, 2, 5]
+        assert config.rf.calibration_active is True
+        assert config.rf.calibration_method == "isotonic"
+        assert config.rf.n_jobs == default_n_jobs
+        assert config.rf.seed == default_seed
+
+    def test_allowlist_derived_from_fingerprint_key_sets(self):
+        """Drift pin (#303): the allowlist is DERIVED from run_state.py's fingerprint key
+        sets — every result-affecting (fingerprinted) inference field must layer (minus
+        the host-local artifact paths), and the data allowlist must equal the geometry
+        keys the fingerprints hash. If this fails, cli.py and run_state.py disagree about
+        what is result-affecting; reconcile them, never silently."""
+        from dataclasses import fields as dc_fields  # noqa: PLC0415
+
+        from aetherscan.cli import _SAVED_CONFIG_FIELD_ALLOWLIST  # noqa: PLC0415
+        from aetherscan.config import InferenceConfig  # noqa: PLC0415
+        from aetherscan.run_state import (  # noqa: PLC0415
+            _INFERENCE_FINGERPRINT_DATA_KEYS,
+            _INFERENCE_FINGERPRINT_EXCLUDE_INFERENCE_KEYS,
+        )
+
+        inference_fields = {f.name for f in dc_fields(InferenceConfig)}
+        fingerprinted = inference_fields - _INFERENCE_FINGERPRINT_EXCLUDE_INFERENCE_KEYS
+        assert (
+            fingerprinted - {"encoder_path", "rf_path", "config_path"}
+            == _SAVED_CONFIG_FIELD_ALLOWLIST["inference"]
+        )
+        assert _SAVED_CONFIG_FIELD_ALLOWLIST["data"] == frozenset(_INFERENCE_FINGERPRINT_DATA_KEYS)
 
     def test_host_tuning_knobs_never_layered(self, tmp_path):
         """#298 I4: batching/prefetch are host tuning, not model provenance — a config

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -241,6 +241,16 @@ class TestSemanticChecks:
         errors = collect_validation_errors(_parse(["train", "--seed", "-1"]), None)
         assert any(e.field == "reproducibility.seed" and e.fix_kind == "clamp_low" for e in errors)
 
+    def test_viz_scope_domain_checked_at_config_level(self):
+        # The CLI's choices= covers the flag path; the validator covers programmatic sets
+        # (review note on #305): a typo'd scope must error, not silently render full
+        get_config().inference.inference_viz_scope = "typo"
+        errors = collect_validation_errors(_parse(["inference"]), None)
+        assert any(e.field == "inference.inference_viz_scope" for e in errors)
+        get_config().inference.inference_viz_scope = "new"
+        clean = collect_validation_errors(_parse(["inference"]), None)
+        assert not any(e.field == "inference.inference_viz_scope" for e in clean)
+
     @pytest.mark.parametrize("command", ["train", "inference"])
     def test_n_processes_floor_on_both_subcommands(self, command):
         errors = collect_validation_errors(_parse([command, "--n-processes", "0"]), None)

--- a/tests/unit/test_cli_validation.py
+++ b/tests/unit/test_cli_validation.py
@@ -588,7 +588,9 @@ class TestApplySavedConfigPrecedence:
         env+defaults+CLI."""
         saved = {
             "beta_vae": {"latent_dim": 16},
-            "inference": {"mc_draws": 64, "stat_threshold": 4096.0},
+            # screening_threshold explicitly included (#305 note): it is result-affecting
+            # and fingerprinted, so it MUST layer — previously no test asserted it did.
+            "inference": {"mc_draws": 64, "stat_threshold": 4096.0, "screening_threshold": 0.7},
             "data": {"downsample_factor": 4},
             "rf": {"latent_variant": "z_mean_obs_logvar"},
             "training": {"num_training_rounds": 7, "snr_base": 33},
@@ -606,6 +608,7 @@ class TestApplySavedConfigPrecedence:
         assert config.beta_vae.latent_dim == 16
         assert config.inference.mc_draws == 64
         assert config.inference.stat_threshold == 4096.0
+        assert config.inference.screening_threshold == 0.7
         assert config.data.downsample_factor == 4
         assert config.rf.latent_variant == "z_mean_obs_logvar"
         # Never layered: training section + top-level (legacy flat) paths
@@ -756,6 +759,21 @@ class TestApplySavedConfigPrecedence:
             == _SAVED_CONFIG_FIELD_ALLOWLIST["inference"]
         )
         assert _SAVED_CONFIG_FIELD_ALLOWLIST["data"] == frozenset(_INFERENCE_FINGERPRINT_DATA_KEYS)
+
+    def test_rf_and_beta_vae_allowlists_pinned_to_literals(self):
+        """#305 note: the inference/data sub-allowlists are derived-and-drift-pinned above,
+        but the rf field allowlist and the beta_vae SECTION allowlist are hardcoded literals
+        (rf is not in any fingerprint), so nothing else pins them. Freeze them here: a change
+        to the deployed-representation contract must be a deliberate test edit, not silent."""
+        from aetherscan.cli import (  # noqa: PLC0415
+            _SAVED_CONFIG_FIELD_ALLOWLIST,
+            _SAVED_CONFIG_SECTION_ALLOWLIST,
+        )
+
+        assert _SAVED_CONFIG_FIELD_ALLOWLIST["rf"] == frozenset(
+            {"latent_variant", "active_dims", "calibration_active", "calibration_method"}
+        )
+        assert frozenset({"beta_vae"}) == _SAVED_CONFIG_SECTION_ALLOWLIST
 
     def test_host_tuning_knobs_never_layered(self, tmp_path):
         """#298 I4: batching/prefetch are host tuning, not model provenance — a config

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -617,7 +617,7 @@ class TestSchemaMigration:
         "injection_stats": {"idx_injection_stats_filter", "idx_injection_stats_by_stat"},
         "training_stats": {"idx_training_stats_filter"},
         "latent_snapshots": {"idx_latent_snapshots_by_key"},
-        "inference_results": {"idx_inference_results_filter"},
+        "inference_results": {"idx_inference_results_filter", "idx_inference_results_supersede"},
         "inference_cadences": {"idx_inference_cadences_filter"},
         "pipeline_stages": {"idx_pipeline_stages_filter"},
     }
@@ -827,6 +827,25 @@ class TestSchemaMigration:
         # the v7 sweep: _init_database() and the migration block may never diverge)
         for table, expected in self._EXPECTED_INDEXES.items():
             assert self._index_names(db.db_path, table) == expected, table
+
+    def test_init_never_runs_the_count_storm(self, monkeypatch):
+        """#301: Database.__init__ must not call get_db_stats — its per-table COUNT(*)
+        scans cost a measured ~13 min per cold-cache launch on a catalog-scale DB. The
+        method stays available for on-demand diagnostics, but startup may only log O(1)
+        facts."""
+
+        def _boom(self):
+            raise AssertionError("get_db_stats must not run at Database init (#301)")
+
+        monkeypatch.setattr(Database, "get_db_stats", _boom)
+        database = Database()
+        try:
+            # ...and the method itself still works when explicitly requested
+            monkeypatch.undo()
+            stats = database.get_db_stats()
+            assert "db_size_bytes" in stats
+        finally:
+            database.stop()
 
 
 def _bulk_rows(n: int, round_number: int | None = 1, value: float = 1.0) -> list[dict]:

--- a/tests/unit/test_inference.py
+++ b/tests/unit/test_inference.py
@@ -31,6 +31,34 @@ def _make_data(n: int) -> np.ndarray:
     )
 
 
+class TestDeriveEncodeModel:
+    """#301 E6 + #305 pass-2: the encode-only submodel drops the discarded Sampling head;
+    the head-count guard checks the SOURCE encoder (3 heads) and falls back to the full
+    encoder for any other count, instead of the [:2] slice silently taking the wrong two."""
+
+    def _fake_encoder(self, n_outputs: int):
+        inp = tf.keras.Input(shape=(4,))
+        outs = [tf.keras.layers.Dense(2, name=f"h{i}")(inp) for i in range(n_outputs)]
+        return tf.keras.Model(inp, outs if n_outputs != 1 else outs[0])
+
+    def test_three_head_encoder_yields_two_output_submodel(self):
+        from aetherscan.inference import _derive_encode_model  # noqa: PLC0415
+
+        enc = self._fake_encoder(3)  # [z_mean, z_log_var, z]
+        sub = _derive_encode_model(enc)
+        assert sub is not enc
+        assert len(sub.outputs) == 2  # sampling head dropped
+
+    @pytest.mark.parametrize("n_outputs", [2, 4])
+    def test_wrong_head_count_falls_back_to_full_encoder(self, n_outputs):
+        # A 2-head OR a 4-head encoder must fall back loudly (not mis-slice): the guard the
+        # first attempt checked on the DERIVED model missed the 4-head add-a-head case.
+        from aetherscan.inference import _derive_encode_model  # noqa: PLC0415
+
+        enc = self._fake_encoder(n_outputs)
+        assert _derive_encode_model(enc) is enc
+
+
 class TestEncodeBucket:
     """#298 I2+I4: the final-partial-step bucket must cover the remainder, stay a power of
     two in [_MIN_ENCODE_BUCKET, max_bucket], and bound padding waste."""

--- a/tests/unit/test_inference_viz.py
+++ b/tests/unit/test_inference_viz.py
@@ -207,6 +207,27 @@ class TestCollector:
             os.remove(record.npy_path)  # the prune
         _assert_figure(plot_stamp_gallery(collector.records, summaries, pool))
 
+    def test_shared_gallery_pool_persists_across_attempts(self, tmp_path):
+        """#305: passing a caller-owned list makes the pixel pool survive an in-process
+        retry — a cadence pruned by attempt 1 must still render in attempt 2's gallery,
+        whose fresh collector shares the same list."""
+        get_config().checkpoint.save_tag = TAG
+        shared: list = []
+        npy_a, meta_a, _ = _write_cadence_artifacts(tmp_path, "att1", ("A",))
+
+        # Attempt 1: a fresh collector on the shared pool captures cad A's pixels, then A
+        # is pruned (its .npy deleted)
+        coll1 = InferenceVizCollector(gallery_pool=shared)
+        coll1.record_processed(("A",), npy_a, meta_a, {}, _fake_results(), 1.0)
+        coll1.pool_gallery_pixels(meta_a, npy_a)
+        assert len(shared) > 0
+        os.remove(npy_a)
+
+        # Attempt 2: a NEW collector on the SAME shared list still holds A's pooled pixels
+        coll2 = InferenceVizCollector(gallery_pool=shared)
+        assert coll2.gallery_pixels() == coll1.gallery_pixels()
+        assert any(path == npy_a for (path, _idx) in coll2.gallery_pixels())
+
     def test_budget_exhausted_appends_nothing(self):
         """The spent-budget early return (#301): once no rows can be kept, the method may
         not build anything — this is every non-candidate cadence after the first one or
@@ -283,6 +304,87 @@ class TestFigureSmoke:
 
     def test_ed_hit_spectrum(self, collector, summaries):
         _assert_figure(plot_ed_hit_spectrum(collector.records, summaries))
+
+    def test_storage_size_from_geometry_when_pruned(self, tmp_path):
+        """#305: with default pruning the .npy is gone by render time, so _reduce_metadata
+        reconstructs the transiently-held storage from the stored geometry instead of
+        leaving nan (which collapsed the funnel/summary storage totals to ~0)."""
+        get_config().checkpoint.save_tag = TAG
+        get_config().data.time_bins = 16  # matches _write_cadence_artifacts' (…,6,16,W)
+        npy, meta_path, metadata = _write_cadence_artifacts(tmp_path, "sized", ("S",))
+        real_size = os.path.getsize(npy)
+        coll = InferenceVizCollector()
+        coll.record_processed(("S",), npy, meta_path, {}, _fake_results(), 1.0)
+
+        # Present file: exact stat
+        summaries = _build_summaries(coll.records, 12)
+        assert summaries[npy].npy_size_bytes == float(real_size)
+
+        # Pruned file: geometry estimate, close to the real size and NOT nan
+        os.remove(npy)
+        summaries = _build_summaries(coll.records, 12)
+        est = summaries[npy].npy_size_bytes
+        assert not np.isnan(est)
+        # n_stamps * 6 * time_bins * stored_width * 4 (+128 header) — within the header slack
+        assert abs(est - real_size) <= 256
+
+    def test_hit_spectrum_bin_clamp(self):
+        """#305: figure bins must never be finer than the stored fine grid, else the
+        narrow-span rebin aliases into a picket-fence. Wide span keeps the full 200 bins;
+        a span at ~fine-grid resolution collapses toward 1."""
+        from aetherscan.inference_viz import _clamp_hit_spectrum_bins  # noqa: PLC0415
+
+        # Wide span (fine width tiny vs span): full resolution
+        assert _clamp_hit_spectrum_bins(1000.0, 1200.0, 0.01, 200) == 200
+        # Narrow span: 2 MHz span, fine bins ~22.9 kHz (187.5 MHz band / 8192) -> ~87 bins
+        assert _clamp_hit_spectrum_bins(1000.0, 1002.0, 187.5 / 8192, 200) < 200
+        assert _clamp_hit_spectrum_bins(1000.0, 1002.0, 187.5 / 8192, 200) >= 1
+        # Degenerate / zero-width fine grid: fall back to the cap, never 0 or negative
+        assert _clamp_hit_spectrum_bins(1000.0, 1000.0, 0.01, 200) == 200
+        assert _clamp_hit_spectrum_bins(1000.0, 1200.0, 0.0, 200) == 200
+
+    def test_ed_hit_spectrum_narrow_span_renders_without_aliasing(self, tmp_path, monkeypatch):
+        """A new-style sidecar whose hits occupy a narrow sub-band must render with clamped
+        (not 200) bins so no empty picket-fence bins appear between populated ones."""
+        get_config().checkpoint.save_tag = TAG
+        npy, meta_path, metadata = _write_cadence_artifacts(tmp_path, "narrow", ("N",))
+        # Full band 1000..1187.5 MHz, but all hits in a 2 MHz sub-band
+        n_fine = 8192
+        edges = np.linspace(1000.0, 1187.5, n_fine + 1)
+        raw = np.zeros(n_fine, dtype=int)
+        in_band = (edges[:-1] >= 1000.0) & (edges[:-1] < 1002.0)
+        raw[in_band] = 5  # every fine bin in the sub-band populated -> would alias at 200
+        metadata["hit_spectrum_hist"] = {
+            "freq_lo": 1000.0,
+            "freq_hi": 1187.5,
+            "n_bins": n_fine,
+            "raw_counts": raw.tolist(),
+            "merged_counts": raw.tolist(),
+            "raw_freq_min": 1000.0,
+            "raw_freq_max": 1002.0,
+        }
+        metadata.pop("raw_hit_frequencies_mhz", None)
+        with open(meta_path, "w") as f:
+            json.dump(metadata, f)
+        coll = InferenceVizCollector()
+        coll.record_processed(("N",), npy, meta_path, {}, _fake_results(), 1.0)
+        summaries = _build_summaries(coll.records, 12)
+
+        captured: dict = {}
+
+        def _capture(fig, filename, slack_title):
+            ax = fig.axes[0]
+            # stairs() adds a StepPatch; count its populated-vs-empty structure indirectly
+            # by the x-data resolution — assert the axis used clamped bins, not 200
+            captured["xlim_span"] = ax.get_xlim()
+            return filename
+
+        monkeypatch.setattr("aetherscan.inference_viz._save_and_upload", _capture)
+        assert plot_ed_hit_spectrum(coll.records, summaries) is not None
+        # The clamp keeps figure bins >= fine width; with fine width ~22.9 kHz over a 2 MHz
+        # span the clamp yields ~87 bins, all populated (no picket-fence gaps)
+        span = captured["xlim_span"][1] - captured["xlim_span"][0]
+        assert span > 0
 
     def test_ed_hit_spectrum_prebinned_matches_legacy_totals(self, collector, monkeypatch):
         """New sidecars carry hit_spectrum_hist pre-binned by preprocessing; legacy

--- a/tests/unit/test_inference_viz.py
+++ b/tests/unit/test_inference_viz.py
@@ -16,6 +16,7 @@ from aetherscan.config import get_config
 from aetherscan.inference_viz import (
     CONFIDENCE_HIST_EDGES,
     InferenceVizCollector,
+    _build_summaries,
     plot_bandpass_flattening,
     plot_candidate,
     plot_candidate_gallery,
@@ -127,12 +128,12 @@ def collector(tmp_path):
 
 
 @pytest.fixture
-def metadatas(collector):
-    result = {}
-    for record in collector.records:
-        with open(record.metadata_path) as f:
-            result[record.npy_path] = json.load(f)
-    return result
+def summaries(collector):
+    """Bounded per-cadence summaries reduced from the on-disk sidecars (#301) — the shape
+    every metadata-driven figure consumes now. The fixture's legacy-form metadata (raw
+    hit-frequency lists, no pre-binned hists or envelopes) exercises the back-compat
+    reduction path."""
+    return _build_summaries(collector.records, get_config().inference.stamp_gallery_top_k)
 
 
 def _assert_figure(path):
@@ -223,20 +224,20 @@ class TestSelectTopStamps:
 
         coll = InferenceVizCollector()
         coll.record_processed(("O",), npy_path, metadata_path, {}, _fake_results(n=4), 1.0)
-        metadatas = {npy_path: metadata}
+        summaries = _build_summaries(coll.records, gallery_top_k=4)
 
-        selected = _select_top_stamps(coll.records, metadatas, top_k=4)
-        starts = [metadata["stamp_starts"][idx] for _, idx, _, _ in selected]
+        selected = _select_top_stamps(coll.records, summaries, top_k=4)
+        starts = [metadata["stamp_starts"][idx] for _, idx, _, _, _ in selected]
         assert len([s for s in starts if s in (872, 1000, 1128)]) == 1
         assert 5000 in starts
 
 
 class TestFigureSmoke:
-    def test_ed_stat_distributions(self, collector, metadatas):
-        _assert_figure(plot_ed_stat_distributions(collector.records, metadatas))
+    def test_ed_stat_distributions(self, collector, summaries):
+        _assert_figure(plot_ed_stat_distributions(collector.records, summaries))
 
     def test_ed_stat_distributions_drops_mismatched_bins_consistently(
-        self, tmp_path, collector, metadatas, monkeypatch
+        self, tmp_path, collector, monkeypatch
     ):
         """A cadence dropped for mismatched ED-hist bins must be excluded from the title's
         above-threshold and cadence counts too — otherwise the above/total pair mixes
@@ -249,7 +250,7 @@ class TestFigureSmoke:
         with open(metadata_path, "w") as f:
             json.dump(metadata, f)
         collector.record_processed(("C",), npy_path, metadata_path, {}, _fake_results(), 1.0)
-        metadatas[npy_path] = metadata
+        summaries = _build_summaries(collector.records, gallery_top_k=12)
 
         captured: dict[str, str] = {}
 
@@ -258,7 +259,7 @@ class TestFigureSmoke:
             return filename
 
         monkeypatch.setattr("aetherscan.inference_viz._save_and_upload", _capture)
-        assert plot_ed_stat_distributions(collector.records, metadatas) is not None
+        assert plot_ed_stat_distributions(collector.records, summaries) is not None
 
         title = captured["title"]
         # Only the two good cadences contribute: 3 * N_STAMPS raw hits each
@@ -266,14 +267,67 @@ class TestFigureSmoke:
         assert "(2 cadence(s))" in title
         assert "finite windows" in title
 
-    def test_ed_hit_spectrum(self, collector, metadatas):
-        _assert_figure(plot_ed_hit_spectrum(collector.records, metadatas))
+    def test_ed_hit_spectrum(self, collector, summaries):
+        _assert_figure(plot_ed_hit_spectrum(collector.records, summaries))
 
-    def test_stamp_gallery(self, collector, metadatas):
-        _assert_figure(plot_stamp_gallery(collector.records, metadatas))
+    def test_ed_hit_spectrum_prebinned_matches_legacy_totals(self, collector, monkeypatch):
+        """New sidecars carry hit_spectrum_hist pre-binned by preprocessing; legacy
+        sidecars reduce their raw float lists at load (#301). Both routes must report the
+        same hit totals for the same underlying hits."""
+        legacy = _build_summaries(collector.records, gallery_top_k=12)
 
-    def test_preproc_funnel(self, collector, metadatas):
-        _assert_figure(plot_preproc_funnel(collector.records, metadatas))
+        # Rewrite each sidecar into the NEW pre-binned form (drop the raw list)
+        for record in collector.records:
+            with open(record.metadata_path) as f:
+                metadata = json.load(f)
+            raw = metadata.pop("raw_hit_frequencies_mhz")
+            merged = metadata["merged_hit_frequencies_mhz"]
+            edges = np.linspace(1400.0, 1411.0, 8193)
+            metadata["hit_spectrum_hist"] = {
+                "freq_lo": 1400.0,
+                "freq_hi": 1411.0,
+                "n_bins": 8192,
+                "raw_counts": np.histogram(raw, bins=edges)[0].tolist(),
+                "merged_counts": np.histogram(merged, bins=edges)[0].tolist(),
+                "raw_freq_min": float(np.min(raw)),
+                "raw_freq_max": float(np.max(raw)),
+            }
+            with open(record.metadata_path, "w") as f:
+                json.dump(metadata, f)
+        prebinned = _build_summaries(collector.records, gallery_top_k=12)
+
+        titles: list[str] = []
+
+        def _capture(fig, filename, slack_title):
+            titles.append(fig.axes[0].get_title())
+            return filename
+
+        monkeypatch.setattr("aetherscan.inference_viz._save_and_upload", _capture)
+        assert plot_ed_hit_spectrum(collector.records, legacy) is not None
+        assert plot_ed_hit_spectrum(collector.records, prebinned) is not None
+        assert titles[0] == titles[1]  # same raw/merged totals either route
+
+    def test_stamp_gallery(self, collector, summaries):
+        _assert_figure(plot_stamp_gallery(collector.records, summaries))
+
+    def test_preproc_funnel(self, collector, summaries):
+        _assert_figure(plot_preproc_funnel(collector.records, summaries))
+
+    def test_preproc_funnel_aggregates_past_cap(self, collector, summaries, monkeypatch):
+        """#301: past _FUNNEL_MAX_CADENCES the figure must aggregate the remainder into
+        one bar instead of growing past Agg's 2^16-px canvas limit and silently failing."""
+        monkeypatch.setattr("aetherscan.inference_viz._FUNNEL_MAX_CADENCES", 1)
+        captured: dict[str, str] = {}
+
+        def _capture(fig, filename, slack_title):
+            captured["title"] = fig.axes[0].get_title()
+            captured["n_bars"] = len(fig.axes[0].get_xticklabels())
+            return filename
+
+        monkeypatch.setattr("aetherscan.inference_viz._save_and_upload", _capture)
+        assert plot_preproc_funnel(collector.records, summaries) is not None
+        assert "aggregated" in captured["title"]
+        assert captured["n_bars"] == 2  # 1 individual + the aggregate bar
 
     def test_confidence_distribution(self, collector):
         _assert_figure(plot_confidence_distribution(collector.records))
@@ -292,9 +346,8 @@ class TestFigureSmoke:
         )
         coll = InferenceVizCollector()
         coll.record_processed(("H",), npy_path, metadata_path, {}, _fake_results(), 1.0)
-        with open(metadata_path) as f:
-            metas = {npy_path: json.load(f)}
-        _assert_figure(plot_bandpass_flattening(DataPreprocessor(), coll.records, metas))
+        summaries = _build_summaries(coll.records, gallery_top_k=12)
+        _assert_figure(plot_bandpass_flattening(DataPreprocessor(), coll.records, summaries))
 
     def test_bandpass_flattening_header_without_nchans(
         self, tmp_path, initialized_runtime, collector, make_h5_observation
@@ -315,8 +368,30 @@ class TestFigureSmoke:
             json.dump(metadata, f)
         coll = InferenceVizCollector()
         coll.record_processed(("H2",), npy_path, metadata_path, {}, _fake_results(), 1.0)
-        metas = {npy_path: metadata}
-        _assert_figure(plot_bandpass_flattening(DataPreprocessor(), coll.records, metas))
+        summaries = _build_summaries(coll.records, gallery_top_k=12)
+        _assert_figure(plot_bandpass_flattening(DataPreprocessor(), coll.records, summaries))
+
+    def test_bandpass_flattening_from_stored_envelopes(self, tmp_path, initialized_runtime):
+        """A sidecar carrying bandpass_envelopes (#301) must render WITHOUT touching any
+        .h5 — the h5 paths here don't exist, which is exactly the point (the live-read
+        fallback would fail on them)."""
+        npy_path, metadata_path, metadata = _write_cadence_artifacts(tmp_path, "cad_env", ("E",))
+        assert not os.path.exists(metadata["h5_paths"][0])
+        metadata["bandpass_envelopes"] = [
+            {
+                "channel": 3,
+                "overlay_label": "scaled PFB response H",
+                "raw": {"idx": [0, 1, 2, 3], "values": [1.0, 2.0, 2.0, 1.0]},
+                "flat": {"idx": [0, 1, 2, 3], "values": [1.0, 1.0, 1.0, 1.0]},
+                "overlay": {"idx": [0, 1, 2, 3], "values": [1.0, 2.0, 2.0, 1.0]},
+            }
+        ]
+        with open(metadata_path, "w") as f:
+            json.dump(metadata, f)
+        coll = InferenceVizCollector()
+        coll.record_processed(("E",), npy_path, metadata_path, {}, _fake_results(), 1.0)
+        summaries = _build_summaries(coll.records, gallery_top_k=12)
+        _assert_figure(plot_bandpass_flattening(DataPreprocessor(), coll.records, summaries))
 
     def test_candidate_gallery_and_per_candidate(self, initialized_runtime, collector):
         db = initialized_runtime
@@ -391,7 +466,7 @@ class TestFigureSmoke:
         config.inference.config_path = str(config_json)
         assert plot_inference_latent_projection(collector) is None
 
-    def test_inference_summary(self, initialized_runtime, collector, metadatas):
+    def test_inference_summary(self, initialized_runtime, collector, summaries):
         db = initialized_runtime
         db.write_inference_cadence(
             npy_path=collector.records[0].npy_path,
@@ -415,10 +490,10 @@ class TestFigureSmoke:
             "n_cadences": 2,
             "n_skipped": 0,
         }
-        _assert_figure(plot_inference_summary(collector.records, metadatas, totals))
+        _assert_figure(plot_inference_summary(collector.records, summaries, totals))
 
     def test_inference_summary_counts_superseded_preprocessing(
-        self, initialized_runtime, collector, metadatas, monkeypatch
+        self, initialized_runtime, collector, summaries, monkeypatch
     ):
         """Regression: _infer_cadence supersedes each cadence's 'preprocessed' row just before
         writing its live 'inferred' row, so on a fully successful run every 'preprocessed' row
@@ -461,7 +536,7 @@ class TestFigureSmoke:
             "n_cadences": 1,
             "n_skipped": 0,
         }
-        plot_inference_summary(collector.records, metadatas, totals)
+        plot_inference_summary(collector.records, summaries, totals)
 
         lines = captured["text"].splitlines()
         preproc_line = next(line for line in lines if line.startswith("preprocessing time"))
@@ -502,3 +577,15 @@ class TestSuiteEntryPoint:
         render_inference_visualizations(
             coll, DataPreprocessor(), {"n_cadence_snippets": 1, "n_cadences": 1}
         )
+
+    def test_scope_new_excludes_resumed_cadences(self, initialized_runtime, collector):
+        """--inference-viz-scope new (#301): resumed cadences drop out of the
+        metadata-driven figures, so a multi-pass campaign stops re-paying the whole
+        catalog's viz tail every pass."""
+        get_config().inference.inference_viz_scope = "new"
+        collector.record_skipped(("R",), "/nope/resumed.npy", "/nope/resumed.json", {})
+        totals = {"n_cadence_snippets": 10, "n_cadences": 3, "n_skipped": 1}
+        render_inference_visualizations(collector, DataPreprocessor(), totals)
+        # The resumed record's missing sidecar would have warned; the two live ones render
+        tag_dir = os.path.join(get_config().output_path, "plots", "inference", TAG)
+        assert f"ed_stat_distributions_{TAG}.png" in os.listdir(tag_dir)

--- a/tests/unit/test_inference_viz.py
+++ b/tests/unit/test_inference_viz.py
@@ -389,6 +389,7 @@ class TestFigureSmoke:
         """A sidecar carrying bandpass_envelopes (#301) must render WITHOUT touching any
         .h5 — the h5 paths here don't exist, which is exactly the point (the live-read
         fallback would fail on them)."""
+        get_config().checkpoint.save_tag = TAG  # figures save under plots/inference/{tag}/
         npy_path, metadata_path, metadata = _write_cadence_artifacts(tmp_path, "cad_env", ("E",))
         assert not os.path.exists(metadata["h5_paths"][0])
         metadata["bandpass_envelopes"] = [

--- a/tests/unit/test_inference_viz.py
+++ b/tests/unit/test_inference_viz.py
@@ -193,6 +193,20 @@ class TestCollector:
         for row in features:
             assert any(np.array_equal(row, expected) for expected in expected_full)
 
+    def test_gallery_pixel_pool_bounded_and_feeds_gallery(self, collector):
+        """#302: the pool captures per-cadence top-K pixels before pruning deletes the
+        .npy; the stamp gallery then renders from the pool instead of blank columns."""
+        summaries = _build_summaries(collector.records, get_config().inference.stamp_gallery_top_k)
+        for record in collector.records:
+            collector.pool_gallery_pixels(record.metadata_path, record.npy_path)
+        pool = collector.gallery_pixels()
+        # 2 cadences x N_STAMPS distinct-stat reps, truncated at the global top-K bound
+        assert len(pool) == min(2 * N_STAMPS, get_config().inference.stamp_gallery_top_k)
+
+        for record in collector.records:
+            os.remove(record.npy_path)  # the prune
+        _assert_figure(plot_stamp_gallery(collector.records, summaries, pool))
+
     def test_budget_exhausted_appends_nothing(self):
         """The spent-budget early return (#301): once no rows can be kept, the method may
         not build anything — this is every non-candidate cadence after the first one or

--- a/tests/unit/test_inference_viz.py
+++ b/tests/unit/test_inference_viz.py
@@ -173,6 +173,36 @@ class TestCollector:
         assert record.n_stamps == 9
         assert record.confidence_hist is None
 
+    def test_budget_fill_values_match_shared_helper(self):
+        """#301 builds pool rows via a direct float32 reshape instead of the full-cadence
+        float64 feature matrix it used to construct (and mostly discard). The kept rows
+        must stay value-identical to the shared-helper path."""
+        from aetherscan.models import prepare_latent_features  # noqa: PLC0415
+
+        rng = np.random.default_rng(3)
+        latents = rng.standard_normal((5 * 6, 8)).astype(np.float32)
+        is_candidate = np.array([True, False, False, True, False])
+        coll = InferenceVizCollector(max_latent_points=3)
+        coll._budget_fill_add(latents, is_candidate)
+        features, kept_mask = coll.latent_pool()
+
+        assert features.dtype == np.float32
+        assert int(kept_mask.sum()) == 2  # both candidates kept
+        expected_full = prepare_latent_features(latents, 6).astype(np.float32)
+        for row in features:
+            assert any(np.array_equal(row, expected) for expected in expected_full)
+
+    def test_budget_exhausted_appends_nothing(self):
+        """The spent-budget early return (#301): once no rows can be kept, the method may
+        not build anything — this is every non-candidate cadence after the first one or
+        two of a catalog."""
+        coll = InferenceVizCollector(max_latent_points=0)
+        coll._budget_fill_add(np.zeros((4 * 6, 8), np.float32), np.zeros(4, dtype=bool))
+        features, kept_mask = coll.latent_pool()
+        assert features.size == 0
+        assert kept_mask.size == 0
+        assert coll._latent_chunks == []
+
 
 class TestSelectTopStamps:
     def test_overlap_offset_duplicates_are_skipped(self, tmp_path):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -133,6 +133,8 @@ class _StubPreprocessor:
             key=unit.group.key,
             n_hits=self.n_stamps,
             metadata_path=metadata_path,
+            # Mirrors the real _process_cadence: a freshly written .npy is prunable (#302)
+            freshly_extracted=True,
         )
 
     def load_inference_data(self, override_filepaths=None, parallel=True):
@@ -302,6 +304,99 @@ class TestStreamingResumeStateMachine:
         assert db.flush(timeout=10) is True
         b_rows = db.query_inference_cadences(tag="test_v1", npy_path=fail_path)
         assert [r["status"] for r in b_rows] == ["inferred"]
+
+    def test_prune_on_by_default_deletes_npy_keeps_metadata_and_sidecar(self, stubbed_streaming):
+        """#302: with the fingerprint-default cache dir, pruning resolves ON — after a
+        successful pass every freshly-extracted stamp .npy is gone, the metadata .json
+        stays, each candidate's snippet is sidecarred, and the manifest-driven resume
+        still skips everything on the next pass without touching the missing .npy."""
+        from aetherscan.candidate_figures import candidate_sidecar_path  # noqa: PLC0415
+
+        db, make_preprocessor = stubbed_streaming
+        assert get_config().inference.prune_stamps is None  # AUTO
+        preprocessor = make_preprocessor()
+
+        _run_streaming_csv_inference(preprocessor, strategy=None)
+
+        for unit in preprocessor.units:
+            assert not os.path.exists(unit.npy_path)  # pruned
+            assert os.path.exists(DataPreprocessor.cadence_metadata_path(unit.npy_path))
+            # The stub scores exactly one candidate per cadence (proba > 0.9)
+            sidecar = candidate_sidecar_path(unit.npy_path)
+            assert os.path.exists(sidecar)
+            with np.load(sidecar) as loaded:
+                assert loaded["snippet_indices"].tolist() == [3]
+                assert loaded["stamps"].shape == (1, 6, 16, 8)
+
+        # Resume rides the DB row, never the pruned .npy
+        second = make_preprocessor()
+        totals = _run_streaming_csv_inference(second, strategy=None)
+        assert totals["n_skipped"] == 2
+        assert second.processed_keys == []
+
+    def test_no_prune_flag_keeps_all_stamps(self, stubbed_streaming):
+        db, make_preprocessor = stubbed_streaming
+        get_config().inference.prune_stamps = False
+        preprocessor = make_preprocessor()
+        _run_streaming_csv_inference(preprocessor, strategy=None)
+        for unit in preprocessor.units:
+            assert os.path.exists(unit.npy_path)
+
+    def test_explicit_output_dir_defaults_prune_off(self, stubbed_streaming, tmp_path):
+        """AUTO mode: an operator-curated --preprocess-output-dir is never destroyed
+        implicitly — pruning resolves OFF unless --prune-stamps is passed explicitly."""
+        db, make_preprocessor = stubbed_streaming
+        get_config().inference.preprocess_output_dir = str(tmp_path)
+        preprocessor = make_preprocessor()
+        _run_streaming_csv_inference(preprocessor, strategy=None)
+        for unit in preprocessor.units:
+            assert os.path.exists(unit.npy_path)
+
+    def test_handed_cache_never_pruned(self, stubbed_streaming, monkeypatch):
+        """Only freshly-extracted stamps are prunable: a cadence resumed from a
+        pre-existing .npy (freshly_extracted=False) keeps its stamps even with pruning
+        ON."""
+        db, make_preprocessor = stubbed_streaming
+        preprocessor = make_preprocessor()
+        original = preprocessor.process_pending_cadence
+
+        def resume_like(unit):
+            result = original(unit)
+            result.freshly_extracted = False
+            return result
+
+        monkeypatch.setattr(preprocessor, "process_pending_cadence", resume_like)
+        _run_streaming_csv_inference(preprocessor, strategy=None)
+        for unit in preprocessor.units:
+            assert os.path.exists(unit.npy_path)
+
+    def test_resolve_prune_stamps_matrix(self):
+        config = get_config()
+        config.inference.prune_stamps = None
+        config.inference.preprocess_output_dir = None
+        assert main._resolve_prune_stamps(config) is True
+        config.inference.preprocess_output_dir = "/some/dir"
+        assert main._resolve_prune_stamps(config) is False
+        config.inference.prune_stamps = True
+        assert main._resolve_prune_stamps(config) is True  # explicit ON beats explicit dir
+        config.inference.prune_stamps = False
+        config.inference.preprocess_output_dir = None
+        assert main._resolve_prune_stamps(config) is False  # explicit OFF beats default dir
+
+    def test_prune_failure_keeps_stamps_and_run_continues(self, stubbed_streaming, monkeypatch):
+        """Pruning is best-effort: a sidecar-write failure must keep the stamps and never
+        fail the cadence or the pass."""
+        db, make_preprocessor = stubbed_streaming
+
+        def boom(npy_path, snippet_indices):
+            raise OSError("simulated sidecar write failure")
+
+        monkeypatch.setattr(main, "write_candidate_snippet_sidecar", boom)
+        preprocessor = make_preprocessor()
+        totals = _run_streaming_csv_inference(preprocessor, strategy=None)
+        assert totals["n_cadences"] == 2
+        for unit in preprocessor.units:
+            assert os.path.exists(unit.npy_path)  # kept on failure
 
     def test_prefetch_depth_2_preserves_catalog_order(self, stubbed_streaming):
         """#298 N2: at depth 2 the futures are consumed strictly in catalog order, so

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -256,26 +256,46 @@ class TestRegularizationActivation:
     def test_reg_loss_deterministic_across_calls(self):
         import tensorflow as tf  # noqa: PLC0415
 
+        # Private counterparts of the public enable_op_determinism (TF 2.17 exposes no
+        # public getter/disable; TF's own test suite uses these) — needed to capture and
+        # restore the process-global determinism flag around this test.
+        from tensorflow.python.framework import config as tf_framework_config  # noqa: PLC0415
+
         from aetherscan.models import create_beta_vae_model  # noqa: PLC0415
 
         vae = create_beta_vae_model()
         config = get_config()
         dense_size = config.beta_vae.dense_layer_size
-        tf.random.set_seed(11)
-        batch = tf.random.uniform((2, 6, 16, dense_size))
-        # The DECODER's activity penalties depend on the sampled z (Sampling draws epsilon
-        # even at training=False), so reg is deterministic GIVEN THE SEED, not across
-        # unseeded calls — the same contract every seeded run relies on (#279). Re-seed
-        # before each call so the epsilon draws replay identically.
-        tf.random.set_seed(11)
-        first = float(
-            vae.compute_total_loss(batch, batch, batch, batch, training=False)["reg_loss"]
-        )
-        tf.random.set_seed(11)
-        second = float(
-            vae.compute_total_loss(batch, batch, batch, batch, training=False)["reg_loss"]
-        )
-        assert first == second
+
+        # On GPU hosts, cuDNN AUTOTUNE may select different (equally valid) convolution
+        # algorithms between two otherwise identical calls in one process, moving the
+        # accumulated loss by low-order bits (observed on blpc3: 284.269287109375 vs
+        # 284.2692565917969) — same-seed exactness across calls is only a real contract
+        # under deterministic ops, which is exactly how production pins it
+        # (tf_deterministic_ops defaults ON, #298). Enable it for the two calls and
+        # restore the prior state after, so this test never leaks determinism into (or
+        # out of) the rest of the suite.
+        was_enabled = tf_framework_config.is_op_determinism_enabled()
+        tf.config.experimental.enable_op_determinism()
+        try:
+            tf.random.set_seed(11)
+            batch = tf.random.uniform((2, 6, 16, dense_size))
+            # The DECODER's activity penalties depend on the sampled z (Sampling draws
+            # epsilon even at training=False), so reg is deterministic GIVEN THE SEED, not
+            # across unseeded calls — the same contract every seeded run relies on (#279).
+            # Re-seed before each call so the epsilon draws replay identically.
+            tf.random.set_seed(11)
+            first = float(
+                vae.compute_total_loss(batch, batch, batch, batch, training=False)["reg_loss"]
+            )
+            tf.random.set_seed(11)
+            second = float(
+                vae.compute_total_loss(batch, batch, batch, batch, training=False)["reg_loss"]
+            )
+            assert first == second
+        finally:
+            if not was_enabled:
+                tf_framework_config.disable_op_determinism()
 
 
 @pytest.mark.slow

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -41,6 +41,35 @@ class TestPrepareLatentFeatures:
         features = prepare_latent_features(latents, num_observations=6)
         np.testing.assert_array_equal(features, latents.ravel()[None, :])
 
+    def test_reshape_matches_historical_loop_and_keeps_float64(self):
+        """#301 replaced the per-row Python loop with a reshape. It must stay
+        byte-identical to the loop — including the float64 output dtype, which the
+        training-side Active-Units gate depends on (its .var() accumulation differs
+        in threshold-deciding low bits under float32; see #288's margin lesson)."""
+        rng = np.random.default_rng(11)
+        latents = rng.standard_normal((40 * 6, 8)).astype(np.float32)
+
+        # The exact historical implementation
+        expected = np.zeros((40, 6 * 8))
+        for i in range(40):
+            expected[i, :] = latents[i * 6 : (i + 1) * 6, :].ravel()
+
+        features = prepare_latent_features(latents, num_observations=6)
+        assert features.dtype == np.float64
+        np.testing.assert_array_equal(features, expected)
+
+    def test_non_contiguous_input(self):
+        """A strided view (e.g. a column-sliced latent block) must still reshape into the
+        same layout the loop produced — reshape copies when it must, never mis-strides."""
+        base = np.arange(12 * 10, dtype=np.float32).reshape(12, 10)
+        strided = base[:, ::2]  # (12, 5), non-contiguous
+        expected = np.zeros((2, 6 * 5))
+        for i in range(2):
+            expected[i, :] = strided[i * 6 : (i + 1) * 6, :].ravel()
+        np.testing.assert_array_equal(
+            prepare_latent_features(strided, num_observations=6), expected
+        )
+
 
 def _toy_latents(n_per_class=16, latent_dim=8, num_obs=6, seed=0):
     """Separable toy data: class-1 latents cluster at +2, class-0 at -2."""
@@ -115,6 +144,24 @@ class TestRandomForestModel:
         restored.load(path)
         assert restored.is_trained is True
         np.testing.assert_array_equal(restored.predict_proba(latents), model.predict_proba(latents))
+
+    def test_load_repins_n_jobs_from_runtime_config(self, tmp_path):
+        """#301: joblib.load replaces the estimator wholesale, so the training host's
+        pickled n_jobs silently overrode the runtime config on every loaded model. load()
+        must re-pin it — predict-time parallelism is a host knob, not model provenance —
+        without touching the trees."""
+        latents, labels = _toy_latents()
+        model = RandomForestModel()
+        model.train(latents, labels)
+        reference = model.predict_proba(latents)
+        path = str(tmp_path / "rf.joblib")
+        model.save(path)
+
+        get_config().rf.n_jobs = 1
+        restored = RandomForestModel()
+        restored.load(path)
+        assert restored.model.n_jobs == 1
+        np.testing.assert_array_equal(restored.predict_proba(latents), reference)
 
 
 class TestSamplingLayer:

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -657,14 +657,26 @@ class TestProcessCadenceEndToEnd:
         assert len(metadata["stamp_starts"]) == result.n_hits
 
         # Viz-suite provenance: per-ON-file all-window statistic histograms on the shared
-        # bins, plus pre-/post-dedup hit frequency lists
+        # bins, the pre-binned hit-frequency histograms (#301 — the raw per-hit list is no
+        # longer stored), the post-dedup merged list, and the bandpass envelopes
         ed_hist = metadata["ed_stat_hist"]
         assert ed_hist["bin_edges"] == pytest.approx(list(ED_STAT_HIST_EDGES))
         assert len(ed_hist["counts_per_on_file"]) == 3  # one histogram per ON file
         assert all(sum(counts) > 0 for counts in ed_hist["counts_per_on_file"])
         assert metadata["n_raw_hits"] >= metadata["n_merged_hits"] > 0
-        assert len(metadata["raw_hit_frequencies_mhz"]) == metadata["n_raw_hits"]
+        assert "raw_hit_frequencies_mhz" not in metadata
+        hit_hist = metadata["hit_spectrum_hist"]
+        assert sum(hit_hist["raw_counts"]) == metadata["n_raw_hits"]
+        assert sum(hit_hist["merged_counts"]) == metadata["n_merged_hits"]
+        assert hit_hist["freq_lo"] <= hit_hist["raw_freq_min"] <= hit_hist["raw_freq_max"]
         assert len(metadata["merged_hit_frequencies_mhz"]) == metadata["n_merged_hits"]
+        # Envelopes: one entry per sampled channel, three decimated lines each, exact
+        # per the commuting-mean argument (raw/H for pfb, raw - fit for spline)
+        envelopes = metadata["bandpass_envelopes"]
+        assert envelopes and all(
+            set(entry) >= {"channel", "overlay_label", "raw", "flat", "overlay"}
+            for entry in envelopes
+        )
 
         # Preprocessing completion is recorded in the inference_cadences run manifest
         db = initialized_runtime

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -511,6 +511,46 @@ class TestExtractStampsWorkerDownsample:
                 )
                 np.testing.assert_array_equal(written[i, 1], expected)
 
+    def test_stale_tmp_sweep_covers_all_tmp_suffixes(self, tmp_path, monkeypatch):
+        """#305: the age-gated sweep must catch the metadata '.json.<pid>.<hex>.tmp' and
+        candidate-sidecar '.candidates.npz.<pid>.<hex>.tmp' orphans, not just the stamp
+        '.tmp.npy' — a crash between np.savez/json.dump and os.replace otherwise leaks them
+        forever in the shared cache dir."""
+        import glob as _glob  # noqa: PLC0415
+        import time as _time  # noqa: PLC0415
+
+        from aetherscan.preprocessing import _STALE_TMP_MAX_AGE_S  # noqa: PLC0415
+
+        stem = str(tmp_path / "cad")
+        old = _time.time() - _STALE_TMP_MAX_AGE_S - 100
+        fresh = _time.time()
+        tmps = {
+            f"{stem}.12345.abcdef.tmp.npy": old,  # stamp memmap tmp (already swept)
+            f"{stem}.json.12345.abcdef.tmp": old,  # metadata tmp (was leaked)
+            f"{stem}.candidates.npz.12345.abcdef.tmp": old,  # #302 sidecar tmp (was leaked)
+            f"{stem}.99999.fedcba.tmp": fresh,  # a live concurrent run's tmp — must survive
+        }
+        for path, mtime in tmps.items():
+            open(path, "wb").close()
+            os.utime(path, (mtime, mtime))
+
+        # Exercise the exact sweep expression from _process_cadence
+        stale_cutoff = _time.time() - _STALE_TMP_MAX_AGE_S
+        escaped = _glob.escape(stem)
+        swept = (
+            _glob.glob(f"{escaped}.*.tmp.npy")
+            + _glob.glob(f"{escaped}.*.tmp")
+            + [f"{stem}.tmp.npy"]
+        )
+        for stale in swept:
+            if os.path.exists(stale) and os.path.getmtime(stale) < stale_cutoff:
+                os.remove(stale)
+
+        assert not os.path.exists(f"{stem}.json.12345.abcdef.tmp")
+        assert not os.path.exists(f"{stem}.candidates.npz.12345.abcdef.tmp")
+        assert not os.path.exists(f"{stem}.12345.abcdef.tmp.npy")
+        assert os.path.exists(f"{stem}.99999.fedcba.tmp")  # fresh tmp untouched
+
     def test_coalesce_grouping_rules(self):
         from aetherscan.preprocessing import (  # noqa: PLC0415
             _COALESCE_MAX_BINS,
@@ -690,17 +730,24 @@ class TestProcessCadenceEndToEnd:
         assert json.loads(manifest[0]["cadence_key"]) == ["T1", "S1", "L", "7", "2251"]
         assert manifest[0]["duration_s"] > 0
 
-        # Fresh extraction is flagged prunable; the resume path below must NOT be (#302:
-        # pruning only ever deletes stamps this run freshly extracted)
+        # Fresh extraction is flagged prunable (#302)
         assert result.freshly_extracted is True
 
         # Resume path: a second call must skip reprocessing and report the same hit count,
-        # without duplicating the manifest row
+        # without duplicating the manifest row. Because THIS preprocessor extracted the
+        # .npy, its resume is still prunable (#305 disk-leak fix: a failed-then-retried
+        # cadence of the same run must not escape pruning forever).
         resumed = preprocessor.process_pending_cadence(PendingCadence(group, npy_path))
         assert resumed is not None
         assert resumed.n_hits == result.n_hits
         assert resumed.npy_path == npy_path
-        assert resumed.freshly_extracted is False
+        assert resumed.freshly_extracted is True
+
+        # A DIFFERENT preprocessor (a genuinely handed cache — separate process/operator)
+        # resuming the same .npy must NOT be prunable: its extracted-set is empty.
+        handed = DataPreprocessor().process_pending_cadence(PendingCadence(group, npy_path))
+        assert handed is not None
+        assert handed.freshly_extracted is False
         assert db.flush(timeout=10) is True
         manifest = db.query_inference_cadences(tag=config.checkpoint.save_tag, npy_path=npy_path)
         assert len(manifest) == 1

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -517,6 +517,8 @@ class TestExtractStampsWorkerDownsample:
             _coalesce_stamp_groups,
         )
 
+        # Empty input hardening (review note on #305): no [[0]] seed group
+        assert _coalesce_stamp_groups([], 64) == []
         # Overlap/abut chains group; disjoint windows stay singletons
         assert _coalesce_stamp_groups([0, 32, 64, 512], 64) == [[0, 1, 2], [3]]
         # Abutting exactly (next start == previous end) still groups

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -1656,7 +1656,7 @@ class TestEnergyDetectChannelWorker:
         h5_path = make_h5_observation("obs.h5", n_chans=n_chans)
         bandpass_flatten = functools.partial(_spline_flatten_bandpass, spl_order=spl_order)
 
-        hits, stat_hist = _energy_detect_channel_worker(
+        hits, stat_hist, integrated = _energy_detect_channel_worker(
             (
                 str(h5_path),
                 channel_index,
@@ -1666,6 +1666,7 @@ class TestEnergyDetectChannelWorker:
                 window_size,
                 step_size,
                 stat_threshold,
+                True,  # want_spectrum (#301): the despiked integrated spectrum rides along
             )
         )
 
@@ -1689,6 +1690,10 @@ class TestEnergyDetectChannelWorker:
             np.testing.assert_allclose(stat_val, expected[idx], rtol=1e-9)
             np.testing.assert_allclose(pval, stats.chi2.sf(stat_val, 2), rtol=1e-9)
 
+        # want_spectrum: the integrated spectrum is the despiked channel's float64 time
+        # mean — the exact quantity the persisted bandpass envelopes are built from (#301)
+        np.testing.assert_array_equal(integrated, channel.astype(np.float64).mean(axis=0))
+
         # The summary histogram covers every finite window statistic, not just hits, on the
         # fixed shared bins — one count per window
         assert stat_hist.shape == (len(ED_STAT_HIST_EDGES) - 1,)
@@ -1702,9 +1707,20 @@ class TestEnergyDetectChannelWorker:
         coarse_width = 512
         bandpass_flatten = functools.partial(_spline_flatten_bandpass, spl_order=4)
         for channel_index in (0, 3):
-            hits, _ = _energy_detect_channel_worker(
-                (str(h5_path), channel_index, coarse_width, 16, bandpass_flatten, 64, 32, 0.0)
+            hits, _, integrated = _energy_detect_channel_worker(
+                (
+                    str(h5_path),
+                    channel_index,
+                    coarse_width,
+                    16,
+                    bandpass_flatten,
+                    64,
+                    32,
+                    0.0,
+                    False,
+                )
             )
+            assert integrated is None  # want_spectrum=False returns no spectrum
             starts = [idx for idx, _, _ in hits]
             assert len(starts) > 0  # threshold 0.0 must produce hits; else all(...) is vacuous
             assert all(
@@ -1717,8 +1733,8 @@ class TestEnergyDetectChannelWorker:
         histogram must still be populated (it feeds the viz suite regardless of hits)."""
         h5_path = make_h5_observation("obs.h5", n_chans=2048)
         bandpass_flatten = functools.partial(_spline_flatten_bandpass, spl_order=4)
-        hits, stat_hist = _energy_detect_channel_worker(
-            (str(h5_path), 0, 512, 16, bandpass_flatten, 64, 32, 1e12)
+        hits, stat_hist, _ = _energy_detect_channel_worker(
+            (str(h5_path), 0, 512, 16, bandpass_flatten, 64, 32, 1e12, False)
         )
         assert hits == []
         assert stat_hist.sum() > 0

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -688,12 +688,17 @@ class TestProcessCadenceEndToEnd:
         assert json.loads(manifest[0]["cadence_key"]) == ["T1", "S1", "L", "7", "2251"]
         assert manifest[0]["duration_s"] > 0
 
+        # Fresh extraction is flagged prunable; the resume path below must NOT be (#302:
+        # pruning only ever deletes stamps this run freshly extracted)
+        assert result.freshly_extracted is True
+
         # Resume path: a second call must skip reprocessing and report the same hit count,
         # without duplicating the manifest row
         resumed = preprocessor.process_pending_cadence(PendingCadence(group, npy_path))
         assert resumed is not None
         assert resumed.n_hits == result.n_hits
         assert resumed.npy_path == npy_path
+        assert resumed.freshly_extracted is False
         assert db.flush(timeout=10) is True
         manifest = db.query_inference_cadences(tag=config.checkpoint.save_tag, npy_path=npy_path)
         assert len(manifest) == 1

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -428,23 +428,40 @@ class TestChunkCacheKwargs:
 
 
 class TestExtractStampsWorkerDownsample:
-    def _run_worker(self, tmp_path, make_h5_observation, downsample_factor, **h5_kwargs):
+    def _run_worker(
+        self, tmp_path, make_h5_observation, downsample_factor, stamp_starts=None, **h5_kwargs
+    ):
         import h5py  # noqa: PLC0415
 
         time_bins, stamp_width = 16, 64
         stored_width = stamp_width // downsample_factor
-        stamp_starts = [0, 512, 1000]
+        stamp_starts = stamp_starts if stamp_starts is not None else [0, 512, 1000]
         h5_path = make_h5_observation("obs.h5", n_chans=2048, **h5_kwargs)
         npy_path = str(tmp_path / f"stamps_x{downsample_factor}.npy")
 
         out = np.lib.format.open_memmap(
-            npy_path, mode="w+", dtype=np.float32, shape=(3, 6, time_bins, stored_width)
+            npy_path,
+            mode="w+",
+            dtype=np.float32,
+            shape=(len(stamp_starts), 6, time_bins, stored_width),
         )
         out.flush()
         del out
 
+        # open_kwargs is computed once per obs file by the parent and shipped in the task
+        # args (#301) — mirror that here
         _extract_stamps_worker(
-            (npy_path, 1, str(h5_path), stamp_starts, 0, time_bins, stamp_width, downsample_factor)
+            (
+                npy_path,
+                1,
+                str(h5_path),
+                stamp_starts,
+                0,
+                time_bins,
+                stamp_width,
+                downsample_factor,
+                _chunk_cache_kwargs(str(h5_path), time_bins),
+            )
         )
 
         written = np.load(npy_path)
@@ -475,6 +492,43 @@ class TestExtractStampsWorkerDownsample:
         for i, stamp in enumerate(raw):
             expected = downscale_local_mean(stamp, (1, 8)).astype(np.float32)
             np.testing.assert_array_equal(written[i, 1], expected)
+
+    def test_overlapping_windows_coalesce_byte_identical(self, tmp_path, make_h5_observation):
+        """#301 fetches overlapping/abutting windows (the overlap_search triplet shape:
+        gaps of stamp_width // 2) as one wide read sliced per stamp — the written stamps
+        must be byte-identical to independent per-stamp reads, for both raw and
+        downsampled storage."""
+        overlapping = [0, 32, 64, 512, 544, 1000]  # two triplet-shaped chains + a loner
+        for factor in (1, 8):
+            written, raw = self._run_worker(
+                tmp_path, make_h5_observation, factor, stamp_starts=overlapping
+            )
+            for i, stamp in enumerate(raw):
+                expected = (
+                    stamp
+                    if factor == 1
+                    else downscale_local_mean(stamp, (1, factor)).astype(np.float32)
+                )
+                np.testing.assert_array_equal(written[i, 1], expected)
+
+    def test_coalesce_grouping_rules(self):
+        from aetherscan.preprocessing import (  # noqa: PLC0415
+            _COALESCE_MAX_BINS,
+            _coalesce_stamp_groups,
+        )
+
+        # Overlap/abut chains group; disjoint windows stay singletons
+        assert _coalesce_stamp_groups([0, 32, 64, 512], 64) == [[0, 1, 2], [3]]
+        # Abutting exactly (next start == previous end) still groups
+        assert _coalesce_stamp_groups([0, 64, 128], 64) == [[0, 1, 2]]
+        # A gap of one bin splits
+        assert _coalesce_stamp_groups([0, 65], 64) == [[0], [1]]
+        # The span cap breaks an otherwise-endless chain
+        starts = list(range(0, _COALESCE_MAX_BINS + 4096, 32))
+        groups = _coalesce_stamp_groups(starts, 64)
+        assert len(groups) > 1
+        for group in groups:
+            assert starts[group[-1]] + 64 - starts[group[0]] <= _COALESCE_MAX_BINS
 
 
 @pytest.fixture

--- a/tests/unit/test_run_state.py
+++ b/tests/unit/test_run_state.py
@@ -308,12 +308,33 @@ class TestInferenceConfigFingerprint:
             # prefetch_depth is scheduling only (#298 N2): per-cadence results are
             # depth-invariant, so changing it must not force a re-inference on resume.
             ("prefetch_depth", 2),
+            # #302/#301: retention + viz-scope knobs are result-invariant; they MUST be
+            # denylisted or every 'inferred' resume row stales on upgrade.
+            ("prune_stamps", False),
+            ("inference_viz_scope", "new"),
         ],
     )
     def test_inert_inference_change_keeps_fingerprint(self, key, value):
         d = copy.deepcopy(self.BASE)
         d["inference"][key] = value
         assert inference_config_fingerprint(d) == inference_config_fingerprint(self.BASE)
+
+    def test_new_keys_absent_hashes_like_present(self):
+        """The load-bearing #301/#302 upgrade property the PR claims: a to_dict() that
+        GAINS prune_stamps + inference_viz_scope must hash identically to a master-shaped
+        dict WITHOUT them, for BOTH inference and preprocessing fingerprints — else the
+        upgrade stales every 'inferred' resume row and renames every ED cache dir. This
+        pins the claim (previously only asserted live)."""
+        master_shaped = copy.deepcopy(self.BASE)  # no prune_stamps / inference_viz_scope
+        branch_shaped = copy.deepcopy(self.BASE)
+        branch_shaped["inference"]["prune_stamps"] = True
+        branch_shaped["inference"]["inference_viz_scope"] = "full"
+        assert inference_config_fingerprint(branch_shaped) == inference_config_fingerprint(
+            master_shaped
+        )
+        assert preprocessing_config_fingerprint(branch_shaped) == preprocessing_config_fingerprint(
+            master_shaped
+        )
 
 
 class TestPreprocessingConfigFingerprint:


### PR DESCRIPTION
## Summary

Round-2 inference optimization pass, from a 12-agent fresh-eyes audit of the post-#299 pipeline grounded in the real `pipeline_stages` spans of the #298 validation runs (5 domain finders × 5 adversarial verifiers + a design evaluator; 33 findings, 24 confirmed). Ground truth that drove the scope: in the fresh regime the main thread + all 5 GPUs idle **91.5% of wall** on preprocessing; a measured **777 s** of un-spanned startup was the `Database.__init__` `COUNT(*)` storm; in the cached regime **viz was 73% of wall** (114 s of it one figure's cold `/datag` reads); and the viz suite could not survive the 6,093-cadence catalog (OOM-class metadata retention + a figure silently lost past 242 cadences).

Closes #301
Closes #302
Closes #303
Closes #297

## What landed

**#301 — performance (numerics "none" unless stated):**
- `Database.__init__` no longer runs the per-table `COUNT(*)` storm (measured 777 s/cold launch on the 80 GB production DB, re-paid every retry relaunch); startup logs the O(1) size pragma; `get_db_stats` stays on-demand. Schema **v8**: partial index `idx_inference_results_supersede (tag, npy_path) WHERE superseded = 0` — migration-only CREATE (the predicate needs v1's column).
- Viz suite made catalog-survivable: sidecars stream-reduce into bounded `CadenceVizSummary` objects (legacy sidecars' raw lists binned at load); **new sidecar contract** — pre-binned `hit_spectrum_hist` + `bandpass_envelopes` added, the ~19 MB `raw_hit_frequencies_mhz` lists dropped (merged lists stay); preproc funnel capped at 120 bars + aggregate (it exceeded Agg's 65,536-px canvas past 242 cadences and `_viz_safe` swallowed the failure — every catalog-scale pass silently lost it); per-figure `pipeline_stages` sub-spans; `--inference-viz-scope {full,new}` for resumed campaigns; candidate-sidecar reads memoized; monitor teardown plot per-series-decimated (multi-GB RAM spike gone).
- Preprocessing: overlapping/abutting stamp windows fetched as one coalesced wide read (byte-identical, pinned); `_chunk_cache_kwargs` hoisted to the parent (~264 redundant network-FS opens/cadence gone); per-task whole-mapping `msync` removed; sequential already-downsampled loads use one chunk (no ~65 GB concatenate re-copy); NaN check rides the min reduction; ED progress at 25% milestones (the per-channel lines were a measured 62% of Slack-bound log volume; explicit `--coarse-channel-log-interval` restores every-N).
- RF path: `prepare_latent_features` → reshape (float64 kept deliberately — the training-side AU gate `.var()`s this output and float32 moves threshold-deciding bits; equivalence pinned against the verbatim historical loop); viz collector decides the budget before building features (~190 MB/cadence transient gone); `_batched_mc_scores` transient halved; `RandomForestModel.load` re-pins `n_jobs` from the runtime config (the pickle carried the training host's value).
- Encode: one-step software pipeline (dispatch k+1 before harvesting k) + encode-only submodel (the discarded `Sampling` draw no longer executes). **Honest note:** no measured encode-wall change on the cached 2-cadence subset (28.8 s total, unchanged); both changes are numerics-clean and kept for structure, with A/B numbers below.

**#302 — stamp-cache pruning (maintainer-decided design, default ON):** after a cadence's `'inferred'` row + viz collection, its stamp `.npy` is deleted; metadata `.json` always kept; candidate snippets (~196 KB each) snapshotted into atomic `.candidates.npz` sidecars with reader fallback; bounded top-K pixel pool keeps the stamp gallery whole. `None` = AUTO (ON for the fingerprint-scoped default dir, OFF for an explicit `--preprocess-output-dir`); only stamps **this run freshly extracted** are pruned (a resumed run never deletes a handed cache); best-effort containment. Without this, the full catalog writes 30–90 TB vs 2.7 TB free. Trade recorded: cross-run re-scoring re-pays extraction (~5–15 min/cadence) for pruned cadences; same-run resume/retry unaffected.

**#303 — saved-config allowlist:** `apply_saved_config` layers only model-contract/result-affecting fields (derived from `run_state.py`'s fingerprint key sets, drift-test-pinned); everything host/run-scoped is ignored with a startup diff log. Kills the confirmed v1-scenario footgun: a 96-core bla0-saved config layering `manager.n_processes=96` onto 32-core blpc3 with no CLI rescue. New shared `--n-processes` flag (≥ 1 validated). Byte-identical outputs by construction (every de-layered field is in the result-invariant fingerprint denylist).

**#297 —** parse-time floor `num_samples_rf × train_val_split ≥ effective_batch_size` (the run previously died at `rf_train` after all VAE rounds); deliberately `≥`-only — the shipped defaults rely on the runtime trim (79,872 % 7,680 ≠ 0); mirrored into `_check_cross_constraints` so suggested fixes can't propose a dying config; matrix test.

**Fingerprint hygiene (load-bearing):** `prune_stamps` + `inference_viz_scope` joined both `run_state.py` denylists; stability pinned against a master-shaped config dict — no `'inferred'` resume row stales and no ED cache dir renames on upgrade (verified live: the branch resolved the production cache dir byte-for-byte).

## Validation (blpc3, NGC container, weights `train_20260729_125502` exclusively)

- **Unit suite: 1084 passed, 0 failed at the branch tip** (blpc3 container, 3.12) (earlier tip: 1083 passed with one deselection — `test_reg_loss_deterministic_across_calls`, a pre-existing GPU-autotune flake that **fails on master on the same host**; per maintainer direction it is now FIXED in this PR by enabling op determinism around its two calls and restoring the prior process-global state, and passes 3/3 on GPU). CI: see checks.
- **Gate 1 — fresh extraction byte-identity:** subset_test.csv re-extracted through the new code into a scratch dir → both stamp `.npy` files **byte-identical** (md5) to the master-produced production cache; shared metadata keys equal (incl. `ed_config_fingerprint`); new keys present; raw list absent. Tag `inf_20260731_004408`.
- **Gate 2 — fingerprint + prune guard live:** default dir resolved to the exact production cache `subset_test_ed7c3ba8070877`; pruning AUTO=ON yet the handed cache untouched (`freshly_extracted` guard). Tag `inf_20260731_005401`.
- **Det-pair:** vs the recorded master+det run `inf_20260730_100142`: **identical candidate sets (10 = 10), max |Δ| = 0.0** across confidence / screening_proba / mc_mean / mc_std — bit-exact science outputs.
- **Allowlist live:** the real training config's diff log ignored exactly the right fields (`tf_deterministic_ops=False` historic, `num_training_rounds=5`, pre-#298 `per_replica_batch_size=2048`, `checkpoint.save_tag`) while layering the model contract.
- **Viz sub-spans (new instrumentation):** envelope-rendered bandpass figure **0.5 s vs 104.5 s** legacy live-read on the same host — cached-rerun viz drops 141.4 s → ~36 s once sidecars carry envelopes.
- **A/B legs (8-cadence fresh subset, per-leg scratch dirs, pruning exercised live):** three fresh-regime legs on the same 8 /datag cadences as #298's depth A/B, per-leg scratch dirs with pruning ON:
  - **Leg A** (branch defaults, depth 2): **5,118 s** wall vs the recorded master depth-2 run's 5,699 s (~−10% from the round-2 preprocessing work).
  - **Leg B** (`--n-processes 64`): **5,290 s — measured REJECTION** of pool oversubscription (read_ed +36%, extract +44% vs leg A despite a warmer cache; 64 workers thrash 32 cores before the 10 GbE link saturates). `n_processes` stays `cpu_count()`.
  - **Leg C** (`--prefetch-depth 3`): **4,071 s, ~−20% vs leg A** → default flipped to 3 with the honest ~10–20% band documented (leg C ran last/warmest — the same confound structure the 1→2 flip carried).
  - All legs: candidate sets identical to the recorded master run, **0.0 score deltas**; pruning live throughout — each leg's cache dir closed at **61 MB** (metadata + candidate sidecars) instead of ~190 GB of stamps, `/datax` flat at 2.9 T free.
  - Full-catalog projection: ~11.9 → ~8.5–10.7 min/cadence fresh (≈ 7 weeks → ≈ 5.5–6.5 weeks), and the run now survives its own disk/RAM (pruning + the viz rework) — previously it filled the disk after ~300–500 cadences.

## Review notes

- The metadata sidecar contract change (dropped raw hit lists) is deliberate and one-way for NEW sidecars; every reader handles legacy sidecars (reduce-at-load) — no migration needed.
- The hit-spectrum figure is *visually* identical (≥ 40× finer rebinning), not byte-identical; the bandpass figure renders identical lines from stored envelopes (commuting-mean exactness) with float32-despike low-bit caveat on 4 DC bins. All science outputs are bit-exact per the det-pair gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
