### PR TITLE
release: v1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ name: Release
 on:
   push:
     tags: ["v*"]
-  # Dry-run path (recommended before the first real release): manual dispatch publishes to
-  # test.pypi.org. Real releases only ever happen via tag pushes — a manual run with
-  # test_pypi unchecked fails the guard.
+  # Dry-run path (recommended before EVERY release — docs/RELEASE.md runbook step 4): manual
+  # dispatch publishes to test.pypi.org. Real releases only ever happen via tag pushes — a manual
+  # run with test_pypi unchecked fails the guard.
   workflow_dispatch:
     inputs:
       test_pypi:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,8 +14,8 @@ authors:
     given-names: "Matt"
     orcid: "https://orcid.org/0000-0002-7042-7566"
 title: "Aetherscan: Breakthrough Listen's first end-to-end production-grade DL pipeline for SETI @ scale"
-version: 0.1.0
-date-released: 2026-01-01
+version: 1.0.0
+date-released: 2026-08-01
 url: "https://github.com/zachtheyek/Aetherscan"
 repository-code: "https://github.com/zachtheyek/Aetherscan"
 keywords:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,5 @@
 cff-version: 1.2.0
+type: software
 message: "If you use this software, please cite it as below."
 authors:
   - family-names: "Yek"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Aetherscan supports two install paths off the same source tree. The NGC containe
   - Blackwell (sm_120, e.g. RTX PRO 6000) — driver ≥570 (native CUDA 12.8)
   - Ampere (sm_86, e.g. RTX A4000) — driver ≥550 (host CUDA 12.3) via CUDA forward compatibility
 - VRAM: **≥8 GB per GPU** recommended — measured peaks ~6 GB/GPU (training) and ~2.5 GB/GPU (inference) on the v1.0.0 release runs; gradient accumulation keeps per-GPU VRAM low
-- RAM: **≥256 GB** for full-scale training and default catalog-scale inference — measured peaks ~260 GB (training; mean ~150 GB) and ~200 GB (inference at the default `--prefetch-depth 3`; mean ~36 GB). Inference RAM scales with `--prefetch-depth` × the largest in-flight cadence, so lower `--prefetch-depth` for smaller-RAM hosts or small catalogs
+- RAM: **≥288 GB** for full-scale training and default catalog-scale inference (measured peaks ~260 GB training / ~200 GB inference, plus headroom — a strict-256 GB host sits too close to the training peak and risks OOM under page-cache pressure). Means are much lower (~150 GB training / ~36 GB inference); inference RAM scales with `--prefetch-depth` × the largest in-flight cadence, so lower `--prefetch-depth` for smaller-RAM hosts or small catalogs
 - Disk: full-scale training round data ~150 GB per retained round (float16 default), up to ~3 TB with `--keep-round-data`; inference stamps are auto-pruned by default (~1 MB/cadence metadata retained + a transient ~5–20 GB/cadence × `--prefetch-depth` during extraction)
 - Apptainer 1.4+ or SingularityCE 4.1+ (Python 3.12 / TF 2.17 / CUDA 12.8 live inside the container)
 - See [`docs/GPU_RUNTIME_GUIDE.md`](docs/GPU_RUNTIME_GUIDE.md) for the full runbook

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ Aetherscan supports two install paths off the same source tree. The NGC containe
 - ≥1x NVIDIA GPU:
   - Blackwell (sm_120, e.g. RTX PRO 6000) — driver ≥570 (native CUDA 12.8)
   - Ampere (sm_86, e.g. RTX A4000) — driver ≥550 (host CUDA 12.3) via CUDA forward compatibility
