### PR TITLE
perf: round-3 audit — inference float32 features, producer/DB/viz efficiency, cadence freq-width validation

### DIFF
--- a/src/aetherscan/data_generation.py
+++ b/src/aetherscan/data_generation.py
@@ -45,6 +45,12 @@ _GLOBAL_BACKGROUNDS = None
 _GLOBAL_SHAPE = None
 _GLOBAL_DTYPE = None
 
+# Per-process memo of Stage-A (raw-background) intensity stats, keyed by background_index.
+# Only consulted on the worker path, where the plate handed to create_* IS this immutable
+# shared-memory block — see _stage_a_stats. Cleared whenever a worker (re)attaches its
+# backgrounds so a recycled process can never serve a previous block's stats.
+_STAGE_A_STATS_CACHE: dict[int, dict[str, float]] = {}
+
 
 def _init_worker(shm_name, shape, dtype, log_queue=None):
     """
@@ -76,6 +82,9 @@ def _init_worker(shm_name, shape, dtype, log_queue=None):
     _GLOBAL_BACKGROUNDS = np.ndarray(shape, dtype=dtype, buffer=_GLOBAL_SHM.buf)
     _GLOBAL_SHAPE = shape
     _GLOBAL_DTYPE = dtype
+
+    # Fresh backgrounds -> drop any Stage-A stats memoized against a prior attachment.
+    _STAGE_A_STATS_CACHE.clear()
 
     # Ignore SIGINT (Ctrl+C) in workers - let manager from parent handle cleanup coordination
     signal.signal(signal.SIGINT, signal.SIG_IGN)
@@ -365,8 +374,11 @@ def _compute_intensity_stats(data: np.ndarray) -> dict[str, float]:
             float("nan"),
         )
 
-    # Temporarily promote to float64 to prevent overflow in higher-order moments (especially for pre-normalization stats)
-    flat = data.ravel().astype(np.float64)
+    # Temporarily promote to float64 to prevent overflow in higher-order moments (especially for
+    # pre-normalization stats). copy=False avoids a redundant copy when `data` is already float64
+    # (Stage B/C inputs) — `flat` is only ever read here (median/mean/std/abs/skew/kurtosis all
+    # produce new arrays), so aliasing `data` is safe.
+    flat = data.ravel().astype(np.float64, copy=False)
     median_val = np.median(flat)
 
     stats = {
@@ -379,6 +391,27 @@ def _compute_intensity_stats(data: np.ndarray) -> dict[str, float]:
     }
 
     return stats
+
+
+def _stage_a_stats(plate: np.ndarray, background_index: int, base: np.ndarray) -> dict[str, float]:
+    """Stage-A (raw-background) intensity stats, memoized per background_index on the worker path.
+
+    Stage A is a pure function of the raw background, but each background is drawn ~n_samples /
+    n_backgrounds times per round (~33x at production defaults), so recomputing its two median
+    sorts + skew/kurtosis every draw is pure redundancy. In a pool worker the `plate` handed to
+    create_* IS `_GLOBAL_BACKGROUNDS` — a single block loaded once and never mutated for the
+    process's life — so caching by index there is byte-identical and safe. Every other caller
+    (the in-process RF-dataset path, tests) passes a different array and is NOT cached, so no
+    stale/foreign plate's stats can ever leak. A fresh dict is returned each call (callers store
+    or .copy() it) so the cached entry is never mutated in place.
+    """
+    if _GLOBAL_BACKGROUNDS is not None and plate is _GLOBAL_BACKGROUNDS:
+        cached = _STAGE_A_STATS_CACHE.get(background_index)
+        if cached is None:
+            cached = _compute_intensity_stats(base)
+            _STAGE_A_STATS_CACHE[background_index] = cached
+        return dict(cached)
+    return _compute_intensity_stats(base)
 
 
 def create_false(
@@ -409,8 +442,9 @@ def create_false(
     n_time = plate.shape[2]
     final = np.zeros((n_obs, n_time, width_bin))
 
-    # STAGE A: Pre-injection, pre-normalization (raw background)
-    stats_a = _compute_intensity_stats(base)
+    # STAGE A: Pre-injection, pre-normalization (raw background). Memoized per background on
+    # the worker path (see _stage_a_stats) — same background, same stats, computed once.
+    stats_a = _stage_a_stats(plate, background_index, base)
 
     # Initialize signal info (will be populated if inject=True)
     signal_info = {}
@@ -423,11 +457,10 @@ def create_false(
     slope_was_clamped = False
     if inject:
         # Prepare data for signal injection by stacking all 6 observations vertically
-        # (6, 16, 512) -> (96, 512)
-        # Obs 0: rows 0-15, Obs 1: rows 16-31, Obs 2: rows 32-47, ...
-        data = np.zeros((n_obs * n_time, width_bin))
-        for i in range(n_obs):
-            data[i * n_time : (i + 1) * n_time, :] = base[i, :, :]
+        # (6, 16, 512) -> (96, 512). base is C-contiguous, so the row-major reshape IS that
+        # obs-major stack (row i*n_time+t = base[i, t]); .astype(float64) yields the fresh,
+        # independent float64 buffer setigen injection then mutates in place (must be a copy).
+        data = base.reshape(n_obs * n_time, width_bin).astype(np.float64)
 
         # Select a random SNR from the given range & inject RFI into all 6 observations
         snr = random.random() * snr_range + snr_base
@@ -495,15 +528,15 @@ def create_true_single(
     n_time = plate.shape[2]
     final = np.zeros((n_obs, n_time, width_bin))
 
-    # STAGE A: Pre-injection, pre-normalization (raw background)
-    stats_a = _compute_intensity_stats(base)
+    # STAGE A: Pre-injection, pre-normalization (raw background). Memoized per background on
+    # the worker path (see _stage_a_stats) — same background, same stats, computed once.
+    stats_a = _stage_a_stats(plate, background_index, base)
 
     # Prepare data for signal injection by stacking all 6 observations vertically
-    # (6, 16, 512) -> (96, 512)
-    # Obs 0: rows 0-15, Obs 1: rows 16-31, Obs 2: rows 32-47, ...
-    data = np.zeros((n_obs * n_time, width_bin))
-    for i in range(n_obs):
-        data[i * n_time : (i + 1) * n_time, :] = base[i, :, :]
+    # (6, 16, 512) -> (96, 512). base is C-contiguous, so the row-major reshape IS that
+    # obs-major stack (row i*n_time+t = base[i, t]); .astype(float64) yields the fresh,
+    # independent float64 buffer setigen injection then mutates in place (must be a copy).
+    data = base.reshape(n_obs * n_time, width_bin).astype(np.float64)
 
     # Select a random SNR from the given range & inject ETI
     snr = random.random() * snr_range + snr_base
@@ -578,15 +611,15 @@ def create_true_double(
     n_time = plate.shape[2]
     final = np.zeros((n_obs, n_time, width_bin))
 
-    # STAGE A: Pre-injection, pre-normalization (raw background)
-    stats_a = _compute_intensity_stats(base)
+    # STAGE A: Pre-injection, pre-normalization (raw background). Memoized per background on
+    # the worker path (see _stage_a_stats) — same background, same stats, computed once.
+    stats_a = _stage_a_stats(plate, background_index, base)
 
     # Prepare data for signal injection by stacking all 6 observations vertically
-    # (6, 16, 512) -> (96, 512)
-    # Obs 0: rows 0-15, Obs 1: rows 16-31, Obs 2: rows 32-47, ...
-    data = np.zeros((n_obs * n_time, width_bin))
-    for i in range(n_obs):
-        data[i * n_time : (i + 1) * n_time, :] = base[i, :, :]
+    # (6, 16, 512) -> (96, 512). base is C-contiguous, so the row-major reshape IS that
+    # obs-major stack (row i*n_time+t = base[i, t]); .astype(float64) yields the fresh,
+    # independent float64 buffer setigen injection then mutates in place (must be a copy).
+    data = base.reshape(n_obs * n_time, width_bin).astype(np.float64)
 
     # Select a random SNR from the given range
     snr = random.random() * snr_range + snr_base

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -626,6 +626,14 @@ class Database:
             # never corrupts the database. That durability is ample for diagnostic telemetry
             # and removes the dominant per-transaction fsync stall (#277).
             conn.execute("PRAGMA synchronous=NORMAL")
+            # Keep GROUP BY / ORDER BY / window-function sorts in RAM instead of spilling to an
+            # on-disk temp b-tree. The read-heavy end-of-round / teardown passes that sort large
+            # scans (per-round injection-stat aggregates, the decimated resource-monitor window
+            # query, whole-tag plot scans) benefit; small result sets never spill, so it is free
+            # otherwise. Per-connection and numerics-neutral. (mmap_size is deliberately NOT set:
+            # its benefit is largely lost to this per-query open/close model, and SQLite mmap I/O
+            # faults surface as SIGBUS on a shared node — not worth the marginal gain.)
+            conn.execute("PRAGMA temp_store=MEMORY")
             yield conn
         finally:
             conn.close()

--- a/src/aetherscan/inference.py
+++ b/src/aetherscan/inference.py
@@ -437,8 +437,14 @@ class InferencePipeline:
                 active_dims = self.config.rf.active_dims
                 latent_dim = self.latent_dim
                 num_observations = self.num_observations
-                mean_flat = prepare_latent_features(z_mean, num_observations)
-                logvar_flat = prepare_latent_features(z_log_var, num_observations)
+                # float32 here (not the training default float64): inference never runs the
+                # Active-Units .var() gate (active_dims comes from the saved config), and every
+                # downstream consumer — build_variant_features, sample_z_flat, the reference
+                # reservoir, predict_proba — casts to float32 anyway, so this is byte-identical
+                # while skipping two full-matrix float64 widenings per cadence on the RF stage
+                # that runs on the main thread while the GPUs are idle.
+                mean_flat = prepare_latent_features(z_mean, num_observations, dtype=np.float32)
+                logvar_flat = prepare_latent_features(z_log_var, num_observations, dtype=np.float32)
 
                 pass1_features = build_variant_features(
                     variant, mean_flat, logvar_flat, num_observations, latent_dim, active_dims

--- a/src/aetherscan/inference_viz.py
+++ b/src/aetherscan/inference_viz.py
@@ -504,10 +504,24 @@ def _build_summaries(
     """One pass over the records' metadata sidecars: parse, reduce, drop — the only place
     the suite touches the raw JSONs (#301)."""
     summaries: dict[str, CadenceVizSummary] = {}
+    envelopes_captured = False
     for record in records:
         metadata = _load_metadata(record)
         if metadata is not None:
-            summaries[record.npy_path] = _reduce_metadata(record, metadata, gallery_top_k)
+            summary = _reduce_metadata(record, metadata, gallery_top_k)
+            # Only plot_bandpass_flattening reads bandpass_envelopes, and it uses the FIRST
+            # cadence (in records order) that carries them, then returns — so retaining every
+            # cadence's envelopes (each ~hundreds of KB of parsed floats) for the whole render
+            # is ~GB of dead RAM at catalog scale, undoing the O(1)-per-cadence bound the
+            # summaries were introduced (#301) to guarantee. Keep them on the first summary
+            # that has them and drop the rest: _build_summaries iterates records in the same
+            # order as the consumer, so the identical cadence is selected — byte-identical figure.
+            if summary.bandpass_envelopes is not None:
+                if envelopes_captured:
+                    summary.bandpass_envelopes = None
+                else:
+                    envelopes_captured = True
+            summaries[record.npy_path] = summary
         del metadata
     return summaries
 

--- a/src/aetherscan/models/random_forest.py
+++ b/src/aetherscan/models/random_forest.py
@@ -10,6 +10,7 @@ import logging
 
 import joblib
 import numpy as np
+import numpy.typing as npt
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.utils import shuffle
 
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 def prepare_latent_features(
     latent_vectors: np.ndarray,
     num_observations: int = 6,
-    dtype: np.typing.DTypeLike = np.float64,
+    dtype: npt.DTypeLike = np.float64,
 ) -> np.ndarray:
     """
     Reshape per-observation latent vectors of shape (num_cadences * num_observations, latent_dim)

--- a/src/aetherscan/models/random_forest.py
+++ b/src/aetherscan/models/random_forest.py
@@ -18,14 +18,19 @@ from aetherscan.config import get_config
 logger = logging.getLogger(__name__)
 
 
-def prepare_latent_features(latent_vectors: np.ndarray, num_observations: int = 6) -> np.ndarray:
+def prepare_latent_features(
+    latent_vectors: np.ndarray,
+    num_observations: int = 6,
+    dtype: np.typing.DTypeLike = np.float64,
+) -> np.ndarray:
     """
     Reshape per-observation latent vectors of shape (num_cadences * num_observations, latent_dim)
     into per-cadence features of shape (num_cadences, num_observations * latent_dim), so each
     cadence's 6 latents are concatenated into a single feature row for the RF.
 
     Caller must keep row i..i+num_observations-1 grouped as cadence i. Raises ValueError if the
-    row count isn't divisible by num_observations.
+    row count isn't divisible by num_observations. `dtype` defaults to float64 (see the note at
+    the return) — training callers MUST keep it; inference passes float32.
     """
     # Expected shape: (num_cadences * num_observations, latent_dim)
     num_latents = latent_vectors.shape[0]
@@ -43,11 +48,16 @@ def prepare_latent_features(latent_vectors: np.ndarray, num_observations: int = 
     # We flatten the observations so all 6 latents in a cadence are grouped together.
     # A row-major reshape IS that flatten (row i = rows i*num_obs..(i+1)*num_obs-1
     # raveled) — the per-row Python loop this replaces cost ~0.1-0.5 s per RFI-dense
-    # cadence at inference (#301). The float64 dtype is deliberate and load-bearing:
-    # the historical np.zeros default, and the training-side Active-Units gate computes
-    # .var() on this output, whose float32 accumulation differs in exactly the low bits
-    # that decide a hovering-at-threshold dim (#288's margin lesson).
-    return np.asarray(latent_vectors, dtype=np.float64).reshape(
+    # cadence at inference (#301). `dtype` defaults to float64 and MUST stay float64 for
+    # the TRAINING callers: the Active-Units gate computes .var() on this output, whose
+    # float32 accumulation differs in exactly the low bits that decide a hovering-at-
+    # threshold dim (#288's margin lesson). Inference passes dtype=float32 — it never runs
+    # that .var() gate (active_dims is loaded from the saved config, not recomputed), and
+    # every inference consumer (build_variant_features, sample_z_flat, predict_proba) casts
+    # to float32 anyway, so float32 here is byte-identical downstream (float32->float64->
+    # float32 round-trips exactly) while skipping two full-matrix float64 widenings per
+    # cadence on the GPU-idle RF stage.
+    return np.asarray(latent_vectors, dtype=dtype).reshape(
         num_cadences, num_observations * latent_dim
     )
 

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -1910,17 +1910,22 @@ class DataPreprocessor:
         # (n_stamps, 6, time_bins, stored_width) memmap slot — a short ON file additionally
         # degrades the k2 statistic silently first, since _sliding_normality_k2 derives its
         # sample count from the rows it receives. Frequency WIDTH is validated for the same
-        # reason: extraction reads the SAME primary-derived channel window [0:n_chans] from
-        # every file, so a file narrower than the primary truncates into a short stamp (the
-        # same broadcast ValueError), and any width mismatch violates the single-shared-grid
-        # assumption the cadence rests on. The whole cadence is skipped rather than
+        # reason: extraction reads the SAME [0:n_chans] channel window from every file, so a
+        # file with FEWER than n_chans channels truncates into a short stamp (the same broadcast
+        # ValueError deep in a worker). The check is `< n_chans` (not strict equality): a file
+        # at least n_chans wide reads cleanly and processed fine on master, so it is left alone —
+        # this only converts the crash case into a clean up-front skip. The whole cadence is
+        # skipped rather than
         # just the offending file: the 6-observation stamp tensor and the num_observations
         # contract downstream (encoder reshape, RF features, ABACAD viz) have no
         # representation for a 5-observation cadence.
+        # n_chans (header channel count, falling back to the data width) is the [0:n_chans]
+        # window read from EVERY file, so it is the reference for the width check below.
+        # Computed here, before the loop, so the geometry pass can use it.
+        n_chans = int(header.get("nchans", data_shape[-1]))
         rank_problems: list[str] = []
         short_problems: list[str] = []
         width_problems: list[str] = []
-        primary_width = int(data_shape[-1])
         for idx, obs_h5 in enumerate(group.h5_paths):
             if idx == 0:
                 # group.h5_paths[0] == primary_h5, already opened above for header/data_shape —
@@ -1936,9 +1941,10 @@ class DataPreprocessor:
                 continue
             if int(obs_shape[0]) < time_bins:
                 short_problems.append(f"{obs_h5} has only {int(obs_shape[0])} time bins")
-            if int(obs_shape[-1]) != primary_width:
+            if int(obs_shape[-1]) < n_chans:
                 width_problems.append(
-                    f"{obs_h5} has frequency width {int(obs_shape[-1])} (primary {primary_width})"
+                    f"{obs_h5} has {int(obs_shape[-1])} frequency channels < the {n_chans}-channel "
+                    f"read window"
                 )
         if rank_problems:
             # The caller (process_pending_cadence) turns this ValueError into a logged skip,
@@ -1957,14 +1963,12 @@ class DataPreprocessor:
             return None
         if width_problems:
             logger.warning(
-                f"Cadence {group.key}: every observation file must share the primary's "
-                f"frequency width ({primary_width}) — the same channel window is read from "
-                f"all 6 files; skipping whole cadence — offending file(s): "
-                f"{'; '.join(width_problems)}"
+                f"Cadence {group.key}: every observation file needs >= {n_chans} frequency "
+                f"channels (the window read from all 6 files); skipping whole cadence — "
+                f"offending file(s): {'; '.join(width_problems)}"
             )
             return None
 
-        n_chans = int(header.get("nchans", data_shape[-1]))
         foff = float(header["foff"])
         fch1 = float(header["fch1"])
 

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -1912,16 +1912,15 @@ class DataPreprocessor:
         # sample count from the rows it receives. Frequency WIDTH is validated for the same
         # reason: extraction reads the SAME [0:n_chans] channel window from every file, so a
         # file with FEWER than n_chans channels truncates into a short stamp (the same broadcast
-        # ValueError deep in a worker). The check is `< n_chans` (not strict equality): a file
-        # at least n_chans wide reads cleanly and processed fine on master, so it is left alone —
-        # this only converts the crash case into a clean up-front skip. The whole cadence is
-        # skipped rather than
-        # just the offending file: the 6-observation stamp tensor and the num_observations
-        # contract downstream (encoder reshape, RF features, ABACAD viz) have no
+        # ValueError deep in a worker). The check is `< n_chans` (not strict equality): a file at
+        # least n_chans wide reads cleanly and processed fine on master, so it is left alone —
+        # this converts only the crash case into a clean up-front skip. The whole cadence is
+        # skipped rather than just the offending file: the 6-observation stamp tensor and the
+        # num_observations contract downstream (encoder reshape, RF features, ABACAD viz) have no
         # representation for a 5-observation cadence.
-        # n_chans (header channel count, falling back to the data width) is the [0:n_chans]
-        # window read from EVERY file, so it is the reference for the width check below.
-        # Computed here, before the loop, so the geometry pass can use it.
+        #
+        # n_chans (header channel count, falling back to the data width) is that read window and
+        # the reference for the check; computed before the loop so the geometry pass can use it.
         n_chans = int(header.get("nchans", data_shape[-1]))
         rank_problems: list[str] = []
         short_problems: list[str] = []

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -1909,12 +1909,18 @@ class DataPreprocessor:
         # ValueError mid-extraction when the short stamp is assigned into its fixed
         # (n_stamps, 6, time_bins, stored_width) memmap slot — a short ON file additionally
         # degrades the k2 statistic silently first, since _sliding_normality_k2 derives its
-        # sample count from the rows it receives. The whole cadence is skipped rather than
+        # sample count from the rows it receives. Frequency WIDTH is validated for the same
+        # reason: extraction reads the SAME primary-derived channel window [0:n_chans] from
+        # every file, so a file narrower than the primary truncates into a short stamp (the
+        # same broadcast ValueError), and any width mismatch violates the single-shared-grid
+        # assumption the cadence rests on. The whole cadence is skipped rather than
         # just the offending file: the 6-observation stamp tensor and the num_observations
         # contract downstream (encoder reshape, RF features, ABACAD viz) have no
         # representation for a 5-observation cadence.
         rank_problems: list[str] = []
         short_problems: list[str] = []
+        width_problems: list[str] = []
+        primary_width = int(data_shape[-1])
         for idx, obs_h5 in enumerate(group.h5_paths):
             if idx == 0:
                 # group.h5_paths[0] == primary_h5, already opened above for header/data_shape —
@@ -1927,8 +1933,13 @@ class DataPreprocessor:
                 rank_problems.append(
                     f"{obs_h5} has 'data' of rank {len(obs_shape)} (shape {obs_shape})"
                 )
-            elif int(obs_shape[0]) < time_bins:
+                continue
+            if int(obs_shape[0]) < time_bins:
                 short_problems.append(f"{obs_h5} has only {int(obs_shape[0])} time bins")
+            if int(obs_shape[-1]) != primary_width:
+                width_problems.append(
+                    f"{obs_h5} has frequency width {int(obs_shape[-1])} (primary {primary_width})"
+                )
         if rank_problems:
             # The caller (process_pending_cadence) turns this ValueError into a logged skip,
             # so the skip-and-continue policy across a large catalog is preserved.
@@ -1942,6 +1953,14 @@ class DataPreprocessor:
                 f"Cadence {group.key}: every observation file needs >= {time_bins} time "
                 f"bins; skipping whole cadence — offending file(s): "
                 f"{'; '.join(short_problems)}"
+            )
+            return None
+        if width_problems:
+            logger.warning(
+                f"Cadence {group.key}: every observation file must share the primary's "
+                f"frequency width ({primary_width}) — the same channel window is read from "
+                f"all 6 files; skipping whole cadence — offending file(s): "
+                f"{'; '.join(width_problems)}"
             )
             return None
 

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -3126,8 +3126,11 @@ class TrainingPipeline:
             # persisted to disk above (random_forest_{tag}_{variant}.joblib) and never
             # referenced again — but the memory-heavy tail (calibration, the MC screening-
             # validation loop, the eval-artifact dump, metrics) would otherwise run at peak
-            # RSS carrying all 8. The winner survives via self.rf_model.model.
+            # RSS carrying all 8. `clf` (the fit-loop variable) still binds the LAST variant's
+            # forest, so it must be dropped too, else the tail carries 2 forests, not 1. The
+            # winner survives via self.rf_model.model.
             variant_models = {winner: variant_models[winner]}
+            del clf
             gc.collect()
             # Record the winner + calibration outcome on the config singleton so
             # final_save's config_{tag}.json tells inference exactly how to rebuild

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -3121,6 +3121,14 @@ class TrainingPipeline:
             # and release tagging all pick it up unchanged
             self.rf_model.model = variant_models[winner]
             self.rf_model.is_trained = True
+            # Free the 7 non-winner fitted forests now rather than at the end of the block:
+            # each is a full n_estimators-tree forest (tens-to-hundreds of MB), already
+            # persisted to disk above (random_forest_{tag}_{variant}.joblib) and never
+            # referenced again — but the memory-heavy tail (calibration, the MC screening-
+            # validation loop, the eval-artifact dump, metrics) would otherwise run at peak
+            # RSS carrying all 8. The winner survives via self.rf_model.model.
+            variant_models = {winner: variant_models[winner]}
+            gc.collect()
             # Record the winner + calibration outcome on the config singleton so
             # final_save's config_{tag}.json tells inference exactly how to rebuild
             # features. Single-threaded orchestration point (same precedent as the

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -707,6 +707,7 @@ def prepare_distributed_train_dataset(
     strategy: tf.distribute.Strategy,
     shuffle: bool = True,
     rng: np.random.Generator | None = None,
+    concat_only: bool = False,
 ) -> dict:
     """
     Build distributed training and validation datasets from the `data` dict, returning a dict
