### PR TITLE
feat: machine-scoped display tag for filenames + plot titles

### DIFF
--- a/src/aetherscan/db/__init__.py
+++ b/src/aetherscan/db/__init__.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from .db import (
     get_db,
+    get_machine_name,
     get_system_metadata,
     init_db,
     merge_db,
@@ -14,6 +15,7 @@ from .db import (
 
 __all__ = [
     "get_db",
+    "get_machine_name",
     "get_system_metadata",
     "init_db",
     "merge_db",

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -97,6 +97,11 @@ _SCHEMA_VERSION = 8
 # round (#277). A spawned child process re-imports the module and rebuilds its own cache, so
 # the PID is always correct.
 _SYSTEM_METADATA_CACHE: str | None = None
+# Per-process cache for get_machine_name(): the machine name is a process-constant too, and the
+# display-tag hot sites now call get_machine_name() several times back-to-back (_model_pair_exists
+# twice, save_models/load_models 3x, every `dtag = ...` line). Memoized off the same metadata as
+# _SYSTEM_METADATA_CACHE; neither is reset in-process, so both survive singleton teardown together.
+_MACHINE_NAME_CACHE: str | None = None
 
 
 def get_system_metadata() -> str:
@@ -150,11 +155,17 @@ def get_machine_name() -> str:
     The single accessor for the machine name: it unifies the two divergent sources that used to
     coexist — ``json.loads(get_system_metadata())["machine_name"]`` (training plots + monitor) and
     a raw ``socket.gethostname()`` (inference-viz, Slack banner) — so every filename / plot title /
-    Slack message derives the identical string. A cached-metadata read, so it is cheap to call at
-    each site (no per-call socket work). See ``aetherscan.display_tag.display_tag``, which composes
-    this into the presentation/filename "display tag".
+    Slack message derives the identical string. A per-process memoized constant: the machine name is
+    derived once (off the already-cached system metadata) and returned directly thereafter, so the
+    display-tag hot sites can call it several times back-to-back at no cost. See
+    ``aetherscan.display_tag.display_tag``, which composes this into the presentation/filename
+    "display tag".
     """
-    return json.loads(get_system_metadata())["machine_name"]
+    global _MACHINE_NAME_CACHE
+    if _MACHINE_NAME_CACHE is not None:
+        return _MACHINE_NAME_CACHE
+    _MACHINE_NAME_CACHE = json.loads(get_system_metadata())["machine_name"]
+    return _MACHINE_NAME_CACHE
 
 
 class Database:

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -144,6 +144,19 @@ def get_system_metadata() -> str:
     return _SYSTEM_METADATA_CACHE
 
 
+def get_machine_name() -> str:
+    """This host's machine name (``socket.gethostname()``), read from the cached system metadata.
+
+    The single accessor for the machine name: it unifies the two divergent sources that used to
+    coexist — ``json.loads(get_system_metadata())["machine_name"]`` (training plots + monitor) and
+    a raw ``socket.gethostname()`` (inference-viz, Slack banner) — so every filename / plot title /
+    Slack message derives the identical string. A cached-metadata read, so it is cheap to call at
+    each site (no per-call socket work). See ``aetherscan.display_tag.display_tag``, which composes
+    this into the presentation/filename "display tag".
+    """
+    return json.loads(get_system_metadata())["machine_name"]
+
+
 class Database:
     """
     Thread-safe SQLite database with asynchronous queue-based writes.

--- a/src/aetherscan/display_tag.py
+++ b/src/aetherscan/display_tag.py
@@ -1,0 +1,53 @@
+"""
+Presentation/filename "display tag" derivation.
+
+A run's DB tag is ``{command}_{datetime}`` (e.g. ``inf_20260731_182011``; see
+``cli.resolve_save_tag``). Two runs of the same command that start in the same second on two
+different machines therefore resolve to the *same* tag, and their on-disk artifacts collide the
+moment they share a directory (e.g. weights copied bla0 -> blpc3). The **display tag** inserts the
+local machine name — ``{command}_{machine}_{datetime}`` (e.g. ``inf_blpc3_20260731_182011``) — and
+is used for every artifact FILENAME/path and every plot title + Slack message, so those no longer
+collide.
+
+The display tag is a DERIVED, presentation-only string: nothing that keys a DB row changes. The tag
+written to and queried from the database (and ``config.checkpoint.save_tag`` itself) stays the plain
+``{command}_{datetime}``.
+
+This module is intentionally dependency-free (stdlib only, no ``aetherscan`` imports) so it is
+import-safe from every consumer — train, inference, viz, monitor, logger, HF upload — with no risk
+of an import cycle, and so ``display_tag`` is unit-testable in isolation. The machine name comes
+from the one accessor ``aetherscan.db.get_machine_name``; callers pass it in.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Fully-resolved run-tag prefixes — mirrors cli._SAVE_TAG_PREFIXES / cli._FULL_TAG_PATTERN. Kept
+# local (a 4-tuple duplicate) so this module stays dependency-free; the set changes ~never.
+_RUN_TAG_PREFIXES = ("test", "train", "inf", "bench")
+# The datetime stamp resolve_save_tag appends: %Y%m%d_%H%M%S.
+_DATETIME_RE = re.compile(r"\d{8}_\d{6}")
+
+
+def display_tag(tag: str, machine_name: str) -> str:
+    """Return the machine-scoped display tag for ``tag``.
+
+    A fully-resolved run tag ``{command}_{datetime}`` (command in {test, train, inf, bench},
+    datetime ``YYYYMMDD_HHMMSS``) becomes ``{command}_{machine_name}_{datetime}`` — the command
+    prefix is the part before the first underscore, the datetime is the rest.
+
+    Anything that is not a run tag is returned UNCHANGED: a ``round_XX`` per-round checkpoint tag,
+    the conventional ``final`` alias, a falsy value (``None`` / ``""`` — an as-yet-unresolved tag),
+    or any malformed string. This selectivity is load-bearing — splicing the machine name into
+    ``round_05`` would both break the ``round_(\\d+)`` checkpoint cleanup regex and produce a name
+    no reader reconstructs, and ``final`` has no datetime to place the machine before. So filename
+    choke points can call this unconditionally: it is the identity on the non-run-tag flavors and
+    only rewrites genuine run tags.
+    """
+    if not tag:
+        return tag
+    command, sep, datetime_part = tag.partition("_")
+    if not sep or command not in _RUN_TAG_PREFIXES or not _DATETIME_RE.fullmatch(datetime_part):
+        return tag
+    return f"{command}_{machine_name}_{datetime_part}"

--- a/src/aetherscan/hf_hub.py
+++ b/src/aetherscan/hf_hub.py
@@ -42,6 +42,8 @@ import tempfile
 from typing import Any
 
 from aetherscan.config import get_config
+from aetherscan.db import get_machine_name
+from aetherscan.display_tag import display_tag
 
 logger = logging.getLogger(__name__)
 
@@ -298,7 +300,9 @@ def compute_rf_metrics(model_path: str, tag: str) -> dict[str, Any] | None:
     (rf_eval_artifacts_{tag}.joblib, written by train_random_forest). Returns None when the
     artifact is missing or unreadable — the card simply omits its metrics section.
     """
-    artifact_path = os.path.join(model_path, f"rf_eval_artifacts_{tag}.joblib")
+    artifact_path = os.path.join(
+        model_path, f"rf_eval_artifacts_{display_tag(tag, get_machine_name())}.joblib"
+    )
     if not os.path.exists(artifact_path):
         logger.info(f"No RF eval artifacts at {artifact_path} — model card omits metrics")
         return None
@@ -474,11 +478,16 @@ def upload_run_to_hf(
     Raises on any failure — the caller (the hf_upload training stage) records it in the run
     manifest without failing the run.
     """
+    # LOCAL artifacts on the training host are display-tagged ({command}_{machine}_{datetime});
+    # this runs on that same host, so the display tag reproduces exactly what training wrote. The
+    # staged Hub names stay the fixed HF_*_FILENAME constants, and the commit message / git tag
+    # below stay the plain DB `tag` (the run's canonical identity).
+    local_tag = display_tag(tag, get_machine_name())
     sources = {
-        HF_ENCODER_FILENAME: os.path.join(model_path, f"vae_encoder_{tag}.keras"),
-        HF_DECODER_FILENAME: os.path.join(model_path, f"vae_decoder_{tag}.keras"),
-        HF_RF_FILENAME: os.path.join(model_path, f"random_forest_{tag}.joblib"),
-        HF_CONFIG_FILENAME: os.path.join(output_path, f"config_{tag}.json"),
+        HF_ENCODER_FILENAME: os.path.join(model_path, f"vae_encoder_{local_tag}.keras"),
+        HF_DECODER_FILENAME: os.path.join(model_path, f"vae_decoder_{local_tag}.keras"),
+        HF_RF_FILENAME: os.path.join(model_path, f"random_forest_{local_tag}.joblib"),
+        HF_CONFIG_FILENAME: os.path.join(output_path, f"config_{local_tag}.json"),
     }
     missing = [path for path in sources.values() if not os.path.exists(path)]
     if missing:
@@ -488,7 +497,7 @@ def upload_run_to_hf(
 
     # Optional fifth artifact (#282): the probability calibrator, present only when training
     # fitted-and-kept one (config.json's rf.calibration_active records which)
-    calibrator_source = os.path.join(model_path, f"rf_calibrator_{tag}.joblib")
+    calibrator_source = os.path.join(model_path, f"rf_calibrator_{local_tag}.joblib")
     if os.path.exists(calibrator_source):
         sources[HF_CALIBRATOR_FILENAME] = calibrator_source
 

--- a/src/aetherscan/inference.py
+++ b/src/aetherscan/inference.py
@@ -18,7 +18,8 @@ import tensorflow as tf
 
 from aetherscan.benchmark import stage_timer
 from aetherscan.config import get_config
-from aetherscan.db import get_db
+from aetherscan.db import get_db, get_machine_name
+from aetherscan.display_tag import display_tag
 from aetherscan.latent_variants import (
     apply_probability_calibrator,
     build_variant_features,
@@ -850,7 +851,10 @@ class InferencePipeline:
         )
 
         tag = self.config.checkpoint.save_tag
-        cloud_path = os.path.join(self.config.output_path, f"inference_reference_cloud_{tag}.npz")
+        cloud_path = os.path.join(
+            self.config.output_path,
+            f"inference_reference_cloud_{display_tag(tag, get_machine_name())}.npz",
+        )
         os.makedirs(os.path.dirname(cloud_path), exist_ok=True)
         np.savez_compressed(
             cloud_path,

--- a/src/aetherscan/inference_viz.py
+++ b/src/aetherscan/inference_viz.py
@@ -28,7 +28,6 @@ import json
 import logging
 import os
 import queue
-import socket
 import threading
 import time
 from collections import Counter
@@ -51,7 +50,8 @@ from aetherscan.candidate_figures import (
 )
 from aetherscan.config import get_config
 from aetherscan.data_generation import log_norm
-from aetherscan.db import get_db
+from aetherscan.db import get_db, get_machine_name
+from aetherscan.display_tag import display_tag
 from aetherscan.logger import get_logger
 from aetherscan.pfb import gen_coarse_channel_response
 from aetherscan.seeding import STREAM_INFERENCE_VIZ, derive_rng
@@ -343,7 +343,9 @@ def _viz_safe(name: str, fn: Callable, *args, **kwargs):
 
 
 def _plots_dir(tag: str) -> str:
-    path = os.path.join(get_config().output_path, "plots", "inference", tag)
+    path = os.path.join(
+        get_config().output_path, "plots", "inference", display_tag(tag, get_machine_name())
+    )
     os.makedirs(path, exist_ok=True)
     return path
 
@@ -362,7 +364,7 @@ def _save_and_upload(fig: Figure, filename: str, slack_title: str) -> str:
     fig.clear()
     logger.info(f"Inference viz saved: {save_path}")
 
-    _uploader.submit(save_path, f"{slack_title} - ({tag}, {socket.gethostname()})")
+    _uploader.submit(save_path, f"{slack_title} - ({display_tag(tag, get_machine_name())})")
     return save_path
 
 
@@ -606,14 +608,18 @@ def plot_ed_stat_distributions(
     ax.set_xlabel("D'Agostino-Pearson $k^2$ statistic")
     ax.set_ylabel("window count")
     ax.set_title(
-        f"Energy-detection statistic distribution ({tag})\n"
+        f"Energy-detection statistic distribution ({display_tag(tag, get_machine_name())})\n"
         f"{total:,} finite windows, {above:,} above threshold "
         f"({len(contributing)} cadence(s))"
     )
     ax.legend(fontsize=8)
     ax.grid(True, which="both", alpha=0.2)
 
-    return _save_and_upload(fig, f"ed_stat_distributions_{tag}.png", "ED Statistic Distribution")
+    return _save_and_upload(
+        fig,
+        f"ed_stat_distributions_{display_tag(tag, get_machine_name())}.png",
+        "ED Statistic Distribution",
+    )
 
 
 def _clamp_hit_spectrum_bins(
@@ -686,13 +692,15 @@ def plot_ed_hit_spectrum(
     ax.set_xlabel("frequency (MHz)")
     ax.set_ylabel("hit count")
     ax.set_title(
-        f"Energy-detection hit spectrum ({tag})\n"
+        f"Energy-detection hit spectrum ({display_tag(tag, get_machine_name())})\n"
         f"{int(raw_total.sum()):,} raw → {int(merged_total.sum()):,} merged hits"
     )
     ax.legend(fontsize=9)
     ax.grid(True, alpha=0.2)
 
-    return _save_and_upload(fig, f"ed_hit_spectrum_{tag}.png", "ED Hit Spectrum")
+    return _save_and_upload(
+        fig, f"ed_hit_spectrum_{display_tag(tag, get_machine_name())}.png", "ED Hit Spectrum"
+    )
 
 
 def _plot_bandpass_from_envelopes(
@@ -741,9 +749,15 @@ def _plot_bandpass_from_envelopes(
 
     method = "pfb" if "PFB" in overlay_label else "spline"
     source = os.path.basename(h5_path) if h5_path else "stored envelopes"
-    fig.suptitle(f"Bandpass flattening ({method}, {tag}): {source}")
+    fig.suptitle(
+        f"Bandpass flattening ({method}, {display_tag(tag, get_machine_name())}): {source}"
+    )
     fig.tight_layout()
-    return _save_and_upload(fig, f"bandpass_flattening_{tag}.png", "Bandpass Flattening")
+    return _save_and_upload(
+        fig,
+        f"bandpass_flattening_{display_tag(tag, get_machine_name())}.png",
+        "Bandpass Flattening",
+    )
 
 
 def plot_bandpass_flattening(
@@ -849,10 +863,16 @@ def plot_bandpass_flattening(
             ax_flat.set_xlabel("fine channel (within coarse channel)")
 
     method = "pfb" if pfb_active else "spline"
-    fig.suptitle(f"Bandpass flattening ({method}, {tag}): {os.path.basename(h5_path)}")
+    fig.suptitle(
+        f"Bandpass flattening ({method}, {display_tag(tag, get_machine_name())}): {os.path.basename(h5_path)}"
+    )
     fig.tight_layout()
 
-    return _save_and_upload(fig, f"bandpass_flattening_{tag}.png", "Bandpass Flattening")
+    return _save_and_upload(
+        fig,
+        f"bandpass_flattening_{display_tag(tag, get_machine_name())}.png",
+        "Bandpass Flattening",
+    )
 
 
 def _select_top_stamps(
@@ -924,9 +944,13 @@ def plot_stamp_gallery(
             f"$k^2$={stat:.3g}\n{freq:.4f} MHz\n{_key_label(record.key, 20)}", fontsize=7
         )
 
-    fig.suptitle(f"Top-{n_cols} energy-detection stamps by statistic ({tag})")
+    fig.suptitle(
+        f"Top-{n_cols} energy-detection stamps by statistic ({display_tag(tag, get_machine_name())})"
+    )
 
-    return _save_and_upload(fig, f"stamp_gallery_{tag}.png", "Stamp Gallery")
+    return _save_and_upload(
+        fig, f"stamp_gallery_{display_tag(tag, get_machine_name())}.png", "Stamp Gallery"
+    )
 
 
 def plot_preproc_funnel(
@@ -1001,12 +1025,14 @@ def plot_preproc_funnel(
     ax.set_xticklabels(labels, rotation=20, ha="right", fontsize=8)
     ax.set_ylabel("count")
     ax.set_title(
-        f"Preprocessing funnel per cadence ({tag}) — stamp storage annotated{aggregated_note}"
+        f"Preprocessing funnel per cadence ({display_tag(tag, get_machine_name())}) — stamp storage annotated{aggregated_note}"
     )
     ax.legend(fontsize=8)
     ax.grid(True, axis="y", alpha=0.2)
 
-    return _save_and_upload(fig, f"preproc_funnel_{tag}.png", "Preprocessing Funnel")
+    return _save_and_upload(
+        fig, f"preproc_funnel_{display_tag(tag, get_machine_name())}.png", "Preprocessing Funnel"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1051,11 +1077,17 @@ def plot_confidence_distribution(records: list[CadenceVizRecord]) -> str | None:
     subtitle = f"{int(total.sum()):,} snippets over {len(with_hist)} cadence(s)"
     if n_skipped:
         subtitle += f" ({n_skipped} cadence(s) resumed earlier, not shown)"
-    ax.set_title(f"Snippet confidence distribution ({tag})\n{subtitle}")
+    ax.set_title(
+        f"Snippet confidence distribution ({display_tag(tag, get_machine_name())})\n{subtitle}"
+    )
     ax.legend(fontsize=8)
     ax.grid(True, alpha=0.2)
 
-    return _save_and_upload(fig, f"confidence_distribution_{tag}.png", "Confidence Distribution")
+    return _save_and_upload(
+        fig,
+        f"confidence_distribution_{display_tag(tag, get_machine_name())}.png",
+        "Confidence Distribution",
+    )
 
 
 def plot_candidate(row: dict, index: int) -> str | None:
@@ -1065,11 +1097,12 @@ def plot_candidate(row: dict, index: int) -> str | None:
     over the TF-free candidate_figures.render_candidate_figure (#298 I9 — the gallery path
     renders these across a forkserver pool; this in-process form serves direct callers)."""
     tag = get_config().checkpoint.save_tag
+    dtag = display_tag(tag, get_machine_name())
     save_path = render_candidate_figure(
-        row, index, tag, _plots_dir(tag), candidate_frequency_range_mhz(row)
+        row, index, dtag, _plots_dir(tag), candidate_frequency_range_mhz(row)
     )
     logger.info(f"Inference viz saved: {save_path}")
-    _uploader.submit(save_path, f"Candidate {index} - ({tag}, {socket.gethostname()})")
+    _uploader.submit(save_path, f"Candidate {index} - ({dtag})")
     return save_path
 
 
@@ -1079,6 +1112,7 @@ def plot_candidate_gallery() -> str | None:
     cadences the resume skipped this pass."""
     config = get_config()
     tag = config.checkpoint.save_tag
+    dtag = display_tag(tag, get_machine_name())
     max_candidate_plots = config.inference.max_candidate_plots
 
     db = get_db()
@@ -1097,13 +1131,12 @@ def plot_candidate_gallery() -> str | None:
     # failures return None and degrade the suite exactly like _viz_safe), then uploaded in
     # index order through the async FIFO uploader.
     top_rows = rows[:max_candidate_plots]
-    rendered = render_candidate_figures(top_rows, tag, _plots_dir(tag))
-    hostname = socket.gethostname()
+    rendered = render_candidate_figures(top_rows, dtag, _plots_dir(tag))
     for index, save_path in rendered:
         if save_path is None:
             continue
         logger.info(f"Inference viz saved: {save_path}")
-        _uploader.submit(save_path, f"Candidate {index} - ({tag}, {hostname})")
+        _uploader.submit(save_path, f"Candidate {index} - ({dtag})")
     if len(rows) > max_candidate_plots:
         logger.info(
             f"Viz: rendered {max_candidate_plots} of {len(rows)} candidate figures "
@@ -1135,9 +1168,13 @@ def plot_candidate_gallery() -> str | None:
             f"P={row.get('confidence', 0):.3f}\n{freq_label}\n{row.get('target') or ''}",
             fontsize=7,
         )
-    fig.suptitle(f"Candidate gallery ({tag}): top {n_cols} of {len(rows)} by confidence")
+    fig.suptitle(
+        f"Candidate gallery ({display_tag(tag, get_machine_name())}): top {n_cols} of {len(rows)} by confidence"
+    )
 
-    return _save_and_upload(fig, f"candidate_gallery_{tag}.png", "Candidate Gallery")
+    return _save_and_upload(
+        fig, f"candidate_gallery_{display_tag(tag, get_machine_name())}.png", "Candidate Gallery"
+    )
 
 
 def plot_candidate_uncertainty() -> str | None:
@@ -1163,7 +1200,9 @@ def plot_candidate_uncertainty() -> str | None:
     )
     rows = [r for r in rows if r.get("mc_mean") is not None and r.get("mc_std") is not None]
 
-    cloud_path = os.path.join(config.output_path, f"inference_reference_cloud_{tag}.npz")
+    cloud_path = os.path.join(
+        config.output_path, f"inference_reference_cloud_{display_tag(tag, get_machine_name())}.npz"
+    )
     cloud = None
     if os.path.exists(cloud_path):
         # Materialize the arrays and close the archive immediately — an NpzFile keeps its
@@ -1228,12 +1267,17 @@ def plot_candidate_uncertainty() -> str | None:
             f" — cloud: {int(cloud['subsample_size'])} of {int(cloud['rejects_seen'])} "
             f"rejects, {int(cloud['mc_draws'])} draws"
         )
-    ax.set_title(f"Candidate uncertainty vs survey population ({tag}){cloud_note}", fontsize=11)
+    ax.set_title(
+        f"Candidate uncertainty vs survey population ({display_tag(tag, get_machine_name())}){cloud_note}",
+        fontsize=11,
+    )
     if rows:
         ax.legend(loc="upper left", fontsize=8)
 
     return _save_and_upload(
-        fig, f"candidate_uncertainty_{tag}.png", "Candidate Uncertainty vs Survey"
+        fig,
+        f"candidate_uncertainty_{display_tag(tag, get_machine_name())}.png",
+        "Candidate Uncertainty vs Survey",
     )
 
 
@@ -1341,13 +1385,15 @@ def plot_inference_latent_projection(collector: InferenceVizCollector) -> str | 
     ax.set_xlabel("UMAP 1")
     ax.set_ylabel("UMAP 2")
     ax.set_title(
-        f"Inference latents through training cadence-level UMAP ({tag})\n"
+        f"Inference latents through training cadence-level UMAP ({display_tag(tag, get_machine_name())})\n"
         f"nn={nn}, md={md}, training tag {train_tag}"
     )
     ax.legend(fontsize=8, loc="best")
 
     return _save_and_upload(
-        fig, f"inference_latent_projection_{tag}.png", "Inference Latent Projection"
+        fig,
+        f"inference_latent_projection_{display_tag(tag, get_machine_name())}.png",
+        "Inference Latent Projection",
     )
 
 
@@ -1433,9 +1479,13 @@ def plot_inference_summary(
         family="monospace",
         transform=ax.transAxes,
     )
-    ax.set_title(f"Inference run summary ({tag})", fontsize=13, pad=14)
+    ax.set_title(
+        f"Inference run summary ({display_tag(tag, get_machine_name())})", fontsize=13, pad=14
+    )
 
-    return _save_and_upload(fig, f"inference_summary_{tag}.png", "Inference Summary")
+    return _save_and_upload(
+        fig, f"inference_summary_{display_tag(tag, get_machine_name())}.png", "Inference Summary"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1453,7 +1503,9 @@ def render_inference_visualizations(
     if config is None:
         raise ValueError("get_config() returned None")
     tag = config.checkpoint.save_tag
-    logger.info(f"Rendering inference visualization suite under plots/inference/{tag}/")
+    logger.info(
+        f"Rendering inference visualization suite under plots/inference/{display_tag(tag, get_machine_name())}/"
+    )
 
     records = collector.records
     if config.inference.inference_viz_scope == "new":

--- a/src/aetherscan/logger/logger.py
+++ b/src/aetherscan/logger/logger.py
@@ -179,12 +179,20 @@ class Logger:
         if self.config is None:
             raise ValueError("get_config() returned None")
 
-        # Per-run, tag-scoped log file: each run writes aetherscan_{tag}.log, so a new run no
-        # longer overwrites the previous run's log. main.py resolves the run's {command}_{datetime}
-        # tag onto config.checkpoint.save_tag before calling init_logger and passes it in here; the
-        # config value is the fallback for any other caller.
+        # Per-run, tag-scoped log file: each run writes aetherscan_{display_tag}.log, so a new run
+        # no longer overwrites the previous run's log. main.py resolves the run's
+        # {command}_{datetime} tag onto config.checkpoint.save_tag before calling init_logger and
+        # passes it in here; the config value is the fallback for any other caller. The FILENAME
+        # carries the display tag ({command}_{machine}_{datetime}); the DB tag is unchanged.
         tag = save_tag if save_tag is not None else self.config.checkpoint.save_tag
-        self.log_path = log_path_for_tag(self.config.output_path, tag)
+        # Deferred import: logger is initialized early and importing db (which pulls in manager) at
+        # module top could cycle — mirror monitor.py's late get_system_metadata import.
+        from aetherscan.db import get_machine_name  # noqa: PLC0415
+        from aetherscan.display_tag import display_tag  # noqa: PLC0415
+
+        self.log_path = log_path_for_tag(
+            self.config.output_path, display_tag(tag, get_machine_name())
+        )
         os.makedirs(os.path.dirname(self.log_path), exist_ok=True)  # Create dir if it doesn't exist
 
         # Create queue for worker processes (no size limit)

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -34,7 +34,8 @@ from aetherscan.cli import (
 )
 from aetherscan.config import get_config, init_config
 from aetherscan.dashboard_launcher import launch_dashboard
-from aetherscan.db import get_db, init_db
+from aetherscan.db import get_db, get_machine_name, init_db
+from aetherscan.display_tag import display_tag
 from aetherscan.hf_hub import resolve_inference_artifacts
 from aetherscan.inference import InferencePipeline, run_inference_pipeline, summarize_confidences
 from aetherscan.inference_viz import InferenceVizCollector, render_inference_visualizations
@@ -291,8 +292,12 @@ def _post_benchmark_report(tag: str) -> None:
             logger.warning(f"Benchmark report skipped: no pipeline_stages rows for tag {tag!r}")
             return
         root = benchmark_report.build_stage_tree(rows)
-        png_path = os.path.join(config.output_path, "plots", f"benchmark_report_{tag}.png")
-        benchmark_report.render_report_png(root, rows, tag, png_path)
+        # tag stays the plain DB tag for load_rows / build_suggestions; the display tag scopes the
+        # PNG filename, on-figure title, and Slack message to this host. The import-free report tool
+        # uses its tag arg only for the suptitle, so passing the display tag there is safe.
+        dtag = display_tag(tag, get_machine_name())
+        png_path = os.path.join(config.output_path, "plots", f"benchmark_report_{dtag}.png")
+        benchmark_report.render_report_png(root, rows, dtag, png_path)
         logger.info(f"Benchmark report saved to {png_path}")
 
         # Bottleneck suggestions ride along as the upload's comment, landing in the run
@@ -304,7 +309,7 @@ def _post_benchmark_report(tag: str) -> None:
         if logger_instance is None:
             raise ValueError("get_logger() returned None")
         if not logger_instance.upload_image_to_slack(
-            png_path, title=f"Benchmark Report - {tag}", message=message
+            png_path, title=f"Benchmark Report - {dtag}", message=message
         ):
             logger.warning("Benchmark report rendered but Slack upload was skipped or failed")
 
@@ -1113,7 +1118,10 @@ def inference_command():
 
     # NOTE: come back to this later (should we create dedicated (tagged) directories inside output_path to store inference results (plots, configs, etc.)? note, data still written to db regardless)
     # Save inference configuration
-    config_path = os.path.join(config.output_path, f"config_{config.checkpoint.save_tag}.json")
+    config_path = os.path.join(
+        config.output_path,
+        f"config_{display_tag(config.checkpoint.save_tag, get_machine_name())}.json",
+    )
     os.makedirs(os.path.dirname(config_path), exist_ok=True)  # Create dir if it doesn't exist
 
     with open(config_path, "w") as f:

--- a/src/aetherscan/main.py
+++ b/src/aetherscan/main.py
@@ -369,9 +369,13 @@ def _post_perband_report(tag: str) -> None:
         spec.loader.exec_module(perband_report)
 
         hostname = socket.gethostname()
-        png_path = os.path.join(config.output_path, "plots", f"perband_inference_perf_{tag}.png")
+        # tag stays the plain DB tag (it keys the pipeline_stages query inside
+        # render_perband_report); the display tag scopes the PNG filename, on-figure title, and
+        # Slack message to this host so cross-host artifacts don't collide (matches the other plots).
+        dtag = display_tag(tag, get_machine_name())
+        png_path = os.path.join(config.output_path, "plots", f"perband_inference_perf_{dtag}.png")
         result = perband_report.render_perband_report(
-            db.db_path, tag, catalog_paths, png_path, hostname
+            db.db_path, tag, catalog_paths, png_path, hostname, display_tag=dtag
         )
         if result is None:
             return  # render_perband_report already logged why it skipped
@@ -381,7 +385,7 @@ def _post_perband_report(tag: str) -> None:
         if logger_instance is None:
             raise ValueError("get_logger() returned None")
         if not logger_instance.upload_image_to_slack(
-            png_path, title=f"Inference performance by band - ({tag}, {hostname})"
+            png_path, title=f"Inference performance by band - ({dtag})"
         ):
             logger.warning(
                 "Per-band inference plot rendered but Slack upload was skipped or failed"

--- a/src/aetherscan/monitor/monitor.py
+++ b/src/aetherscan/monitor/monitor.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import contextlib
 import gc
-import json
 import logging
 import math
 import os
@@ -706,13 +705,15 @@ class ResourceMonitor:
         fig, axes = plt.subplots(3, 1, figsize=(14, 15), sharex=True)
 
         # Late import to avoid circular dependency (db imports from manager)
-        from aetherscan.db import get_system_metadata  # noqa: PLC0415
+        from aetherscan.db import get_machine_name  # noqa: PLC0415
+        from aetherscan.display_tag import display_tag  # noqa: PLC0415
 
-        metadata_json = get_system_metadata()
-        machine_name = json.loads(metadata_json).get("machine_name")
+        # self.tag stays the plain DB tag (its DB queries above); the display tag scopes the
+        # figure title, filename, and Slack message to this host.
+        dtag = display_tag(self.tag, get_machine_name())
 
         fig.suptitle(
-            f"Aetherscan Pipeline: Resource Utilization ({self.tag}, {machine_name})",
+            f"Aetherscan Pipeline: Resource Utilization ({dtag})",
             fontsize=16,
             fontweight="bold",
         )
@@ -879,7 +880,7 @@ class ResourceMonitor:
 
         # Save plot
         output_path = os.path.join(
-            self.config.output_path, "plots", f"resource_utilization_{self.tag}.png"
+            self.config.output_path, "plots", f"resource_utilization_{dtag}.png"
         )
         os.makedirs(os.path.dirname(output_path), exist_ok=True)  # Create dir if it doesn't exist
 
@@ -894,7 +895,7 @@ class ResourceMonitor:
         if logger_instance:
             logger_instance.upload_image_to_slack(
                 output_path,
-                title=f"Resource Utilization - {self.tag}",
+                title=f"Resource Utilization - {dtag}",
             )
 
 

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -38,7 +38,8 @@ from skimage.transform import downscale_local_mean
 from aetherscan.benchmark import stage_timer
 from aetherscan.config import get_config
 from aetherscan.data_generation import log_norm
-from aetherscan.db import get_db
+from aetherscan.db import get_db, get_machine_name
+from aetherscan.display_tag import display_tag
 from aetherscan.logger import init_worker_logging
 from aetherscan.manager import get_manager
 from aetherscan.pfb import edge_mid_band_slices, equalize_passband, gen_coarse_channel_response
@@ -2683,10 +2684,11 @@ class DataPreprocessor:
         fig.tight_layout()
 
         tag = self.config.checkpoint.save_tag
-        save_dir = os.path.join(self.config.output_path, "plots", "inference", tag)
+        dtag = display_tag(tag, get_machine_name())
+        save_dir = os.path.join(self.config.output_path, "plots", "inference", dtag)
         os.makedirs(save_dir, exist_ok=True)
         stem = os.path.splitext(os.path.basename(npy_path))[0]
-        out_path = os.path.join(save_dir, f"bandpass_overlay_{stem}_{tag}.png")
+        out_path = os.path.join(save_dir, f"bandpass_overlay_{stem}_{dtag}.png")
         # No close/registry bookkeeping needed: an OO-API Figure is garbage-collected
         fig.savefig(out_path, dpi=120)
         logger.info(f"Saved bandpass overlay debug plot: {out_path}")

--- a/src/aetherscan/tag_guards.py
+++ b/src/aetherscan/tag_guards.py
@@ -31,7 +31,8 @@ import os
 import sys
 
 from aetherscan.config import get_config
-from aetherscan.db import get_db
+from aetherscan.db import get_db, get_machine_name
+from aetherscan.display_tag import display_tag
 from aetherscan.run_state import STAGE_FINAL_SAVE, load_run_state, run_state_path
 
 logger = logging.getLogger(__name__)
@@ -49,11 +50,15 @@ def find_train_tag_collisions(tag: str) -> list[str]:
     db = get_db()
     collisions: list[str] = []
 
-    encoder_path = os.path.join(config.model_path, f"vae_encoder_{tag}.keras")
+    encoder_path = os.path.join(
+        config.model_path, f"vae_encoder_{display_tag(tag, get_machine_name())}.keras"
+    )
     if os.path.exists(encoder_path):
         collisions.append(f"model artifact exists: {encoder_path}")
 
-    config_path = os.path.join(config.output_path, f"config_{tag}.json")
+    config_path = os.path.join(
+        config.output_path, f"config_{display_tag(tag, get_machine_name())}.json"
+    )
     if os.path.exists(config_path):
         collisions.append(f"saved run config exists: {config_path}")
 
@@ -81,7 +86,9 @@ def find_inference_tag_collisions(tag: str) -> list[str]:
     db = get_db()
     collisions: list[str] = []
 
-    config_path = os.path.join(config.output_path, f"config_{tag}.json")
+    config_path = os.path.join(
+        config.output_path, f"config_{display_tag(tag, get_machine_name())}.json"
+    )
     if os.path.exists(config_path):
         collisions.append(f"saved run config exists (completed run marker): {config_path}")
 
@@ -159,7 +166,7 @@ def enforce_tag_guards(args: argparse.Namespace) -> None:
 
     if command == "train":
         if explicit:
-            manifest_path = run_state_path(config.output_path, tag)
+            manifest_path = run_state_path(config.output_path, display_tag(tag, get_machine_name()))
             # Only an UNFINISHED run's manifest exempts the collision guard. The manifest
             # persists on success, so a completed run's manifest must NOT keep disabling dedup
             # for that tag — otherwise a reused --save-tag would silently overwrite a finished

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -5966,8 +5966,7 @@ class TrainingPipeline:
         if tag is None:
             tag = self.config.checkpoint.save_tag
 
-        metadata_json = get_system_metadata()
-        machine_name = json.loads(metadata_json).get("machine_name")
+        machine_name = get_machine_name()
 
         max_fpr = self.config.rf.selection_max_fpr
 
@@ -5992,7 +5991,7 @@ class TrainingPipeline:
 
         fig = plt.figure(figsize=(13, 10))
         fig.suptitle(
-            f"RF Latent-Variant Selection ({tag}, {machine_name})",
+            f"RF Latent-Variant Selection ({display_tag(tag, machine_name)})",
             fontsize=16,
             fontweight="bold",
         )
@@ -6086,7 +6085,8 @@ class TrainingPipeline:
         plt.tight_layout(rect=[0, 0, 1, 0.96])
 
         save_path = os.path.join(
-            self._training_plots_dir(dir), f"latent_variant_selection_{tag}.png"
+            self._training_plots_dir(dir),
+            f"latent_variant_selection_{display_tag(tag, machine_name)}.png",
         )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=200, bbox_inches="tight")
@@ -6097,7 +6097,7 @@ class TrainingPipeline:
         if logger_instance:
             logger_instance.upload_image_to_slack(
                 save_path,
-                title=f"RF Latent-Variant Selection - ({tag}, {machine_name})",
+                title=f"RF Latent-Variant Selection - ({display_tag(tag, machine_name)})",
             )
 
     # TODO: implement plot_rf_snr_sensitivity_curve()

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -48,7 +48,8 @@ from tensorflow.keras.layers import Conv2D, Dense
 from aetherscan.benchmark import round_stage_name, stage_timer
 from aetherscan.config import get_config
 from aetherscan.data_generation import DataGenerator
-from aetherscan.db import get_db, get_system_metadata
+from aetherscan.db import get_db, get_machine_name
+from aetherscan.display_tag import display_tag
 from aetherscan.hf_hub import upload_run_to_hf
 from aetherscan.latent_gif import run_umap_gif_sweep
 from aetherscan.latent_variants import (
@@ -252,8 +253,10 @@ def archive_directory(base_dir: str, target_dirs: list[str] | None = None, round
 
 def _model_pair_exists(base_dir: str, tag: str) -> bool:
     """True when the encoder/decoder pair for `tag` both exist in base_dir."""
-    return os.path.exists(os.path.join(base_dir, f"vae_encoder_{tag}.keras")) and os.path.exists(
-        os.path.join(base_dir, f"vae_decoder_{tag}.keras")
+    return os.path.exists(
+        os.path.join(base_dir, f"vae_encoder_{display_tag(tag, get_machine_name())}.keras")
+    ) and os.path.exists(
+        os.path.join(base_dir, f"vae_decoder_{display_tag(tag, get_machine_name())}.keras")
     )
 
 
@@ -381,7 +384,7 @@ def check_val_auc_floor(
         logger.warning(
             f"MODEL QUALITY GATE UNMET: validation ROC-AUC {val_auc:.4f} is below the "
             f"configured floor training.min_val_auc={min_val_auc} for tag '{tag}'. The "
-            f"trained model may be degenerate — inspect rf_eval_artifacts_{tag}.joblib "
+            f"trained model may be degenerate — inspect rf_eval_artifacts_{display_tag(tag, get_machine_name())}.joblib "
             f"before promoting this model."
         )
     else:
@@ -1330,7 +1333,12 @@ class TrainingPipeline:
           epochs corrupt the loss-curve plots (which sort by (round, epoch)).
         """
         tag = self.config.checkpoint.save_tag
-        self._run_state_path = run_state_path(self.config.output_path, tag)
+        # Manifest FILENAME carries the display tag (this host); its stored `tag` field below stays
+        # the plain DB tag (identity / DB supersede). Resume derives the same display tag on the
+        # same host, so it locates the manifest a prior attempt wrote.
+        self._run_state_path = run_state_path(
+            self.config.output_path, display_tag(tag, get_machine_name())
+        )
 
         state = load_run_state(self._run_state_path)
 
@@ -1497,7 +1505,9 @@ class TrainingPipeline:
         round_data_root = self.config.training.round_data_dir or self.config.get_training_file_path(
             "round_data"
         )
-        self._round_data_base_dir = os.path.join(round_data_root, self.config.checkpoint.save_tag)
+        self._round_data_base_dir = os.path.join(
+            round_data_root, display_tag(self.config.checkpoint.save_tag, get_machine_name())
+        )
         prepare_round_data_dir(
             self._round_data_base_dir,
             start_round,
@@ -3103,7 +3113,8 @@ class TrainingPipeline:
                         f"Brier={metrics['brier']:.4f}, ECE={metrics['ece']:.4f}"
                     )
                     variant_path = os.path.join(
-                        self.config.model_path, f"random_forest_{tag}_{variant}.joblib"
+                        self.config.model_path,
+                        f"random_forest_{display_tag(tag, get_machine_name())}_{variant}.joblib",
                     )
                     os.makedirs(os.path.dirname(variant_path), exist_ok=True)
                     joblib.dump(clf, variant_path)
@@ -3222,7 +3233,8 @@ class TrainingPipeline:
             self.config.rf.calibration_method = calibrator["method"] if calibrator else None
             if calibrator is not None:
                 calibrator_path = os.path.join(
-                    self.config.model_path, f"rf_calibrator_{tag}.joblib"
+                    self.config.model_path,
+                    f"rf_calibrator_{display_tag(tag, get_machine_name())}.joblib",
                 )
                 joblib.dump(calibrator, calibrator_path)
                 logger.info(f"Saved probability calibrator to {calibrator_path}")
@@ -3310,7 +3322,10 @@ class TrainingPipeline:
                     "test_idx": test_idx,
                 },
             }
-            artifact_path = os.path.join(self.config.model_path, f"rf_eval_artifacts_{tag}.joblib")
+            artifact_path = os.path.join(
+                self.config.model_path,
+                f"rf_eval_artifacts_{display_tag(tag, get_machine_name())}.joblib",
+            )
             os.makedirs(os.path.dirname(artifact_path), exist_ok=True)
             joblib.dump(artifacts, artifact_path)
             logger.info(f"Saved RF eval artifacts to {artifact_path}")
@@ -3327,7 +3342,10 @@ class TrainingPipeline:
             # Persist the trained RF immediately (final_save re-saves it later): a retry that
             # resumes into rf_plots/final_save can then reload the model without regenerating
             # data — see try_load_rf_for_resume()
-            rf_model_path = os.path.join(self.config.model_path, f"random_forest_{tag}.joblib")
+            rf_model_path = os.path.join(
+                self.config.model_path,
+                f"random_forest_{display_tag(tag, get_machine_name())}.joblib",
+            )
             self.rf_model.save(rf_model_path)
             logger.info(f"Saved Random Forest to {rf_model_path}")
 
@@ -3436,8 +3454,13 @@ class TrainingPipeline:
         and ready; False falls back to full RF training.
         """
         tag = self.config.checkpoint.save_tag
-        rf_model_path = os.path.join(self.config.model_path, f"random_forest_{tag}.joblib")
-        artifact_path = os.path.join(self.config.model_path, f"rf_eval_artifacts_{tag}.joblib")
+        rf_model_path = os.path.join(
+            self.config.model_path, f"random_forest_{display_tag(tag, get_machine_name())}.joblib"
+        )
+        artifact_path = os.path.join(
+            self.config.model_path,
+            f"rf_eval_artifacts_{display_tag(tag, get_machine_name())}.joblib",
+        )
 
         if not (os.path.exists(rf_model_path) and os.path.exists(artifact_path)):
             return False
@@ -3480,7 +3503,10 @@ class TrainingPipeline:
         if tag in self._rf_artifacts_cache:
             return self._rf_artifacts_cache[tag]
 
-        artifact_path = os.path.join(self.config.model_path, f"rf_eval_artifacts_{tag}.joblib")
+        artifact_path = os.path.join(
+            self.config.model_path,
+            f"rf_eval_artifacts_{display_tag(tag, get_machine_name())}.joblib",
+        )
         if not os.path.exists(artifact_path):
             raise FileNotFoundError(
                 f"RF eval artifacts not found at {artifact_path}. "
@@ -3522,7 +3548,9 @@ class TrainingPipeline:
         if tag in self._rf_shap_cache:
             return self._rf_shap_cache[tag]
 
-        shap_path = os.path.join(self.config.model_path, f"rf_shap_values_{tag}.joblib")
+        shap_path = os.path.join(
+            self.config.model_path, f"rf_shap_values_{display_tag(tag, get_machine_name())}.joblib"
+        )
 
         if os.path.exists(shap_path):
             logger.info(f"Loading cached SHAP values from {shap_path}")
@@ -3551,7 +3579,9 @@ class TrainingPipeline:
         # shap's TreeSHAP C extension is single-threaded, so we chunk the samples across processes
         # (aetherscan.shap_parallel), each rebuilding a stock TreeExplainer — byte-identical to the
         # serial result. Workers load the RF from its persisted joblib, so make sure it is on disk.
-        rf_path = os.path.join(self.config.model_path, f"random_forest_{tag}.joblib")
+        rf_path = os.path.join(
+            self.config.model_path, f"random_forest_{display_tag(tag, get_machine_name())}.joblib"
+        )
         # Always (re)dump so the workers load exactly the in-process model — a stale on-disk RF under
         # a reused tag would otherwise silently diverge from the expected_value computed below.
         joblib.dump(self.rf_model.model, rf_path)
@@ -3640,7 +3670,10 @@ class TrainingPipeline:
     def _training_plots_dir(self, subdir: str | None = None) -> str:
         """This run's training-plots base: ``{output_path}/plots/training/{save_tag}[/subdir]``."""
         base = os.path.join(
-            self.config.output_path, "plots", "training", self.config.checkpoint.save_tag
+            self.config.output_path,
+            "plots",
+            "training",
+            display_tag(self.config.checkpoint.save_tag, get_machine_name()),
         )
         return os.path.join(base, subdir) if subdir else base
 
@@ -3649,8 +3682,7 @@ class TrainingPipeline:
         if tag is None:
             tag = self.config.checkpoint.save_tag
 
-        metadata_json = get_system_metadata()
-        machine_name = json.loads(metadata_json).get("machine_name")
+        machine_name = get_machine_name()
 
         current_time = time.time()
 
@@ -3713,7 +3745,9 @@ class TrainingPipeline:
         ax_false = fig.add_subplot(gs[1, 3])
 
         fig.suptitle(
-            f"Beta-VAE Loss Curves ({tag}, {machine_name})", fontsize=18, fontweight="bold"
+            f"Beta-VAE Loss Curves ({display_tag(tag, machine_name)})",
+            fontsize=18,
+            fontweight="bold",
         )
 
         # Top subplot gets shading + text annotations, bottom subplots get shading only
@@ -3789,7 +3823,10 @@ class TrainingPipeline:
         plt.tight_layout()
 
         # Save plot
-        save_path = os.path.join(self._training_plots_dir(dir), f"beta_vae_loss_curves_{tag}.png")
+        save_path = os.path.join(
+            self._training_plots_dir(dir),
+            f"beta_vae_loss_curves_{display_tag(tag, machine_name)}.png",
+        )
 
         os.makedirs(os.path.dirname(save_path), exist_ok=True)  # Create dir if it doesn't exist
 
@@ -3804,7 +3841,7 @@ class TrainingPipeline:
         if logger_instance:
             logger_instance.upload_image_to_slack(
                 save_path,
-                title=f"Beta-VAE Loss Curves - ({tag}, {machine_name})",
+                title=f"Beta-VAE Loss Curves - ({display_tag(tag, machine_name)})",
             )
 
         # NOTE:
@@ -3834,8 +3871,7 @@ class TrainingPipeline:
         if tag is None:
             tag = self.config.checkpoint.save_tag
 
-        metadata_json = get_system_metadata()
-        machine_name = json.loads(metadata_json).get("machine_name")
+        machine_name = get_machine_name()
 
         current_time = time.time()
 
@@ -3899,7 +3935,9 @@ class TrainingPipeline:
         ax_max = fig.add_subplot(gs[1, 2])
 
         fig.suptitle(
-            f"Beta-VAE Training Stability ({tag}, {machine_name})", fontsize=18, fontweight="bold"
+            f"Beta-VAE Training Stability ({display_tag(tag, machine_name)})",
+            fontsize=18,
+            fontweight="bold",
         )
 
         # Top subplot gets shading + text annotations, bottom subplots get shading only
@@ -4013,7 +4051,8 @@ class TrainingPipeline:
 
         # Save plot
         save_path = os.path.join(
-            self._training_plots_dir(dir), f"beta_vae_training_stability_{tag}.png"
+            self._training_plots_dir(dir),
+            f"beta_vae_training_stability_{display_tag(tag, machine_name)}.png",
         )
 
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
@@ -4028,7 +4067,7 @@ class TrainingPipeline:
         if logger_instance:
             logger_instance.upload_image_to_slack(
                 save_path,
-                title=f"Beta-VAE Training Stability - ({tag}, {machine_name})",
+                title=f"Beta-VAE Training Stability - ({display_tag(tag, machine_name)})",
             )
 
         del history, snr_by_round, epochs
@@ -4233,7 +4272,10 @@ class TrainingPipeline:
         ax_active.grid(True, alpha=0.3)
 
         plt.tight_layout()
-        save_path = os.path.join(self._training_plots_dir(dir), f"posterior_collapse_{tag}.png")
+        save_path = os.path.join(
+            self._training_plots_dir(dir),
+            f"posterior_collapse_{display_tag(tag, get_machine_name())}.png",
+        )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=200, bbox_inches="tight")
         plt.close()
@@ -4242,7 +4284,8 @@ class TrainingPipeline:
         logger_instance = get_logger()
         if logger_instance:
             logger_instance.upload_image_to_slack(
-                save_path, title=f"Posterior Collapse Diagnostics - ({tag})"
+                save_path,
+                title=f"Posterior Collapse Diagnostics - ({display_tag(tag, get_machine_name())})",
             )
 
     # TODO: reorder plot methods (def & call sites): train -> latent -> injection
@@ -4269,8 +4312,7 @@ class TrainingPipeline:
         save_dir = self._training_plots_dir(dir)
         os.makedirs(save_dir, exist_ok=True)
 
-        metadata_json = get_system_metadata()
-        machine_name = json.loads(metadata_json).get("machine_name")
+        machine_name = get_machine_name()
 
         current_time = time.time()
 
@@ -4400,7 +4442,9 @@ class TrainingPipeline:
         ]
         del results
 
