### PR TITLE
chore: reset master to 1.0.1.dev0 after v1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ name = "aetherscan"
 # via importlib.metadata). Kept a pre-release between releases; the release PR bumps it to
 # the final X.Y.Z, and the CD workflow (.github/workflows/release.yml) enforces that the
 # pushed git tag matches it exactly.
-version = "1.0.0"
+version = "1.0.1.dev0"
 authors = [
     { name = "Zach Yek", email = "xiaoxiyek1.5@gmail.com" },
 ]


### PR DESCRIPTION
Closes #314

Runbook **step 9** (docs/RELEASE.md): now that **v1.0.0 is released** (PyPI `aetherscan 1.0.0` + GitHub Release `v1.0.0` + HF `v1.0.0` weights tag all live), reset the single-source `version` from `1.0.0` to `1.0.1.dev0` so `master` no longer advertises itself as a shipped stable release between releases.

- Version-only change; `src/aetherscan/__init__.py` reads it back via `importlib.metadata`.
- Safe w.r.t. weight resolution: `version_default_revision()` only pins `v{__version__}` when it matches the exact `vX.Y.Z` release-tag family, so a `.devN` version falls back to latest-release (`v1.0.0`) resolution — a source-tree/dev install won't accidentally try to pull a nonexistent `v1.0.1.dev0` HF tag.
- Classifier stays `5 - Production/Stable` (maturity unchanged).