@@ -716,6 +717,13 @@ def prepare_distributed_train_dataset(
     `rng` supplies all randomness (stratified split, trim subsampling, per-epoch shuffles):
     callers pass a Generator derived from the pipeline root seed for reproducible runs (see
     aetherscan.seeding.derive_rng); None falls back to OS entropy (the historical behavior).
+
+    `concat_only=True` builds a leaner dataset that gathers ONLY the 'concatenated' block per
+    batch, skipping the 'true'/'false' gathers and their host->device transfer: the RF-feature
+    encode (train_random_forest) consumes only concat, so this cuts that pass's gather+transfer
+    ~3x -> 1x. Batch order and the returned train/val indices are unchanged, so the RF label
+    alignment is byte-identical; the per-replica element is then a single tensor (not the
+    ((concat, true, false), concat) tuple), which the RF encode_fn destructures accordingly.
 
     `data` must contain 'concatenated', 'true', 'false', and 'labels' — typically the
     copy-on-write memmaps returned by round_data.load_round_arrays(), though plain in-RAM
@@ -890,6 +898,12 @@ def prepare_distributed_train_dataset(
         # the training graph sees float32 either way).
         with tf.device("/CPU:0"):
             concat_batch = tf.cast(tf.gather(concat_t, batch_indices), tf.float32)
+            if concat_only:
+                # RF encode consumes ONLY the concat block (its encode_fn discards true/false),
+                # so skip those two gathers and their host->device transfer entirely (~3x -> 1x
+                # gather/transfer volume). The concat gather and the index stream are unchanged,
+                # so batch order and the train_indices/val_indices label alignment stay identical.
+                return concat_batch
             true_batch = tf.cast(tf.gather(true_t, batch_indices), tf.float32)
             false_batch = tf.cast(tf.gather(false_t, batch_indices), tf.float32)
         return (concat_batch, true_batch, false_batch), concat_batch
@@ -2865,6 +2879,10 @@ class TrainingPipeline:
             num_replicas=self.strategy.num_replicas_in_sync,
             strategy=self.strategy,
             shuffle=False,
+            # RF encode reads only the concat block, so gather concat alone and skip the
+            # true/false gather + host->device transfer (~59 GB -> ~19.6 GB one-time). Batch
+            # order + the returned train/val indices are unchanged, so label alignment holds.
+            concat_only=True,
             # RF dataset uses the round-0 STREAM_DATASET key (beta-VAE rounds are 1-based,
             # so no collision). Its DATA GENERATION uses the num_training_rounds+1 sentinel
             # on STREAM_DATA_GEN (see the round_num comment above) — different stream ids,
@@ -2907,7 +2925,9 @@ class TrainingPipeline:
 
             def encode_fn(data):
                 """Per-replica encoding step"""
-                (concat_data, _, _), _ = data
+                # The concat_only dataset yields the concat block directly (not the
+                # ((concat, true, false), concat) training tuple) — see prepare_distributed_train_dataset.
+                concat_data = data
 
                 # Reshape for encoder: (batch, 6, 16, 512) -> (batch * 6, 16, 512, 1)
                 concat_reshaped = tf.reshape(concat_data, [-1, time_bins, width_bin, 1])

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -758,7 +758,8 @@ def prepare_distributed_train_dataset(
     pressure the kernel evicts pages instead of OOM-killing the process, which is exactly the
     failure mode the old in-RAM arrays hit.
 
-    Each logical global batch has the signature ((concat, true, false), concat). Sample
+    Each logical global batch has the signature ((concat, true, false), concat) — or, under
+    concat_only=True (see above), just the bare concat tensor. Sample
     counts are trimmed to the global / effective batch size to keep all replicas evenly fed
     (so every epoch pass yields whole batches exactly); the holder is shared by both index
     generators so neither pays a memory cost beyond index subsets.

--- a/tests/unit/test_data_generation.py
+++ b/tests/unit/test_data_generation.py
@@ -602,6 +602,26 @@ class TestStageAStatsMemo:
         assert b_stats != a_stats
         data_generation._STAGE_A_STATS_CACHE.clear()
 
+    def test_init_worker_clears_stage_a_cache(self):
+        """A recycled worker that re-attaches (possibly a DIFFERENT) background block must drop
+        stats memoized against the prior attachment — _init_worker's cache clear is the sole
+        guard for that, so pin it via the real production entry point rather than a manual clear."""
+        import contextlib  # noqa: PLC0415
+        from multiprocessing.shared_memory import SharedMemory  # noqa: PLC0415
+
+        data_generation._STAGE_A_STATS_CACHE[999] = {"stale": 1.0}
+        plate = np.zeros((2, 6, 4, 4), dtype=np.float32)
+        shm = SharedMemory(create=True, size=plate.nbytes)
+        try:
+            np.ndarray(plate.shape, dtype=plate.dtype, buffer=shm.buf)[:] = plate
+            data_generation._init_worker(shm.name, plate.shape, plate.dtype)
+            assert data_generation._STAGE_A_STATS_CACHE == {}
+        finally:
+            with contextlib.suppress(Exception):
+                data_generation._GLOBAL_SHM.close()  # the view _init_worker attached
+            shm.close()
+            shm.unlink()
+
 
 class _RecordingDB:
     """Minimal stand-in for the DB singleton: records injection-stat rows. Since #277

--- a/tests/unit/test_data_generation.py
+++ b/tests/unit/test_data_generation.py
@@ -621,6 +621,10 @@ class TestStageAStatsMemo:
                 data_generation._GLOBAL_SHM.close()  # the view _init_worker attached
             shm.close()
             shm.unlink()
+            # Drop the now-dangling references to the freed block so no later test can index
+            # _GLOBAL_BACKGROUNDS (a view over unlinked shared memory) and segfault.
+            data_generation._GLOBAL_BACKGROUNDS = None
+            data_generation._GLOBAL_SHM = None
 
 
 class _RecordingDB:

--- a/tests/unit/test_data_generation.py
+++ b/tests/unit/test_data_generation.py
@@ -558,6 +558,51 @@ class TestComputeIntensityStats:
         assert math.isnan(stats["global_kurtosis"])
 
 
+class TestStageAStatsMemo:
+    """_stage_a_stats memoizes raw-background stats per index ONLY on the worker path (where the
+    plate IS the immutable shared block _GLOBAL_BACKGROUNDS), and must stay byte-identical to a
+    direct _compute_intensity_stats everywhere with zero cross-plate contamination."""
+
+    def test_direct_path_is_byte_identical_when_not_the_worker_block(self, monkeypatch):
+        rng = np.random.default_rng(0)
+        plate = rng.chisquare(df=4, size=(3, 6, 16, 8)).astype(np.float32)
+        monkeypatch.setattr(data_generation, "_GLOBAL_BACKGROUNDS", None)
+        data_generation._STAGE_A_STATS_CACHE.clear()
+        for idx in range(plate.shape[0]):
+            assert data_generation._stage_a_stats(
+                plate, idx, plate[idx]
+            ) == _compute_intensity_stats(plate[idx])
+        assert not data_generation._STAGE_A_STATS_CACHE  # never cached off the worker block
+
+    def test_worker_path_caches_but_stays_byte_identical(self, monkeypatch):
+        rng = np.random.default_rng(1)
+        plate = rng.chisquare(df=4, size=(3, 6, 16, 8)).astype(np.float32)
+        monkeypatch.setattr(data_generation, "_GLOBAL_BACKGROUNDS", plate)
+        data_generation._STAGE_A_STATS_CACHE.clear()
+
+        first = data_generation._stage_a_stats(plate, 1, plate[1])
+        second = data_generation._stage_a_stats(plate, 1, plate[1])
+        assert first == second == _compute_intensity_stats(plate[1])
+        assert 1 in data_generation._STAGE_A_STATS_CACHE
+        # A fresh dict every call so a caller can never mutate the cached entry.
+        assert first is not second
+        data_generation._STAGE_A_STATS_CACHE.clear()
+
+    def test_no_cross_plate_contamination(self, monkeypatch):
+        rng = np.random.default_rng(2)
+        plate_a = rng.chisquare(df=4, size=(3, 6, 16, 8)).astype(np.float32)
+        plate_b = rng.chisquare(df=4, size=(3, 6, 16, 8)).astype(np.float32)
+        monkeypatch.setattr(data_generation, "_GLOBAL_BACKGROUNDS", plate_a)
+        data_generation._STAGE_A_STATS_CACHE.clear()
+
+        a_stats = data_generation._stage_a_stats(plate_a, 1, plate_a[1])  # cached (worker block)
+        # plate_b is NOT the worker block -> computed directly, plate_a's cache cannot leak.
+        b_stats = data_generation._stage_a_stats(plate_b, 1, plate_b[1])
+        assert b_stats == _compute_intensity_stats(plate_b[1])
+        assert b_stats != a_stats
+        data_generation._STAGE_A_STATS_CACHE.clear()
+
+
 class _RecordingDB:
     """Minimal stand-in for the DB singleton: records injection-stat rows. Since #277
     write_segment_stats batches everything through write_injection_stats_bulk; each row dict

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -33,6 +33,21 @@ def db(tmp_path):
     database.stop()
 
 
+class TestConnectionPragmas:
+    def test_temp_store_is_memory(self, db):
+        """_get_connection sets temp_store=MEMORY so large GROUP BY/ORDER BY/window sorts in the
+        teardown/plot passes stay in RAM instead of spilling to an on-disk temp b-tree
+        (2 == MEMORY; 0 == DEFAULT, 1 == FILE)."""
+        with db._get_connection() as conn:
+            assert conn.execute("PRAGMA temp_store").fetchone()[0] == 2
+
+    def test_synchronous_is_normal(self, db):
+        """The pre-existing synchronous=NORMAL pragma (#277) must still apply alongside the new
+        temp_store setting (1 == NORMAL)."""
+        with db._get_connection() as conn:
+            assert conn.execute("PRAGMA synchronous").fetchone()[0] == 1
+
+
 class TestWriterThreadLifecycle:
     def test_start_spawns_writer_thread(self, db):
         assert db.writer_thread is not None

--- a/tests/unit/test_inference_viz.py
+++ b/tests/unit/test_inference_viz.py
@@ -510,6 +510,37 @@ class TestFigureSmoke:
         summaries = _build_summaries(coll.records, gallery_top_k=12)
         _assert_figure(plot_bandpass_flattening(DataPreprocessor(), coll.records, summaries))
 
+    def test_build_summaries_retains_bandpass_envelopes_on_first_cadence_only(
+        self, tmp_path, initialized_runtime
+    ):
+        """#301 bound: plot_bandpass_flattening reads envelopes from only the FIRST cadence
+        (records order) that has them, so _build_summaries keeps them on that one and drops
+        the rest — otherwise every cadence's envelopes stay resident (~GB at catalog scale).
+        Figure output is unchanged because the same first cadence is selected."""
+        env = [
+            {
+                "channel": 3,
+                "overlay_label": "scaled PFB response H",
+                "raw": {"idx": [0, 1, 2, 3], "values": [1.0, 2.0, 2.0, 1.0]},
+                "flat": {"idx": [0, 1, 2, 3], "values": [1.0, 1.0, 1.0, 1.0]},
+                "overlay": {"idx": [0, 1, 2, 3], "values": [1.0, 2.0, 2.0, 1.0]},
+            }
+        ]
+        coll = InferenceVizCollector()
+        for name, key in (("cad_e0", ("E0",)), ("cad_e1", ("E1",)), ("cad_e2", ("E2",))):
+            npy_path, metadata_path, metadata = _write_cadence_artifacts(tmp_path, name, key)
+            metadata["bandpass_envelopes"] = env
+            with open(metadata_path, "w") as f:
+                json.dump(metadata, f)
+            coll.record_processed(key, npy_path, metadata_path, {}, _fake_results(), 1.0)
+
+        summaries = _build_summaries(coll.records, gallery_top_k=12)
+        retained = [summaries[r.npy_path].bandpass_envelopes is not None for r in coll.records]
+        # Exactly one cadence retains envelopes, and it is the first in records order — the
+        # same one plot_bandpass_flattening would pick.
+        assert retained == [True, False, False]
+        assert summaries[coll.records[0].npy_path].bandpass_envelopes == env
+
     def test_candidate_gallery_and_per_candidate(self, initialized_runtime, collector):
         db = initialized_runtime
         config = get_config()

--- a/tests/unit/test_inference_viz.py
+++ b/tests/unit/test_inference_viz.py
@@ -514,9 +514,11 @@ class TestFigureSmoke:
         self, tmp_path, initialized_runtime
     ):
         """#301 bound: plot_bandpass_flattening reads envelopes from only the FIRST cadence
-        (records order) that has them, so _build_summaries keeps them on that one and drops
-        the rest — otherwise every cadence's envelopes stay resident (~GB at catalog scale).
-        Figure output is unchanged because the same first cadence is selected."""
+        (records order) that has them, so _build_summaries keeps them on that one and drops the
+        rest — otherwise every cadence's envelopes stay resident (~GB at catalog scale). Pins
+        (a) exactly one summary retains them, (b) it's the first in records order, and (c) the
+        consumer still renders from the nulled summaries (same cadence selected)."""
+        get_config().checkpoint.save_tag = TAG  # figure saves under plots/inference/{tag}/
         env = [
             {
                 "channel": 3,
@@ -540,6 +542,9 @@ class TestFigureSmoke:
         # same one plot_bandpass_flattening would pick.
         assert retained == [True, False, False]
         assert summaries[coll.records[0].npy_path].bandpass_envelopes == env
+        # The nulled summaries still render (from the retained first cadence's envelopes),
+        # without touching any .h5 — proving the consumer is unaffected.
+        _assert_figure(plot_bandpass_flattening(DataPreprocessor(), coll.records, summaries))
 
     def test_candidate_gallery_and_per_candidate(self, initialized_runtime, collector):
         db = initialized_runtime

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -60,11 +60,16 @@ class TestPrepareLatentFeatures:
 
     def test_dtype_float32_is_opt_in_and_byte_identical_downstream(self):
         """Inference passes dtype=np.float32 to skip the float64 widening. The result must be
-        (a) float32, (b) exactly the default float64 output cast to float32, and (c) for a
-        float32 input, bit-identical to the input reshaped — i.e. float32->float64->float32
-        round-trips exactly, so every float32-casting inference consumer sees the same bytes."""
+        (a) float32, (b) exactly the default float64 output cast to float32, (c) for a float32
+        input, bit-identical to the input reshaped (float32->float64->float32 round-trips
+        exactly), and (d) byte-identical THROUGH a real consumer that uses both blocks
+        (build_variant_features casts to float32), which is the property the inference change
+        actually relies on."""
+        from aetherscan.latent_variants import build_variant_features  # noqa: PLC0415
+
         rng = np.random.default_rng(11)
         latents = rng.standard_normal((40 * 6, 8)).astype(np.float32)
+        logvars = rng.standard_normal((40 * 6, 8)).astype(np.float32)
 
         default = prepare_latent_features(latents, num_observations=6)  # float64
         f32 = prepare_latent_features(latents, num_observations=6, dtype=np.float32)
@@ -76,6 +81,16 @@ class TestPrepareLatentFeatures:
         np.testing.assert_array_equal(f32, default.astype(np.float32))
         # And for a float32 input the reshape is bit-exact against a plain reshape.
         np.testing.assert_array_equal(f32, latents.reshape(40, 6 * 8))
+
+        # Through a real consumer that uses BOTH the lead and the logvar block: the features
+        # built from float32 prepare-outputs must be byte-identical to those from float64
+        # outputs, since build_variant_features casts everything to float32.
+        default_lv = prepare_latent_features(logvars, num_observations=6)
+        f32_lv = prepare_latent_features(logvars, num_observations=6, dtype=np.float32)
+        dims = [0, 1, 2, 3, 4, 5, 6, 7]
+        feats64 = build_variant_features("z_mean_logvar", default, default_lv, 6, 8, dims)
+        feats32 = build_variant_features("z_mean_logvar", f32, f32_lv, 6, 8, dims)
+        np.testing.assert_array_equal(feats64, feats32)
 
     def test_non_contiguous_input(self):
         """A strided view (e.g. a column-sliced latent block) must still reshape into the

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -58,6 +58,25 @@ class TestPrepareLatentFeatures:
         assert features.dtype == np.float64
         np.testing.assert_array_equal(features, expected)
 
+    def test_dtype_float32_is_opt_in_and_byte_identical_downstream(self):
+        """Inference passes dtype=np.float32 to skip the float64 widening. The result must be
+        (a) float32, (b) exactly the default float64 output cast to float32, and (c) for a
+        float32 input, bit-identical to the input reshaped — i.e. float32->float64->float32
+        round-trips exactly, so every float32-casting inference consumer sees the same bytes."""
+        rng = np.random.default_rng(11)
+        latents = rng.standard_normal((40 * 6, 8)).astype(np.float32)
+
+        default = prepare_latent_features(latents, num_observations=6)  # float64
+        f32 = prepare_latent_features(latents, num_observations=6, dtype=np.float32)
+
+        assert default.dtype == np.float64  # default unchanged (training AU-gate contract)
+        assert f32.dtype == np.float32
+        # The float32 output is exactly the float64 output downcast — what every inference
+        # consumer would compute either way.
+        np.testing.assert_array_equal(f32, default.astype(np.float32))
+        # And for a float32 input the reshape is bit-exact against a plain reshape.
+        np.testing.assert_array_equal(f32, latents.reshape(40, 6 * 8))
+
     def test_non_contiguous_input(self):
         """A strided view (e.g. a column-sliced latent block) must still reshape into the
         same layout the loop produced — reshape copies when it must, never mis-strides."""

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -906,15 +906,13 @@ class TestProcessCadenceEndToEnd:
         warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
         assert any(short_path in m and "time bins" in m for m in warnings)
 
-    @pytest.mark.parametrize("width_delta", [-64, 64])
-    def test_frequency_width_mismatch_in_any_file_skips_whole_cadence(
-        self, tmp_path, initialized_runtime, caplog, width_delta
+    @pytest.mark.parametrize("channel_deficit", [64, 1])
+    def test_narrow_frequency_width_in_any_file_skips_whole_cadence(
+        self, tmp_path, initialized_runtime, caplog, channel_deficit
     ):
-        """One observation file whose frequency width differs from the primary — narrower
-        (extraction would truncate into a short stamp, a broadcast ValueError deep in a worker)
-        or wider (violates the single-shared-frequency-grid assumption) — skips the whole
-        cadence up front with a warning naming the file. Equal width (the real-data norm) is a
-        no-op, so well-formed cadences are unaffected."""
+        """An observation file with FEWER channels than the [0:n_chans] read window would
+        truncate into a short stamp — a broadcast ValueError deep in a pool worker — so the
+        up-front geometry check turns it into a clean skip-and-warn naming the file."""
         import h5py  # noqa: PLC0415
 
         from aetherscan.preprocessing import CadenceGroup  # noqa: PLC0415
@@ -927,7 +925,7 @@ class TestProcessCadenceEndToEnd:
             t, p, w = hf["data"].shape
             del hf["data"]
             dset = hf.create_dataset(
-                "data", data=np.ones((t, p, w + width_delta), dtype=np.float32)
+                "data", data=np.ones((t, p, w - channel_deficit), dtype=np.float32)
             )
             for k, v in attrs.items():
                 dset.attrs[k] = v
@@ -938,7 +936,7 @@ class TestProcessCadenceEndToEnd:
             expected_obs=6,
             is_valid=True,
         )
-        npy_path = str(tmp_path / "out" / "cad_bad_width.npy")
+        npy_path = str(tmp_path / "out" / "cad_narrow_width.npy")
         os.makedirs(os.path.dirname(npy_path), exist_ok=True)
 
         with caplog.at_level(logging.WARNING, logger="aetherscan.preprocessing"):
@@ -948,7 +946,46 @@ class TestProcessCadenceEndToEnd:
         assert not os.path.exists(npy_path)
         assert not os.path.exists(os.path.splitext(npy_path)[0] + ".tmp.npy")
         warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
-        assert any(off_path in m and "frequency width" in m for m in warnings)
+        assert any(off_path in m and "read window" in m for m in warnings)
+
+    def test_wider_off_file_is_not_rejected(self, tmp_path, initialized_runtime, caplog):
+        """A file WIDER than the n_chans read window reads cleanly ([0:n_chans]) and processed
+        on master, so the width guard deliberately leaves it alone — the check is `< n_chans`,
+        not strict equality. Only genuinely narrow files (the crash case) are skipped."""
+        import h5py  # noqa: PLC0415
+
+        from aetherscan.preprocessing import CadenceGroup  # noqa: PLC0415
+
+        self._configure()
+        h5_paths = self._make_cadence(tmp_path)
+        off_path = h5_paths[1]
+        with h5py.File(off_path, "r+") as hf:
+            attrs = dict(hf["data"].attrs)  # nchans stays 2048 -> read window unchanged
+            data = hf["data"][:]
+            del hf["data"]
+            pad = np.random.default_rng(7).normal(
+                1000.0, 10.0, size=(data.shape[0], data.shape[1], 64)
+            )
+            wider = np.concatenate([data, pad.astype(np.float32)], axis=-1)
+            dset = hf.create_dataset("data", data=wider)
+            for k, v in attrs.items():
+                dset.attrs[k] = v
+        group = CadenceGroup(
+            key=("T9", "S1", "L", "15", "2251"),
+            h5_paths=h5_paths,
+            csv_path="unused.csv",
+            expected_obs=6,
+            is_valid=True,
+        )
+        npy_path = str(tmp_path / "out" / "cad_wider.npy")
+        os.makedirs(os.path.dirname(npy_path), exist_ok=True)
+
+        with caplog.at_level(logging.WARNING, logger="aetherscan.preprocessing"):
+            DataPreprocessor().process_pending_cadence(PendingCadence(group, npy_path))
+
+        warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert not any("read window" in m for m in warnings)  # width guard did NOT fire
+        assert os.path.exists(npy_path)  # processed through to writing stamps, like master
 
     def test_wrong_rank_data_is_skipped_not_fatal(self, tmp_path, initialized_runtime):
         """process_pending_cadence swallows the rank ValueError into a logged skip (returns

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -906,6 +906,50 @@ class TestProcessCadenceEndToEnd:
         warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
         assert any(short_path in m and "time bins" in m for m in warnings)
 
+    @pytest.mark.parametrize("width_delta", [-64, 64])
+    def test_frequency_width_mismatch_in_any_file_skips_whole_cadence(
+        self, tmp_path, initialized_runtime, caplog, width_delta
+    ):
+        """One observation file whose frequency width differs from the primary — narrower
+        (extraction would truncate into a short stamp, a broadcast ValueError deep in a worker)
+        or wider (violates the single-shared-frequency-grid assumption) — skips the whole
+        cadence up front with a warning naming the file. Equal width (the real-data norm) is a
+        no-op, so well-formed cadences are unaffected."""
+        import h5py  # noqa: PLC0415
+
+        from aetherscan.preprocessing import CadenceGroup  # noqa: PLC0415
+
+        self._configure()
+        h5_paths = self._make_cadence(tmp_path)
+        off_path = h5_paths[1]
+        with h5py.File(off_path, "r+") as hf:
+            attrs = dict(hf["data"].attrs)
+            t, p, w = hf["data"].shape
+            del hf["data"]
+            dset = hf.create_dataset(
+                "data", data=np.ones((t, p, w + width_delta), dtype=np.float32)
+            )
+            for k, v in attrs.items():
+                dset.attrs[k] = v
+        group = CadenceGroup(
+            key=("T8", "S1", "L", "14", "2251"),
+            h5_paths=h5_paths,
+            csv_path="unused.csv",
+            expected_obs=6,
+            is_valid=True,
+        )
+        npy_path = str(tmp_path / "out" / "cad_bad_width.npy")
+        os.makedirs(os.path.dirname(npy_path), exist_ok=True)
+
+        with caplog.at_level(logging.WARNING, logger="aetherscan.preprocessing"):
+            result = DataPreprocessor().process_pending_cadence(PendingCadence(group, npy_path))
+
+        assert result is None
+        assert not os.path.exists(npy_path)
+        assert not os.path.exists(os.path.splitext(npy_path)[0] + ".tmp.npy")
+        warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(off_path in m and "frequency width" in m for m in warnings)
+
     def test_wrong_rank_data_is_skipped_not_fatal(self, tmp_path, initialized_runtime):
         """process_pending_cadence swallows the rank ValueError into a logged skip (returns
         None, no .npy written), so one malformed cadence can't abort a large-catalog run."""

--- a/tests/unit/test_train_datasets.py
+++ b/tests/unit/test_train_datasets.py
@@ -128,8 +128,12 @@ class TestPrepareDistributedTrainDataset:
         concat — so the RF encode reads identical cadences with byte-identical train_indices
         alignment while skipping the true/false gather + host->device transfer."""
         data = _make_data()
-        full = _build(data, shuffle=False)
-        lean = _build(data, shuffle=False, concat_only=True)
+        # Seed both builds identically so the stratified split (rng-driven) matches — the point
+        # is to compare the GATHER output/order, not the split. Two fresh generators with the same
+        # seed give identical splits; a single shared generator would NOT (the first build would
+        # advance its state before the second reads it).
+        full = _build(data, shuffle=False, rng=np.random.default_rng(0))
+        lean = _build(data, shuffle=False, concat_only=True, rng=np.random.default_rng(0))
         assert lean["train_indices"].tolist() == full["train_indices"].tolist()
         n_batches = full["train_steps"] * full["accumulation_steps"]
 

--- a/tests/unit/test_train_datasets.py
+++ b/tests/unit/test_train_datasets.py
@@ -36,7 +36,7 @@ def _make_data(n_samples=40):
     }
 
 
-def _build(data, shuffle, train_val_split=0.8, prb=4, eb=8, prvb=4, rng=None):
+def _build(data, shuffle, train_val_split=0.8, prb=4, eb=8, prvb=4, rng=None, concat_only=False):
     return prepare_distributed_train_dataset(
         data=data,
         train_val_split=train_val_split,
@@ -47,6 +47,7 @@ def _build(data, shuffle, train_val_split=0.8, prb=4, eb=8, prvb=4, rng=None):
         strategy=tf.distribute.get_strategy(),
         shuffle=shuffle,
         rng=rng,
+        concat_only=concat_only,
     )
 
 
@@ -120,6 +121,36 @@ class TestPrepareDistributedTrainDataset:
             second.extend(_batch_row_ids(next(iterator)).tolist())
         assert second == seen
         results["_train_holder"].clear()
+
+    def test_concat_only_yields_concat_block_in_identical_order(self):
+        """#10: concat_only=True yields ONLY the concat block (a single tensor per step, not the
+        ((concat, true, false), concat) tuple), in the EXACT same order as the full dataset's
+        concat — so the RF encode reads identical cadences with byte-identical train_indices
+        alignment while skipping the true/false gather + host->device transfer."""
+        data = _make_data()
+        full = _build(data, shuffle=False)
+        lean = _build(data, shuffle=False, concat_only=True)
+        assert lean["train_indices"].tolist() == full["train_indices"].tolist()
+        n_batches = full["train_steps"] * full["accumulation_steps"]
+
+        full_it = iter(full["train_dataset"])
+        lean_it = iter(lean["train_dataset"])
+        full_ids, lean_ids = [], []
+        for _ in range(n_batches):
+            full_ids.extend(_batch_row_ids(next(full_it)).tolist())
+            lean_batch = next(lean_it)
+            # concat_only element is the concat tensor directly (no unpacking).
+            assert lean_batch.shape == (4, *_SAMPLE_SHAPE)
+            lean_ids.extend(lean_batch.numpy()[:, 0, 0, 0].astype(np.int64).tolist())
+        assert lean_ids == full_ids == full["train_indices"].tolist()
+        # val path is concat-only too.
+        lean_val = iter(lean["val_dataset"])
+        val_ids = []
+        for _ in range(lean["val_steps"]):
+            val_ids.extend(next(lean_val).numpy()[:, 0, 0, 0].astype(np.int64).tolist())
+        assert val_ids == lean["val_indices"].tolist()
+        full["_train_holder"].clear()
+        lean["_train_holder"].clear()
 
     def test_val_yields_val_indices_order(self):
         results = _build(_make_data(), shuffle=True)


### PR DESCRIPTION
Closes #308

## What & why

A third fresh-eyes performance/correctness audit of the pipeline (after #299 and #305) surfaced a
set of **net-new, numerics-neutral** optimizations plus one robustness hardening. Every change was
adversarially verified to be **byte-identical** — no detection outcome moves. The core
science/logic is untouched; this is purely faster/leaner.

Methodology: 7 ledger-grounded finder agents → maintainer triage of the trade-offs → one
adversarial skeptic per surviving finding (all confirmed `numerics=none`). Each behavioural
surface ships a unit test.

## Commits (one per finding, all GPG-signed)

| Commit | Finding | Effect | Numerics |
|---|---|---|---|
| `858adb6` | **A** inference float32 RF features | skips two per-cadence float64 widenings on the GPU-idle RF stage | none (float32→float64→float32 round-trips exact; training default stays float64 for the #288 AU-gate) |
| `ca8a7c5` | **B** free non-winner variant forests | training peak RSS through the calibration/MC/SHAP tail | none (memory-only) |
| `860440a` | **C** memoize Stage-A background stats + gen micro-allocs | producer throughput (Stage A recomputed ~33×/round → once) | none (byte-identical `injection_stats`) |
| `396fb18` | **E** freq-width geometry validation | cryptic deep-worker crash → clean skip-and-warn | none (no-op for valid equal-width cadences) |
| `19364da` | **H** one-cadence bandpass-envelope retention | ~GB viz RAM at catalog scale | none (byte-identical figure) |
| `c861a7f` | **G** `temp_store=MEMORY` | teardown/plot sorts stay in RAM | none |

### Safety notes worth reviewing

- **A**: verified inference never runs the `.var()` Active-Units gate (`active_dims` comes from the
  saved config); the float64 default is preserved for training and pinned by
  `test_reshape_matches_historical_loop_and_keeps_float64`.
- **C**: the memo is consulted **only** on the worker path where the plate IS the immutable
  `_GLOBAL_BACKGROUNDS` block (identity-guarded), cleared on each fresh attach, and returns a fresh
  dict per call — the in-process/test path is never cached, so no foreign plate's stats can leak.
  The stacking `astype` stays a copy (setigen mutates it in place); `copy=False` is only on the
  read-only stats cast.
- **E**: rejects only genuinely mismatched cadences; equal-width (the real-data norm) is a no-op.
- **G**: `mmap_size` deliberately **not** set (SIGBUS risk on shared cluster nodes + benefit lost
  to the per-query open/close model).

## Deferred (follow-up)

Cadence-level encode↔RF/DB pipeline (reproducibility-sensitive), parallel viz metadata reduction
(large-catalog only), RF-encode concat-only gather (delicate) — all need benchmarking, tracked for
a separate PR. bf16 confirmed staying off (science change); dropping the `injection_stats.metadata`
column was declined by the maintainer (keep per-row provenance).

## Validation

- Full container unit suite: **1106 passed** on the NGC image (bla0), `not gpu and not cluster`.
- Ruff lint + format clean.
- Adversarial-verify pass: all 6 findings `numerics=none`, byte-identical.
- (Context) the v1 Phase-3 inference run is proceeding on blpc3 against `train_20260729_152426`
  on current master — unaffected by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update — follow-up items (Closes #310)

Per maintainer decision, the three deferred items (#308) were dispositioned with the completed run's measured stage profile:

- **#10 — RF-encode concat-only gather: ADDED to this PR** (`85e34ef`). `prepare_distributed_train_dataset` gains a `concat_only` flag so the RF feature encode gathers only the concat block (it discards true/false) — cutting that one-time gather + host→device transfer ~3× → 1× (~59 GB → ~19.6 GB). Index generators + concat gather untouched → batch order and `train_indices`/`val_indices` alignment byte-identical (pinned by `test_concat_only_yields_concat_block_in_identical_order`).
- **#2 — encode↔RF/DB overlap: DECLINED (removed from backlog).** Measured run is preprocessing-bound (~49,600 s preprocessing vs ~2,088 s mostly-already-overlapped encode+rf+db); the overlap buys ~nothing and its background RF thread would contend with the 32-worker preprocess pool — net-negative, plus reproducibility risk.
- **#8 — parallel viz metadata reduction: DECLINED.** `inference.viz.load_metadata` = 8.37 s / 350 cadences → ~2–3 min at full-catalog scale, negligible on a weeks-long preprocessing-bound run; and it would need a new TF-free module split. Disproportionate.

Validation: full container unit suite green on the branch tip (incl. the new #10 test); the 350-cadence subset re-run on the branch reproduces the master run's candidate set (numerics-neutral gate).