-- ≥12 GB combined VRAM (training) / ≥9 GB combined VRAM (inference)
-- ≥150 GB RAM (training) / ≥100 GB RAM (inference)
+- VRAM: **≥8 GB per GPU** recommended — measured peaks ~6 GB/GPU (training) and ~2.5 GB/GPU (inference) on the v1.0.0 release runs; gradient accumulation keeps per-GPU VRAM low
+- RAM: **≥256 GB** for full-scale training and default catalog-scale inference — measured peaks ~260 GB (training; mean ~150 GB) and ~200 GB (inference at the default `--prefetch-depth 3`; mean ~36 GB). Inference RAM scales with `--prefetch-depth` × the largest in-flight cadence, so lower `--prefetch-depth` for smaller-RAM hosts or small catalogs
+- Disk: full-scale training round data ~150 GB per retained round (float16 default), up to ~3 TB with `--keep-round-data`; inference stamps are auto-pruned by default (~1 MB/cadence metadata retained + a transient ~5–20 GB/cadence × `--prefetch-depth` during extraction)
 - Apptainer 1.4+ or SingularityCE 4.1+ (Python 3.12 / TF 2.17 / CUDA 12.8 live inside the container)
 - See [`docs/GPU_RUNTIME_GUIDE.md`](docs/GPU_RUNTIME_GUIDE.md) for the full runbook
 
@@ -53,9 +54,8 @@ Aetherscan supports two install paths off the same source tree. The NGC containe
 > [!NOTE]
 > There are no plans to support non-Nvidia GPUs
 
-> [!WARNING]
->
-> # TODO: update system requirements after proper benchmarking (`docs/benchmarks.md`?)
+> [!NOTE]
+> The figures above are measured from the v1.0.0 release runs — training on 6× RTX A4000 (16 GB) + 503 GB RAM (tag `train_20260729_152426`) and inference on 5× RTX PRO 6000 (96 GB) + 503 GB RAM over a 350-cadence `/datag` catalog subset (tag `inf_20260731_182011`) — via the always-on resource instrumentation (`system_resources` DB rows). They characterize full-scale runs; small runs need substantially less.
 
 ### Run From Container
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -218,13 +218,15 @@ the assistant can drive; **CD** = automatic. Each step gates the next; do not re
    CD's HF-verify checks it); re-running for an existing tag errors clearly rather than
    duplicating.
 
-6. **Sign + push the tag (maintainer ONLY).** Make sure local `master` is at the release PR's merge
+6. **Sign + push the tag (maintainer ONLY).** Update local `master` to the release PR's merge
    commit (`git checkout master && git pull`), then:
    ```bash
    git tag -s vX.Y.Z && git push origin vX.Y.Z
    ```
-   Signed with your GPG key — **the assistant cannot do this step.** The push is the point of no
-   return: it triggers the real CD, and PyPI versions are immutable.
+   Signed with your GPG key — **the assistant cannot do this step.** If unrelated work merged to
+   `master` after the release PR, don't tag `HEAD` — tag that PR's merge commit explicitly so the
+   release captures exactly the reviewed tree: `git tag -s vX.Y.Z <release-PR-merge-sha>`. The push
+   is the point of no return: it triggers the real CD, and PyPI versions are immutable.
 
 7. **CD does the rest (automatic — watch it).** guard (signed tag + `tag == v+version`) → tests →
    HF-weights verify → build + wheel smoke → publish to PyPI (trusted publishing) → GitHub Release

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -22,7 +22,7 @@ its matching weights at runtime because the package version is the default HF re
 
 ```
 pip install aetherscan==1.0.0
-aetherscan.main inference ...        # no model-path flags
+python -m aetherscan.main inference ...   # no model-path flags
   → resolves HF revision v1.0.0 → downloads the blessed weights → runs
 ```
 
