### PR TITLE
docs: finish #304 install-path coverage + add SemVer release policy

### DIFF
--- a/.claude/skills/aetherscan-repo-context/SKILL.md
+++ b/.claude/skills/aetherscan-repo-context/SKILL.md
@@ -15,12 +15,13 @@ Aetherscan is Breakthrough Listen's first end-to-end production-grade deep-learn
 
 `src/aetherscan/main.py` is the **primary** designated entry point for the pipeline. Non-development workflows should never call other scripts/modules directly — the one exception is `aetherscan-dashboard`, the console script for manual dashboard runs against a saved DB (see `dashboard_cli.py`). `main.py` dispatches to one of two subcommands via the first positional argument: `train` or `inference`.
 
-There are two install paths off the same source tree:
+There are three install paths — two off the same source tree, plus the published PyPI package for off-cluster use:
 
 | Path                                        | Status                                                     | When                          | Launcher                                                                    |
 | ------------------------------------------- | ---------------------------------------------------------- | ----------------------------- | --------------------------------------------------------------------------- |
 | **NGC container** (Apptainer/SingularityCE) | Canonical; runs on both clusters; only option on Blackwell | Default                       | `./utils/run_container.sh python -m aetherscan.main {train\|inference} ...` |
 | **Conda env**                               | Alternative; **Ampere only**                               | When containers aren't usable | `PYTHONPATH=src python -m aetherscan.main {train\|inference} ...`           |
+| **PyPI package** (`pip install aetherscan`) | Off-cluster analysis; container still **mandatory on Blackwell** | Local / off-cluster use | `pip install aetherscan` → `python -m aetherscan.main {train\|inference} ...` (v1.0.0 needs the `tf_keras` workaround — see the **Install From PyPI (pip)** section of `README.md`) |
 
 CLI flags are identical between the two paths; only the launcher differs. `PYTHONPATH=src` makes the `aetherscan` package importable from `src/` without a `pip install -e .`; the container sets `PYTHONPATH` automatically.
 

--- a/.claude/skills/aetherscan-repo-context/SKILL.md
+++ b/.claude/skills/aetherscan-repo-context/SKILL.md
@@ -23,7 +23,7 @@ There are three install paths — two off the same source tree, plus the publish
 | **Conda env**                               | Alternative; **Ampere only**                               | When containers aren't usable | `PYTHONPATH=src python -m aetherscan.main {train\|inference} ...`           |
 | **PyPI package** (`pip install aetherscan`) | Off-cluster analysis; container still **mandatory on Blackwell** | Local / off-cluster use | `pip install aetherscan` → `python -m aetherscan.main {train\|inference} ...` (v1.0.0 needs the `tf_keras` workaround — see the **Install From PyPI (pip)** section of `README.md`) |
 
-CLI flags are identical between the two paths; only the launcher differs. `PYTHONPATH=src` makes the `aetherscan` package importable from `src/` without a `pip install -e .`; the container sets `PYTHONPATH` automatically.
+CLI flags are identical across all three install paths; only the launcher differs. For the two source-tree paths, `PYTHONPATH=src` makes the `aetherscan` package importable from `src/` without a `pip install -e .` (the container sets `PYTHONPATH` automatically); the installed PyPI wheel needs no `PYTHONPATH`.
 
 - **Container build:** `singularity build aetherscan-ngc25.02.sif aetherscan.def` (or `apptainer build ...`) — same `aetherscan.def` recipe builds with either runtime. Build on the cluster you intend to run on.
 - **Conda env:** `conda env create -f environment.yml && conda activate aetherscan`

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -665,3 +665,12 @@ fields that still exist but are not allowlisted). **No action required** — unl
 seed case, nothing is lost: the flag defaulted to `False`, and the objective now has no
 regularization term at any setting, so loading a pre-#324 config (including the released
 v1.0.0 one) reproduces the same numerics it always did.
