### PR TITLE
fix(deps): pull tf_keras for legacy-Keras mode off-cluster (Closes #323)

### DIFF
--- a/.github/workflows/claude-dependency-check.yml
+++ b/.github/workflows/claude-dependency-check.yml
@@ -119,8 +119,8 @@ jobs:
                  `environment.yml` and `requirements-container.txt` (numpy, scipy, scikit-learn,
                  scikit-image, astropy, matplotlib, joblib, setuptools, setigen, imageio,
                  umap-learn, shap, slack-sdk, python-dotenv). Conda-only deps (h5py, hdf5plugin,
-                 psutil, pytest, ipykernel) are intentionally ABSENT from requirements-container.txt
-                 because the NGC base ships them — that is NOT drift.
+                 psutil, pytest, ipykernel, tf_keras) are intentionally ABSENT from
+                 requirements-container.txt because the NGC base ships them — that is NOT drift.
                - The **runtime stack** version must agree across `aetherscan.def` (its `From:` base
                  image tag and `%labels` for Base / Python / TF / CUDA / cuDNN / NCCL),
                  `Dockerfile` (its `FROM ...@sha256:<digest>` — MUST pin the SAME NGC base image,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,17 +46,21 @@ jobs:
 
       # Mirror the NGC container's dependency surface on a CPU-only runner:
       # tensorflow-cpu stands in for the container's GPU TF 2.17 build, the pinned
-      # extras come from requirements-container.txt, and tf_keras/h5py/hdf5plugin/
-      # pandas/psutil/pytest are installed explicitly because the NGC base image ships
-      # them (so the requirements file intentionally omits them; hdf5plugin is
-      # pinned explicitly in environment.yml too — don't rely on setigen pulling
-      # it transitively). tf_keras backs legacy-Keras mode (TF_USE_LEGACY_KERAS is set
-      # in aetherscan/__init__.py), so the suite runs the way the pipeline does; without
-      # it, importing aetherscan under that flag fails `from tensorflow import keras`.
+      # extras come from requirements-container.txt, and h5py/hdf5plugin/pandas/
+      # psutil/pytest are installed explicitly because the NGC base image ships them
+      # (so the requirements file intentionally omits them; hdf5plugin is pinned
+      # explicitly in environment.yml too — don't rely on setigen pulling it
+      # transitively). tf_keras backs legacy-Keras mode (TF_USE_LEGACY_KERAS) and is
+      # installed separately with --no-deps: pulling it normally would drag in the
+      # 601 MB GPU tensorflow wheel on top of tensorflow-cpu, because its
+      # `tensorflow>=2.17` edge isn't satisfied by the -cpu distribution name. tf_keras
+      # imports the `tensorflow` module tensorflow-cpu already provides — the same
+      # arrangement as the NGC image, where tf_keras sits next to a TF it never installed.
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "tensorflow-cpu==2.17.*" "tf_keras==2.17.*" -r requirements-container.txt h5py hdf5plugin pandas psutil pytest
+          pip install "tensorflow-cpu==2.17.*" -r requirements-container.txt h5py hdf5plugin pandas psutil pytest
+          pip install --no-deps "tf_keras==2.17.*"
 
       # GPU- and cluster-marked tests need physical GPUs / cluster-resident data;
       # everything else (including slow CPU TF graph tests) runs here

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,15 +46,17 @@ jobs:
 
       # Mirror the NGC container's dependency surface on a CPU-only runner:
       # tensorflow-cpu stands in for the container's GPU TF 2.17 build, the pinned
-      # extras come from requirements-container.txt, and h5py/hdf5plugin/pandas/
-      # psutil/pytest are installed explicitly because the NGC base image ships
+      # extras come from requirements-container.txt, and tf_keras/h5py/hdf5plugin/
+      # pandas/psutil/pytest are installed explicitly because the NGC base image ships
       # them (so the requirements file intentionally omits them; hdf5plugin is
       # pinned explicitly in environment.yml too — don't rely on setigen pulling
-      # it transitively)
+      # it transitively). tf_keras backs legacy-Keras mode (TF_USE_LEGACY_KERAS is set
+      # in aetherscan/__init__.py), so the suite runs the way the pipeline does; without
+      # it, importing aetherscan under that flag fails `from tensorflow import keras`.
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "tensorflow-cpu==2.17.*" -r requirements-container.txt h5py hdf5plugin pandas psutil pytest
+          pip install "tensorflow-cpu==2.17.*" "tf_keras==2.17.*" -r requirements-container.txt h5py hdf5plugin pandas psutil pytest
 
       # GPU- and cluster-marked tests need physical GPUs / cluster-resident data;
       # everything else (including slow CPU TF graph tests) runs here

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ RUN pip install --no-cache-dir -r /opt/aetherscan-requirements.txt \
     && rm -f /opt/aetherscan-requirements.txt
 
 # Mirrors aetherscan.def's %environment: don't pick up host-side Python packages that would
-# shadow the pinned image versions; quieten TF's C++ INFO flood (INFO+ still prints).
+# shadow the pinned image versions; quieten TF's C++ INFO flood (INFO+ still prints); run legacy
+# Keras (#323) — the NGC base already sets TF_USE_LEGACY_KERAS, but declare it explicitly so a
+# future base swap can't silently drop it (aetherscan/__init__.py is the Python-level backstop).
 ENV PYTHONNOUSERSITE=1 \
-    TF_CPP_MIN_LOG_LEVEL=1
+    TF_CPP_MIN_LOG_LEVEL=1 \
+    TF_USE_LEGACY_KERAS=1

--- a/aetherscan.def
+++ b/aetherscan.def
@@ -43,6 +43,11 @@ From: nvcr.io/nvidia/tensorflow:25.02-tf2-py3@sha256:c83b37d26f19ab00d8a13cf974e
     export PYTHONNOUSERSITE=1
     # Quieten TF startup noise; INFO+ still prints, only the C++ INFO floodgate closes.
     export TF_CPP_MIN_LOG_LEVEL=1
+    # Legacy-Keras mode (#323): the v1.0.0 .keras weights are Keras-2 format, so
+    # `from tensorflow import keras` must resolve to tf_keras. The NGC base image already
+    # sets this, but declare it explicitly so a future base swap can't silently drop it
+    # (aetherscan/__init__.py also sets it via setdefault as the Python-level backstop).
+    export TF_USE_LEGACY_KERAS=1
 
 %labels
     Maintainer Zach Yek <xiaoxiyek1.5@gmail.com>

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -106,8 +106,8 @@ compatibility promises; from `1.0.0` onward, these rules hold.
   `requires-python = ">=3.10,<3.13"`.
 - **Dependencies**: `[project].dependencies` mirrors
   [`requirements-container.txt`](../requirements-container.txt)'s ranges **plus** the
-  packages the NGC base image provides implicitly (`tensorflow[and-cuda]==2.17.*`, `h5py`,
-  `hdf5plugin`, `psutil`) — a pip install has no base image to lean on.
+  packages the NGC base image provides implicitly (`tensorflow[and-cuda]==2.17.*`, `tf_keras`,
+  `h5py`, `hdf5plugin`, `psutil`) — a pip install has no base image to lean on.
   Optional extras: `dev = ["ruff", "pre-commit", "pytest>=9.0.3"]` (the `pytest` floor is a
   security floor — GHSA-6w46-j5rx-g56g, tmpdir handling; dev/test-only) and
   `dashboard = ["streamlit>=1.54.0,<1.55", "plotly>=5.24,<6", "pandas>=2.0,<3"]` —

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -76,7 +76,8 @@ tests/
 │   ├── test_dashboard.py            # dashboard pure data layer (DB-driven plot data)
 │   ├── test_dashboard_cli.py        # aetherscan-dashboard console entry: exec-argv builder + streamlit-missing guard
 │   ├── test_dashboard_launcher.py   # dashboard launcher argv builder + guard paths
-│   └── test_logger.py               # StreamToLogger redirect probes + log_path_for_tag / tagged FileHandler
+│   ├── test_logger.py               # StreamToLogger redirect probes + log_path_for_tag / tagged FileHandler
+│   └── test_legacy_keras_env.py     # TF_USE_LEGACY_KERAS default: import sets it, explicit value kept, tf.keras == tf_keras
 └── integration/                 # marked integration+gpu+cluster: needs real GPUs + cluster data
     ├── conftest.py                  # repo-root launcher + cluster path resolution
     ├── test_train_smoke.py          # known-good training smoke config, end to end
@@ -203,7 +204,9 @@ Consequences worth knowing:
 - `MPLBACKEND=Agg`, `TF_CPP_MIN_LOG_LEVEL=2`, and `TF_USE_LEGACY_KERAS=1` are set before any
   aetherscan or TensorFlow import (train.py imports pyplot at module level; CI runners are
   headless; the legacy-Keras default (#323) must land before any test module imports TF, not just
-  the ones that import aetherscan first).
+  the ones that import aetherscan first). If collection fails with `ImportError: Keras cannot be
+  imported`, the env has TensorFlow but not `tf_keras` — `pip install "tf_keras==2.17.*"` (the
+  conda/pip manifests already pull it; this only bites hand-rolled environments).
 - Singleton imports inside the fixture are deferred so **integration runs never import
   TensorFlow into the pytest parent process** — the integration tests exercise the pipeline
   as a subprocess and inherit the real environment instead.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -200,8 +200,10 @@ Consequences worth knowing:
 
 - Constructing a `ResourceManager` in a test installs real signal handlers — the fixture
   restores them, but don't spawn threads that outlive the test.
-- `MPLBACKEND=Agg` and `TF_CPP_MIN_LOG_LEVEL=2` are set before any aetherscan import
-  (train.py imports pyplot at module level; CI runners are headless).
+- `MPLBACKEND=Agg`, `TF_CPP_MIN_LOG_LEVEL=2`, and `TF_USE_LEGACY_KERAS=1` are set before any
+  aetherscan or TensorFlow import (train.py imports pyplot at module level; CI runners are
+  headless; the legacy-Keras default (#323) must land before any test module imports TF, not just
+  the ones that import aetherscan first).
 - Singleton imports inside the fixture are deferred so **integration runs never import
   TensorFlow into the pytest parent process** — the integration tests exercise the pipeline
   as a subprocess and inherit the real environment instead.
@@ -232,7 +234,8 @@ pushes to master, on Python **3.10, 3.11, and 3.12** (the full `requires-python`
 3.10 and 3.12 are the conda and NGC-container runtimes; `fail-fast: false` so all report):
 
 ```
-pip install "tensorflow-cpu==2.17.*" "tf_keras==2.17.*" -r requirements-container.txt h5py hdf5plugin pandas psutil pytest
+pip install "tensorflow-cpu==2.17.*" -r requirements-container.txt h5py hdf5plugin pandas psutil pytest
+pip install --no-deps "tf_keras==2.17.*"   # legacy-Keras backend; --no-deps avoids the GPU TF wheel
 pytest -m "not gpu and not cluster and not integration" -q
 ```
 
@@ -242,11 +245,13 @@ fixture) that would otherwise leak into CI without a `gpu` or `cluster`
 co-marker. Today every `integration` test is also `gpu`+`cluster`, so the
 `and not integration` clause is a no-op on the current suite.
 
-`tensorflow-cpu` stands in for the container's GPU TF 2.17 build; `tf_keras`/`h5py`/`hdf5plugin`/
-`pandas`/`psutil` are installed explicitly because the NGC base image ships them (so
-`requirements-container.txt` intentionally omits them). `tf_keras` in particular is required
-because importing `aetherscan` sets `TF_USE_LEGACY_KERAS=1` (#323), so the suite exercises the
-same legacy-Keras backend the pipeline runs on. A few tests assert Linux-only
+`tensorflow-cpu` stands in for the container's GPU TF 2.17 build; `h5py`/`hdf5plugin`/`pandas`/
+`psutil` are installed explicitly because the NGC base image ships them (so
+`requirements-container.txt` intentionally omits them). `tf_keras` is installed separately with
+`--no-deps`: it backs legacy-Keras mode (`conftest.py` sets `TF_USE_LEGACY_KERAS=1`, #323, so the
+suite exercises the same backend the pipeline runs on), and a plain install would drag the 601 MB
+GPU `tensorflow` wheel in on top of `tensorflow-cpu` (its `tensorflow>=2.17` edge isn't satisfied
+by the `-cpu` distribution name). A few tests assert Linux-only
 behavior (PSS memory accounting) and self-skip elsewhere — the suite is green on macOS
 locally, with skips. See [`GITHUB_AUTOMATION.md`](GITHUB_AUTOMATION.md) for how the test
 workflow feeds the weekly flaky-test tracker.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -232,7 +232,7 @@ pushes to master, on Python **3.10, 3.11, and 3.12** (the full `requires-python`
 3.10 and 3.12 are the conda and NGC-container runtimes; `fail-fast: false` so all report):
 
 ```
-pip install "tensorflow-cpu==2.17.*" -r requirements-container.txt h5py hdf5plugin pandas psutil pytest
+pip install "tensorflow-cpu==2.17.*" "tf_keras==2.17.*" -r requirements-container.txt h5py hdf5plugin pandas psutil pytest
 pytest -m "not gpu and not cluster and not integration" -q
 ```
 
@@ -242,9 +242,11 @@ fixture) that would otherwise leak into CI without a `gpu` or `cluster`
 co-marker. Today every `integration` test is also `gpu`+`cluster`, so the
 `and not integration` clause is a no-op on the current suite.
 
-`tensorflow-cpu` stands in for the container's GPU TF 2.17 build; `h5py`/`hdf5plugin`/
+`tensorflow-cpu` stands in for the container's GPU TF 2.17 build; `tf_keras`/`h5py`/`hdf5plugin`/
 `pandas`/`psutil` are installed explicitly because the NGC base image ships them (so
-`requirements-container.txt` intentionally omits them). A few tests assert Linux-only
+`requirements-container.txt` intentionally omits them). `tf_keras` in particular is required
+because importing `aetherscan` sets `TF_USE_LEGACY_KERAS=1` (#323), so the suite exercises the
+same legacy-Keras backend the pipeline runs on. A few tests assert Linux-only
 behavior (PSS memory accounting) and self-skip elsewhere — the suite is green on macOS
 locally, with skips. See [`GITHUB_AUTOMATION.md`](GITHUB_AUTOMATION.md) for how the test
 workflow feeds the weekly flaky-test tracker.

--- a/environment.yml
+++ b/environment.yml
@@ -59,7 +59,7 @@ dependencies:
       # tf_keras backs legacy-Keras mode (TF_USE_LEGACY_KERAS, set in aetherscan/__init__.py);
       # the v1.0.0 .keras weights are Keras-2 format (#323). The NGC container gets tf_keras from
       # its base image (so requirements-container.txt omits it), but conda/pip has no base.
-      - tf_keras~=2.17.0
+      - tf_keras==2.17.*
       # Range mirrors requirements-container.txt (see the rationale there).
       - setigen>=2.6,<3
       - imageio>=2.34,<3

--- a/environment.yml
+++ b/environment.yml
@@ -56,6 +56,10 @@ dependencies:
       # nvidia-nccl-cu12 2.21.x, etc. -- the exact ABI the TF 2.17 wheel was built
       # against. Driver requirement: NVIDIA driver >= 525.60 on the host.
       - tensorflow[and-cuda]==2.17.*
+      # tf_keras backs legacy-Keras mode (TF_USE_LEGACY_KERAS, set in aetherscan/__init__.py);
+      # the v1.0.0 .keras weights are Keras-2 format (#323). The NGC container gets tf_keras from
+      # its base image (so requirements-container.txt omits it), but conda/pip has no base.
+      - tf_keras~=2.17.0
       # Range mirrors requirements-container.txt (see the rationale there).
       - setigen>=2.6,<3
       - imageio>=2.34,<3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ dependencies = [
     # them); a pip install has no base image to lean on and must declare them. Ranges
     # mirror environment.yml's pins.
     "tensorflow[and-cuda]==2.17.*",
+    # tf_keras backs legacy-Keras mode (TF_USE_LEGACY_KERAS, set in aetherscan/__init__.py):
+    # the v1.0.0 .keras weights are Keras-2 format, so a bare pip install must pull it (#323).
+    "tf_keras~=2.17.0",
     "h5py>=3.11,<3.12",
     "hdf5plugin",
     "psutil>=6.0,<6.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "tensorflow[and-cuda]==2.17.*",
     # tf_keras backs legacy-Keras mode (TF_USE_LEGACY_KERAS, set in aetherscan/__init__.py):
     # the v1.0.0 .keras weights are Keras-2 format, so a bare pip install must pull it (#323).
-    "tf_keras~=2.17.0",
+    "tf_keras==2.17.*",
     "h5py>=3.11,<3.12",
     "hdf5plugin",
     "psutil>=6.0,<6.1",

--- a/requirements-container.txt
+++ b/requirements-container.txt
@@ -1,6 +1,8 @@
 # Pip-only extras layered into the NGC TensorFlow 25.02 base image
 # (nvcr.io/nvidia/tensorflow:25.02-tf2-py3 already ships with numpy, scipy,
-# scikit-learn, matplotlib, pandas, h5py, psutil, pytest, and tensorflow 2.17).
+# scikit-learn, matplotlib, pandas, h5py, psutil, pytest, tensorflow 2.17, and
+# tf_keras 2.17 -- so tf_keras is omitted here; pyproject.toml / environment.yml declare it
+# for the base-less pip/conda paths that back legacy-Keras mode, #323).
 # Version ranges should be kept in lockstep with conda environment that targets the
 # Ampere cluster (see environment.yml)
 

--- a/src/aetherscan/__init__.py
+++ b/src/aetherscan/__init__.py
@@ -9,7 +9,15 @@ exposes only the version string.
 
 from __future__ import annotations
 
+import os
 from importlib.metadata import PackageNotFoundError, version
+
+# tf_keras / legacy-Keras compatibility (#323): Aetherscan runs on legacy Keras
+# (`from tensorflow import keras` == tf_keras) and the released `.keras` weights are Keras-2
+# format. Set the flag at package-import time — importing `aetherscan` runs this before any
+# submodule performs a TF import — using setdefault so an explicit environment value (or the
+# NGC container, which already exports it) always wins.
+os.environ.setdefault("TF_USE_LEGACY_KERAS", "1")
 
 # Version is single-sourced from pyproject.toml's [project].version via the installed
 # distribution's metadata. Source-tree runs (PYTHONPATH=src, the NGC container) have no

--- a/src/aetherscan/models/vae.py
+++ b/src/aetherscan/models/vae.py
@@ -21,9 +21,9 @@ logger = logging.getLogger(__name__)
 
 
 # Use keras.utils.* rather than keras.saving.* — the latter is the canonical
-# Keras 3 path, but `from tensorflow import keras` in TF 2.17 + NGC 25.02
-# resolves to the tf-keras compat shim (`keras._tf_keras.keras`), which
-# doesn't re-export the `saving` submodule. keras.utils.register_keras_serializable
+# Keras 3 path, but the pipeline runs legacy Keras (TF_USE_LEGACY_KERAS=1, set in
+# aetherscan/__init__.py and by the NGC base image), so `from tensorflow import keras`
+# resolves to tf_keras (`tf_keras.api._v2.keras`). keras.utils.register_keras_serializable
 # is the back-compat alias that exists in both tf.keras lineages and standalone
 # Keras 3 — pick the path that works everywhere.
 @keras.utils.register_keras_serializable(package="aetherscan")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,11 @@ import pytest
 os.environ.setdefault("MPLBACKEND", "Agg")
 # Quiet TF's C++ INFO/WARNING chatter in test output.
 os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
+# Legacy Keras (#323): set before ANY test module imports tensorflow — not just the ones that
+# happen to import aetherscan first. A TF-first module collected early would otherwise pin the
+# whole session to Keras 3 and hide a missing tf_keras. aetherscan/__init__.py still carries this
+# at runtime; conftest makes the test session order-proof (and covers subprocesses that inherit it).
+os.environ.setdefault("TF_USE_LEGACY_KERAS", "1")
 
 
 def _reset_all_singletons():

--- a/tests/unit/test_legacy_keras_env.py
+++ b/tests/unit/test_legacy_keras_env.py
@@ -1,11 +1,16 @@
-"""Unit tests for the TF_USE_LEGACY_KERAS default set in ``aetherscan/__init__.py`` (#323).
+"""Unit tests for the TF_USE_LEGACY_KERAS default (#323).
 
 The v1.0.0 ``.keras`` weights are Keras-2 (tf_keras) format, so ``from tensorflow import keras``
-must resolve to tf_keras — importing the package sets ``TF_USE_LEGACY_KERAS=1`` early, before any
-submodule imports TF. These assertions run in a *subprocess* because ``aetherscan`` is already
-imported (and the ``setdefault`` already run) in the test process, so the flag's value here would
-not reflect a fresh import. Same subprocess pattern as ``test_train_distribution.py``. The child
-imports only ``aetherscan`` + ``os`` (no TensorFlow), so these stay fast and CPU-only.
+must resolve to tf_keras. Two layers guarantee that:
+
+* ``aetherscan/__init__.py`` sets the flag on import — the runtime path; and
+* ``tests/conftest.py`` sets it before any test module imports TensorFlow — the order-proof test
+  path (a TF-first module collected early would otherwise pin the session to Keras 3).
+
+The env-var assertions run in a *subprocess* because ``aetherscan`` is already imported (and its
+``setdefault`` already run) in the test process, so a fresh import cannot be observed here — same
+subprocess pattern as ``test_train_distribution.py``. ``src`` reaches the child via
+``pyproject.toml``'s ``[tool.pytest.ini_options] pythonpath = ["src"]``, which is propagated below.
 """
 
 from __future__ import annotations
@@ -21,17 +26,18 @@ _SNIPPET = "import aetherscan, os; print(os.environ.get('TF_USE_LEGACY_KERAS'))"
 def _import_aetherscan_with(env_overrides: dict[str, str]) -> str:
     """Run ``import aetherscan`` in a clean child and return the flag it observed."""
     env = {k: v for k, v in os.environ.items() if k != "TF_USE_LEGACY_KERAS"}
-    # Make aetherscan importable in the child exactly as it is here — CI runs the suite via
-    # PYTHONPATH=src (no installed dist), so propagate this process's import path.
+    # Reproduce this process's import path in the child (``src`` is on ``sys.path`` via pyproject's
+    # pytest ``pythonpath``, not a ``PYTHONPATH`` prefix), then apply the case-specific override.
     env["PYTHONPATH"] = os.pathsep.join(p for p in sys.path if p)
     env.update(env_overrides)
-    result = subprocess.run(
+    result = subprocess.run(  # noqa: PLW1510 — returncode asserted below so the child output shows
         [sys.executable, "-c", _SNIPPET],
         capture_output=True,
         text=True,
+        timeout=120,
         env=env,
-        check=True,
     )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     return result.stdout.strip()
 
 
@@ -45,3 +51,13 @@ def test_import_preserves_explicit_legacy_keras():
     # setdefault, not assignment: an explicit environment value (or the container's own export)
     # must win, so a deliberate opt-out is never silently overridden.
     assert _import_aetherscan_with({"TF_USE_LEGACY_KERAS": "0"}) == "0"
+
+
+def test_tensorflow_resolves_to_tf_keras_in_this_session():
+    # The env var is necessary but not sufficient — assert TF actually honored it and that
+    # `tensorflow.keras` is the tf_keras lineage (matches the in-container check,
+    # `tf_keras.api._v2.keras`). This is the assertion that would have gone red on master
+    # before #323. conftest.py sets the flag before this module imports TF.
+    import tensorflow as tf  # noqa: PLC0415 — deferred so the module stays importable TF-free
+
+    assert "tf_keras" in tf.keras.__name__

--- a/tests/unit/test_legacy_keras_env.py
+++ b/tests/unit/test_legacy_keras_env.py
@@ -1,0 +1,47 @@
+"""Unit tests for the TF_USE_LEGACY_KERAS default set in ``aetherscan/__init__.py`` (#323).
+
+The v1.0.0 ``.keras`` weights are Keras-2 (tf_keras) format, so ``from tensorflow import keras``
+must resolve to tf_keras — importing the package sets ``TF_USE_LEGACY_KERAS=1`` early, before any
+submodule imports TF. These assertions run in a *subprocess* because ``aetherscan`` is already
+imported (and the ``setdefault`` already run) in the test process, so the flag's value here would
+not reflect a fresh import. Same subprocess pattern as ``test_train_distribution.py``. The child
+imports only ``aetherscan`` + ``os`` (no TensorFlow), so these stay fast and CPU-only.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+# Print the flag the child sees right after importing the package.
+_SNIPPET = "import aetherscan, os; print(os.environ.get('TF_USE_LEGACY_KERAS'))"
+
+
+def _import_aetherscan_with(env_overrides: dict[str, str]) -> str:
+    """Run ``import aetherscan`` in a clean child and return the flag it observed."""
+    env = {k: v for k, v in os.environ.items() if k != "TF_USE_LEGACY_KERAS"}
+    # Make aetherscan importable in the child exactly as it is here — CI runs the suite via
+    # PYTHONPATH=src (no installed dist), so propagate this process's import path.
+    env["PYTHONPATH"] = os.pathsep.join(p for p in sys.path if p)
+    env.update(env_overrides)
+    result = subprocess.run(
+        [sys.executable, "-c", _SNIPPET],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def test_import_sets_legacy_keras_when_unset():
+    # With the var unset, importing aetherscan defaults it to "1" so `from tensorflow import
+    # keras` resolves to tf_keras (the Keras-2 lineage the v1.0.0 weights were saved under).
+    assert _import_aetherscan_with({}) == "1"
+
+
+def test_import_preserves_explicit_legacy_keras():
+    # setdefault, not assignment: an explicit environment value (or the container's own export)
+    # must win, so a deliberate opt-out is never silently overridden.
+    assert _import_aetherscan_with({"TF_USE_LEGACY_KERAS": "0"}) == "0"


### PR DESCRIPTION
> [!IMPORTANT]
> **Prepared, not for immediate merge.** This is the v1.0.1 fix for #323. Merging it does not cut a release (master stays `1.0.1.dev0`), but per the post-release plan the **maintainer decides v1.0.1 timing** — hold until then. Once v1.0.1 ships, the README pip-install section (added in #338) moves from the documented workaround to the clean `pip install aetherscan` path.

## Problem (#323)

A clean `pip install aetherscan==1.0.0` (and the conda env) installs and resolves the v1.0.0 HF weights but **cannot load the encoder**:

```
Could not locate class 'Functional'. ... tf_keras.src.engine.functional
```

The released `.keras` weights are **Keras-2 (tf_keras)** format, but no manifest pulls `tf_keras` and TF 2.17 defaults to Keras 3. The **NGC container path is unaffected** — its base image ships `tf_keras` and already sets `TF_USE_LEGACY_KERAS=1` (verified in-container: `tf.keras` resolves to `tf_keras.api._v2.keras`), so this PR's `setdefault` is a no-op there. This PR additionally declares the flag in `aetherscan.def`'s `%environment` so a future base-image swap can't silently drop it.

## Fix

- **`tf_keras==2.17.*`** declared in `pyproject.toml` (the "NGC base provides these implicitly" block) and `environment.yml` — the two base-less install paths. The NGC container already ships `tf_keras 2.17` from its base image (verified in-container: `tf 2.17.0` / `tf_keras 2.17.0`), so `requirements-container.txt` keeps **omitting** it, now documented in its header next to `tensorflow` — this keeps the "requirements-container.txt omits base-provided packages" convention intact rather than double-pinning.
- **`os.environ.setdefault("TF_USE_LEGACY_KERAS", "1")`** at the top of `src/aetherscan/__init__.py`, before any submodule TF import, so `from tensorflow import keras` resolves to `tf_keras`. `setdefault` means an explicit env value (or the container's own export) still wins.

## Note on manifest placement

HANDOFF-era guidance said "add `tf_keras` to all three manifests," but doing so would falsify pyproject's own "(so requirements-container.txt omits them)" comment and double-pin a base-provided package (like `tensorflow`, which `requirements-container.txt` also omits). I took the convention-consistent route above; happy to pin it in `requirements-container.txt` too if you'd rather have it explicit there.

## Testing

CI now runs the suite under **legacy Keras** (the pipeline's real runtime), since the `setdefault` fires on `import aetherscan` — a stronger check than the previous implicit-Keras-3 CI. Verified locally (TF-free): `import aetherscan` sets the flag when unset and preserves an explicit `TF_USE_LEGACY_KERAS=0`.

Closes #323.
