### PR TITLE
docs(release): fix stale RELEASE.md runbook step-number citations in the release tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
           tag_sha=$(jq -r '.object.sha' <<<"$ref_json")
           if [ "$obj_type" != "tag" ]; then
             echo "::error::Release tag '$REF_NAME' is a lightweight tag. Cut it signed:" \
-                 "git tag -s $REF_NAME (docs/RELEASE.md step 5)."
+                 "git tag -s $REF_NAME (docs/RELEASE.md step 6)."
             exit 1
           fi
           tag_json=$(gh api "repos/$GH_REPO/git/tags/$tag_sha")
@@ -102,7 +102,7 @@ jobs:
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             if [ "$TEST_PYPI" != "true" ]; then
               echo "::error::Manual runs only support the TestPyPI dry run (test_pypi: true)." \
-                   "Real releases must go through a signed tag push (docs/RELEASE.md step 5)."
+                   "Real releases must go through a signed tag push (docs/RELEASE.md step 6)."
               exit 1
             fi
             echo "dry_run=true" >> "$GITHUB_OUTPUT"
@@ -117,7 +117,7 @@ jobs:
           if [ "$REF_NAME" != "v$VERSION" ]; then
             echo "::error::Tag '$REF_NAME' does not match pyproject.toml version '$VERSION'" \
                  "(expected tag 'v$VERSION'). Land the release PR that bumps the version," \
-                 "then tag its merge commit (docs/RELEASE.md steps 4-5)."
+                 "then tag its merge commit (docs/RELEASE.md steps 3 and 6)."
             exit 1
           fi
           echo "Version guard passed: $REF_NAME == v$VERSION"
@@ -172,7 +172,7 @@ jobs:
               f"weights but never creates them. Bless the trained weights first — "
               f"python utils/hf_tag_release.py --save-tag <final_vN> --release {tag} — "
               f"then re-run this workflow. The git tag is already correct; do not re-push it. "
-              f"See docs/RELEASE.md step 3."
+              f"See docs/RELEASE.md step 5."
           )
           sys.exit(1)
           EOF
@@ -258,7 +258,7 @@ jobs:
 
   # Decorate the tag into a GitHub Release with generated notes and the built artifacts
   # attached. The generated notes are a starting point — curate the body from the per-PR
-  # claude-release-notes comments afterwards (docs/RELEASE.md step 6).
+  # claude-release-notes comments afterwards (docs/RELEASE.md step 7).
   github-release:
     needs: [guard, publish]
     if: needs.guard.outputs.dry_run != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,7 +258,7 @@ jobs:
 
   # Decorate the tag into a GitHub Release with generated notes and the built artifacts
   # attached. The generated notes are a starting point — curate the body from the per-PR
-  # claude-release-notes comments afterwards (docs/RELEASE.md step 7).
+  # claude-release-notes comments afterwards (docs/RELEASE.md step 7 + the "Release notes" note).
   github-release:
     needs: [guard, publish]
     if: needs.guard.outputs.dry_run != 'true'

--- a/utils/hf_tag_release.py
+++ b/utils/hf_tag_release.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Bless trained weights as a release: create the HF release tag (vX.Y.Z) pointing at a
-training upload's commit (docs/RELEASE.md step 3).
+training upload's commit (docs/RELEASE.md step 5).
 
     python utils/hf_tag_release.py --save-tag train_20260101_120000 --release v1.0.0
 
@@ -39,7 +39,7 @@ _RELEASE_TAG_PATTERN = re.compile(r"^v\d+\.\d+\.\d+$")
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Bless trained weights as a release: create the HF release tag (vX.Y.Z) "
-        "pointing at a training upload's commit (docs/RELEASE.md step 3)."
+        "pointing at a training upload's commit (docs/RELEASE.md step 5)."
     )
     parser.add_argument(
         "--save-tag",


### PR DESCRIPTION
Closes #344

## What

The #338 drift sweep found that the release tooling cites `docs/RELEASE.md` runbook **step numbers** that drifted after the runbook was renumbered. `docs/RELEASE.md` declares itself the authoritative contract (top of file), so the tooling is the stale side. These are **human-facing log/comment strings only — no functional effect.**

Verified each against the current runbook: `1 Prereqs · 2 Train · 3 Release PR · 4 Dry-run · 5 Bless · 6 Sign + push · 7 CD · 8 Smoke · 9 Reset`.

| Location | Was | Now | Why |
| --- | --- | --- | --- |
| `utils/hf_tag_release.py:4,42`, `release.yml:175` | step 3 | **step 5** | the bless is step 5 |
| `release.yml:75,105` | step 5 | **step 6** | the signed-tag push is step 6 |
| `release.yml:120` | steps 4-5 | **steps 3 and 6** | "land the release PR" = step 3, "tag" = step 6 |
| `release.yml:261` | step 6 | **step 7** | the GitHub Release is created by CD, step 7 ("→ GitHub Release (notes + sdist/wheel)") |
| `release.yml:21` | step 4 | *(unchanged)* | the dry-run genuinely is step 4 — correct |

## Notes

No dedicated tracking issue exists — the drift surfaced inside the #338 docs-consolidation sweep, which deliberately left this code-side item to a focused follow-up. Referencing that cleanup here rather than `Closes #N`.

## Testing

Comment/log-string edits only (release CD isn't exercised by CI); pre-commit clean, `check-yaml` green on `release.yml`.