-        save_path = os.path.join(save_dir, f"injected_signal_characteristics_{tag}.png")
+        save_path = os.path.join(
+            save_dir, f"injected_signal_characteristics_{display_tag(tag, machine_name)}.png"
+        )
         self._plot_injected_signal_characteristics(
             eti_stats,
             rfi_stats,
@@ -4465,7 +4509,9 @@ class TrainingPipeline:
                 clamping_rates_by_round[round_num] = clamped / total if total > 0 else 0.0
         del clamping_results
 
-        save_path = os.path.join(save_dir, f"injection_stability_{tag}.png")
+        save_path = os.path.join(
+            save_dir, f"injection_stability_{display_tag(tag, machine_name)}.png"
+        )
         self._plot_injection_stability(
             sanitization_rates_by_stat,
             clamping_rates_by_round,
@@ -4510,7 +4556,8 @@ class TrainingPipeline:
 
             # Generate plot for this signal_type
             save_path = os.path.join(
-                save_dir, f"{signal_type}_global_intensity_distributions_{tag}.png"
+                save_dir,
+                f"{signal_type}_global_intensity_distributions_{display_tag(tag, machine_name)}.png",
             )
             self._plot_global_intensity_distributions(
                 stats_by_stage, signal_type, tag, machine_name, save_path
@@ -4556,7 +4603,9 @@ class TrainingPipeline:
 
                 transitions[stat_name][signal_type] = (values_a, values_b)
 
-        save_path = os.path.join(save_dir, f"a_b_global_intensity_biases_{tag}.png")
+        save_path = os.path.join(
+            save_dir, f"a_b_global_intensity_biases_{display_tag(tag, machine_name)}.png"
+        )
         self._plot_injection_intensity_biases(transitions, tag, machine_name, save_path)
 
         del transitions
@@ -4581,7 +4630,9 @@ class TrainingPipeline:
                 stats_by_type[signal_type][stat_name] = [r["value"] for r in results]
                 del results
 
-        save_path = os.path.join(save_dir, f"final_global_intensity_biases_{tag}.png")
+        save_path = os.path.join(
+            save_dir, f"final_global_intensity_biases_{display_tag(tag, machine_name)}.png"
+        )
         self._plot_final_intensity_biases(stats_by_type, tag, machine_name, save_path)
 
         del stats_by_type
@@ -4624,7 +4675,7 @@ class TrainingPipeline:
         gs = fig.add_gridspec(3, 3, height_ratios=[1, 1, 1], hspace=0.3, wspace=0.3)
 
         fig.suptitle(
-            f"Injected Signal Characteristics ({tag}, {machine_name})",
+            f"Injected Signal Characteristics ({display_tag(tag, machine_name)})",
             fontsize=16,
             fontweight="bold",
         )
@@ -4730,7 +4781,7 @@ class TrainingPipeline:
         if logger_instance:
             logger_instance.upload_image_to_slack(
                 save_path,
-                title=f"Injected signal characteristics - ({tag}, {machine_name})",
+                title=f"Injected signal characteristics - ({display_tag(tag, machine_name)})",
             )
 
     def _plot_injection_stability(
@@ -4785,7 +4836,7 @@ class TrainingPipeline:
         ax_clamping = fig.add_subplot(gs[1])
 
         fig.suptitle(
-            f"Injection Stability ({tag}, {machine_name})",
+            f"Injection Stability ({display_tag(tag, machine_name)})",
             fontsize=16,
             fontweight="bold",
         )
@@ -4878,7 +4929,7 @@ class TrainingPipeline:
         if logger_instance:
             logger_instance.upload_image_to_slack(
                 save_path,
-                title=f"Injection stability - ({tag}, {machine_name})",
+                title=f"Injection stability - ({display_tag(tag, machine_name)})",
             )
 
         del snr_by_round
@@ -4912,7 +4963,7 @@ class TrainingPipeline:
 
         fig, axes = plt.subplots(2, 3, figsize=(15, 10))
         fig.suptitle(
-            f"{signal_type} Global Intensities ({tag}, {machine_name})",
+            f"{signal_type} Global Intensities ({display_tag(tag, machine_name)})",
             fontsize=16,
             fontweight="bold",
         )
@@ -4992,7 +5043,7 @@ class TrainingPipeline:
         if logger_instance:
             logger_instance.upload_image_to_slack(
                 save_path,
-                title=f"{signal_type} global intensity distributions - ({tag}, {machine_name})",
+                title=f"{signal_type} global intensity distributions - ({display_tag(tag, machine_name)})",
             )
 
     def _plot_injection_intensity_biases(
@@ -5046,7 +5097,7 @@ class TrainingPipeline:
 
         fig, axes = plt.subplots(2, 3, figsize=(15, 10))
         fig.suptitle(
-            f"A→B Global Intensity Biases — Subsampled {max_points} pts, {outlier_pct} pct ({tag}, {machine_name})",
+            f"A→B Global Intensity Biases — Subsampled {max_points} pts, {outlier_pct} pct ({display_tag(tag, machine_name)})",
             fontsize=16,
             fontweight="bold",
         )
@@ -5148,7 +5199,7 @@ class TrainingPipeline:
         if logger_instance:
             logger_instance.upload_image_to_slack(
                 save_path,
-                title=f"A→B global intensity biases - ({tag}, {machine_name})",
+                title=f"A→B global intensity biases - ({display_tag(tag, machine_name)})",
             )
 
     def _plot_final_intensity_biases(
@@ -5191,7 +5242,7 @@ class TrainingPipeline:
 
         fig, axes = plt.subplots(2, 3, figsize=(15, 10))
         fig.suptitle(
-            f"Final Global Intensity Biases ({tag}, {machine_name})",
+            f"Final Global Intensity Biases ({display_tag(tag, machine_name)})",
             fontsize=16,
             fontweight="bold",
         )
@@ -5249,7 +5300,7 @@ class TrainingPipeline:
         if logger_instance:
             logger_instance.upload_image_to_slack(
                 save_path,
-                title=f"Final global intensity biases - ({tag}, {machine_name})",
+                title=f"Final global intensity biases - ({display_tag(tag, machine_name)})",
             )
 
     # NOTE: come back to this later (verify what happens when self._latent_viz_batch and/or self._latent_viz_labels is None)
@@ -5538,7 +5589,8 @@ class TrainingPipeline:
                             "bundle_path": bundle_path,
                             "frames_dir": temp_dir,
                             "gif_path": os.path.join(
-                                save_dir, f"latent_space_{method_name}_{tag}.gif"
+                                save_dir,
+                                f"latent_space_{method_name}_{display_tag(tag, get_machine_name())}.gif",
                             ),
                             "umap_path": os.path.join(
                                 self.config.model_path,
@@ -5577,7 +5629,7 @@ class TrainingPipeline:
                 if logger_instance:
                     logger_instance.upload_image_to_slack(
                         result["gif_path"],
-                        title=f"Latent Space {result['display_method']} - ({tag})",
+                        title=f"Latent Space {result['display_method']} - ({display_tag(tag, get_machine_name())})",
                     )
 
         # Cleanup (frame PNGs + the sweep input bundle)
@@ -5616,8 +5668,7 @@ class TrainingPipeline:
             )
             return
 
-        metadata_json = get_system_metadata()
-        machine_name = json.loads(metadata_json).get("machine_name")
+        machine_name = get_machine_name()
 
         num_steps = self.config.training.latent_traversal_num_steps
         max_sigma = self.config.training.latent_traversal_max_sigma
@@ -5762,7 +5813,7 @@ class TrainingPipeline:
             squeeze=False,
         )
         fig.suptitle(
-            f"Latent Traversal — {display_name} ({tag}, {machine_name})",
+            f"Latent Traversal — {display_name} ({display_tag(tag, machine_name)})",
             fontsize=16,
             fontweight="bold",
         )
@@ -5801,9 +5852,9 @@ class TrainingPipeline:
 
         self._save_traversal_figure(
             fig,
-            f"latent_traversal_{signal_type}_{tag}.png",
+            f"latent_traversal_{signal_type}_{display_tag(tag, machine_name)}.png",
             dir,
-            slack_title=f"Latent Traversal ({display_name}) - ({tag}, {machine_name})",
+            slack_title=f"Latent Traversal ({display_name}) - ({display_tag(tag, machine_name)})",
         )
 
     def _render_traversal_spectra(
@@ -5830,7 +5881,7 @@ class TrainingPipeline:
             nrows, ncols, figsize=(4.5 * ncols, 3.2 * nrows + 1.0), squeeze=False
         )
         fig.suptitle(
-            f"Latent Traversal Spectra — {display_name} ({tag}, {machine_name})",
+            f"Latent Traversal Spectra — {display_name} ({display_tag(tag, machine_name)})",
             fontsize=16,
             fontweight="bold",
         )
@@ -5877,9 +5928,9 @@ class TrainingPipeline:
 
         self._save_traversal_figure(
             fig,
-            f"latent_traversal_spectra_{signal_type}_{tag}.png",
+            f"latent_traversal_spectra_{signal_type}_{display_tag(tag, machine_name)}.png",
             dir,
-            slack_title=f"Latent Traversal Spectra ({display_name}) - ({tag}, {machine_name})",
+            slack_title=f"Latent Traversal Spectra ({display_name}) - ({display_tag(tag, machine_name)})",
         )
 
     def plot_rf_latent_variant_selection(
@@ -6052,8 +6103,7 @@ class TrainingPipeline:
         if tag is None:
             tag = self.config.checkpoint.save_tag
 
-        metadata_json = get_system_metadata()
-        machine_name = json.loads(metadata_json).get("machine_name")
+        machine_name = get_machine_name()
 
         artifacts = self._load_rf_eval_artifacts(tag)
         val_binary = artifacts["val_binary_labels"]
@@ -6102,7 +6152,7 @@ class TrainingPipeline:
         ax_subtype = fig.add_subplot(gs[0, 1])
 
         fig.suptitle(
-            f"Random Forest Confusion Matrices (t={classification_threshold:.2f}, {tag}, {machine_name})",
+            f"Random Forest Confusion Matrices (t={classification_threshold:.2f}, {display_tag(tag, machine_name)})",
             fontsize=15,
             fontweight="bold",
         )
@@ -6151,7 +6201,10 @@ class TrainingPipeline:
 
         plt.tight_layout()
 
-        save_path = os.path.join(self._training_plots_dir(dir), f"rf_confusion_matrices_{tag}.png")
+        save_path = os.path.join(
+            self._training_plots_dir(dir),
+            f"rf_confusion_matrices_{display_tag(tag, machine_name)}.png",
+        )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
         plt.close(fig)
@@ -6161,7 +6214,7 @@ class TrainingPipeline:
         if logger_instance:
             logger_instance.upload_image_to_slack(
                 save_path,
-                title=f"RF Confusion Matrices - ({tag}, {machine_name})",
+                title=f"RF Confusion Matrices - ({display_tag(tag, machine_name)})",
             )
 
         del artifacts, cm_binary, cm_binary_norm, cm_subtype, cm_subtype_norm
@@ -6176,8 +6229,7 @@ class TrainingPipeline:
         if tag is None:
             tag = self.config.checkpoint.save_tag
 
-        metadata_json = get_system_metadata()
-        machine_name = json.loads(metadata_json).get("machine_name")
+        machine_name = get_machine_name()
 
         artifacts = self._load_rf_eval_artifacts(tag)
         val_binary = artifacts["val_binary_labels"]
@@ -6205,7 +6257,7 @@ class TrainingPipeline:
 
         fig, axes = plt.subplots(2, 2, figsize=(14, 12))
         fig.suptitle(
-            f"Random Forest Classification Curves ({tag}, {machine_name})",
+            f"Random Forest Classification Curves ({display_tag(tag, machine_name)})",
             fontsize=15,
             fontweight="bold",
         )
@@ -6324,7 +6376,8 @@ class TrainingPipeline:
         plt.tight_layout()
 
         save_path = os.path.join(
-            self._training_plots_dir(dir), f"rf_classification_curves_{tag}.png"
+            self._training_plots_dir(dir),
+            f"rf_classification_curves_{display_tag(tag, machine_name)}.png",
         )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
@@ -6335,7 +6388,7 @@ class TrainingPipeline:
         if logger_instance:
             logger_instance.upload_image_to_slack(
                 save_path,
-                title=f"RF Classification Curves - ({tag}, {machine_name})",
+                title=f"RF Classification Curves - ({display_tag(tag, machine_name)})",
             )
 
         del artifacts, fpr, tpr, roc_thresholds, precision, recall, pr_thresholds
@@ -6365,8 +6418,7 @@ class TrainingPipeline:
         if tag is None:
             tag = self.config.checkpoint.save_tag
 
-        metadata_json = get_system_metadata()
-        machine_name = json.loads(metadata_json).get("machine_name")
+        machine_name = get_machine_name()
 
         artifacts = self._load_rf_eval_artifacts(tag)
         shap_data = self._compute_or_load_shap_values(artifacts)
@@ -6387,13 +6439,15 @@ class TrainingPipeline:
         )
         fig = plt.gcf()
         fig.suptitle(
-            f"Random Forest SHAP Summary ({tag}, {machine_name})",
+            f"Random Forest SHAP Summary ({display_tag(tag, machine_name)})",
             fontsize=14,
             fontweight="bold",
             y=1.02,
         )
 
-        save_path = os.path.join(self._training_plots_dir(dir), f"rf_shap_summary_{tag}.png")
+        save_path = os.path.join(
+            self._training_plots_dir(dir), f"rf_shap_summary_{display_tag(tag, machine_name)}.png"
+        )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
         plt.close(fig)
@@ -6403,7 +6457,7 @@ class TrainingPipeline:
         if logger_instance:
             logger_instance.upload_image_to_slack(
                 save_path,
-                title=f"RF SHAP Summary - ({tag}, {machine_name})",
+                title=f"RF SHAP Summary - ({display_tag(tag, machine_name)})",
             )
 
         del artifacts, shap_data, shap_values, summary_indices, features_sub
@@ -6418,8 +6472,7 @@ class TrainingPipeline:
         if tag is None:
             tag = self.config.checkpoint.save_tag
 
-        metadata_json = get_system_metadata()
-        machine_name = json.loads(metadata_json).get("machine_name")
+        machine_name = get_machine_name()
 
         artifacts = self._load_rf_eval_artifacts(tag)
         shap_data = self._compute_or_load_shap_values(artifacts)
@@ -6440,7 +6493,7 @@ class TrainingPipeline:
         axes_flat = axes.flatten() if n_rows * n_cols > 1 else [axes]
 
         fig.suptitle(
-            f"Random Forest SHAP Dependence ({tag}, {machine_name})",
+            f"Random Forest SHAP Dependence ({display_tag(tag, machine_name)})",
             fontsize=15,
             fontweight="bold",
         )
@@ -6478,7 +6531,10 @@ class TrainingPipeline:
 
         plt.tight_layout(rect=[0, 0, 1, 0.96])
 
-        save_path = os.path.join(self._training_plots_dir(dir), f"rf_shap_dependence_{tag}.png")
+        save_path = os.path.join(
+            self._training_plots_dir(dir),
+            f"rf_shap_dependence_{display_tag(tag, machine_name)}.png",
+        )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
         plt.close(fig)
@@ -6488,7 +6544,7 @@ class TrainingPipeline:
         if logger_instance:
             logger_instance.upload_image_to_slack(
                 save_path,
-                title=f"RF SHAP Dependence - ({tag}, {machine_name})",
+                title=f"RF SHAP Dependence - ({display_tag(tag, machine_name)})",
             )
 
         del artifacts, shap_data, shap_values, summary_indices, features_sub
@@ -6506,8 +6562,7 @@ class TrainingPipeline:
         if tag is None:
             tag = self.config.checkpoint.save_tag
 
-        metadata_json = get_system_metadata()
-        machine_name = json.loads(metadata_json).get("machine_name")
+        machine_name = get_machine_name()
 
         artifacts = self._load_rf_eval_artifacts(tag)
         shap_data = self._compute_or_load_shap_values(artifacts)
@@ -6542,13 +6597,16 @@ class TrainingPipeline:
 
         fig = plt.gcf()
         fig.suptitle(
-            f"Random Forest SHAP Interactions ({tag}, {machine_name})",
+            f"Random Forest SHAP Interactions ({display_tag(tag, machine_name)})",
             fontsize=14,
             fontweight="bold",
             y=1.02,
         )
 
-        save_path = os.path.join(self._training_plots_dir(dir), f"rf_shap_interactions_{tag}.png")
+        save_path = os.path.join(
+            self._training_plots_dir(dir),
+            f"rf_shap_interactions_{display_tag(tag, machine_name)}.png",
+        )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
         plt.close(fig)
@@ -6558,7 +6616,7 @@ class TrainingPipeline:
         if logger_instance:
             logger_instance.upload_image_to_slack(
                 save_path,
-                title=f"RF SHAP Interactions - ({tag}, {machine_name})",
+                title=f"RF SHAP Interactions - ({display_tag(tag, machine_name)})",
             )
 
         del artifacts, shap_data, interaction_values, interaction_indices, features_sub
@@ -6576,8 +6634,7 @@ class TrainingPipeline:
         if tag is None:
             tag = self.config.checkpoint.save_tag
 
-        metadata_json = get_system_metadata()
-        machine_name = json.loads(metadata_json).get("machine_name")
+        machine_name = get_machine_name()
 
         artifacts = self._load_rf_eval_artifacts(tag)
         shap_data = self._compute_or_load_shap_values(artifacts)
@@ -6597,7 +6654,7 @@ class TrainingPipeline:
 
         fig, axes = plt.subplots(1, 2, figsize=(16, 6))
         fig.suptitle(
-            f"Random Forest SHAP Loss Monitoring ({tag}, {machine_name})",
+            f"Random Forest SHAP Loss Monitoring ({display_tag(tag, machine_name)})",
             fontsize=15,
             fontweight="bold",
         )
@@ -6651,7 +6708,8 @@ class TrainingPipeline:
         plt.tight_layout()
 
         save_path = os.path.join(
-            self._training_plots_dir(dir), f"rf_shap_loss_monitoring_{tag}.png"
+            self._training_plots_dir(dir),
+            f"rf_shap_loss_monitoring_{display_tag(tag, machine_name)}.png",
         )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
@@ -6662,7 +6720,7 @@ class TrainingPipeline:
         if logger_instance:
             logger_instance.upload_image_to_slack(
                 save_path,
-                title=f"RF SHAP Loss Monitoring - ({tag}, {machine_name})",
+                title=f"RF SHAP Loss Monitoring - ({display_tag(tag, machine_name)})",
             )
 
         del artifacts, shap_data, shap_logloss, per_sample_logloss, mean_logloss_shap
@@ -6680,8 +6738,7 @@ class TrainingPipeline:
         if tag is None:
             tag = self.config.checkpoint.save_tag
 
-        metadata_json = get_system_metadata()
-        machine_name = json.loads(metadata_json).get("machine_name")
+        machine_name = get_machine_name()
 
         artifacts = self._load_rf_eval_artifacts(tag)
         shap_data = self._compute_or_load_shap_values(artifacts)
@@ -6699,7 +6756,10 @@ class TrainingPipeline:
         # layout. Unlike the cadence-level UMAP that plot_latent_space_gif fits
         # on raw latents, this projection is over the (n_summary × 48) SHAP
         # matrix, so it lives in its own joblib.
-        clustering_path = os.path.join(self.config.model_path, f"rf_shap_clustering_{tag}.joblib")
+        clustering_path = os.path.join(
+            self.config.model_path,
+            f"rf_shap_clustering_{display_tag(tag, get_machine_name())}.joblib",
+        )
         if os.path.exists(clustering_path):
             logger.info(f"Loading cached SHAP clustering from {clustering_path}")
             cached = joblib.load(clustering_path)
@@ -6746,7 +6806,7 @@ class TrainingPipeline:
 
         fig, ax = plt.subplots(1, 1, figsize=(11, 9))
         fig.suptitle(
-            f"Random Forest SHAP Explanation Clustering (t={classification_threshold:.2f}, {tag}, {machine_name})",
+            f"Random Forest SHAP Explanation Clustering (t={classification_threshold:.2f}, {display_tag(tag, machine_name)})",
             fontsize=14,
             fontweight="bold",
         )
@@ -6814,7 +6874,8 @@ class TrainingPipeline:
         plt.tight_layout()
 
         save_path = os.path.join(
-            self._training_plots_dir(dir), f"rf_shap_explanation_clustering_{tag}.png"
+            self._training_plots_dir(dir),
+            f"rf_shap_explanation_clustering_{display_tag(tag, machine_name)}.png",
         )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
@@ -6825,7 +6886,7 @@ class TrainingPipeline:
         if logger_instance:
             logger_instance.upload_image_to_slack(
                 save_path,
-                title=f"RF SHAP Explanation Clustering - ({tag}, {machine_name})",
+                title=f"RF SHAP Explanation Clustering - ({display_tag(tag, machine_name)})",
             )
 
         del artifacts, shap_data, shap_values, embedding, cluster_labels
@@ -6840,8 +6901,7 @@ class TrainingPipeline:
         if tag is None:
             tag = self.config.checkpoint.save_tag
 
-        metadata_json = get_system_metadata()
-        machine_name = json.loads(metadata_json).get("machine_name")
+        machine_name = get_machine_name()
 
         artifacts = self._load_rf_eval_artifacts(tag)
         val_binary = artifacts["val_binary_labels"]
@@ -6870,7 +6930,7 @@ class TrainingPipeline:
 
         fig, axes = plt.subplots(2, 1, figsize=(9, 11), gridspec_kw={"height_ratios": [2, 1]})
         fig.suptitle(
-            f"Random Forest Calibration Curve ({tag}, {machine_name})",
+            f"Random Forest Calibration Curve ({display_tag(tag, machine_name)})",
             fontsize=15,
             fontweight="bold",
         )
@@ -6922,7 +6982,10 @@ class TrainingPipeline:
 
         plt.tight_layout()
 
-        save_path = os.path.join(self._training_plots_dir(dir), f"rf_calibration_curve_{tag}.png")
+        save_path = os.path.join(
+            self._training_plots_dir(dir),
+            f"rf_calibration_curve_{display_tag(tag, machine_name)}.png",
+        )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
         plt.close(fig)
@@ -6932,7 +6995,7 @@ class TrainingPipeline:
         if logger_instance:
             logger_instance.upload_image_to_slack(
                 save_path,
-                title=f"RF Calibration Curve - ({tag}, {machine_name})",
+                title=f"RF Calibration Curve - ({display_tag(tag, machine_name)})",
             )
 
         del artifacts, val_binary, val_probas, frac_pos, mean_pred
@@ -6946,8 +7009,7 @@ class TrainingPipeline:
         if tag is None:
             tag = self.config.checkpoint.save_tag
 
-        metadata_json = get_system_metadata()
-        machine_name = json.loads(metadata_json).get("machine_name")
+        machine_name = get_machine_name()
 
         artifacts = self._load_rf_eval_artifacts(tag)
         train_features = artifacts["train_features"]
@@ -7014,7 +7076,7 @@ class TrainingPipeline:
 
         fig, ax = plt.subplots(1, 1, figsize=(11, 6))
         fig.suptitle(
-            f"Random Forest Ensemble Accuracy vs Tree Count ({tag}, {machine_name})",
+            f"Random Forest Ensemble Accuracy vs Tree Count ({display_tag(tag, machine_name)})",
             fontsize=14,
             fontweight="bold",
         )
@@ -7042,7 +7104,10 @@ class TrainingPipeline:
 
         plt.tight_layout()
 
-        save_path = os.path.join(self._training_plots_dir(dir), f"rf_oob_accuracy_curve_{tag}.png")
+        save_path = os.path.join(
+            self._training_plots_dir(dir),
+            f"rf_oob_accuracy_curve_{display_tag(tag, machine_name)}.png",
+        )
         os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches="tight")
         plt.close(fig)
@@ -7052,7 +7117,7 @@ class TrainingPipeline:
         if logger_instance:
             logger_instance.upload_image_to_slack(
                 save_path,
-                title=f"RF Ensemble Accuracy vs Trees - ({tag}, {machine_name})",
+                title=f"RF Ensemble Accuracy vs Trees - ({display_tag(tag, machine_name)})",
             )
 
         del artifacts, val_features, val_binary, train_features, train_binary
@@ -7071,8 +7136,7 @@ class TrainingPipeline:
         if tag is None:
             tag = self.config.checkpoint.save_tag
 
-        metadata_json = get_system_metadata()
-        machine_name = json.loads(metadata_json).get("machine_name")
+        machine_name = get_machine_name()
 
         artifacts = self._load_rf_eval_artifacts(tag)
         val_features = artifacts["val_features"]
@@ -7176,7 +7240,7 @@ class TrainingPipeline:
                 fig, ax = plt.subplots(1, 1, figsize=(11, 9))
                 fig.suptitle(
                     f"Random Forest Decision Boundary (nn={nn}, md={md}, "
-                    f"t={classification_threshold:.2f}) — ({tag}, {machine_name})",
+                    f"t={classification_threshold:.2f}) — ({display_tag(tag, machine_name)})",
                     fontsize=13,
                     fontweight="bold",
                 )
@@ -7240,7 +7304,7 @@ class TrainingPipeline:
 
                 plt.tight_layout()
 
-                filename = f"rf_latent_decision_boundary_nn{nn}_md{md}_{tag}.png"
+                filename = f"rf_latent_decision_boundary_nn{nn}_md{md}_{display_tag(tag, machine_name)}.png"
                 save_path = os.path.join(self._training_plots_dir(dir), filename)
                 os.makedirs(os.path.dirname(save_path), exist_ok=True)
                 plt.savefig(save_path, dpi=300, bbox_inches="tight")
@@ -7251,7 +7315,7 @@ class TrainingPipeline:
                 if logger_instance:
                     logger_instance.upload_image_to_slack(
                         save_path,
-                        title=f"RF Decision Boundary (nn={nn}, md={md}) - ({tag}, {machine_name})",
+                        title=f"RF Decision Boundary (nn={nn}, md={md}) - ({display_tag(tag, machine_name)})",
                     )
 
                 n_generated += 1
@@ -7454,13 +7518,32 @@ class TrainingPipeline:
             tag = self.config.checkpoint.save_tag
 
         if dir is not None:
-            encoder_path = os.path.join(self.config.model_path, dir, f"vae_encoder_{tag}.keras")
-            decoder_path = os.path.join(self.config.model_path, dir, f"vae_decoder_{tag}.keras")
-            rf_path = os.path.join(self.config.model_path, dir, f"random_forest_{tag}.joblib")
+            encoder_path = os.path.join(
+                self.config.model_path,
+                dir,
+                f"vae_encoder_{display_tag(tag, get_machine_name())}.keras",
+            )
+            decoder_path = os.path.join(
+                self.config.model_path,
+                dir,
+                f"vae_decoder_{display_tag(tag, get_machine_name())}.keras",
+            )
+            rf_path = os.path.join(
+                self.config.model_path,
+                dir,
+                f"random_forest_{display_tag(tag, get_machine_name())}.joblib",
+            )
         else:
-            encoder_path = os.path.join(self.config.model_path, f"vae_encoder_{tag}.keras")
-            decoder_path = os.path.join(self.config.model_path, f"vae_decoder_{tag}.keras")
-            rf_path = os.path.join(self.config.model_path, f"random_forest_{tag}.joblib")
+            encoder_path = os.path.join(
+                self.config.model_path, f"vae_encoder_{display_tag(tag, get_machine_name())}.keras"
+            )
+            decoder_path = os.path.join(
+                self.config.model_path, f"vae_decoder_{display_tag(tag, get_machine_name())}.keras"
+            )
+            rf_path = os.path.join(
+                self.config.model_path,
+                f"random_forest_{display_tag(tag, get_machine_name())}.joblib",
+            )
 
         os.makedirs(
             os.path.dirname(encoder_path), exist_ok=True
@@ -7494,9 +7577,15 @@ class TrainingPipeline:
         tag = _resolve_load_tag(base_dir, tag)
 
         # Construct filepaths
-        encoder_path = os.path.join(base_dir, f"vae_encoder_{tag}.keras")
-        decoder_path = os.path.join(base_dir, f"vae_decoder_{tag}.keras")
-        rf_path = os.path.join(base_dir, f"random_forest_{tag}.joblib")
+        encoder_path = os.path.join(
+            base_dir, f"vae_encoder_{display_tag(tag, get_machine_name())}.keras"
+        )
+        decoder_path = os.path.join(
+            base_dir, f"vae_decoder_{display_tag(tag, get_machine_name())}.keras"
+        )
+        rf_path = os.path.join(
+            base_dir, f"random_forest_{display_tag(tag, get_machine_name())}.joblib"
+        )
 
         # Load the models
         try:
@@ -7651,7 +7740,8 @@ class TrainingPipeline:
         self.save_models()
 
         config_path = os.path.join(
-            self.config.output_path, f"config_{self.config.checkpoint.save_tag}.json"
+            self.config.output_path,
+            f"config_{display_tag(self.config.checkpoint.save_tag, get_machine_name())}.json",
         )
         os.makedirs(os.path.dirname(config_path), exist_ok=True)
         with open(config_path, "w") as f:

--- a/src/aetherscan/train.py
+++ b/src/aetherscan/train.py
@@ -267,13 +267,20 @@ def _resolve_load_tag(base_dir: str, tag: str | None) -> str:
     An explicitly requested tag must exist on disk — we never fall back to "the latest" tag,
     which could silently resume from a stale, unrelated model while reporting success (issue
     #142). The tag=None default loads the conventional "final" model, or fails loudly.
+
+    NOTE: existence is checked against this host's machine-scoped display tag (via
+    _model_pair_exists), so a model pair copied from another host is not resolvable via --load-tag.
     """
     if tag is not None:
         if _model_pair_exists(base_dir, tag):
             return tag
         msg = (
             f"No models tagged '{tag}' in {base_dir} — refusing to fall back to the latest tag "
-            f"for an explicitly requested tag."
+            f"for an explicitly requested tag. On-disk model filenames are machine-scoped "
+            f"(vae_encoder_{{command}}_{{machine}}_{{datetime}}.keras) and this looked for the "
+            f"local machine's display tag, so a run's artifacts copied from another host won't be "
+            f"found by --load-tag; for cross-host inference use explicit "
+            f"--encoder-path/--rf-path/--config-path, or the HuggingFace path (fixed filenames)."
         )
         # The per-round-checkpoint hint only helps for a round_XX tag; for any other explicit
         # tag (e.g. a typo'd full run tag) it's a red herring, so only append it for round tags.

--- a/tests/unit/test_display_tag.py
+++ b/tests/unit/test_display_tag.py
@@ -1,0 +1,61 @@
+"""Unit tests for aetherscan.display_tag.display_tag — the pure derivation of the
+presentation/filename "display tag" `{command}_{machine}_{datetime}` from a run's DB tag
+`{command}_{datetime}`. Dependency-free (no TF / DB import needed to exercise the function)."""
+
+from __future__ import annotations
+
+import pytest
+
+from aetherscan.display_tag import _RUN_TAG_PREFIXES, display_tag
+
+
+class TestRunTagRewrite:
+    """A fully-resolved run tag gains the machine token between command and datetime."""
+
+    def test_matches_the_documented_example(self):
+        assert display_tag("inf_20260731_182011", "blpc3") == "inf_blpc3_20260731_182011"
+
+    @pytest.mark.parametrize("prefix", _RUN_TAG_PREFIXES)
+    def test_every_command_prefix_round_trips(self, prefix):
+        # command prefix preserved, machine inserted, datetime (the rest, incl. its own
+        # underscore) preserved verbatim.
+        tag = f"{prefix}_20260101_000000"
+        assert display_tag(tag, "bla0") == f"{prefix}_bla0_20260101_000000"
+
+    def test_command_and_datetime_are_split_on_the_first_underscore(self):
+        # The command is the part before the first underscore; the datetime is the rest.
+        out = display_tag("train_20260731_182011", "m")
+        assert out.split("_", 1) == ["train", "m_20260731_182011"]
+
+    def test_distinct_machines_do_not_collide(self):
+        tag = "inf_20260731_182011"
+        assert display_tag(tag, "bla0") != display_tag(tag, "blpc3")
+
+
+class TestNonRunTagsPassThrough:
+    """Only a genuine run tag is rewritten; every other shape is returned unchanged so the
+    machine name is never spliced into a name no reader reconstructs."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "round_01",  # per-round checkpoint tag (breaks the round_(\d+) cleanup regex if rewritten)
+            "round_99",
+            "final",  # the conventional load alias (no datetime to place the machine before)
+            "test_v30",  # a legacy hand-numbered tag (no YYYYMMDD_HHMMSS)
+            "train",  # a bare command prefix (unresolved)
+            "prod_20260101_000000",  # datetime shape but an unknown command prefix
+            "inf_2026_182011",  # malformed datetime (too short)
+            "inf_20260731_1820",  # malformed datetime (too short)
+            "garbage",
+            "",
+            None,
+        ],
+    )
+    def test_passes_through_unchanged(self, value):
+        assert display_tag(value, "blpc3") == value
+
+    def test_a_second_underscore_group_that_is_not_a_datetime_is_left_alone(self):
+        # partition() splits on the FIRST underscore, so a non-datetime remainder is rejected
+        # wholesale rather than partially rewritten.
+        assert display_tag("test_v30_extra", "m") == "test_v30_extra"

--- a/tests/unit/test_perband_report.py
+++ b/tests/unit/test_perband_report.py
@@ -146,6 +146,29 @@ def test_render_writes_nonempty_png(make_inference_csv, tmp_path):
     assert out_png.stat().st_size > 0
 
 
+def test_render_accepts_display_tag_without_affecting_db_query(make_inference_csv, tmp_path):
+    # The display tag scopes only the on-figure title; `tag` still keys the pipeline_stages
+    # query. If render mistakenly queried on the display tag it would find no umbrella spans and
+    # return None — so a successful render here proves the two are decoupled.
+    db_path = tmp_path / "aetherscan.db"
+    _make_db(db_path, "test_v1", _UMBRELLA, _CHILDREN)
+    csv_path = _catalog(make_inference_csv, _VALID_GROUPS + [_FLAGGED_GROUP])
+    out_png = tmp_path / "plots" / "perband_inference_perf_inf_testhost_20260101_120000.png"
+
+    result = perband_report.render_perband_report(
+        str(db_path),
+        "test_v1",
+        str(csv_path),
+        str(out_png),
+        "testhost",
+        display_tag="inf_testhost_20260101_120000",
+    )
+
+    assert result == str(out_png)
+    assert out_png.exists()
+    assert out_png.stat().st_size > 0
+
+
 def test_render_skips_on_count_mismatch(make_inference_csv, tmp_path):
     # DB has only three umbrella spans, but the catalog maps four valid cadences: the plan-index
     # guard must skip (return None) rather than render a misleading plot.

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -21,6 +21,8 @@ from skimage.transform import downscale_local_mean
 
 from aetherscan.config import get_config
 from aetherscan.data_generation import log_norm
+from aetherscan.db import get_machine_name
+from aetherscan.display_tag import display_tag
 from aetherscan.pfb import edge_mid_power_ratio, equalize_passband, gen_coarse_channel_response
 from aetherscan.preprocessing import (
     ED_STAT_HIST_EDGES,
@@ -1028,12 +1030,16 @@ class TestProcessCadenceEndToEnd:
         result = DataPreprocessor().process_pending_cadence(PendingCadence(group, npy_path))
 
         assert result is not None
+        # The debug overlay is display-tagged ({command}_{machine}_{datetime}), matching the
+        # inference-viz plot dir; save_tag ("inf_20260101_120000") is a real run tag, so the
+        # machine token is inserted.
+        dtag = display_tag(config.checkpoint.save_tag, get_machine_name())
         plot_path = os.path.join(
             config.output_path,
             "plots",
             "inference",
-            config.checkpoint.save_tag,
-            f"bandpass_overlay_cadence_dbg_{config.checkpoint.save_tag}.png",
+            dtag,
+            f"bandpass_overlay_cadence_dbg_{dtag}.png",
         )
         assert os.path.exists(plot_path)
         assert os.path.getsize(plot_path) > 0

--- a/tests/unit/test_train_utils.py
+++ b/tests/unit/test_train_utils.py
@@ -18,6 +18,8 @@ import numpy as np
 import pytest
 
 from aetherscan.config import get_config
+from aetherscan.db import get_machine_name
+from aetherscan.display_tag import display_tag
 from aetherscan.round_data import RoundDataPaths
 from aetherscan.run_state import (
     STAGE_FINAL_SAVE,
@@ -47,10 +49,14 @@ from aetherscan.train import (
 
 
 def _touch_pair(checkpoints_dir, tag):
-    """Create a matching encoder/decoder checkpoint pair for `tag`."""
+    """Create a matching encoder/decoder checkpoint pair for `tag`, named exactly as save_models
+    lands them on disk: the display tag ({command}_{machine}_{datetime}) for a resolved run tag,
+    else `tag` unchanged (round_XX / final / non-run-tags pass through). _resolve_load_tag /
+    _model_pair_exists reconstruct the same name from the plain tag on this host."""
     os.makedirs(checkpoints_dir, exist_ok=True)
+    fname_tag = display_tag(tag, get_machine_name())
     for prefix in ("vae_encoder", "vae_decoder"):
-        with open(os.path.join(checkpoints_dir, f"{prefix}_{tag}.keras"), "w") as f:
+        with open(os.path.join(checkpoints_dir, f"{prefix}_{fname_tag}.keras"), "w") as f:
             f.write("stub")
 
 
@@ -100,6 +106,37 @@ class TestResolveLoadTag:
             _resolve_load_tag(str(tmp_path), None)
 
 
+class TestDisplayTagFilenameInvariant:
+    """The join-key guarantee behind the display-tag refactor: save_models writes the model pair
+    under the DISPLAY-tagged filename ({command}_{machine}_{datetime}), and the resume/load path
+    (_model_pair_exists -> _resolve_load_tag) reconstructs that same name from the plain DB tag +
+    this host. So a resume on the writing host locates its own artifacts, while the plain-tagged
+    name another host would leave is deliberately NOT accepted (the display tag is f(DB tag,
+    local machine); the DB tag alone no longer locates the file)."""
+
+    def test_reader_reconstructs_the_writers_display_name(self, tmp_path):
+        tag = "train_20260731_182011"  # a real {command}_{datetime} run tag
+        # Writer side: exactly what save_models(tag) lands on disk this host.
+        _touch_pair(str(tmp_path), tag)
+        expected = os.path.join(
+            str(tmp_path), f"vae_encoder_{display_tag(tag, get_machine_name())}.keras"
+        )
+        assert os.path.exists(expected)
+        assert get_machine_name() in os.path.basename(expected)  # the machine token is present
+        # Reader side: derives the same display name, then adopts the plain DB tag for identity.
+        assert _resolve_load_tag(str(tmp_path), tag) == tag
+
+    def test_plain_tagged_pair_is_not_accepted_for_a_run_tag(self, tmp_path):
+        # A plain {command}_{datetime} pair (no machine token — e.g. copied from another host, or
+        # a pre-refactor write) must NOT satisfy the display-tag reader on this host.
+        tag = "train_20260731_182011"
+        for prefix in ("vae_encoder", "vae_decoder"):
+            with open(os.path.join(str(tmp_path), f"{prefix}_{tag}.keras"), "w") as f:
+                f.write("stub")
+        with pytest.raises(FileNotFoundError):
+            _resolve_load_tag(str(tmp_path), tag)
+
+
 class TestTrainingPlotsDir:
     """_training_plots_dir centralizes this run's plots base:
     {output_path}/plots/training/{save_tag}[/subdir]."""
@@ -145,7 +182,8 @@ class TestResumeInPlace:
             config_fingerprint=config_fingerprint(config.to_dict()),
             completed_rounds=[1, 2, 3],
         )
-        save_run_state(state, run_state_path(str(tmp_path), tag))
+        # Manifest FILENAME is display-tagged (mirrors _init_run_state); its stored `tag` stays plain.
+        save_run_state(state, run_state_path(str(tmp_path), display_tag(tag, get_machine_name())))
 
         pipeline = TrainingPipeline.__new__(TrainingPipeline)
         pipeline.config = config

--- a/utils/perband_report.py
+++ b/utils/perband_report.py
@@ -281,15 +281,16 @@ def format_summary_table(agg: OrderedDict[str, dict]) -> str:
 def _render_figure(
     rows: list[CadenceBandRow],
     agg: OrderedDict[str, dict],
-    tag: str,
-    hostname: str,
+    title_tag: str,
     output_path: str,
 ) -> None:
-    """Write the 2-panel figure: per-band distribution (Panel A) + wall-vs-frequency (Panel B)."""
+    """Write the 2-panel figure: per-band distribution (Panel A) + wall-vs-frequency (Panel B).
+
+    ``title_tag`` is the already-composed suptitle identifier (the machine-scoped display tag when
+    the caller has one, else ``"{tag}, {hostname}"``).
+    """
     fig = Figure(figsize=(15, 6))
-    fig.suptitle(
-        f"Inference performance by band ({tag}, {hostname})", fontsize=15, fontweight="bold"
-    )
+    fig.suptitle(f"Inference performance by band ({title_tag})", fontsize=15, fontweight="bold")
     ax_a, ax_b = fig.subplots(1, 2)
 
     # --- Panel A: per-band boxplot (no fliers) + jittered strip, x ordered [L, S, C, X] ---
@@ -375,6 +376,7 @@ def render_perband_report(
     catalog_csv_path,
     output_path: str,
     hostname: str,
+    display_tag: str | None = None,
 ) -> str | None:
     """
     Join per-cadence preprocessing walls (pipeline_stages umbrella spans) to catalog band /
@@ -385,6 +387,11 @@ def render_perband_report(
     mismatch between the mapped catalog-cadence count and the umbrella-span count (the
     plan-index assumption not holding, e.g. a resumed run or non-default cadence_group_by_cols).
     `catalog_csv_path` may be a single path or a list of paths (processed in planner order).
+
+    `tag` is always the plain DB tag: it keys the `pipeline_stages` query below and must not carry
+    the machine name. `display_tag` is the presentation-only machine-scoped tag
+    (`{cmd}_{machine}_{datetime}`) the caller derives; when given it labels the on-figure title
+    (matching every other plot), else the title falls back to `"{tag}, {hostname}"`.
     """
     durations = load_umbrella_preprocess_durations(db_path, tag)
     if not durations:
@@ -420,9 +427,10 @@ def render_perband_report(
             return None
         rows.append(CadenceBandRow(n=n, band=band, frequency_mhz=freq, preprocess_s=durations[n]))
 
+    title_tag = display_tag if display_tag else f"{tag}, {hostname}"
     agg = aggregate_by_band(rows)
-    logger.info(f"Per-band preprocessing summary ({tag}):\n{format_summary_table(agg)}")
-    _render_figure(rows, agg, tag, hostname, output_path)
+    logger.info(f"Per-band preprocessing summary ({title_tag}):\n{format_summary_table(agg)}")
+    _render_figure(rows, agg, title_tag, output_path)
     return output_path
 
 


### PR DESCRIPTION
Introduces a machine-scoped **display tag** `{command}_{machine}_{datetime}` (e.g. `inf_blpc3_20260731_182011`) used for every artifact filename/path and every plot title + Slack message, so artifacts of two same-second runs on different hosts no longer collide when copied together (e.g. weights bla0 → blpc3).

**The DB tag is unchanged.** `config.checkpoint.save_tag`, every DB write/query, and `resolve_save_tag` all still use the plain `{command}_{datetime}`. The display tag is derived, presentation/filename-only.

### Core
- `display_tag(tag, machine_name)` (new `display_tag.py`, stdlib-only, import-safe everywhere): rewrites a genuine run tag to `{cmd}_{machine}_{datetime}`; returns `round_XX`, `final`, empty, and malformed tags **unchanged** (load-bearing — splicing the machine into `round_05` would break the checkpoint-cleanup regex).
- `get_machine_name()` (new, in `db.py`): the single machine accessor, unifying the two former sources (`get_system_metadata()["machine_name"]` vs raw `socket.gethostname()`).

### Threaded through
Model trio / RF / variant / calibrator / eval / shap joblibs, `config_{tag}.json`, `run_state`, log file, `inference_reference_cloud`, round-data dir, every training + inference viz PNG/GIF, benchmark-report + resource-utilization filenames — and every plot title + Slack string (machine moved out of the `({tag}, {machine})` parenthetical into `({display_tag})`, and added to the sites that lacked it).

### Correctness (join-key invariants)
- **Resume** reconstructs `display_tag(save_tag, local_host)` on the same host that wrote the files → matches. `round_XX`/`final` pass through unchanged, so checkpoint load + cleanup are intact.
- **HF upload** runs on the training host, so it globs the display-tagged local files onto the fixed Hub filenames; the HF commit/tag stays the plain DB tag.
- **Inference load** uses explicit `--encoder-path`/`--rf-path` or fixed HF names (display tag irrelevant); the calibrator-by-`replace` operates on the passed basename.

### Deliberate exception
**umap joblibs stay on the plain tag.** `inference_viz.plot_inference_latent_projection` locates `umap_cadence_…_{train_tag}.joblib` by reconstructing it from the *training* run's DB `save_tag` (from the config JSON), potentially on a **different** host whose machine name isn't recorded there — display-tagging umap would break that cross-host reader. umaps aren't among the copied artifacts, so this doesn't reintroduce the collision.

### Tests
`test_display_tag.py` (15 cases incl. passthrough + non-collision), a resume-invariant test (writer name == reader-reconstructed name; a plain-named pair is rejected for a run tag), and updates to the two existing tests that used real `{cmd}_{datetime}` tags.

### Follow-ups before merge
- Rebase over #318 and apply the same treatment to its two new plots (`plot_rf_latent_variant_selection`, `_post_perband_report`/`utils/perband_report.py`) — they don't exist on this branch (off master).
- Cluster smoke: a scaled train → resume → inference run to confirm the write/resume/load paths end-to-end.

Closes #321
🤖 Generated with [Claude Code](https://claude.com/claude-code)
