### PR TITLE
docs: document the #318 RF variant-identity guard in the pipeline docs

### DIFF
--- a/docs/INFERENCE_PIPELINE.md
+++ b/docs/INFERENCE_PIPELINE.md
@@ -148,10 +148,13 @@ paths:
   otherwise silently score the **wrong representation**. **(3) Active-dims identity** — the forest's
   `aetherscan_active_dims_` stamp vs `rf.active_dims`, checked only for `z_mean_logvar_active`
   (whose `log_var` columns are active-dim-indexed), where two equal-length dim *sets* share a
-  feature count yet select different columns. Forests trained before #318 (including the released
-  v1.0.0 weights) carry no stamps, so checks 2–3 no-op on them. The guard fires on mixed
-  `--config-path`/`--rf-path` from different runs or a hand-edited config, never on the sanctioned
-  HF path (which ships the winning forest with its own config).
+  feature count yet select different columns (compared as sorted sets, so a reordered-but-equivalent
+  `active_dims` doesn't false-trip). Forests trained before #318 (including the released v1.0.0
+  weights) carry no stamps, so checks 2–3 no-op on them. The guard fires on mixed
+  `--config-path`/`--rf-path` from different runs, a hand-edited config, or the likeliest slip —
+  pointing `--rf-path` at a sibling `random_forest_{tag}_{variant}.joblib` sweep artifact in the
+  same directory under the same tag (same run, same tag, wrong representation — the case checks 2–3
+  exist for); never on the sanctioned HF path (which ships the winning forest with its own config).
 - `--config-path` → the training run's `config_{tag}.json`, layered onto the singleton by
   `cli.apply_saved_config()` **before validation** so shape-critical fields
   (`width_bin`, `stamp_width`, `latent_dim`, `dense_layer_size`, ...) match what the encoder

--- a/docs/INFERENCE_PIPELINE.md
+++ b/docs/INFERENCE_PIPELINE.md
@@ -136,14 +136,22 @@ paths:
   when training calibrated would be a silent train/serve mismatch. The saved
   `rf.latent_variant` / `rf.active_dims` drive how features are rebuilt from the encoder
   outputs (never hardcoded — see the two-pass cascade below), and `_check_rf_feature_layout()`
-  cross-checks them against the loaded forest's own `n_features_in_`, raising
-  `ValueError("RF feature-count mismatch: ...")` when they disagree. sklearn's built-in check
-  cannot catch this on its own: `z`, `z_mean`, and `z_aug` are all
-  `num_observations × latent_dim` wide, so a config declaring one while the weights were fit on
-  another passes the width test and inference silently scores the **wrong representation**. The
-  guard fires on mixed `--config-path`/`--rf-path` from different runs or a hand-edited config,
-  never on the sanctioned HF path (which ships the winning forest with its own config), and
-  no-ops on a forest that carries no `n_features_in_`.
+  cross-checks them against the loaded forest via **three complementary checks** (#282/#318),
+  each no-opping when the forest lacks its signal (so they only get stricter as a forest
+  self-describes). **(1) Feature count** — the config variant's expected feature count vs the
+  forest's `n_features_in_`, catching a different-width mismatch (a `z_mean`=48 config against a
+  `z_mean_logvar`=96 forest) at load time; no-ops on a forest with no `n_features_in_`.
+  **(2) Variant identity** — the forest's `aetherscan_latent_variant_` stamp (written at train
+  time) vs `rf.latent_variant`. This catches what the count check cannot: `z`, `z_mean`, and
+  `z_aug` are all `num_observations × latent_dim` wide, so a config declaring one while the weights
+  were fit on another passes the width test *and* sklearn's own check, and inference would
+  otherwise silently score the **wrong representation**. **(3) Active-dims identity** — the forest's
+  `aetherscan_active_dims_` stamp vs `rf.active_dims`, checked only for `z_mean_logvar_active`
+  (whose `log_var` columns are active-dim-indexed), where two equal-length dim *sets* share a
+  feature count yet select different columns. Forests trained before #318 (including the released
+  v1.0.0 weights) carry no stamps, so checks 2–3 no-op on them. The guard fires on mixed
+  `--config-path`/`--rf-path` from different runs or a hand-edited config, never on the sanctioned
+  HF path (which ships the winning forest with its own config).
 - `--config-path` → the training run's `config_{tag}.json`, layered onto the singleton by
   `cli.apply_saved_config()` **before validation** so shape-critical fields
   (`width_bin`, `stamp_width`, `latent_dim`, `dense_layer_size`, ...) match what the encoder

--- a/docs/TRAINING_PIPELINE.md
+++ b/docs/TRAINING_PIPELINE.md
@@ -495,6 +495,15 @@ the [CLI Reference](../README.md#cli-reference) for the exact flag help.
 | `config_{tag}.json` (resolved config snapshot) | `final_save` stage | `{output_path}/` |
 | `run_state_{tag}.json` | Updated after every stage/round transition | `{output_path}/` |
 
+The RF forests are **self-describing** (#318): each is stamped at the fit site with
+`aetherscan_latent_variant_` (the variant it was trained on) and `aetherscan_active_dims_` (the
+run's active-dim set), so `random_forest_{tag}.joblib` and all 8 `random_forest_{tag}_{variant}.joblib`
+sweep artifacts record their own representation. Inference reads these back in
+`_check_rf_feature_layout` to reject a config↔weights mismatch the feature-count check alone cannot
+see — the same-width variants (`z`/`z_mean`/`z_aug`) and, for `z_mean_logvar_active`, two
+equal-length active-dim sets (see [`INFERENCE_PIPELINE.md`](INFERENCE_PIPELINE.md) and
+[`MODELS.md`](MODELS.md)).
+
 ### The run-state manifest
 
 [`run_state.py`](../src/aetherscan/run_state.py)`:TrainingRunState` persists (atomically,


### PR DESCRIPTION
Closes #351. Auto-spawned by the #346 merge — the guard change left the pipeline docs behind.

## What changed
- **`docs/INFERENCE_PIPELINE.md`** (Loading the resolved artifacts): the guard bullet described only the feature-count check and was **stale** — it still claimed the same-width `z`/`z_mean`/`z_aug` collision 'passes the width test and inference silently scores the wrong representation', which is exactly what #318 now *catches*. Rewritten to the **three complementary checks**: (1) feature count, (2) variant identity via the `aetherscan_latent_variant_` stamp, (3) active-dims identity via `aetherscan_active_dims_` (scoped to `z_mean_logvar_active`) — each no-opping when the forest lacks its signal, so pre-#318 forests (incl. v1.0.0) skip checks 2–3.
- **`docs/TRAINING_PIPELINE.md`** (What gets saved when): added a note that the RF forests are self-describing — stamped at the fit site so the deployed winner and all 8 sweep artifacts record their representation — cross-referencing the inference guard and MODELS.md.

Docs-only; no `.py` touched. Consistent with the guard's docstring and the MODELS.md artifact rows updated in #346.