### PR TITLE
docs: fold the #318 guard's incidental mentions into ARCHITECTURE/RELEASE/TESTING

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -196,9 +196,11 @@ Every run is identified by `config.checkpoint.save_tag` — the **tag** — `{co
 resolved once at startup by `cli.resolve_save_tag()` (before `init_logger`, so the log / config /
 artifacts all share one datetime). The tag keys every DB row and is the run's canonical identity;
 on-disk **filenames, plot titles, and Slack messages instead carry the machine-scoped _display tag_**
-`{command}_{machine}_{YYYYMMDD_HHMMSS}` (`aetherscan.display_tag`, host from `db.get_machine_name()`),
-so two hosts that resolve the same command+datetime do not collide when their artifacts land in one
-directory (e.g. weights copied bla0→blpc3). The display tag is presentation-only — nothing that keys
+`{command}_{machine}_{YYYYMMDD_HHMMSS}` (`aetherscan.display_tag`, host from `db.get_machine_name()`,
+with the spliced machine name sanitized to filename-safe characters — identity on real RFC-1123
+hostnames — so the display tag is safe to embed in a path by construction), so two hosts that resolve
+the same command+datetime do not collide when their artifacts land in one directory (e.g. weights
+copied bla0→blpc3). The display tag is presentation-only — nothing that keys
 a DB row, `save_tag` included, changes:
 
 | On the CLI | Resolves to | Use |

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -42,7 +42,9 @@ Aetherscan follows [Semantic Versioning 2.0.0](https://semver.org): every releas
 - the `python -m aetherscan.main {train,inference}` **CLI** — subcommand set, flag names, and the
   defaults that decide behavior when a flag is omitted;
 - the **saved-artifact + config-JSON formats** and the **model contract** inference reads from them
-  (`latent_dim`, the RF feature layout / `latent_variant`, the `.keras`/`.joblib` formats, the HF
+  (`latent_dim`, the RF feature layout / `latent_variant` — plus the forest's additive,
+  backward-compatible `aetherscan_latent_variant_` / `aetherscan_active_dims_` stamps, which
+  inference's identity checks simply no-op on when absent — the `.keras`/`.joblib` formats, the HF
   repo layout and weight-resolution rules);
 - the **supported runtimes** (NGC container / conda env / PyPI package) and their documented floors.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -57,7 +57,7 @@ tests/
 │   │                                #   counts, batched-transform split preservation
 │   ├── test_models.py               # feature layout, RF train/predict, encoder/decoder symmetry
 │   ├── test_latent_variants.py      # variant feature builders, active-unit detection, recall@FPR/
-│   │                                #   ECE/min-margin selection, probability calibrator (TF-free)
+│   │                                #   ECE/min-margin selection, probability calibrator, variant/active-dims stamp joblib round-trip (TF-free)
 │   ├── test_rf_metrics.py           # pure RF eval-metric helper: AUC/AP/Brier/confusion/quantile hand-computed cases, degenerate single-class split
 │   ├── test_shap_parallel.py        # positive-class shape normalization + MP-vs-single-process byte-identity (all three passes)
 │   ├── test_preprocessing.py        # k² equivalence gates, dedup, grouping, DC spike, spline


### PR DESCRIPTION
Closes #354. Follow-up to the merged #353 and the closed duplicate carrier #352.

#351's stated scope was the two pipeline docs (done in #353). The bot's #352 additionally, and correctly, touched three more files with incidental guard mentions — two of which are real minor drift from #346. Rather than rebase #352 over the now-merged #353 (conflict on the two overlapping files), this folds those three edits in fresh, verified against #352's diff and current source:

- **docs/ARCHITECTURE.md** — display-tag section notes the machine name is sanitized to filename-safe chars (#346), path-safe by construction.
- **docs/RELEASE.md** — SemVer contract-surface bullet notes the forest's additive, backward-compatible `aetherscan_latent_variant_` / `aetherscan_active_dims_` stamps (identity checks no-op when absent).
- **docs/TESTING.md** — `test_latent_variants.py` tree annotation mentions the new joblib round-trip test.

Docs-only; no `.py` touched.