### PR TITLE
feat: inference-run observability (variant-selection plot, feature guard, per-band plot) + candidate frequency axis

### DIFF
--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -166,6 +166,38 @@ Thresholds are module constants (`DATA_GEN_ROUND_FRACTION`, `GPU_UTIL_INPUT_BOUN
 `PREPROCESS_WALL_FRACTION`, `RAM_PEAK_WARN`) — tune them there if a rule is too eager for your
 hardware.
 
+## The per-band inference plot (`utils/perband_report.py`)
+
+A sibling tool (same stdlib `sqlite3` + `csv` + numpy + matplotlib, no `aetherscan` imports) that
+answers a question the flame timeline can't: **is a whole observing band or frequency region
+systematically slower to preprocess?** It writes
+`{output_path}/plots/perband_inference_perf_{tag}.png` — a two-panel, log-y figure of per-cadence
+energy-detection preprocessing wall-clock: Panel A is a per-band boxplot + jittered strip (bands
+ordered L, S, C, X, each annotated with median/max/n), Panel B scatters the same walls against the
+catalog `Frequency` (MHz), colored by band. The preprocessing wall per cadence is the umbrella
+`inference.preprocess_cadence_<N>` span (its `.read_ed`/`.dedup`/`.extract` children are excluded),
+and the band/frequency come from the run's inference catalog CSV. It fires **automatically at the
+tail of every streaming-CSV `inference` run** right after the benchmark report
+(`_post_perband_report` in [`main.py`](../src/aetherscan/main.py), same
+`monitor.benchmark_report_enabled` gate, same Slack upload, fully guarded — a plot failure never
+fails the run), and is also runnable standalone:
+
+```bash
+python utils/perband_report.py --save-tag test --catalog /path/to/catalog.csv \
+    --db-path /path/to/aetherscan.db
+```
+
+**Join caveat.** The umbrella span carries only the 1-based planner index `N`, and no DB table maps
+`N` to a band, so the cadence → band/frequency map is reconstructed from the catalog by mirroring
+`preprocessing.group_observations_from_csv` (group rows by the default
+`cadence_group_by_cols` = `["Target", "Session", "Band", "Cadence ID", "Frequency"]`, keep the
+6-obs valid groups in first-appearance order; the i-th is cadence `N=i`). This **assumes the run
+used the default group-by columns / expected-obs**. A runtime guard compares the mapped catalog
+cadence count to the umbrella-span count and skips the plot (logged warning, never a crash) when
+they disagree — so a resumed run (fewer fresh preprocess spans than catalog cadences) or a
+non-default grouping degrades to no plot rather than a misleading one. The legacy `--test-files`
+path (no catalog CSV) is skipped for the same reason.
+
 ## Standalone benchmarks (`benchmarks/`)
 
 Small standalone scripts that time individual pipeline kernels in isolation, so a change to

--- a/src/aetherscan/candidate_figures.py
+++ b/src/aetherscan/candidate_figures.py
@@ -130,8 +130,9 @@ def draw_cadence_strip(
     freq_range_mhz: tuple[float, float] | None = None,
 ) -> None:
     """Draw one snippet's 6 observation waterfalls down a column of axes. With
-    freq_range_mhz, the bottom axis is labeled with the stamp's frequency span (bin order,
-    so a descending pair reflects a negative foff)."""
+    freq_range_mhz, the bottom panel's x-axis carries a "Frequency (MHz)" title and two
+    tick labels — the frequency at the left and right borders (bin order, so a descending
+    pair reflects a negative foff)."""
     for obs_idx, ax in enumerate(axes_column):
         ax.imshow(
             snippet[obs_idx],
@@ -147,8 +148,15 @@ def draw_cadence_strip(
         if label_rows:
             ax.set_ylabel(OBS_ROW_LABELS[obs_idx], fontsize=8, rotation=0, ha="right", va="center")
     if freq_range_mhz is not None:
-        low, high = freq_range_mhz
-        axes_column[-1].set_xlabel(f"{low:.4f} → {high:.4f} MHz", fontsize=6)
+        # Annotate the frequency axis at its left/right borders under a "Frequency (MHz)"
+        # title (bin 0 → last bin, so a negative foff prints the borders high → low).
+        left_mhz, right_mhz = freq_range_mhz
+        bottom = axes_column[-1]
+        n_freq_bins = snippet.shape[-1]
+        bottom.set_xticks([0, n_freq_bins - 1])
+        bottom.set_xticklabels([f"{left_mhz:.4f}", f"{right_mhz:.4f}"])
+        bottom.tick_params(axis="x", length=2, pad=1, labelsize=6)
+        bottom.set_xlabel("Frequency (MHz)", fontsize=7)
 
 
 def candidate_annotation(row: dict) -> str:
@@ -220,12 +228,7 @@ def render_candidate_figure(
     fig = Figure(figsize=(11, 7))
     grid = fig.add_gridspec(n_obs, 2, width_ratios=(2.2, 1.6), hspace=0.15, wspace=0.25, right=0.97)
     waterfall_axes = [fig.add_subplot(grid[i, 0]) for i in range(n_obs)]
-    draw_cadence_strip(waterfall_axes, snippet, label_rows=True)
-    if freq_range_mhz is not None:
-        low, high = freq_range_mhz
-        waterfall_axes[-1].set_xlabel(f"frequency: {low:.6f} → {high:.6f} MHz")
-    else:
-        waterfall_axes[-1].set_xlabel("frequency bin")
+    draw_cadence_strip(waterfall_axes, snippet, label_rows=True, freq_range_mhz=freq_range_mhz)
 
     # Right column: latent bar chart on top, provenance text below. A nested gridspec gives
     # the two panels a dedicated vertical gap so the bar chart's x-axis label can never

--- a/src/aetherscan/candidate_figures.py
+++ b/src/aetherscan/candidate_figures.py
@@ -157,6 +157,10 @@ def draw_cadence_strip(
         bottom.set_xticklabels([f"{left_mhz:.4f}", f"{right_mhz:.4f}"])
         bottom.tick_params(axis="x", length=2, pad=1, labelsize=6)
         bottom.set_xlabel("Frequency (MHz)", fontsize=7)
+    else:
+        # No per-stamp MHz available (legacy sidecar / missing fch1|foff): keep the axis
+        # informative with a generic bin-index title rather than a blank axis.
+        axes_column[-1].set_xlabel("Frequency (bin)", fontsize=7)
 
 
 def candidate_annotation(row: dict) -> str:

--- a/src/aetherscan/inference.py
+++ b/src/aetherscan/inference.py
@@ -23,6 +23,7 @@ from aetherscan.latent_variants import (
     apply_probability_calibrator,
     build_variant_features,
     sample_z_flat,
+    variant_feature_count,
 )
 from aetherscan.models import RandomForestModel, prepare_latent_features
 from aetherscan.seeding import (
@@ -324,6 +325,8 @@ class InferencePipeline:
             logger.error(f"Error loading Random Forest: {e}")
             raise  # Re-raise to propagate error
 
+        self._check_rf_feature_layout()
+
         # Probability calibrator (#282): the saved training config records whether one is
         # active; applying it identically at inference is mandatory (an unapplied calibrator
         # is a silent train/serve mismatch), so a missing artifact is a hard error
@@ -348,6 +351,31 @@ class InferencePipeline:
             f"Inference feature layout: latent_variant='{self.config.rf.latent_variant}', "
             f"active_dims={self.config.rf.active_dims}"
         )
+
+    def _check_rf_feature_layout(self) -> None:
+        """#282 hardening: fail loud if the loaded forest's expected feature count doesn't
+        match the variant the config declares. Several variants are the SAME width
+        (z / z_mean / z_aug all = num_observations*latent_dim), so a config↔weights mismatch
+        from mixed or hand-edited artifacts would NOT trip sklearn's own feature-count check —
+        inference would silently score the wrong representation. (The sanctioned HF path always
+        ships the winner RF with its own config, so this never fires there; it guards
+        --config-path/--rf-path pairings from different runs, or a hand-edited config.)"""
+        expected_features = variant_feature_count(
+            self.config.rf.latent_variant,
+            self.config.data.num_observations,
+            self.config.beta_vae.latent_dim,
+            self.config.rf.active_dims,
+        )
+        actual_features = getattr(self.rf_model.model, "n_features_in_", None)
+        if actual_features is not None and actual_features != expected_features:
+            raise ValueError(
+                f"RF feature-count mismatch: the loaded forest expects {actual_features} "
+                f"features, but the config declares latent_variant="
+                f"'{self.config.rf.latent_variant}' (active_dims={self.config.rf.active_dims}) "
+                f"→ {expected_features} features. The config and RF weights are from different "
+                "runs, or the config was hand-edited — refusing to score the wrong "
+                "latent representation."
+            )
 
     def run_inference(
         self,

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -12,6 +12,7 @@ import importlib.util
 import json
 import logging
 import os
+import socket
 import sys
 import time
 from collections import deque
@@ -316,6 +317,74 @@ def _post_benchmark_report(tag: str) -> None:
         # TODO: if utils/benchmark_report.py's load_rows ever stops raising SystemExit for
         # a pre-benchmarking-schema DB, narrow this back to `except Exception`.
         logger.error(f"Benchmark report generation failed: {e}")
+
+
+def _post_perband_report(tag: str) -> None:
+    """
+    Render the per-band inference-performance plot (utils/perband_report.py) and post it to
+    Slack, at the tail of an inference run alongside _post_benchmark_report.
+
+    Groups per-cadence energy-detection preprocessing wall-clock by band (L/S/C/X) and by
+    frequency, joining the pipeline_stages umbrella spans to the run's inference catalog CSV(s)
+    via the plan-index reconstruction. Gated by the same monitor.benchmark_report_enabled flag,
+    and fully guarded: any failure logs an error and never fails the run. Skips quietly when the
+    run has no inference catalog (the legacy --test-files path), when the join assumption doesn't
+    hold, or when the report tool file isn't alongside the package (mirrors _post_benchmark_report).
+    """
+    try:
+        config = get_config()
+        if config is None:
+            raise ValueError("get_config() returned None")
+        if not config.monitor.benchmark_report_enabled:
+            return  # _post_benchmark_report already logged the disabled notice
+
+        # The per-band join needs the run's inference catalog CSV(s). The legacy --test-files
+        # path has no catalog (it loads a pre-built .npy), so there is nothing to group by band.
+        if not config.data.inference_files:
+            logger.info(
+                "Per-band inference plot skipped: no inference catalog CSV (--test-files run)"
+            )
+            return
+        catalog_paths = [config.get_inference_file_path(f) for f in config.data.inference_files]
+
+        db = get_db()
+        if db is None:
+            raise ValueError("get_db() returned None")
+        db.flush(timeout=config.db.flush_timeout)
+
+        # Load the tool by file path, preserving its no-aetherscan-imports contract (same
+        # pattern as _post_benchmark_report / tests/unit/test_benchmark.py).
+        report_path = Path(__file__).resolve().parents[2] / "utils" / "perband_report.py"
+        if not report_path.exists():
+            logger.warning(f"Per-band inference plot skipped: {report_path} does not exist")
+            return
+        spec = importlib.util.spec_from_file_location("perband_report", report_path)
+        perband_report = importlib.util.module_from_spec(spec)
+        sys.modules["perband_report"] = perband_report
+        spec.loader.exec_module(perband_report)
+
+        hostname = socket.gethostname()
+        png_path = os.path.join(config.output_path, "plots", f"perband_inference_perf_{tag}.png")
+        result = perband_report.render_perband_report(
+            db.db_path, tag, catalog_paths, png_path, hostname
+        )
+        if result is None:
+            return  # render_perband_report already logged why it skipped
+        logger.info(f"Per-band inference plot saved to {png_path}")
+
+        logger_instance = get_logger()
+        if logger_instance is None:
+            raise ValueError("get_logger() returned None")
+        if not logger_instance.upload_image_to_slack(
+            png_path, title=f"Inference performance by band - ({tag}, {hostname})"
+        ):
+            logger.warning(
+                "Per-band inference plot rendered but Slack upload was skipped or failed"
+            )
+
+    except Exception as e:
+        # Observability must never fail an otherwise-finished run (matches _post_benchmark_report)
+        logger.error(f"Per-band inference plot generation failed: {e}")
 
 
 def train_command():
@@ -1064,6 +1133,7 @@ def inference_command():
     logger.info("=" * 60)
 
     _post_benchmark_report(config.checkpoint.save_tag)
+    _post_perband_report(config.checkpoint.save_tag)
 
 
 def main():

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -3160,6 +3160,13 @@ class TrainingPipeline:
             self.config.rf.latent_variant = winner
             self.config.rf.active_dims = active_dims
 
+            # Surface the selection visually (winner + the tie-break story) straight from the
+            # in-memory sweep metrics. Best-effort: a plot failure must never fail the run.
+            try:
+                self.plot_rf_latent_variant_selection(variant_metrics, winner)
+            except Exception as e:
+                logger.warning(f"Failed to plot latent-variant selection: {e}")
+
             val_probas = variant_val_probas[winner]
             val_features = build_variant_features(
                 winner, val_mean_flat, val_logvar_flat, num_observations, latent_dim, active_dims
@@ -5883,6 +5890,166 @@ class TrainingPipeline:
             dir,
             slack_title=f"Latent Traversal Spectra ({display_name}) - ({tag}, {machine_name})",
         )
+
+    def plot_rf_latent_variant_selection(
+        self,
+        variant_metrics: dict[str, dict[str, float]],
+        winner: str,
+        tag: str | None = None,
+        dir: str | None = None,
+    ) -> None:
+        """
+        Make the #282 latent-variant SELECTION legible in a single figure. The winner is
+        otherwise surfaced only as a log line + DB scalars; here all 8 swept variants are
+        compared on the selection split. The primary panel is a horizontal recall@FPR bar chart
+        ordered simple->complex (VARIANT_ORDER, simplest on top): the winner bar is highlighted
+        with a "★ winner" tag, and when the minimum-margin tie-break passed over a HIGHER-recall
+        variant a shaded band spans from the winner's recall up to that best recall — the recall
+        the pipeline deliberately traded away because the two are statistically indistinguishable
+        (bootstrap margin) and the winner is the simpler / cheaper representation. Companion
+        panels compare ROC-AUC, Brier, ECE, and feature count (the complexity axis the tie-break
+        trades against) per variant.
+
+        Reads the in-memory metrics the sweep already computed (variant_metrics) plus the winner
+        name — no DB round-trip — so it is called inline right after selection. Purely additive:
+        it never touches the selection numerics.
+        """
+        if tag is None:
+            tag = self.config.checkpoint.save_tag
+
+        metadata_json = get_system_metadata()
+        machine_name = json.loads(metadata_json).get("machine_name")
+
+        max_fpr = self.config.rf.selection_max_fpr
+
+        # Order simple->complex per the selection contract; keep only variants actually swept.
+        variants = [v for v in VARIANT_ORDER if v in variant_metrics]
+        recalls = [float(variant_metrics[v]["recall_at_fpr"]) for v in variants]
+        # Replicate select_winner's "best": max recall, ties broken toward the simpler (earlier)
+        # variant. The tie-break may still land on a simpler winner sitting BELOW this best.
+        best = max(
+            variants,
+            key=lambda v: (variant_metrics[v]["recall_at_fpr"], -variants.index(v)),
+        )
+        winner_recall = float(variant_metrics[winner]["recall_at_fpr"])
+        best_recall = float(variant_metrics[best]["recall_at_fpr"])
+
+        winner_color = "#2ca02c"
+        other_color = "#a6bddb"
+        tie_color = "#ff7f0e"
+        n = len(variants)
+        y = np.arange(n)
+        bar_colors = [winner_color if v == winner else other_color for v in variants]
+
+        fig = plt.figure(figsize=(13, 10))
+        fig.suptitle(
+            f"RF Latent-Variant Selection ({tag}, {machine_name})",
+            fontsize=16,
+            fontweight="bold",
+        )
+        gs = fig.add_gridspec(2, 4, height_ratios=[2.3, 1.3], hspace=0.32, wspace=0.28)
+
+        # -------------------------------------------------- primary: recall@FPR per variant
+        ax = fig.add_subplot(gs[0, :])
+        ax.barh(y, recalls, color=bar_colors, edgecolor="gray", linewidth=0.6)
+        ax.set_yticks(y)
+        ax.set_yticklabels(variants, fontsize=11)
+        ax.invert_yaxis()  # simplest (VARIANT_ORDER[0]) on top
+        ax.set_xlabel(f"Recall @ {max_fpr:g} FPR (selection split)", fontsize=12)
+        ax.set_title(
+            "Primary metric: recall @ fixed FPR; recall ties (bootstrap margin) break toward "
+            "the simpler variant",
+            fontsize=11,
+        )
+        ax.grid(True, axis="x", alpha=0.3)
+
+        # Zoom the x-axis to resolve near-ceiling differences: recalls cluster just under 1.0, so
+        # a 0-based axis would hide the very gap the tie-break turns on.
+        finite = [r for r in recalls if np.isfinite(r)]
+        lo, hi = (min(finite), max(finite)) if finite else (0.0, 1.0)
+        margin = (hi - lo) * 0.35 + 0.002
+        ax.set_xlim(max(0.0, lo - margin), min(1.0005, hi + margin))
+
+        # Tie band: from the winner's recall up to the (higher) best recall — the recall traded
+        # away for the simpler representation. Drawn only when the winner is not itself the best.
+        if best != winner and best_recall > winner_recall:
+            ax.axvspan(winner_recall, best_recall, color=tie_color, alpha=0.15, zorder=0)
+            ax.axvline(best_recall, color=tie_color, linestyle="--", linewidth=1.5)
+            ax.annotate(
+                f"highest recall: '{best}' ({best_recall:.4f})",
+                xy=(best_recall, y[variants.index(best)]),
+                xytext=(4, -14),
+                textcoords="offset points",
+                fontsize=9,
+                color=tie_color,
+                fontweight="bold",
+            )
+
+        # Per-bar recall value; the winner additionally carries the ★ tag.
+        for yi, v, r in zip(y, variants, recalls, strict=True):
+            if not np.isfinite(r):
+                continue
+            label = f"  {r:.4f}  ★ winner" if v == winner else f"  {r:.4f}"
+            ax.text(
+                r,
+                yi,
+                label,
+                va="center",
+                ha="left",
+                fontsize=10,
+                fontweight="bold" if v == winner else "normal",
+                color=winner_color if v == winner else "black",
+            )
+
+        legend_handles = [
+            mpatches.Patch(color=winner_color, label="selected winner (simplest tied variant)"),
+            mpatches.Patch(color=other_color, label="other variants"),
+            mpatches.Patch(
+                color=tie_color, alpha=0.3, label="statistical tie band (recall traded away)"
+            ),
+        ]
+        ax.legend(handles=legend_handles, loc="lower left", fontsize=9, framealpha=0.95)
+
+        # -------------------------------------------------- companions: AUC / Brier / ECE / F
+        aucs = [float(variant_metrics[v]["roc_auc"]) for v in variants]
+        briers = [float(variant_metrics[v]["brier"]) for v in variants]
+        eces = [float(variant_metrics[v]["ece"]) for v in variants]
+        feats = [float(variant_metrics[v]["n_features"]) for v in variants]
+        secondary = [
+            ("ROC-AUC  (↑ better)", aucs, "{:.4f}"),
+            ("Brier  (↓ better)", briers, "{:.4f}"),
+            ("ECE  (↓ better)", eces, "{:.4f}"),
+            ("Feature count F  (↓ simpler)", feats, "{:.0f}"),
+        ]
+        for col, (title, values, fmt) in enumerate(secondary):
+            sub = fig.add_subplot(gs[1, col])
+            sub.barh(y, values, color=bar_colors, edgecolor="gray", linewidth=0.5)
+            sub.set_yticks(y)
+            sub.set_yticklabels(variants if col == 0 else [], fontsize=8)
+            sub.invert_yaxis()
+            sub.set_title(title, fontsize=10, fontweight="bold")
+            sub.grid(True, axis="x", alpha=0.3)
+            vmax = max(values) if max(values) > 0 else 1.0
+            for yi, val in zip(y, values, strict=True):
+                sub.text(val + vmax * 0.02, yi, fmt.format(val), va="center", ha="left", fontsize=7)
+            sub.set_xlim(0, vmax * 1.28)
+
+        plt.tight_layout(rect=[0, 0, 1, 0.96])
+
+        save_path = os.path.join(
+            self._training_plots_dir(dir), f"latent_variant_selection_{tag}.png"
+        )
+        os.makedirs(os.path.dirname(save_path), exist_ok=True)
+        plt.savefig(save_path, dpi=200, bbox_inches="tight")
+        plt.close(fig)
+        logger.info(f"RF latent-variant selection plot saved to: {save_path}")
+
+        logger_instance = get_logger()
+        if logger_instance:
+            logger_instance.upload_image_to_slack(
+                save_path,
+                title=f"RF Latent-Variant Selection - ({tag}, {machine_name})",
+            )
 
     # TODO: implement plot_rf_snr_sensitivity_curve()
     def plot_rf_confusion_matrices(self, tag: str | None = None, dir: str | None = None):

--- a/tests/unit/test_candidate_figures.py
+++ b/tests/unit/test_candidate_figures.py
@@ -8,10 +8,12 @@ import os
 
 import numpy as np
 import pytest
+from matplotlib.figure import Figure
 
 from aetherscan.candidate_figures import (
     candidate_frequency_range_mhz,
     candidate_sidecar_path,
+    draw_cadence_strip,
     load_display_cadence,
     render_candidate_figure,
     render_candidate_figures,
@@ -156,3 +158,33 @@ class TestRenderCandidateFigures:
 
     def test_empty_rows(self, tmp_path):
         assert render_candidate_figures([], "test_v1", str(tmp_path)) == []
+
+
+class TestDrawCadenceStripFreqAxis:
+    """Task J: the cadence-strip frequency axis annotates the left/right border MHz values
+    under a "Frequency (MHz)" title (border ticks), replacing the old "low → high MHz"
+    span-string x-label. Only the bottom panel carries the axis; the rest stay blank."""
+
+    def _strip(self, freq_range):
+        snippet = np.random.default_rng(0).random((6, 16, 512)).astype(np.float32)
+        fig = Figure(figsize=(3, 7))
+        axes = [fig.add_subplot(6, 1, i + 1) for i in range(6)]
+        draw_cadence_strip(axes, snippet, label_rows=True, freq_range_mhz=freq_range)
+        return fig, axes, snippet
+
+    def test_border_ticks_and_title(self):
+        _fig, axes, snippet = self._strip((1420.5000, 1420.1000))  # descending (negative foff)
+        bottom = axes[-1]
+        width = snippet.shape[-1]
+        assert list(bottom.get_xticks()) == [0, width - 1]
+        assert [t.get_text() for t in bottom.get_xticklabels()] == ["1420.5000", "1420.1000"]
+        assert bottom.get_xlabel() == "Frequency (MHz)"
+        for ax in axes[:-1]:  # every non-bottom panel keeps a blank x-axis
+            assert list(ax.get_xticks()) == []
+            assert ax.get_xlabel() == ""
+
+    def test_no_freq_range_leaves_axis_blank(self):
+        _fig, axes, _snippet = self._strip(None)
+        bottom = axes[-1]
+        assert list(bottom.get_xticks()) == []
+        assert bottom.get_xlabel() == ""

--- a/tests/unit/test_candidate_figures.py
+++ b/tests/unit/test_candidate_figures.py
@@ -183,8 +183,9 @@ class TestDrawCadenceStripFreqAxis:
             assert list(ax.get_xticks()) == []
             assert ax.get_xlabel() == ""
 
-    def test_no_freq_range_leaves_axis_blank(self):
+    def test_no_freq_range_uses_bin_fallback(self):
+        # No MHz available (legacy sidecar / missing fch1|foff) -> generic bin-index label, no ticks
         _fig, axes, _snippet = self._strip(None)
         bottom = axes[-1]
         assert list(bottom.get_xticks()) == []
-        assert bottom.get_xlabel() == ""
+        assert bottom.get_xlabel() == "Frequency (bin)"

--- a/tests/unit/test_inference.py
+++ b/tests/unit/test_inference.py
@@ -4,6 +4,8 @@ order preservation, tail padding/truncation, bounded trace shapes), the batched 
 
 from __future__ import annotations
 
+import types
+
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -399,3 +401,36 @@ class TestReferenceCloudReservoir:
         assert reservoir.seen == 20
         np.testing.assert_array_equal(mean_rows[:, 0], [14.0, 20.0, 22.0])
         np.testing.assert_allclose(screening_vals, [0.14, 0.20, 0.22], atol=1e-6)
+
+
+class TestRfFeatureLayoutGuard:
+    """#282 hardening: init_models fails loud on a config↔RF feature-count mismatch —
+    same-width variants (z/z_mean/z_aug all = num_obs*latent_dim) make it silent otherwise."""
+
+    def _pipeline(self, variant, active_dims, n_features):
+        config = get_config()
+        config.data.num_observations = 6
+        config.beta_vae.latent_dim = 8
+        config.rf.latent_variant = variant
+        config.rf.active_dims = active_dims
+        pipeline = InferencePipeline.__new__(InferencePipeline)
+        pipeline.config = config
+        model = types.SimpleNamespace()
+        if n_features is not None:
+            model.n_features_in_ = n_features
+        pipeline.rf_model = types.SimpleNamespace(model=model)
+        return pipeline
+
+    def test_matching_count_passes(self):
+        # z_mean at num_obs=6, latent_dim=8 -> 6*8 = 48 features
+        self._pipeline("z_mean", list(range(8)), 48)._check_rf_feature_layout()
+
+    def test_mismatched_count_raises(self):
+        # config declares z_mean (48) but the loaded forest carries z_mean_logvar (96) features
+        pipeline = self._pipeline("z_mean", list(range(8)), 96)
+        with pytest.raises(ValueError, match="feature-count mismatch"):
+            pipeline._check_rf_feature_layout()
+
+    def test_absent_n_features_is_a_noop(self):
+        # an unfitted/stub forest without n_features_in_ -> the guard skips silently
+        self._pipeline("z_mean", list(range(8)), None)._check_rf_feature_layout()

--- a/tests/unit/test_perband_report.py
+++ b/tests/unit/test_perband_report.py
@@ -1,0 +1,162 @@
+"""Unit tests for utils/perband_report.py — the per-band inference-performance plot.
+
+Builds a tiny synthetic pipeline_stages SQLite DB (a few `inference.preprocess_cadence_<N>`
+umbrella spans plus `.extract`/`.read_ed`/`.dedup` children that must be excluded) and a tiny
+catalog CSV (mixed bands, one flagged cadence with the wrong obs count), then exercises the
+plan-index join, the per-band aggregation, and the PNG render. Stdlib + matplotlib + numpy only
+(no TensorFlow), so it runs fast; skipped cleanly when matplotlib isn't installed."""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# The report tool imports matplotlib at module load; skip the whole module without it.
+pytest.importorskip("matplotlib")
+
+# utils/ is not a package — load the tool straight from its file (same pattern as
+# tests/unit/test_benchmark.py loads benchmark_report). The sys.modules registration must
+# precede exec_module: the module's @dataclass resolves its own module by name at class
+# creation (PEP 563 string annotations).
+_TOOL_PATH = Path(__file__).resolve().parents[2] / "utils" / "perband_report.py"
+_spec = importlib.util.spec_from_file_location("perband_report", _TOOL_PATH)
+perband_report = importlib.util.module_from_spec(_spec)
+sys.modules["perband_report"] = perband_report
+_spec.loader.exec_module(perband_report)
+
+
+def _make_db(db_path: Path, tag: str, umbrella: dict[int, float], children: dict[str, float]):
+    """Create a minimal pipeline_stages DB and insert umbrella + child spans for `tag`.
+
+    `umbrella` maps N -> duration for `inference.preprocess_cadence_<N:03d>` spans; `children`
+    maps a full child stage name -> duration (e.g. `inference.preprocess_cadence_001.extract`).
+    """
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE pipeline_stages ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, stage TEXT NOT NULL, start_time REAL NOT NULL, "
+        "end_time REAL NOT NULL, duration_s REAL NOT NULL, tag TEXT, metadata TEXT)"
+    )
+    t = 1000.0
+    rows = [(f"inference.preprocess_cadence_{n:03d}", dur) for n, dur in sorted(umbrella.items())]
+    rows += list(children.items())
+    for stage, dur in rows:
+        conn.execute(
+            "INSERT INTO pipeline_stages (stage, start_time, end_time, duration_s, tag, metadata) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (stage, t, t + dur, dur, tag, None),
+        )
+        t += dur
+    conn.commit()
+    conn.close()
+
+
+# The four valid cadences (planner order) + one flagged cadence (3 obs) the planner skips.
+_VALID_GROUPS = [
+    ({"Target": "HIP1", "Session": "S1", "Band": "L", "Cadence ID": "1", "Frequency": "1400.0"}, 6),
+    ({"Target": "HIP2", "Session": "S1", "Band": "C", "Cadence ID": "2", "Frequency": "5000.0"}, 6),
+    ({"Target": "HIP3", "Session": "S1", "Band": "L", "Cadence ID": "3", "Frequency": "1500.0"}, 6),
+    ({"Target": "HIP4", "Session": "S1", "Band": "X", "Cadence ID": "4", "Frequency": "9000.0"}, 6),
+]
+_FLAGGED_GROUP = (
+    {"Target": "HIP5", "Session": "S1", "Band": "S", "Cadence ID": "5", "Frequency": "2500.0"},
+    3,
+)
+# N -> preprocess wall (seconds): L={100, 300}, C={200}, X={50}
+_UMBRELLA = {1: 100.0, 2: 200.0, 3: 300.0, 4: 50.0}
+_CHILDREN = {
+    "inference.preprocess_cadence_001.extract": 40.0,
+    "inference.preprocess_cadence_001.read_ed": 30.0,
+    "inference.preprocess_cadence_001.dedup": 5.0,
+}
+
+
+def _catalog(make_inference_csv, groups):
+    """Build a catalog CSV from (key_dict, n_obs) pairs via the repo's make_inference_csv."""
+    return make_inference_csv(
+        filename="perband_catalog.csv",
+        groups=[(key, [f"/data/{key['Target']}_{i}.h5" for i in range(n)]) for key, n in groups],
+    )
+
+
+def test_umbrella_durations_exclude_children(tmp_path):
+    db_path = tmp_path / "aetherscan.db"
+    _make_db(db_path, "test_v1", _UMBRELLA, _CHILDREN)
+
+    durations = perband_report.load_umbrella_preprocess_durations(str(db_path), "test_v1")
+
+    # Only the four umbrella spans survive; the .extract/.read_ed/.dedup children are dropped.
+    assert durations == {1: 100.0, 2: 200.0, 3: 300.0, 4: 50.0}
+
+
+def test_map_catalog_cadences_skips_flagged_group(make_inference_csv):
+    csv_path = _catalog(make_inference_csv, _VALID_GROUPS + [_FLAGGED_GROUP])
+
+    mapping = perband_report.map_catalog_cadences(str(csv_path))
+
+    # The 3-obs S cadence is flagged (no planner index / span), so only the four valid cadences
+    # map, with global 1-based planner indices in first-appearance order.
+    assert mapping == [
+        (1, "L", 1400.0),
+        (2, "C", 5000.0),
+        (3, "L", 1500.0),
+        (4, "X", 9000.0),
+    ]
+
+
+def test_aggregate_by_band_counts_and_order(make_inference_csv, tmp_path):
+    db_path = tmp_path / "aetherscan.db"
+    _make_db(db_path, "test_v1", _UMBRELLA, _CHILDREN)
+    csv_path = _catalog(make_inference_csv, _VALID_GROUPS + [_FLAGGED_GROUP])
+
+    durations = perband_report.load_umbrella_preprocess_durations(str(db_path), "test_v1")
+    mapping = perband_report.map_catalog_cadences(str(csv_path))
+    rows = [
+        perband_report.CadenceBandRow(n=n, band=band, frequency_mhz=freq, preprocess_s=durations[n])
+        for n, band, freq in mapping
+    ]
+
+    agg = perband_report.aggregate_by_band(rows)
+
+    # Per-band counts, plus [L, S, C, X] ordering with S absent.
+    assert list(agg.keys()) == ["L", "C", "X"]
+    assert {band: agg[band]["n"] for band in agg} == {"L": 2, "C": 1, "X": 1}
+    # L = {100, 300}: median 200, p90 280, max 300.
+    assert agg["L"]["median"] == pytest.approx(200.0)
+    assert agg["L"]["p90"] == pytest.approx(280.0)
+    assert agg["L"]["max"] == pytest.approx(300.0)
+
+
+def test_render_writes_nonempty_png(make_inference_csv, tmp_path):
+    db_path = tmp_path / "aetherscan.db"
+    _make_db(db_path, "test_v1", _UMBRELLA, _CHILDREN)
+    csv_path = _catalog(make_inference_csv, _VALID_GROUPS + [_FLAGGED_GROUP])
+    out_png = tmp_path / "plots" / "perband_inference_perf_test_v1.png"
+
+    result = perband_report.render_perband_report(
+        str(db_path), "test_v1", str(csv_path), str(out_png), "testhost"
+    )
+
+    assert result == str(out_png)
+    assert out_png.exists()
+    assert out_png.stat().st_size > 0
+
+
+def test_render_skips_on_count_mismatch(make_inference_csv, tmp_path):
+    # DB has only three umbrella spans, but the catalog maps four valid cadences: the plan-index
+    # guard must skip (return None) rather than render a misleading plot.
+    db_path = tmp_path / "aetherscan.db"
+    _make_db(db_path, "test_v1", {1: 100.0, 2: 200.0, 3: 300.0}, {})
+    csv_path = _catalog(make_inference_csv, _VALID_GROUPS)
+    out_png = tmp_path / "plots" / "perband_inference_perf_test_v1.png"
+
+    result = perband_report.render_perband_report(
+        str(db_path), "test_v1", str(csv_path), str(out_png), "testhost"
+    )
+
+    assert result is None
+    assert not out_png.exists()

--- a/tests/unit/test_perband_report.py
+++ b/tests/unit/test_perband_report.py
@@ -160,3 +160,14 @@ def test_render_skips_on_count_mismatch(make_inference_csv, tmp_path):
 
     assert result is None
     assert not out_png.exists()
+
+
+def test_map_catalog_cadences_missing_required_column(tmp_path):
+    # A catalog missing a required grouping column (here 'Band') can't reproduce the planner's
+    # cadence grouping, so the map degrades to None (-> the plot is skipped) rather than
+    # silently regrouping on a subset of columns and mis-counting cadences.
+    csv_path = tmp_path / "no_band.csv"
+    csv_path.write_text(
+        "Target,Session,Cadence ID,Frequency,.h5 path\nHIP1,S1,1,1400.0,/data/a.h5\n"
+    )
+    assert perband_report.map_catalog_cadences(str(csv_path)) is None

--- a/tests/unit/test_train_utils.py
+++ b/tests/unit/test_train_utils.py
@@ -1095,3 +1095,68 @@ class TestCheckScreeningThreshold:
         assert stats["screen_recall_cascade"] == pytest.approx(0.5)
         assert stats["screen_max_safe_threshold"] == pytest.approx(0.3)
         assert any("SCREENING THRESHOLD UNSAFE" in r.message for r in caplog.records)
+
+
+class TestLatentVariantSelectionPlot:
+    """plot_rf_latent_variant_selection renders the #282 variant-selection figure straight from
+    the in-memory metrics dict + winner name (no DB, no TF): the recall bar chart with the winner
+    highlighted and — when the tie-break passed over a higher-recall variant — the tie band, plus
+    the AUC/Brier/ECE/feature-count companions. Driven off a bare __new__ instance."""
+
+    def _pipeline(self, tag):
+        pipeline = TrainingPipeline.__new__(TrainingPipeline)
+        pipeline.config = get_config()
+        pipeline.config.checkpoint.save_tag = tag
+        return pipeline
+
+    def _variant_metrics(self):
+        # Realistic #282 shape: the simplest variant (z_mean) sits a hair BELOW the top recall
+        # (z / z_aug), so the tie-break can pick it and the plot's band spans the traded recall.
+        recalls = {
+            "z_mean": 0.9994,
+            "z": 0.9996,
+            "z_aug": 0.9996,
+            "z_mean_total_kl": 0.9990,
+            "z_mean_obs_logvar": 0.9992,
+            "z_mean_dim_logvar": 0.9988,
+            "z_mean_logvar_active": 0.9985,
+            "z_mean_logvar": 0.9989,
+        }
+        feats = {
+            "z_mean": 48,
+            "z": 48,
+            "z_aug": 48,
+            "z_mean_total_kl": 49,
+            "z_mean_obs_logvar": 54,
+            "z_mean_dim_logvar": 56,
+            "z_mean_logvar_active": 72,
+            "z_mean_logvar": 96,
+        }
+        return {
+            name: {
+                "recall_at_fpr": recalls[name],
+                "roc_auc": 0.990 + 0.001 * i,
+                "brier": 0.010 + 0.001 * i,
+                "ece": 0.020 + 0.001 * i,
+                "n_features": feats[name],
+            }
+            for i, name in enumerate(recalls)
+        }
+
+    def test_writes_nonempty_png_with_tiebreak_winner(self):
+        # winner (z_mean) has LOWER recall than the best (z): exercises the tie-band path.
+        pipeline = self._pipeline("sel_tiebreak")
+        pipeline.plot_rf_latent_variant_selection(self._variant_metrics(), "z_mean")
+        path = os.path.join(
+            pipeline._training_plots_dir(), "latent_variant_selection_sel_tiebreak.png"
+        )
+        assert os.path.exists(path)
+        assert os.path.getsize(path) > 0
+
+    def test_writes_nonempty_png_when_winner_is_top_recall(self):
+        # winner == best (no tie-break): the band collapses; the figure must still render.
+        pipeline = self._pipeline("sel_top")
+        pipeline.plot_rf_latent_variant_selection(self._variant_metrics(), "z")
+        path = os.path.join(pipeline._training_plots_dir(), "latent_variant_selection_sel_top.png")
+        assert os.path.exists(path)
+        assert os.path.getsize(path) > 0

--- a/utils/perband_report.py
+++ b/utils/perband_report.py
@@ -41,6 +41,7 @@ import contextlib
 import csv
 import logging
 import os
+import re
 import socket
 import sqlite3
 import sys
@@ -85,11 +86,16 @@ class CadenceBandRow:
 # ---------------------------------------------------------------------------
 
 
+# Anchored so a hypothetical future child span ending in `_<digits>` can never be misclassified
+# as an umbrella — the pattern is a promise, not a coincidence of the current
+# `.read_ed`/`.dedup`/`.extract` child naming.
+_UMBRELLA_RE = re.compile(r"^inference\.preprocess_cadence_\d+$")
+
+
 def _is_umbrella_stage(stage: str) -> bool:
-    """True iff `stage` is an `inference.preprocess_cadence_<N>` UMBRELLA span (the tail after
-    the last underscore is a pure integer), not one of its `.read_ed`/`.dedup`/`.extract`
-    children (whose tail keeps the `<N>.child` suffix and so is not all-digits)."""
-    return stage.rsplit("_", 1)[-1].isdigit()
+    """True iff `stage` is an `inference.preprocess_cadence_<N>` UMBRELLA span, not one of its
+    `.read_ed`/`.dedup`/`.extract` children."""
+    return _UMBRELLA_RE.match(stage) is not None
 
 
 def load_umbrella_preprocess_durations(db_path: str, tag: str) -> dict[int, float]:
@@ -149,28 +155,30 @@ def _group_catalog_csv(
     mirroring preprocessing.group_observations_from_csv: rows with a missing/empty h5-path cell
     are skipped (so they don't inflate a cadence's obs count). Each group records its member
     count plus the band/frequency of its first row (both are group-by columns, so constant
-    within the group). Returns None when the CSV can't be read or lacks Band/Frequency.
+    within the group). Returns None when the CSV can't be read or is missing ANY required column
+    — 'Band'/'Frequency', any group-by column, or the h5-path column — matching
+    group_observations_from_csv's all-columns-required contract (it degrades to no plot rather
+    than silently regrouping on a subset of columns, which could mis-count cadences).
     """
     try:
         with open(csv_path, newline="") as f:
             reader = csv.DictReader(f)
             header = reader.fieldnames or []
-            if "Band" not in header or "Frequency" not in header:
+            required = ["Band", "Frequency", h5_path_col, *group_by_cols]
+            missing = [c for c in dict.fromkeys(required) if c not in header]
+            if missing:
                 logger.warning(
-                    f"Per-band plot: catalog {csv_path} lacks a 'Band'/'Frequency' column "
-                    f"(have {header}); cannot map cadences to bands"
+                    f"Per-band plot: catalog {csv_path} is missing required column(s) {missing} "
+                    f"(have {header}); cannot reproduce the planner's cadence grouping — skipping"
                 )
                 return None
-            eff_cols = [c for c in group_by_cols if c in header]
-            has_h5 = h5_path_col in header
 
             groups: OrderedDict[tuple, dict] = OrderedDict()
             for row in reader:
-                if has_h5:
-                    h5 = row.get(h5_path_col)
-                    if h5 is None or not str(h5).strip():
-                        continue
-                key = tuple(row.get(c) for c in eff_cols)
+                h5 = row.get(h5_path_col)
+                if h5 is None or not str(h5).strip():
+                    continue
+                key = tuple(row.get(c) for c in group_by_cols)
                 if key not in groups:
                     groups[key] = {
                         "count": 0,

--- a/utils/perband_report.py
+++ b/utils/perband_report.py
@@ -203,7 +203,8 @@ def map_catalog_cadences(
     [(N, band, frequency_mhz), ...] for every VALID cadence (obs count == expected_obs), with N
     the global 1-based planner index (== PendingCadence.index). CSVs are processed in the given
     order and their valid groups share one running index, matching plan_cadences(). Returns
-    None when any CSV can't be read or lacks the Band/Frequency columns.
+    None when any CSV can't be read or is missing any column the planner grouping requires
+    (Band/Frequency, a group-by column, or the h5-path column — see _group_catalog_csv).
     """
     if group_by_cols is None:
         group_by_cols = DEFAULT_GROUP_BY_COLS

--- a/utils/perband_report.py
+++ b/utils/perband_report.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+"""
+Render a per-band inference-performance plot for one streaming-CSV inference run.
+
+Groups per-cadence energy-detection preprocessing wall-clock BY BAND (L/S/C/X) and by
+frequency, to reveal whether a band or frequency region is systematically faster/slower.
+Fires automatically at the tail of every inference run (alongside benchmark_report.py) and
+is also runnable standalone against a database copied off a cluster.
+
+Two data sources, joined per cadence:
+1. the SQLite DB `pipeline_stages` table — per-cadence preprocessing wall is the umbrella
+   span `inference.preprocess_cadence_<N>` (1-based N in planner order), EXCLUDING its
+   `.read_ed` / `.dedup` / `.extract` children (they roll up into the umbrella);
+2. the run's inference catalog CSV(s) — the `Band` and `Frequency` columns.
+
+Join (plan-index): the umbrella span carries only N, and the DB has no table mapping N to a
+band, so the cadence -> band/frequency map is reconstructed from the catalog by mirroring
+preprocessing.group_observations_from_csv — cadences are the CSV rows grouped by
+config.inference.cadence_group_by_cols (default
+["Target", "Session", "Band", "Cadence ID", "Frequency"]), keeping only groups with exactly
+cadence_expected_obs (default 6) observations, in first-appearance order; the i-th such valid
+group is cadence N=i (== PendingCadence.index that names the span). ASSUMES the run used the
+default group-by columns / expected-obs. A runtime guard compares the mapped cadence count to
+the number of umbrella spans and skips the plot (warning, never a crash) if they disagree — so
+a resumed run or a non-default grouping degrades to no plot rather than a misleading one.
+
+Reads the SQLite file directly (stdlib sqlite3 + csv + numpy + matplotlib only — no aetherscan
+imports), so it also runs against a database fetched from a cluster with
+utils/fetch_run_outputs.sh:
+
+    python utils/perband_report.py --save-tag test_20260101_120000 \
+        --catalog /path/to/catalog.csv
+    python utils/perband_report.py --save-tag test --catalog a.csv b.csv \
+        --db-path /path/to/aetherscan.db
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import csv
+import logging
+import os
+import socket
+import sqlite3
+import sys
+from collections import OrderedDict
+from dataclasses import dataclass
+
+import matplotlib
+
+matplotlib.use("Agg")  # Non-interactive backend for headless environments
+
+import numpy as np  # noqa: E402
+from matplotlib.figure import Figure  # noqa: E402
+from matplotlib.transforms import blended_transform_factory  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+# Per-band colors + the Panel-A x-axis band order (fixed by the spec)
+BAND_COLORS = {"L": "#4C72B0", "S": "#55A868", "C": "#C44E52", "X": "#8172B3"}
+BAND_ORDER = ["L", "S", "C", "X"]
+_UNKNOWN_BAND_COLOR = "#888888"
+
+# Planner defaults (config.inference.*) the plan-index join assumes — see module docstring
+DEFAULT_GROUP_BY_COLS = ["Target", "Session", "Band", "Cadence ID", "Frequency"]
+DEFAULT_H5_PATH_COL = ".h5 path"
+DEFAULT_EXPECTED_OBS = 6
+
+DPI = 130
+
+
+@dataclass
+class CadenceBandRow:
+    """One cadence's joined per-band datum: planner index, band, frequency, preprocess wall."""
+
+    n: int  # 1-based planner index (from the umbrella span name)
+    band: str
+    frequency_mhz: float | None
+    preprocess_s: float
+
+
+# ---------------------------------------------------------------------------
+# DB access: per-cadence preprocessing umbrella durations
+# ---------------------------------------------------------------------------
+
+
+def _is_umbrella_stage(stage: str) -> bool:
+    """True iff `stage` is an `inference.preprocess_cadence_<N>` UMBRELLA span (the tail after
+    the last underscore is a pure integer), not one of its `.read_ed`/`.dedup`/`.extract`
+    children (whose tail keeps the `<N>.child` suffix and so is not all-digits)."""
+    return stage.rsplit("_", 1)[-1].isdigit()
+
+
+def load_umbrella_preprocess_durations(db_path: str, tag: str) -> dict[int, float]:
+    """
+    Map planner index N -> per-cadence preprocessing wall (seconds), read from the umbrella
+    `inference.preprocess_cadence_<N>` spans of `pipeline_stages` for this tag. Children are
+    excluded. On the rare retried cadence (a second umbrella span for the same N), the latest
+    attempt wins (rows are read start_time-ordered). Returns {} when the tag has no such spans.
+    """
+    with contextlib.closing(sqlite3.connect(db_path)) as conn:
+        conn.row_factory = sqlite3.Row
+        try:
+            cursor = conn.execute(
+                "SELECT stage, duration_s FROM pipeline_stages "
+                "WHERE tag = ? AND stage LIKE 'inference.preprocess_cadence_%' "
+                "ORDER BY start_time",
+                (tag,),
+            )
+            rows = cursor.fetchall()
+        except sqlite3.OperationalError as e:
+            logger.warning(f"Could not read pipeline_stages from {db_path}: {e}")
+            return {}
+
+    durations: dict[int, float] = {}
+    for row in rows:
+        stage = str(row["stage"])
+        if not _is_umbrella_stage(stage):
+            continue
+        n = int(stage.rsplit("_", 1)[-1])
+        durations[n] = float(row["duration_s"])  # later (retried) attempt overwrites earlier
+    return durations
+
+
+# ---------------------------------------------------------------------------
+# Catalog access: plan-index -> (band, frequency)
+# ---------------------------------------------------------------------------
+
+
+def _norm_band(value) -> str:
+    """Canonicalize a catalog Band cell to an upper-case, stripped label ('?' when empty)."""
+    text = str(value).strip().upper() if value is not None else ""
+    return text or "?"
+
+
+def _parse_float(value) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _group_catalog_csv(
+    csv_path: str, group_by_cols: list[str], h5_path_col: str
+) -> OrderedDict[tuple, dict] | None:
+    """
+    Group one catalog CSV's rows into cadences by `group_by_cols` (first-appearance order),
+    mirroring preprocessing.group_observations_from_csv: rows with a missing/empty h5-path cell
+    are skipped (so they don't inflate a cadence's obs count). Each group records its member
+    count plus the band/frequency of its first row (both are group-by columns, so constant
+    within the group). Returns None when the CSV can't be read or lacks Band/Frequency.
+    """
+    try:
+        with open(csv_path, newline="") as f:
+            reader = csv.DictReader(f)
+            header = reader.fieldnames or []
+            if "Band" not in header or "Frequency" not in header:
+                logger.warning(
+                    f"Per-band plot: catalog {csv_path} lacks a 'Band'/'Frequency' column "
+                    f"(have {header}); cannot map cadences to bands"
+                )
+                return None
+            eff_cols = [c for c in group_by_cols if c in header]
+            has_h5 = h5_path_col in header
+
+            groups: OrderedDict[tuple, dict] = OrderedDict()
+            for row in reader:
+                if has_h5:
+                    h5 = row.get(h5_path_col)
+                    if h5 is None or not str(h5).strip():
+                        continue
+                key = tuple(row.get(c) for c in eff_cols)
+                if key not in groups:
+                    groups[key] = {
+                        "count": 0,
+                        "band": _norm_band(row.get("Band")),
+                        "frequency_mhz": _parse_float(row.get("Frequency")),
+                    }
+                groups[key]["count"] += 1
+    except FileNotFoundError:
+        logger.warning(f"Per-band plot: catalog CSV not found: {csv_path}")
+        return None
+    return groups
+
+
+def map_catalog_cadences(
+    catalog_csv_paths,
+    group_by_cols: list[str] | None = None,
+    h5_path_col: str = DEFAULT_H5_PATH_COL,
+    expected_obs: int = DEFAULT_EXPECTED_OBS,
+) -> list[tuple[int, str, float | None]] | None:
+    """
+    Reconstruct the planner's cadence order across one or more catalog CSVs and return
+    [(N, band, frequency_mhz), ...] for every VALID cadence (obs count == expected_obs), with N
+    the global 1-based planner index (== PendingCadence.index). CSVs are processed in the given
+    order and their valid groups share one running index, matching plan_cadences(). Returns
+    None when any CSV can't be read or lacks the Band/Frequency columns.
+    """
+    if group_by_cols is None:
+        group_by_cols = DEFAULT_GROUP_BY_COLS
+    if isinstance(catalog_csv_paths, (str, os.PathLike)):
+        catalog_csv_paths = [catalog_csv_paths]
+
+    records: list[tuple[int, str, float | None]] = []
+    n = 0
+    for csv_path in catalog_csv_paths:
+        groups = _group_catalog_csv(str(csv_path), group_by_cols, h5_path_col)
+        if groups is None:
+            return None
+        for info in groups.values():
+            if info["count"] != expected_obs:
+                continue  # flagged group — planner skips it, so it gets no index / span
+            n += 1
+            records.append((n, info["band"], info["frequency_mhz"]))
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Aggregation + summary
+# ---------------------------------------------------------------------------
+
+
+def _ordered_bands(bands) -> list[str]:
+    """Known bands first in BAND_ORDER, then any unexpected extras in first-seen order."""
+    present = list(bands)
+    return [b for b in BAND_ORDER if b in present] + [b for b in present if b not in BAND_ORDER]
+
+
+def aggregate_by_band(rows: list[CadenceBandRow]) -> OrderedDict[str, dict]:
+    """
+    Per-band reduction of the joined cadence rows. Returns an OrderedDict (bands ordered
+    [L, S, C, X] then any extras) of {n, median, mean, p90, max, values} over each band's
+    preprocessing wall times. The `n` (per-band count) is what the unit test asserts against.
+    """
+    grouped: OrderedDict[str, list[float]] = OrderedDict()
+    for row in rows:
+        grouped.setdefault(row.band, []).append(row.preprocess_s)
+
+    agg: OrderedDict[str, dict] = OrderedDict()
+    for band in _ordered_bands(grouped.keys()):
+        arr = np.asarray(grouped[band], dtype=float)
+        agg[band] = {
+            "n": int(arr.size),
+            "median": float(np.median(arr)),
+            "mean": float(np.mean(arr)),
+            "p90": float(np.percentile(arr, 90)),
+            "max": float(np.max(arr)),
+            "values": grouped[band],
+        }
+    return agg
+
+
+def format_summary_table(agg: OrderedDict[str, dict]) -> str:
+    """A small fixed-width text table (band, n, median, mean, p90, max) over the per-band agg."""
+    header = f"{'band':<6}{'n':>6}{'median':>10}{'mean':>10}{'p90':>10}{'max':>10}"
+    lines = [header, "-" * len(header)]
+    for band, stats in agg.items():
+        lines.append(
+            f"{band:<6}{stats['n']:>6}"
+            f"{stats['median']:>9.1f}s{stats['mean']:>9.1f}s"
+            f"{stats['p90']:>9.1f}s{stats['max']:>9.1f}s"
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Plot
+# ---------------------------------------------------------------------------
+
+
+def _render_figure(
+    rows: list[CadenceBandRow],
+    agg: OrderedDict[str, dict],
+    tag: str,
+    hostname: str,
+    output_path: str,
+) -> None:
+    """Write the 2-panel figure: per-band distribution (Panel A) + wall-vs-frequency (Panel B)."""
+    fig = Figure(figsize=(15, 6))
+    fig.suptitle(
+        f"Inference performance by band ({tag}, {hostname})", fontsize=15, fontweight="bold"
+    )
+    ax_a, ax_b = fig.subplots(1, 2)
+
+    # --- Panel A: per-band boxplot (no fliers) + jittered strip, x ordered [L, S, C, X] ---
+    present_bands = list(agg.keys())
+    positions = list(range(1, len(present_bands) + 1))
+    ax_a.boxplot(
+        [agg[b]["values"] for b in present_bands],
+        positions=positions,
+        widths=0.5,
+        showfliers=False,
+        medianprops={"color": "black"},
+    )
+    rng = np.random.default_rng(0)  # deterministic jitter
+    trans = blended_transform_factory(ax_a.transData, ax_a.transAxes)
+    for pos, band in zip(positions, present_bands, strict=True):
+        vals = agg[band]["values"]
+        xs = pos + rng.uniform(-0.16, 0.16, size=len(vals))
+        ax_a.scatter(
+            xs,
+            vals,
+            s=14,
+            color=BAND_COLORS.get(band, _UNKNOWN_BAND_COLOR),
+            alpha=0.55,
+            edgecolors="none",
+            zorder=3,
+        )
+        ax_a.text(
+            pos,
+            0.99,
+            f"med {agg[band]['median']:.1f}s\nmax {agg[band]['max']:.1f}s\nn={agg[band]['n']}",
+            transform=trans,
+            ha="center",
+            va="top",
+            fontsize=8,
+        )
+    ax_a.set_yscale("log")
+    ax_a.set_xticks(positions)
+    ax_a.set_xticklabels(present_bands)
+    ax_a.set_xlabel("Band", fontsize=11, fontweight="bold")
+    ax_a.set_ylabel("Preprocess wall (s)", fontsize=11, fontweight="bold")
+    ax_a.set_title("Per-cadence preprocessing by band", fontsize=11)
+    ax_a.grid(True, axis="y", alpha=0.3)
+
+    # --- Panel B: preprocess wall vs frequency (continuous MHz x-axis), colored by band ---
+    for band in present_bands:
+        pts = [
+            (r.frequency_mhz, r.preprocess_s)
+            for r in rows
+            if r.band == band and r.frequency_mhz is not None
+        ]
+        if not pts:
+            continue
+        fx, fy = zip(*pts, strict=True)
+        ax_b.scatter(
+            fx,
+            fy,
+            s=16,
+            color=BAND_COLORS.get(band, _UNKNOWN_BAND_COLOR),
+            alpha=0.6,
+            edgecolors="none",
+            label=f"{band} (n={len(pts)})",
+        )
+    ax_b.set_yscale("log")
+    ax_b.set_xlabel("Frequency (MHz)", fontsize=11, fontweight="bold")
+    ax_b.set_ylabel("Preprocess wall (s)", fontsize=11, fontweight="bold")
+    ax_b.set_title("Per-cadence preprocessing vs frequency", fontsize=11)
+    ax_b.grid(True, alpha=0.3)
+    ax_b.legend(title="Band", fontsize=8)
+
+    fig.tight_layout(rect=(0, 0, 1, 0.95))
+    # dirname is "" for a bare filename (cwd) — makedirs("") would raise, so only create a
+    # parent directory when output_path actually has one
+    out_dir = os.path.dirname(output_path)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    fig.savefig(output_path, dpi=DPI, bbox_inches="tight")
+    fig.clear()
+
+
+def render_perband_report(
+    db_path: str,
+    tag: str,
+    catalog_csv_path,
+    output_path: str,
+    hostname: str,
+) -> str | None:
+    """
+    Join per-cadence preprocessing walls (pipeline_stages umbrella spans) to catalog band /
+    frequency (plan-index join) and write the per-band performance PNG to `output_path`.
+
+    Returns the written path on success, or None (with a logged warning, never an exception)
+    when the plot is skipped: no umbrella spans, an unreadable/column-less catalog, or a
+    mismatch between the mapped catalog-cadence count and the umbrella-span count (the
+    plan-index assumption not holding, e.g. a resumed run or non-default cadence_group_by_cols).
+    `catalog_csv_path` may be a single path or a list of paths (processed in planner order).
+    """
+    durations = load_umbrella_preprocess_durations(db_path, tag)
+    if not durations:
+        logger.warning(
+            f"Per-band inference plot skipped: no preprocess umbrella spans for tag {tag!r}"
+        )
+        return None
+
+    cadence_map = map_catalog_cadences(catalog_csv_path)
+    if cadence_map is None:
+        logger.warning("Per-band inference plot skipped: catalog CSV unreadable or missing columns")
+        return None
+
+    # Runtime guard on the plan-index join: the number of valid catalog cadences must equal the
+    # number of umbrella spans, else the N-th span and the N-th catalog cadence aren't the same
+    # cadence and any band mapping would be misleading — skip rather than mislead.
+    if len(cadence_map) != len(durations):
+        logger.warning(
+            f"Per-band inference plot skipped: mapped {len(cadence_map)} catalog cadence(s) but "
+            f"found {len(durations)} preprocess umbrella span(s) for tag {tag!r} — the plan-index "
+            f"join assumption does not hold (resumed run or non-default cadence_group_by_cols?); "
+            f"not rendering to avoid a misleading plot"
+        )
+        return None
+
+    rows: list[CadenceBandRow] = []
+    for n, band, freq in cadence_map:
+        if n not in durations:
+            logger.warning(
+                f"Per-band inference plot skipped: catalog cadence N={n} has no matching "
+                f"umbrella span for tag {tag!r}"
+            )
+            return None
+        rows.append(CadenceBandRow(n=n, band=band, frequency_mhz=freq, preprocess_s=durations[n]))
+
+    agg = aggregate_by_band(rows)
+    logger.info(f"Per-band preprocessing summary ({tag}):\n{format_summary_table(agg)}")
+    _render_figure(rows, agg, tag, hostname, output_path)
+    return output_path
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def default_db_path() -> str:
+    output_path = os.environ.get(
+        "AETHERSCAN_OUTPUT_PATH", "/datax/scratch/zachy/outputs/aetherscan"
+    )
+    return os.path.join(output_path, "db", "aetherscan.db")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Render a per-band inference-performance plot (preprocessing wall grouped "
+        "by band/frequency) for one Aetherscan inference run."
+    )
+    parser.add_argument("--save-tag", required=True, help="Run tag to report on")
+    parser.add_argument(
+        "--catalog",
+        required=True,
+        nargs="+",
+        help="Inference catalog CSV path(s), in planner order (same as config.data.inference_files)",
+    )
+    parser.add_argument(
+        "--db-path",
+        default=None,
+        help="Path to aetherscan.db (default: {AETHERSCAN_OUTPUT_PATH}/db/aetherscan.db)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Directory for the plot PNG (default: <db parent>/../plots)",
+    )
+    parser.add_argument(
+        "--hostname",
+        default=None,
+        help="Hostname for the suptitle (default: this machine's hostname)",
+    )
+    args = parser.parse_args(argv)
+
+    db_path = args.db_path or default_db_path()
+    if not os.path.exists(db_path):
+        print(f"Database not found: {db_path}", file=sys.stderr)
+        return 1
+
+    output_dir = args.output_dir or os.path.join(os.path.dirname(os.path.dirname(db_path)), "plots")
+    output_path = os.path.join(output_dir, f"perband_inference_perf_{args.save_tag}.png")
+    hostname = args.hostname or socket.gethostname()
+
+    result = render_perband_report(db_path, args.save_tag, args.catalog, output_path, hostname)
+    if result is None:
+        print("Per-band plot was skipped (see warnings above).")
+        return 1
+
+    # Re-derive the summary for the standalone stdout emit (render logs it too)
+    durations = load_umbrella_preprocess_durations(db_path, args.save_tag)
+    cadence_map = map_catalog_cadences(args.catalog) or []
+    rows = [
+        CadenceBandRow(n=n, band=band, frequency_mhz=freq, preprocess_s=durations[n])
+        for n, band, freq in cadence_map
+        if n in durations
+    ]
+    print(f"Per-band inference performance for tag {args.save_tag!r} ({len(rows)} cadence(s))")
+    print()
+    print(format_summary_table(aggregate_by_band(rows)))
+    print()
+    print(f"Plot written to {result}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Four inference-run observability / candidate-viz improvements. **No science numerics change** — every item is additive or a fail-loud guard.

### 1. Candidate spectrogram frequency axis (`candidate_figures.py`)
The `low → high MHz` text-and-arrow span x-label on the candidate/stamp waterfalls is replaced with border tick labels — the MHz value at the left and right edges — under a `Frequency (MHz)` x-axis title. `render_candidate_figure` now routes its waterfall through the shared `draw_cadence_strip` helper, so all four real-MHz waterfalls share one implementation; bin-order semantics preserved (a negative `foff` prints borders high → low).

### 2. RF latent-variant selection plot (`train.py`)
`plot_rf_latent_variant_selection` makes the #282 winner explicit (previously only a log line + DB scalars): a recall@FPR bar chart per variant ordered simple→complex, the winner flagged, and — when the minimum-margin tie-break passed over a higher-recall variant — a shaded band showing the recall deliberately traded for the simpler representation. Companion panels: AUC / Brier / ECE / feature-count. Reads the in-memory `variant_metrics` (no DB round-trip, no TF); called inline after selection, guarded best-effort.

### 3. RF feature-count guard (`inference.py`)
`init_models` now asserts the loaded forest's `n_features_in_` matches the feature count implied by the config's declared `latent_variant`. Same-width variants (`z`/`z_mean`/`z_aug` all = `num_obs*latent_dim`) mean a config↔weights mismatch from mixed `--config-path`/`--rf-path` pairings or a hand-edited config would otherwise silently score the wrong representation — it now fails loud. (`variant_feature_count()` already existed for this but was unused; the sanctioned HF path always ships matching artifacts so it never fires there.)

### 4. Per-band inference-performance plot (`utils/perband_report.py` + `main.py`)
Auto-fires after each inference run (alongside `benchmark_report`, same `benchmark_report_enabled` gate, fully guarded). Groups per-cadence preprocessing wall-clock by band (L/S/C/X) and frequency from `pipeline_stages`, joined to the run's inference catalog via the planner's own first-appearance cadence grouping. Stdlib-only (`sqlite3`+`csv`+matplotlib), no `aetherscan`/TF imports — same self-contained style as `benchmark_report.py`. Documented in `docs/BENCHMARKING.md`.

### Tests
`TestDrawCadenceStripFreqAxis`, `TestRfFeatureLayoutGuard`, `TestLatentVariantSelectionPlot`, and `tests/unit/test_perband_report.py` (synthetic DB + catalog, umbrella-vs-child isolation, count-guard skip).

Docs for items 2–3 will be folded into the forthcoming documentation-sweep PR.

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)
