### PR TITLE
chore(deps): weekly update 2026-W31 — security bumps + pre-commit/action catch-up

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "claude[bot]"

--- a/.github/workflows/claude-contribution-check.yml
+++ b/.github/workflows/claude-contribution-check.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Contribution Check
-        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-dependency-check.yml
+++ b/.github/workflows/claude-dependency-check.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Run Claude Dependency Check
         if: steps.guard.outputs.already_filed != 'true'
-        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-flaky-test-tracker.yml
+++ b/.github/workflows/claude-flaky-test-tracker.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Run Claude Flaky Test Tracker
         if: steps.guard.outputs.already_filed != 'true'
-        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Issue Triage
-        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "claude[bot]"

--- a/.github/workflows/claude-release-notes.yml
+++ b/.github/workflows/claude-release-notes.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Run Claude Release Notes
         if: steps.dedup.outputs.already_commented != 'true'
-        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-style-check.yml
+++ b/.github/workflows/claude-style-check.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Run Claude Style Check
         if: steps.guard.outputs.already_filed != 'true'
-        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-update-docs.yml
+++ b/.github/workflows/claude-update-docs.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Run Claude Documentation Analysis
         if: steps.guard.outputs.already_filed != 'true'
-        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Run Claude Assistant
         id: claude
-        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Allow the Claude automation bots

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 repos:
   # Ruff - fast Python linter and formatter
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.14
+    rev: v0.15.22
     hooks:
       # Run linter
       - id: ruff
@@ -41,6 +41,6 @@ repos:
 
   # Scan for sensitive data (secrets, credentials, etc.)
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.29.1
+    rev: v8.30.1
     hooks:
       - id: gitleaks

--- a/environment.yml
+++ b/environment.yml
@@ -47,7 +47,8 @@ dependencies:
   - h5py=3.11.*
   - hdf5plugin
   - psutil=6.0.*
-  - pytest=8.2.*
+  # Security floor: pytest >=9.0.3 fixes GHSA-6w46-j5rx-g56g (tmpdir handling); dev/test-only.
+  - pytest>=9.0.3,<9.1
   - ipykernel
   - pip
   - pip:
@@ -66,9 +67,9 @@ dependencies:
       - python-dotenv>=1.2.2,<2
       # Model weight distribution via the HuggingFace Hub — pin range mirrors
       # requirements-container.txt (see the rationale there).
-      - huggingface_hub>=1.21,<1.22
+      - huggingface_hub>=1.22,<1.23
       # Live monitoring dashboard (aetherscan/dashboard.py). Kept in lockstep with
-      # requirements-container.txt; streamlit 1.39 coexists with TF 2.17 (protobuf 4.x)
+      # requirements-container.txt; streamlit 1.54 coexists with TF 2.17 (protobuf 4.x)
       # and numpy<2. plotly is pure-Python.
-      - streamlit>=1.39,<1.41
+      - streamlit>=1.54.0,<1.55
       - plotly>=5.24,<6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "slack-sdk>=3.31.0,<4",
     # Floor >=1.2.2 per GHSA-mf9w-mj56-hr94 (CVE-2026-28684; fixed in 1.2.2).
     "python-dotenv>=1.2.2,<2",
-    "huggingface_hub>=1.21,<1.22",
+    "huggingface_hub>=1.22,<1.23",
     # setuptools provides pkg_resources, which blimpy (transitive via setigen) imports at
     # module load; <81 because setuptools 81 removed the vendored pkg_resources.
     # Floor >=78.1.1 per GHSA-5rjg-fvgr-3xxf (CVE-2025-47273; fixed in 78.1.1).
@@ -98,13 +98,13 @@ Issues = "https://github.com/zachtheyek/Aetherscan/issues"
 aetherscan-dashboard = "aetherscan.dashboard_cli:main"
 
 [project.optional-dependencies]
-dev = ["ruff", "pre-commit", "pytest"]
+dev = ["ruff", "pre-commit", "pytest>=9.0.3"]
 # Live monitoring dashboard (aetherscan/dashboard.py, auto-launched by main.py). Opt-in extra so a
 # bare `pip install aetherscan` stays lean; `pip install aetherscan[dashboard]` pulls the stack.
-# Ranges mirror requirements-container.txt / environment.yml (kept in lockstep); streamlit 1.39
+# Ranges mirror requirements-container.txt / environment.yml (kept in lockstep); streamlit 1.54
 # coexists with TF 2.17's protobuf 4.x and numpy<2, plotly is pure-Python, pandas backs the data
 # layer (the NGC base ships pandas, so requirements-container.txt omits it there).
-dashboard = ["streamlit>=1.39,<1.41", "plotly>=5.24,<6", "pandas>=2.0,<3"]
+dashboard = ["streamlit>=1.54.0,<1.55", "plotly>=5.24,<6", "pandas>=2.0,<3"]
 
 [tool.pytest.ini_options]
 # Make `import aetherscan` work without a PYTHONPATH=src prefix

--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -23,9 +23,9 @@ slack-sdk>=3.31.0,<4
 # fixed in 1.2.2).
 python-dotenv>=1.2.2,<2
 # Model weight distribution via the HuggingFace Hub (upload after training, download for
