### PR TITLE
ci: skip the contribution check on maintainer-authored PRs

### DIFF
--- a/.github/workflows/claude-contribution-check.yml
+++ b/.github/workflows/claude-contribution-check.yml
@@ -21,11 +21,15 @@ jobs:
     # up a runner and claude-code-action would abort with a "non-human actor" error — a red
     # failure on every bot issue. Skip the whole job instead. (allowed_bots is already unset, so
     # no comment is ever posted; this additionally avoids the noisy failed run.) See issue #83.
+    # Also skip PRs authored by the maintainer (#373) — the compliance reminder is for incoming
+    # contributions. Issue-opened events still fire regardless of author: the pull_request
+    # context is empty on an issues event, so the login clause can't match there.
     if: >-
       github.event.issue.user.type != 'Bot' &&
       github.event.pull_request.user.type != 'Bot' &&
       !endsWith(github.actor, '[bot]') &&
-      github.actor != 'claude'
+      github.actor != 'claude' &&
+      github.event.pull_request.user.login != 'zachtheyek'
     runs-on: ubuntu-latest
     # Contribution check shouldn't take more than 5 mins (refine if data shows otherwise)
     timeout-minutes: 5

--- a/docs/GITHUB_AUTOMATION.md
+++ b/docs/GITHUB_AUTOMATION.md
@@ -86,7 +86,7 @@ double-post.
 | [`claude.yml`](../.github/workflows/claude.yml) | Handle mention / assignment / `claude` label on issues, PRs, Discussions, comments, reviews | The general-purpose assistant: answers, implements, opens PRs on `claude/*` branches. `allowed_bots: "claude,claude[bot]"` — deliberately, so issues *filed by* the other workflows (as the `claude` bot) can invoke it for follow-up PRs. | — |
 | [`claude-code-review.yml`](../.github/workflows/claude-code-review.yml) | PR opened / ready_for_review | Automated first-pass code review with inline comments. Every PR gets one on open; address the actionable notes and resolve the conversations before human review. | — |
 | [`claude-issue-triage.yml`](../.github/workflows/claude-issue-triage.yml) | Issue opened | Triage: applies labels (type/area/priority) so label sync can propagate them to the eventual PR. | — |
-| [`claude-contribution-check.yml`](../.github/workflows/claude-contribution-check.yml) | Issue or PR opened | Verifies workflow compliance (issue linkage, branch-prefix conventions, template use) and comments when something's missing. **Never runs for bot authors** — see the gotcha below. | — |
+| [`claude-contribution-check.yml`](../.github/workflows/claude-contribution-check.yml) | Issue or PR opened | Verifies workflow compliance (issue linkage, branch-prefix conventions, template use) and comments when something's missing. **Never runs for bot authors, nor on maintainer-authored PRs** (issue-opened events still fire for every human author) — see the gotcha below. | — |
 | [`claude-release-notes.yml`](../.github/workflows/claude-release-notes.yml) | PR **merged** to master | Drafts a release-note entry as a PR comment — the curated raw material for release bodies (see [`RELEASE.md`](RELEASE.md)). | `<!-- claude-release-notes -->` first line of the comment |
 | [`claude-style-check.yml`](../.github/workflows/claude-style-check.yml) | PR merged to master | Scans the merged diff's *added* lines against the project style rules ruff can't express (docstring prose style, canonical comment markers, logging idioms); files one consolidated issue when violations exist. | `<!-- aetherscan-style-check pr=<N> -->` |
 | [`claude-update-docs.yml`](../.github/workflows/claude-update-docs.yml) | PR merged to master; `workflow_dispatch` with a `pr_number` (re-scan an old PR with the *current* workflow logic) | Detects doc drift caused by the merge. If `cli.py` changed, a **shell step** regenerates the README CLI Reference blocks with `utils/print_cli_help.py` (Python pinned to 3.12 — argparse help formatting changes in 3.13) and embeds the output in the issue, because the follow-up assistant run has no `python` in its tool allowlist. The filed issue contains an intentional handle mention, which triggers `claude.yml` to open the actual docs PR. | `<!-- aetherscan-update-docs pr=<N> -->` |
@@ -122,7 +122,11 @@ its `allowed_bots` list. Three configurations coexist here, each deliberate:
   excludes bot actors entirely.** Without the `if:`, every bot-filed issue would spin up a
   runner just for the action to abort with a "non-human actor" error — a red ✗ on every
   automated issue (this is the other half of the issue #83 story). Skipping the job at the
-  `if:` level avoids both the comment and the noisy failure.
+  `if:` level avoids both the comment and the noisy failure. The same guard also skips
+  **maintainer-authored PRs** (#373) — the compliance reminder targets incoming
+  contributions, so the maintainer's own PRs don't spend a runner on it; maintainer-opened
+  *issues* still get the discussion-link nudge (the `pull_request` context is empty on an
+  issues event, so the login clause can't match there).
 
 When adding a workflow, decide explicitly which side of this each trigger actor falls on.
 


### PR DESCRIPTION
## Summary

Adds one clause to `claude-contribution-check.yml`'s job-level `if:` guard: PRs authored by `zachtheyek` no longer trigger the compliance check. The check exists to enforce workflow rules on incoming contributions — on maintainer PRs it only cost a runner spin-up and an action invocation per PR.

## Semantics

- The workflow fires on `issues: opened` and `pull_request: opened`. On an issues event `github.event.pull_request` is empty, so the new `login != 'zachtheyek'` clause evaluates true there — **issue-opened events keep firing for every human author**, exactly as before.
- The existing bot-actor exclusions are untouched; this composes with them via `&&`.

## Verification

The expression change is minimal and mirrors the established pattern in the same guard. YAML validity is covered by pre-commit's check-yaml; behavior is observable on the very next maintainer PR (this one fires the *old* definition from master, since `pull_request` workflows run from the base branch — the first PR opened *after* this merges is the real test).

Closes #373