+
+The same field removal also shifts the **training-resume** config fingerprint. `config_fingerprint`
+hashes the whole `beta_vae` section, so a run-state manifest persisted **mid-training** under
+v1.0.0 (whose `beta_vae` dict still carried `regularization_active`) hashes differently after the
+#324 upgrade → `config_changed()` returns True, and an in-place `--load-tag` resume is treated as a
+config change and **restarts from round 1** rather than resuming. This is inherent to removing any
+fingerprinted field and is the intended clean-break behavior — the config-drift guard logs the
+mismatch loudly (nothing silent) — and it only bites the narrow window of upgrading the codebase
+mid-v1.0.0-training and relaunching to resume. A fresh (post-#324) training run is unaffected.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Aetherscan supports two install paths off the same source tree — the **NGC con
 
 ### Install From PyPI (pip)
 
-For **off-cluster** use, Aetherscan is published on PyPI. The container stays canonical on the clusters (and is **mandatory on Blackwell** — see the caveats). **v1.0.0 needs a one-time workaround** (removed in v1.0.1):
+For **off-cluster** use, Aetherscan is published on PyPI. The container stays canonical on the clusters (and is **mandatory on Blackwell** — see the caveats). **v1.0.0 needs a one-time workaround** (removed in the next release):
 
 ```bash
 pip install aetherscan==1.0.0
@@ -80,7 +80,7 @@ python -m aetherscan.main inference --inference-files catalog.csv --save-tag inf
 - **No CPU mode.** Both `train` and `inference` hard-exit when no GPU is visible (`"… requires GPU"`).
 - **The two end-of-run report PNGs do not render on a pip install.** The wheel ships only `src/aetherscan` (not `utils/`), so `benchmark_report.py` / `perband_report.py` aren't found — those two plots log a warning and skip; the inference viz suite, DB, and results are unaffected. Use the container or source tree if you need them.
 - The live dashboard needs the extra: `pip install 'aetherscan[dashboard]'`.
-- The `tf_keras` + `TF_USE_LEGACY_KERAS` steps are the **v1.0.0** workaround only ([#323](https://github.com/zachtheyek/Aetherscan/issues/323) — the released `.keras` weights are Keras-2 while pip pulls Keras 3). Once **v1.0.1** ships they become unnecessary and the install collapses to `pip install aetherscan`; this section will be updated at that point.
+- The `tf_keras` + `TF_USE_LEGACY_KERAS` steps are the **v1.0.0** workaround only ([#323](https://github.com/zachtheyek/Aetherscan/issues/323) — the released `.keras` weights are Keras-2 while pip pulls Keras 3). Once **the next release** ships they become unnecessary and the install collapses to `pip install aetherscan`; this section will be updated at that point.
 
 ### Run From Container
 

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -186,8 +186,9 @@ energy-detection preprocessing wall-clock: Panel A is a per-band boxplot + jitte
 ordered L, S, C, X, each annotated with median/max/n), Panel B scatters the same walls against the
 catalog `Frequency` (MHz), colored by band. On the automatic end-of-run fire that `{tag}` is the
 machine-scoped *display* tag `{cmd}_{machine}_{datetime}` (matching the other auto-fired report
-PNGs); run standalone, it's the plain `--save-tag` you pass. The preprocessing wall per cadence is the umbrella
-`inference.preprocess_cadence_<N>` span (its `.read_ed`/`.dedup`/`.extract` children are excluded),
+PNGs); run standalone, it's the plain `--save-tag` you pass. The preprocessing wall per cadence is
+the umbrella `inference.preprocess_cadence_<N>` span (its `.read_ed`/`.dedup`/`.extract` children
+are excluded),
 and the band/frequency come from the run's inference catalog CSV. It fires **automatically at the
 tail of every streaming-CSV `inference` run** right after the benchmark report
 (`_post_perband_report` in [`main.py`](../src/aetherscan/main.py), same

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -181,7 +181,9 @@ hardware.
 A sibling tool (same stdlib `sqlite3` + `csv` + numpy + matplotlib, no `aetherscan` imports) that
 answers a question the flame timeline can't: **is a whole observing band or frequency region
 systematically slower to preprocess?** It writes
-`{output_path}/plots/perband_inference_perf_{tag}.png` — a two-panel, log-y figure of per-cadence
+`{output_path}/plots/perband_inference_perf_{tag}.png` (auto-fired at an inference tail, `{tag}` is
+the machine-scoped *display* tag `{cmd}_{machine}_{datetime}`, matching the other auto-fired report
+PNGs; run standalone, it's the plain `--save-tag` you pass) — a two-panel, log-y figure of per-cadence
 energy-detection preprocessing wall-clock: Panel A is a per-band boxplot + jittered strip (bands
 ordered L, S, C, X, each annotated with median/max/n), Panel B scatters the same walls against the
 catalog `Frequency` (MHz), colored by band. The preprocessing wall per cadence is the umbrella

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -181,12 +181,12 @@ hardware.
 A sibling tool (same stdlib `sqlite3` + `csv` + numpy + matplotlib, no `aetherscan` imports) that
 answers a question the flame timeline can't: **is a whole observing band or frequency region
 systematically slower to preprocess?** It writes
-`{output_path}/plots/perband_inference_perf_{tag}.png` (auto-fired at an inference tail, `{tag}` is
-the machine-scoped *display* tag `{cmd}_{machine}_{datetime}`, matching the other auto-fired report
-PNGs; run standalone, it's the plain `--save-tag` you pass) — a two-panel, log-y figure of per-cadence
+`{output_path}/plots/perband_inference_perf_{tag}.png` — a two-panel, log-y figure of per-cadence
 energy-detection preprocessing wall-clock: Panel A is a per-band boxplot + jittered strip (bands
 ordered L, S, C, X, each annotated with median/max/n), Panel B scatters the same walls against the
-catalog `Frequency` (MHz), colored by band. The preprocessing wall per cadence is the umbrella
+catalog `Frequency` (MHz), colored by band. On the automatic end-of-run fire that `{tag}` is the
+machine-scoped *display* tag `{cmd}_{machine}_{datetime}` (matching the other auto-fired report
+PNGs); run standalone, it's the plain `--save-tag` you pass. The preprocessing wall per cadence is the umbrella
 `inference.preprocess_cadence_<N>` span (its `.read_ed`/`.dedup`/`.extract` children are excluded),
 and the band/frequency come from the run's inference catalog CSV. It fires **automatically at the
 tail of every streaming-CSV `inference` run** right after the benchmark report

--- a/docs/CONFIG_AND_CLI.md
+++ b/docs/CONFIG_AND_CLI.md
@@ -7,7 +7,10 @@ exist precisely so that one mode's parameters can't silently contaminate the oth
 For where config initialization sits in the overall startup sequence (and the singleton
 pattern's rules), see [`ARCHITECTURE.md`](ARCHITECTURE.md); for what the individual
 training/inference fields *do*, see [`TRAINING_PIPELINE.md`](TRAINING_PIPELINE.md) and
-[`INFERENCE_PIPELINE.md`](INFERENCE_PIPELINE.md).
+[`INFERENCE_PIPELINE.md`](INFERENCE_PIPELINE.md). The CLI is identical across every install
+path (NGC container, conda env, and the off-cluster PyPI package); for choosing and setting one
+up, see [`GPU_RUNTIME_GUIDE.md`](GPU_RUNTIME_GUIDE.md) and the README's
+[Install From PyPI (pip)](../README.md#install-from-pypi-pip) section.
 
 ## TL;DR
 

--- a/docs/GPU_RUNTIME_GUIDE.md
+++ b/docs/GPU_RUNTIME_GUIDE.md
@@ -1,6 +1,6 @@
 # GPU Runtime Guide
 
-This runbook covers running Aetherscan across GPU architectures — the Blackwell (RTX PRO 6000) workstation and the Ampere (A4000) cluster. The pipeline source tree is identical on both machines, and as of [`aetherscan.def`](../aetherscan.def) the NGC container is the canonical runtime on both clusters — one recipe builds and runs on each. The pre-container conda env is kept as an alternative install path on Ampere. This document is about the *runtime*; for what the pipeline itself does once it's running, start at [`ARCHITECTURE.md`](ARCHITECTURE.md).
+This runbook covers running Aetherscan across GPU architectures — the Blackwell (RTX PRO 6000) workstation and the Ampere (A4000) cluster. The pipeline source tree is identical on both machines, and as of [`aetherscan.def`](../aetherscan.def) the NGC container is the canonical runtime on both clusters — one recipe builds and runs on each. The pre-container conda env is kept as an alternative install path on Ampere. For **off-cluster** use there is also a published PyPI package (`pip install aetherscan`) — see the README's [Install From PyPI (pip)](../README.md#install-from-pypi-pip) section (and its v1.0.0 caveats); the container stays canonical on the clusters and is **mandatory on Blackwell**. This document is about the *runtime*; for what the pipeline itself does once it's running, start at [`ARCHITECTURE.md`](ARCHITECTURE.md).
 
 ## TL;DR
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -63,7 +63,7 @@ of the contract. Bump the leftmost segment that applies:
   code loads old weights). The weights are the product, so re-blessing on the same contract is a
   user-facing feature → at least a MINOR bump.
 - **PATCH (`Z`) — backward-compatible fixes**: no new capability, no contract change. Examples: a bug
-  fix (e.g. #340's off-cluster `tf_keras` weight-load fix); a dependency security bump inside the
+  fix (e.g. the off-cluster `tf_keras` weight-load fix for [#323](https://github.com/zachtheyek/Aetherscan/issues/323)); a dependency security bump inside the
   documented version ranges; a docs-only correction; a packaging fix. If a user would see no
   behavioral difference except that something broken now works, it's a PATCH.
 
@@ -77,8 +77,11 @@ Two rules make bundled releases unambiguous:
    is a **MINOR** → `v1.1.0`.)
 
 Between releases `master` carries a `.devN` pre-release version (e.g. `1.0.1.dev0`) so it never
-advertises itself as a shipped stable version — see the dev-version reset in the runbook below. The
-pre-`1.0.0` `0.y.z` line made no compatibility promises; from `1.0.0` onward, these rules hold.
+advertises itself as a shipped stable version — see the dev-version reset in the runbook below. That
+`.devN` number is only a *not-yet-released* placeholder, **not** a commitment to the next version:
+the actual next release number is chosen at release time by the rules above, so `1.0.1.dev0` on
+`master` does not mean the next release is `1.0.1`. The pre-`1.0.0` `0.y.z` line made no
+compatibility promises; from `1.0.0` onward, these rules hold.
 
 ## Packaging
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -32,6 +32,54 @@ Two invariants to internalize:
 - **Installing `aetherscan==1.0.0` *is* the tagged source** — the sdist/wheel are built from
   the tag by CD. There is nothing further to "sync" between PyPI and GitHub.
 
+## Versioning policy (SemVer)
+
+Aetherscan follows [Semantic Versioning 2.0.0](https://semver.org): every release is
+`MAJOR.MINOR.PATCH` (`vX.Y.Z`). Now that the project is past `1.0.0` the number is a
+**compatibility contract**, not just a date stamp. The public surface the contract covers is:
+
+- the `python -m aetherscan.main {train,inference}` **CLI** — subcommand set, flag names, and the
+  defaults that decide behavior when a flag is omitted;
+- the **saved-artifact + config-JSON formats** and the **model contract** inference reads from them
+  (`latent_dim`, the RF feature layout / `latent_variant`, the `.keras`/`.joblib` formats, the HF
+  repo layout and weight-resolution rules);
+- the **supported runtimes** (NGC container / conda env / PyPI package) and their documented floors.
+
+Internal implementation details, private helpers, log wording, and plot cosmetics are **not** part
+of the contract. Bump the leftmost segment that applies:
+
+- **MAJOR (`X`) — incompatible changes** that force a user to change how they invoke, configure, or
+  consume the pipeline, or that make an existing released artifact unusable with the new code.
+  Examples: removing or renaming a CLI flag/subcommand without a compatibility alias; a config-schema
+  or artifact-format change a prior release's saved config/weights can no longer load; changing the
+  model contract so an old artifact is silently reinterpreted; raising the Python/CUDA/TF floor so a
+  previously-supported runtime stops working; a backward-incompatible DB-schema change. A retrain
+  whose weights need new code to load is a MAJOR change **to the weights**.
+- **MINOR (`Y`) — backward-compatible additions**: anything a user could ignore and keep working
+  exactly as before. Examples: a new CLI flag whose default preserves prior behavior; a new optional
+  config field; new observability/plots; a new latent-variant; a performance change with identical
+  outputs; or **new blessed weights from a retrain whose artifact + config + model contract are
+  unchanged** (same `latent_dim`, feature layout, and file formats — old configs still load and new
+  code loads old weights). The weights are the product, so re-blessing on the same contract is a
+  user-facing feature → at least a MINOR bump.
+- **PATCH (`Z`) — backward-compatible fixes**: no new capability, no contract change. Examples: a bug
+  fix (e.g. #340's off-cluster `tf_keras` weight-load fix); a dependency security bump inside the
+  documented version ranges; a docs-only correction; a packaging fix. If a user would see no
+  behavioral difference except that something broken now works, it's a PATCH.
+
+Two rules make bundled releases unambiguous:
+
+1. **Highest bump wins.** A release takes the largest bump any single change in it requires — one
+   breaking change makes the whole release MAJOR no matter how many MINOR/PATCH changes ride along.
+2. **Code and weights share the one version string** (see the coupling contract above): if *either*
+   the code or the weights warrant a given bump, the release takes at least that bump. (So the next
+   release after `1.0.0` bundling new features, the `tf_keras` PATCH fix, and a same-contract retrain
+   is a **MINOR** → `v1.1.0`.)
+
+Between releases `master` carries a `.devN` pre-release version (e.g. `1.0.1.dev0`) so it never
+advertises itself as a shipped stable version — see the dev-version reset in the runbook below. The
+pre-`1.0.0` `0.y.z` line made no compatibility promises; from `1.0.0` onward, these rules hold.
+
 ## Packaging
 
 - **Build system**: hatchling (`[build-system] requires = ["hatchling"]` in

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -63,8 +63,9 @@ of the contract. Bump the leftmost segment that applies:
   code loads old weights). The weights are the product, so re-blessing on the same contract is a
   user-facing feature → at least a MINOR bump.
 - **PATCH (`Z`) — backward-compatible fixes**: no new capability, no contract change. Examples: a bug
-  fix (e.g. the off-cluster `tf_keras` weight-load fix for [#323](https://github.com/zachtheyek/Aetherscan/issues/323)); a dependency security bump inside the
-  documented version ranges; a docs-only correction; a packaging fix. If a user would see no
+  fix (e.g. the off-cluster `tf_keras` weight-load fix for
+  [#323](https://github.com/zachtheyek/Aetherscan/issues/323)); a dependency security bump inside
+  the documented version ranges; a docs-only correction; a packaging fix. If a user would see no
   behavioral difference except that something broken now works, it's a PATCH.
 
 Two rules make bundled releases unambiguous:


### PR DESCRIPTION
Closes #347. Post-v1.0.0 audit follow-ups — docs only.

## #304 install-path coverage
#338 satisfied #304's README ask but left the deep-dive install docs pointing at container+conda only. Adds off-cluster PyPI/pip pointers to:
- `docs/GPU_RUNTIME_GUIDE.md` (install framing, line 3)
- `docs/CONFIG_AND_CLI.md` (intro cross-refs)
- `.claude/skills/aetherscan-repo-context/SKILL.md` — the install-paths deep-dive CLAUDE.md designates; "two install paths" → "three … plus the published PyPI package", with a PyPI table row. (Uses SKILL.md's root-relative reference convention, per its own line-10 note, not a `../` link.)

All three point at the README's `Install From PyPI (pip)` section, with its v1.0.0 caveats.

## New — SemVer release policy (`docs/RELEASE.md`)
A **Versioning policy (SemVer)** section after the version-coupling contract: what the compatibility contract covers (CLI / artifact+config formats + model contract / supported runtimes), MAJOR/MINOR/PATCH triggers with project-specific examples (incl. how a retrain's weights are classified — same-contract re-bless = MINOR, weights-need-new-code = MAJOR), highest-bump-wins, and code↔weights sharing one version string. Worked example: features + the `tf_keras` PATCH fix + a same-contract retrain ⇒ **MINOR ⇒ v1.1.0**.

## Doc nits
- `KNOWN_ISSUES.md`: extend the pre-#324 note with the training-resume config-fingerprint-shift caveat (previously covered only inference config loading).
- `docs/BENCHMARKING.md`: clarify the auto-fired per-band PNG uses the machine-scoped display tag, not the plain save-tag.

## Verification
`git diff --check` clean (no whitespace/EOF errors); all relative link targets confirmed to resolve on disk; SKILL.md path convention matched to its own root-relative style.

Note: the SKILL.md PyPI-path edit overlaps part of #341's scope (which #342 left in its PR body). This PR does the install-path reconciliation only — #341's perband_report.py / HF-flag items remain for a separate decision on #342.