-# inference). 1.21 per SECURITY.md's version policy: two minors below the latest stable
-# (1.23) at pin time, newer than the newest >=6-month-old release.
-huggingface_hub>=1.21,<1.22
+# inference). 1.22 per SECURITY.md's version policy: two minors below the latest stable
+# (1.24) at pin time; the client-side upload/download API is unchanged from 1.21.
+huggingface_hub>=1.22,<1.23
 # setuptools provides pkg_resources, which blimpy (transitive via setigen)
 # imports at module load. Recent pip / Python releases dropped setuptools
 # from the bootstrap, so we install it explicitly. Upper-bound at <81 because
@@ -36,10 +36,10 @@ setuptools>=78.1.1,<81
 # Range covers the proven 2.6/2.7 line (2.7.0 in current use) and blocks a future
 # major-version break; keep in lockstep with environment.yml and pyproject.toml.
 setigen>=2.6,<3
-# Live monitoring dashboard (aetherscan/dashboard.py, auto-launched by main.py). streamlit 1.39
-# per SECURITY.md's version policy (proven, >=6-month-old); it accepts protobuf>=3.20,<6 and
-# numpy>=1.23, so it coexists with TF 2.17's protobuf 4.x pin and the numpy<2 ceiling (pyarrow
-# /tornado/altair pulled transitively). plotly is pure-Python (no numpy ABI coupling). pandas
-# is already shipped by the NGC base, so it is not repinned here.
-streamlit>=1.39,<1.41
+# Live monitoring dashboard (aetherscan/dashboard.py, auto-launched by main.py). streamlit 1.54
+# fixes GHSA-7p48-42j8-8846 (SSRF, <1.54.0) and GHSA-vqwp-45wm-r9r5 (cache hash collision, <1.53.1);
+# it still accepts protobuf>=3.20,<6 and numpy>=1.23, so it coexists with TF 2.17's protobuf 4.x pin
+# and the numpy<2 ceiling (pyarrow/tornado/altair pulled transitively). plotly is pure-Python (no
+# numpy ABI coupling). pandas is already shipped by the NGC base, so it is not repinned here.
+streamlit>=1.54.0,<1.55
 plotly>=5.24,<6

--- a/utils/benchmark_report.py
+++ b/utils/benchmark_report.py
@@ -387,7 +387,7 @@ def render_report_png(root: StageNode, rows: list[dict], tag: str, output_path: 
     families = sorted({str(row["stage"]).split(".")[0] for row in rows})
 
     def family_color(stage: str):
-        family = stage.split(".")[0]
+        family = stage.split(".", maxsplit=1)[0]
         if family in _FAMILY_COLORS:
             return _FAMILY_COLORS[family]
         return fallback_colors[families.index(family) % 10]


### PR DESCRIPTION
Addresses the actionable, low-risk findings from the **2026-W31** dependency check (#285). Manifests kept in lockstep (`environment.yml` / `requirements-container.txt` / `pyproject.toml`).

## Security advisories on currently-pinned versions
| package | before | after | advisory |
|---|---|---|---|
| `pytest` | `8.2.*` | `>=9.0.3,<9.1` | GHSA-6w46-j5rx-g56g (tmpdir handling) — dev/test-only |
| `streamlit` | `>=1.39,<1.41` | `>=1.54.0,<1.55` | GHSA-7p48-42j8-8846 (SSRF `<1.54.0`), GHSA-vqwp-45wm-r9r5 (cache hash collision `<1.53.1`) |

`streamlit` 1.54 still accepts `protobuf>=3.20,<6` and `numpy>=1.23`, so the TF 2.17 protobuf-4.x pin and the `numpy<2` ceiling are intact.

## Upstream catch-up (no advisory; within SECURITY.md's lag policy)
- `huggingface_hub` `>=1.21,<1.22` → `>=1.22,<1.23` (client upload/download API unchanged)
- `ruff-pre-commit` `v0.14.14` → `v0.15.22` — surfaced one new lint (`PLC0207`) in `utils/benchmark_report.py`, autofixed: `split(".")[0]` → `split(".", maxsplit=1)[0]` (semantically identical). Verified `ruff check .` + `ruff format --check .` clean at 0.15.22.
- `gitleaks` `v8.29.1` → `v8.30.1`
- `anthropics/claude-code-action` `v1.0.102` → `v1.0.183` (same major, SHA-pinned; 9 workflow files)

## Deferred (intentional)
- **Documented ceilings / NGC TF 2.17 ABI:** numpy, scipy, scikit-learn, matplotlib, tensorflow, setuptools. The `setuptools` GHSA-h35f-9h28-mq5c is macOS-sdist-only (near-zero exposure on a Linux container build) and is blocked by the documented `<81` `pkg_resources` ceiling.
- **Pending validation:** GitHub Actions **major** catch-ups (checkout / setup-python / upload-artifact / download-artifact / cache / github-script — Node-runtime changes) and evaluate-later majors (astropy / pandas / plotly / shap / psutil / h5py).
- **Manifest drift:** none.

## Follow-up
- `streamlit` 1.50 changed `st.dataframe` object-dtype sort behaviour (`dashboard.py`) — cosmetic; verify on the next dashboard launch (not exercised by CI).

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)