@@ -85,7 +85,7 @@ versioning**:
 | Tag family | Created by | Points at |
 | --- | --- | --- |
 | Training tags (`train_20260101_120000`, ...) | Training runs with `--hf-upload` (tag = the run's `save_tag`) | The commit that upload produced |
-| Release tags (`v1.0.0`, ...) | The release runbook (step 3 below) | The blessed training upload's commit |
+| Release tags (`v1.0.0`, ...) | The release runbook (the bless, step 5 below) | The blessed training upload's commit |
 
 Uploads need a write-scoped `HF_TOKEN` in the environment (`.env` on the clusters —
 gitignored, forwarded into the container; never logged, never committed). Upload failure
@@ -139,50 +139,126 @@ recommended dry-run before the first real release.
 
 ### One-time setup (maintainer)
 
-- **PyPI**: create the `aetherscan` project and add GitHub as a **trusted publisher** —
-  repository `zachtheyek/Aetherscan`, workflow `release.yml`, environment `pypi`. This is
-  what step 6 authenticates against; no token to rotate, nothing to leak.
-- **HF**: confirm the model repo `zachtheyek/aetherscan` exists and that the clusters'
-  `.env` files carry a write-scoped `HF_TOKEN` (for training uploads only — CD never
-  writes to HF).
+All of this is already done for `zachtheyek/Aetherscan` — it is listed so a fork or a future
+maintainer can reproduce it, and so the runbook's prereq check (step 1) has something concrete to
+verify against.
+
+- **PyPI (real release)**: create the `aetherscan` project on pypi.org and add GitHub as a
+  **trusted publisher** — repository `zachtheyek/Aetherscan`, workflow `release.yml`, environment
+  `pypi` — then create the `pypi` environment in this repo (Settings → Environments). The publish
+  step authenticates against this via OIDC; no API token is ever stored or rotated.
+- **TestPyPI (dry run)**: the **same** trusted-publisher setup on test.pypi.org, with a `testpypi`
+  environment in this repo. Required for the dry-run step (runbook step 4) to publish — without it
+  the dry run's build/tests still run but its final publish step fails at authentication.
+- **HF**: confirm the model repo `zachtheyek/aetherscan` exists and is **public** (inference
+  downloads need no token), and that wherever the bless is run (a cluster, or any machine running
+  `hf_tag_release.py`) has a **write-scoped** `HF_TOKEN` in its gitignored `.env`. CD never writes
+  to HF — only the training upload and the bless do.
+- **Verify** the environments exist before a release:
+  `gh api repos/zachtheyek/Aetherscan/environments --jq '.environments[].name'` must list both
+  `pypi` and `testpypi`.
 
 ## Release runbook
 
-Steps for cutting `vX.Y.Z` (maintainer + agent together):
+The concrete, in-order sequence for cutting `vX.Y.Z`. **This is the exact process used for the
+v1.0.0 release** — substitute your version and training tag. Roles: **maintainer** = a human with
+repo admin + a registered GPG signing key + (for the bless) a write `HF_TOKEN`; **agent** = steps
+the assistant can drive; **CD** = automatic. Each step gates the next; do not reorder.
 
-1. **Prereqs** — one-time setup above is done; all intended PRs are merged; `master` is
-   green.
-2. **Train the release model** — full-scale
-   `train --save-tag train --hf-upload` on the chosen cluster (the run tag resolves to
-   `train_{YYYYMMDD_HHMMSS}` — note it for the next step). Weights land locally and on HF tagged
-   with that run tag. **Review the training artifacts** — the loss curves, injection
-   stats, latent diagnostics, and RF plots ([`TRAINING_PIPELINE.md`](TRAINING_PIPELINE.md))
-   are the release-qualification evidence.
-3. **Bless the weights** — create the release tag on HF pointing at the training upload:
-   `utils/hf_tag_release.py --save-tag train_{YYYYMMDD_HHMMSS} --release vX.Y.Z` (the run tag from
-   step 2; a thin wrapper over `HfApi.create_tag`). This is the human "these weights are the
-   release" decision — CD deliberately cannot make it.
-4. **Release PR** — bump `version = "X.Y.Z"` in `pyproject.toml`, revisit the Development
-   Status classifier, draft the release notes (curate the `claude-release-notes` comments),
-   regenerate anything version-stamped. Merge through normal review.
-5. **Tag** — from the release PR's merge commit on master:
-   `git tag -s vX.Y.Z && git push origin vX.Y.Z` (signed, like every commit in this repo).
-6. **CD does the rest** — guard → tests → HF verify → build → PyPI → GitHub Release. Watch
-   the run. If the HF-verify step fails, you skipped step 3: don't touch the git tag (it's
-   already correct) — run step 3, then re-run the failed workflow.
-7. **Smoke the release** — on a clean venv/machine:
-   `pip install aetherscan==X.Y.Z`, then run inference with **no model-path flags** against
-   a small catalog; confirm it downloads the `vX.Y.Z` weights and completes. That closes the
-   loop on the contract.
-8. **Reset the dev version** — in a small follow-up chore PR right after the release lands, bump
-   `pyproject.toml` `version` from the just-released `X.Y.Z` to the next pre-release (e.g.
-   `X.Y.(Z+1).dev0`) so `master` no longer advertises itself as a shipped stable version between
+1. **Prereqs (maintainer/agent).** One-time setup above is done — verify with
+   `gh api repos/zachtheyek/Aetherscan/environments --jq '.environments[].name'` (must list `pypi`
+   and `testpypi`). Every intended PR is merged and `master` is green
+   (`gh run list --branch master --limit 1`). Decide two things up front: the version `X.Y.Z` and
+   the Development-Status classifier (`4 - Beta` vs `5 - Production/Stable`).
+
+2. **Train the release model (maintainer).** Full-scale `train --save-tag train --hf-upload` on
+   the chosen cluster. The run stamps its own datetime, so the tag resolves to
+   `train_{YYYYMMDD_HHMMSS}` — **copy it from the startup log; every later step needs it.** Weights
+   land locally *and* on HF under that training tag (this upload is separate from the release tag
+   created in step 5). **Review the artifacts** (loss curves, injection stats, latent diagnostics,
+   RF plots — [`TRAINING_PIPELINE.md`](TRAINING_PIPELINE.md)); this is the release-qualification
+   evidence. Recommended: also do a Phase-3 inference pass on a real `/datag` catalog subset — it
+   sanity-checks the weights on real data and captures the inference RAM/VRAM/disk numbers (from
+   the always-on `system_resources` DB rows) that the README update in step 3 needs.
+
+3. **Release PR (agent drafts, maintainer merges).** One PR that:
+   - bumps `version` in `pyproject.toml` to `X.Y.Z` — the single source of truth; CD enforces the
+     pushed git tag equals `v` + this;
+   - sets the Development-Status classifier per step 1;
+   - updates the README **System Requirements** with the real RAM/VRAM/disk numbers from the
+     training + inference runs (issue #183; read them off the `system_resources` DB rows — cite the
+     run tags + hardware for provenance);
+   - bumps `CITATION.cff` `version` and `date-released`;
+   - links the release issue (`Closes #183`).
+   Run the normal review loop. **This repo allows merge commits only** (rebase/squash are
+   disabled), and branch protection keeps the PR at `mergeStateStatus: BLOCKED` until it has a
+   review approval — merge after approval, or with `gh pr merge <n> --admin --merge --delete-branch`
+   if an admin is cutting the release directly.
+
+4. **Dry-run to TestPyPI (agent/maintainer).** *After* the release PR merges (so the build carries
+   the real `X.Y.Z`, not the dev pre-release), trigger the dry run on master and watch it:
+   ```bash
+   gh workflow run release.yml -f test_pypi=true --ref master
+   gh run watch "$(gh run list --workflow=release.yml --limit 1 --json databaseId --jq '.[0].databaseId')"
+   ```
+   The dry run does guard → tests → build + **wheel smoke** → publish to test.pypi.org. It
+   **skips** the signed-tag gate, the HF-weights verification, and the GitHub Release — so it needs
+   **no bless and no git tag**. Its whole job is to catch packaging / version-single-sourcing /
+   build breakage *before* you spend the immutable real version number. Confirm it went green (and,
+   if you like, that `aetherscan X.Y.Z` shows up on test.pypi.org) before continuing.
+
+5. **Bless the weights (maintainer, or agent if authorized + `HF_TOKEN` is present).** Create the
+   release tag *on HF*, pointing at the training upload's commit:
+   ```bash
+   python utils/hf_tag_release.py --save-tag train_{YYYYMMDD_HHMMSS} --release vX.Y.Z
+   ```
+   Run it where a write-scoped `HF_TOKEN` is available (a cluster `.env`, etc.); it is a thin
+   wrapper over `HfApi.create_tag`. This is the human "these weights **are** the release" decision
+   — CD verifies the tag but deliberately cannot create it. It must be done before step 6 (the real
+   CD's HF-verify checks it); re-running for an existing tag errors clearly rather than
+   duplicating.
+
+6. **Sign + push the tag (maintainer ONLY).** Make sure local `master` is at the release PR's merge
+   commit (`git checkout master && git pull`), then:
+   ```bash
+   git tag -s vX.Y.Z && git push origin vX.Y.Z
+   ```
+   Signed with your GPG key — **the assistant cannot do this step.** The push is the point of no
+   return: it triggers the real CD, and PyPI versions are immutable.
+
+7. **CD does the rest (automatic — watch it).** guard (signed tag + `tag == v+version`) → tests →
+   HF-weights verify → build + wheel smoke → publish to PyPI (trusted publishing) → GitHub Release
+   (notes + sdist/wheel). If **HF-verify** fails, you skipped step 5: the git tag is already
+   correct, so **do NOT retag** — run step 5, then re-run the failed workflow
+   (`gh run rerun <run-id> --failed`).
+
+8. **Smoke the release (agent/maintainer).** On a clean venv/machine (**not** the source tree, so
+   `__version__` comes from the installed package):
+   ```bash
+   pip install aetherscan==X.Y.Z
+   python -m aetherscan.main inference --inference-files <small_catalog.csv>   # no --encoder-path/--rf-path/--config-path
+   ```
+   Confirm it lazily downloads the `vX.Y.Z` weights from HF and completes. That closes the loop on
+   the version-coupling contract.
+
+9. **Reset the dev version (agent drafts, maintainer merges).** Small follow-up chore PR right
+   after the release lands: bump `pyproject.toml` `version` from `X.Y.Z` to the next pre-release
+   (e.g. `X.Y.(Z+1).dev0`) so `master` stops advertising itself as a shipped stable version between
    releases (`src/aetherscan/__init__.py` reads it back via `importlib.metadata`). Revisit the
-   Development-Status classifier only if the maturity level actually changes.
+   Development-Status classifier only if the maturity level actually changed.
+
+> **Release notes.** CD creates the GitHub Release with `--generate-notes`; curate the body
+> afterward from the per-merge `claude-release-notes` comments (see
+> [`GITHUB_AUTOMATION.md`](GITHUB_AUTOMATION.md)) — they are the raw material, written one merge at
+> a time for exactly this purpose.
+>
+> **Recovering from a broken release.** PyPI versions are immutable: if a published release is
+> broken, fix forward with `vX.Y.(Z+1)` (a fresh release PR + tag). You can `pip`-yank the bad
+> version on PyPI so resolvers skip it, but the number is spent.
 
 ## FAQ
 
-- *Can GitHub releases and HF tagged weights get out of sync?* Only by skipping step 3 —
+- *Can GitHub releases and HF tagged weights get out of sync?* Only by skipping the bless (step 5) —
   and then CD refuses to publish. The same tag string on both sides, with CD enforcing
   existence, is the whole synchronization mechanism.
 - *Why can't CI produce the weights?* Training needs cluster GPUs, hundreds of GB of

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -174,6 +174,11 @@ Steps for cutting `vX.Y.Z` (maintainer + agent together):
    `pip install aetherscan==X.Y.Z`, then run inference with **no model-path flags** against
    a small catalog; confirm it downloads the `vX.Y.Z` weights and completes. That closes the
    loop on the contract.
+8. **Reset the dev version** — in a small follow-up chore PR right after the release lands, bump
+   `pyproject.toml` `version` from the just-released `X.Y.Z` to the next pre-release (e.g.
+   `X.Y.(Z+1).dev0`) so `master` no longer advertises itself as a shipped stable version between
+   releases (`src/aetherscan/__init__.py` reads it back via `importlib.metadata`). Revisit the
+   Development-Status classifier only if the maturity level actually changes.
 
 ## FAQ
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ name = "aetherscan"
 # via importlib.metadata). Kept a pre-release between releases; the release PR bumps it to
 # the final X.Y.Z, and the CD workflow (.github/workflows/release.yml) enforces that the
 # pushed git tag matches it exactly.
-version = "0.9.0.dev0"
+version = "1.0.0"
 authors = [
     { name = "Zach Yek", email = "xiaoxiyek1.5@gmail.com" },
 ]
@@ -69,10 +69,9 @@ keywords = [
     "Data Methods",
 ]
 classifiers = [
-    # TODO: v1 release PR — flip to "Development Status :: 4 - Beta" or
-    # "Development Status :: 5 - Production/Stable" (maintainer's call at release time;
-    # revisit in every release PR per docs/RELEASE.md)
-    "Development Status :: 2 - Pre-Alpha",
+    # Revisit in every release PR per docs/RELEASE.md. v1.0.0 ships blessed release weights +
+    # a stable CLI/config contract, so: Production/Stable.
+    "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Closes #183

## v1.0.0 release PR (docs/RELEASE.md step 4)

Cuts the first stable release. Version is single-sourced in `pyproject.toml`; the CD workflow enforces that the pushed `v1.0.0` git tag matches it exactly.

### Changes
- **`pyproject.toml`**: `version` `0.9.0.dev0` → **`1.0.0`**; Development Status `2 - Pre-Alpha` → **`5 - Production/Stable`** (per the maintainer — v1.0.0 ships blessed release weights + a stable CLI/config contract).
- **README System Requirements (#183)**: replaced the placeholder VRAM/RAM guesses with numbers **measured from the v1.0.0 release runs** via the always-on `system_resources` instrumentation, and dropped the stale "update after benchmarking" TODO:
  - VRAM ~6 GB/GPU (training) / ~2.5 GB/GPU (inference) → **≥8 GB/GPU** recommended
  - RAM ~260 GB training peak (mean ~150) / ~200 GB inference peak at default `--prefetch-depth 3` (mean ~36; tunable) → **≥256 GB** for full-scale
  - Disk ~150 GB/retained round (up to ~3 TB with `--keep-round-data`); inference stamps auto-pruned by default
  - Provenance: training `train_20260729_152426` (6× RTX A4000 16 GB); inference `inf_20260731_182011` (5× RTX PRO 6000 96 GB, 350-cadence `/datag` subset)
- **`CITATION.cff`**: `version` `0.1.0` → `1.0.0`, `date-released` → `2026-08-01`.

### Release sequence (this PR = step 4)
After this merges: TestPyPI dry-run (`workflow_dispatch test_pypi:true`) → **bless** the HF weights (`hf_tag_release.py --save-tag train_20260729_152426 --release v1.0.0`) → **signed tag** (`git tag -s v1.0.0 && git push origin v1.0.0`, maintainer) → CD (guard → tests → HF-verify → build → PyPI → GitHub Release) → `pip install aetherscan==1.0.0` smoke.

No source-code changes; `__version__` continues to read the single-sourced version via `importlib.metadata`.
