### PR TITLE
feat(config): raise default training scale — 50 rounds, injection SNR window 1–100

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -239,7 +239,8 @@ Index: `(tag, round_number, epoch_number, step_number, model_name, timestamp)`
 loads one capture per frame — up to `latent_viz_gif_max_frames` (500) queries with equality
 on the capture key and the run window trailing — and the old timestamp-second shape
 answered each by scanning the tag's whole window (measured 67× slower per frame at 2 M
-rows; ~1.5 h → ~2 s per GIF pass at the ~100 M-row release scale). Key columns lead so the
+rows; ~1.5 h → ~2 s per GIF pass at the ~100 M-row release scale — measured at the
+pre-#372 20-round default; a 50-round run carries ~2.5× the rows). Key columns lead so the
 dashboard's model-less latest-capture lookup walks the index backward instead of sorting
 the partition; write cost is unchanged because `round/epoch/step` grow monotonically like
 `timestamp`, so both shapes append at the B-tree's right edge
@@ -432,8 +433,9 @@ cost a multi-GB teardown RAM spike for invisible detail.
 `get_db_stats()` returns row counts per table, the covered time range, and the database file
 size — **on-demand diagnostics only** since #301: its per-table `COUNT(*)` full scans
 measured ~13 min per cold-cache launch on the 80 GB production DB (re-paid on every
-retry-loop relaunch), so `Database.__init__` no longer calls it and startup logs only the
-O(1) `db_size_bytes` pragma.
+retry-loop relaunch; both figures from a 20-round run — the #372 50-round default grows
+the DB, and that scan, ~2.5×), so `Database.__init__` no longer calls it and startup logs
+only the O(1) `db_size_bytes` pragma.
 
 ## Growth expectations
 
@@ -446,13 +448,14 @@ Rules of thumb at full-scale defaults (dominant terms only):
   signal-characteristic rows for `true_eti_rfi`, so their mean is 6.5). That is
   **~24.5 rows per cadence** (18 + 6.5). A training round generates `3 × num_samples_beta_vae`
   cadences (main + true + false), so at defaults:
-  `3 × 499 200 × ~24.5 ≈ 37 M rows per round`, times 20 rounds plus the RF dataset. This is
+  `3 × 499 200 × ~24.5 ≈ 37 M rows per round`, times 50 rounds plus the RF dataset
+  (~1.85 B rows). This is
   why these rows ride the bounded bulk lane in per-segment batches (#277), why the drainer
   runs off the training critical
   path, and why the injection plots subsample (`plot_injection_subsampling_count`). If the
   database size becomes a problem, this table is where the budget goes — smoke-scale runs
   (`--num-samples-beta-vae 3072`) keep it trivial.
-- **`training_stats`**: ~21 + `latent_dim` rows/epoch → ~58 k rows for 20 × 100 epochs at
+- **`training_stats`**: ~21 + `latent_dim` rows/epoch → ~145 k rows for 50 × 100 epochs at
   the default `latent_dim` 8; the RF stage adds
   a negligible tail (~25 scalars + `classification_threshold` + the #282 sweep/test/screen
   metrics + the per-tree
@@ -460,7 +463,7 @@ Rules of thumb at full-scale defaults (dominant terms only):
 - **`latent_snapshots`**: one row per viz cadence per capture — 3840 cadences
   (`latent_viz_num_cadences_per_type=960` × 4 signal types) × one capture every
   `latent_viz_step_interval` steps (plus the final step) × epochs. At full scale
-  (130 steps/epoch → 13 captures/epoch): ~100 M rows over 20 × 100 epochs, each carrying a
+  (130 steps/epoch → 13 captures/epoch): ~250 M rows over 50 × 100 epochs, each carrying a
   48-float JSON vector. Still the second heaviest table (behind `injection_stats`);
   `latent_viz_step_interval` and `latent_viz_num_cadences_per_type` are the knobs.
 - **`system_resources`**: (4 + 2 × n_GPUs) rows/second — ~1.2 M rows/day on a 6-GPU node.

--- a/docs/TRAINING_PIPELINE.md
+++ b/docs/TRAINING_PIPELINE.md
@@ -36,7 +36,7 @@ fresh datetime tag and starts a new run).
 
 ## Round lifecycle
 
-`TrainingPipeline.train_beta_vae()` runs `training.num_training_rounds` rounds (default 20) of
+`TrainingPipeline.train_beta_vae()` runs `training.num_training_rounds` rounds (default 50) of
 `training.epochs_per_round` epochs (default 100). Each round (`train_round()`):
 
 1. **Obtain data** — reuse a validated on-disk round dataset if one exists, else wait on the
@@ -76,8 +76,9 @@ a fresh optimization problem. Adam moments are curriculum-stage-local by the sam
 ### Curriculum schedules
 
 `_calculate_curriculum_snr(round_idx)` narrows the injection SNR range from
-`initial_snr_range` (40) down to `final_snr_range` (10) above `snr_base` (10) across the
-rounds — early rounds see bright, easy signals; late rounds see predominantly faint ones.
+`initial_snr_range` (99) down to `final_snr_range` (9) above `snr_base` (1) across the
+rounds — the easiest window spans SNR 1–100, the hardest narrows to the quietest decade
+(1–10); early rounds see bright, easy signals; late rounds see predominantly faint ones.
 Three schedules (`--curriculum-schedule`):
 
 | Schedule | Behavior | Knobs |
@@ -145,7 +146,7 @@ Key properties (all in [`round_data.py`](../src/aetherscan/round_data.py) /
 > footprint at ~294 GB). `--keep-round-data` retains every round's exact on-disk dataset (plus the
 > RF training set) under `{data_path}/training/round_data/{save_tag}/{round_XX,rf}/`, so a release
 > model's training data is reproducible/inspectable after the fact — at the cost of holding the full
-> run on disk (~147 GB × num_training_rounds, e.g. ~2.94 TB for a 20-round run; double both under
+> run on disk (~147 GB × num_training_rounds, e.g. ~7.35 TB for a 50-round run; double both under
 > the `float32` setting). Nothing in the pipeline
 > *reads* an earlier round once it has trained, so this flag is purely for post-hoc retention.
 

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -278,7 +278,7 @@ class TrainingConfig:
     # Reproducibility now lives in ReproducibilityConfig (#279): one root seed shared by both
     # pipelines instead of a training-only seed plus an independent rf.seed.
 
-    num_training_rounds: int = 20
+    num_training_rounds: int = 50
     epochs_per_round: int = 100
 
     # Posterior-collapse guard (#282): a latent dim counts ACTIVE while its batch-mean KL
@@ -425,15 +425,19 @@ class TrainingConfig:
     # Model-quality gate params (issue #139 Gate 1)
     min_val_auc: float = 0.0  # Opt-in floor on the RF's validation ROC-AUC; 0.0 disables the check. When set and unmet after the RF fit, training logs a loud WARNING (reaches the Slack summary) rather than failing the run
 
-    # Curriculum learning params
-    snr_base: int = 10
-    initial_snr_range: int = 40
-    final_snr_range: int = 10
+    # Curriculum learning params. Injected signals draw snr = snr_base + U(0,1) * snr_range,
+    # so the easiest window spans snr_base..snr_base+initial_snr_range (1-100) and the hardest
+    # narrows to snr_base..snr_base+final_snr_range (1-10, the quietest decade).
+    snr_base: int = 1
+    initial_snr_range: int = 99
+    final_snr_range: int = 9
     curriculum_schedule: str = "exponential"  # "linear", "exponential", "step"
     exponential_decay_rate: float = -3.0  # How quickly schedule should progress from easy to hard (must be <0) (more negative = less easy rounds & more hard rounds)
     # TODO: generalize this to receive a step schedule (as a list/dict?) validate that len(list/dict) is divisible by num_training_rounds
-    step_easy_rounds: int = 5  # Number of rounds with easy signals
-    step_hard_rounds: int = 15  # Number of rounds with challenging signals
+    step_easy_rounds: int = (
+        10  # Number of rounds with easy signals (must sum with hard to num_training_rounds)
+    )
+    step_hard_rounds: int = 40  # Number of rounds with challenging signals
 
     # Adaptive LR params
     base_learning_rate: float = 0.001

--- a/tests/integration/test_model_behavior.py
+++ b/tests/integration/test_model_behavior.py
@@ -41,8 +41,10 @@ _BACKGROUND_FILE = "real_filtered_LARGE_HIP110750.npy"  # first default train fi
 # behavioral gate exercises.
 _FREQ_RESOLUTION = 2.7939677238464355  # Hz
 _TIME_RESOLUTION = 18.25361108  # seconds
-# Controlled SNRs spanning the training curriculum (snr_base=10, initial range 40 → the
-# model saw SNR 10-50 during training).
+# Controlled SNRs spanning the training curriculum of the persisted smoke model
+# (snr_base=10, initial range 40 → it saw SNR 10-50 during training; these are the
+# pre-#372 defaults — retune to span 1-100, e.g. (2.0, 5.0, 20.0, 80.0), when the smoke
+# model is retrained at the current defaults).
 _SNRS = (10.0, 20.0, 35.0, 50.0)
 _CADENCES_PER_SNR = 32
 # Allowed decrease in mean P(true) between consecutive SNR levels; absorbs sampling noise

--- a/tests/integration/test_model_behavior.py
+++ b/tests/integration/test_model_behavior.py
@@ -44,7 +44,9 @@ _TIME_RESOLUTION = 18.25361108  # seconds
 # Controlled SNRs spanning the training curriculum of the persisted smoke model
 # (snr_base=10, initial range 40 → it saw SNR 10-50 during training; these are the
 # pre-#372 defaults — retune to span 1-100, e.g. (2.0, 5.0, 20.0, 80.0), when the smoke
-# model is retrained at the current defaults).
+# model is retrained at the current defaults, and revisit _TOLERANCE/_CADENCES_PER_SNR
+# with it: a bottom rung near the noise floor is both close to chance and noisier than
+# the 10-and-up rungs these values were sized for).
 _SNRS = (10.0, 20.0, 35.0, 50.0)
 _CADENCES_PER_SNR = 32
 # Allowed decrease in mean P(true) between consecutive SNR levels; absorbs sampling noise

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -150,3 +150,12 @@ class TestCoupledDefaultsGuard:
             Config()
         # Don't leave the half-built diverged singleton behind for the fixture teardown.
         Config._reset()
+
+    def test_default_step_schedule_sums_to_round_count(self):
+        # Not a default-value assertion (those stay unpinned on purpose) but an invariant on
+        # the shipped combination: _calculate_curriculum_snr raises when
+        # step_easy_rounds + step_hard_rounds != num_training_rounds, so a default
+        # `--curriculum-schedule step` run must never trip it out of the box (#372 rescaled
+        # 5/15 -> 10/40 alongside num_training_rounds 20 -> 50 for exactly this reason).
+        training = get_config().training
+        assert training.step_easy_rounds + training.step_hard_rounds == training.num_training_rounds


### PR DESCRIPTION
## Summary

Maintainer-requested default changes for the next release, applied **coherently** across the interacting curriculum knobs rather than as two isolated flips:

| Field | Old | New | Why together |
| --- | --- | --- | --- |
| `num_training_rounds` | 20 | 50 | requested |
| `snr_base` | 10 | 1 | signals draw `snr = snr_base + U(0,1)·snr_range`, so the easiest window becomes exactly **SNR 1–100** |
| `initial_snr_range` | 40 | 99 | ditto (10–50 → 1–100) |
| `final_snr_range` | 10 | 9 | the hardest window becomes the quietest decade, **1–10** (maintainer's pick over preserving the old 10-wide window) |
| `step_easy_rounds` / `step_hard_rounds` | 5 / 15 | 10 / 40 | `_calculate_curriculum_snr` **validates easy+hard == num_training_rounds at runtime** — the old split would crash a 50-round `--curriculum-schedule step` run out of the box; 10/40 is the maintainer's pick |
| `exponential_decay_rate` | −3.0 | −3.0 (unchanged) | the exponential schedule is normalized over `progress ∈ [0,1]`, so its shape is invariant to the round count |

## Scope notes

- CLI: no `cli.py` change — validation is generic (positivity + `initial ≥ final` ordering, all satisfied) and argparse help strings don't embed these numeric defaults, so the README CLI Reference is untouched.
- Docs: `docs/TRAINING_PIPELINE.md` updated where it states the old numbers (round-count default, the SNR-window prose, and the `--retain-round-data` disk-size example, ~147 GB × rounds → ~7.35 TB at 50).
- No unit tests assert these defaults (they all set values explicitly); no test change needed.
- The released weights (`train_20260729_152426`) keep their own config snapshot — these defaults govern *future* runs only, and the code-default-vs-released-config divergence is expected.
- Contract note for the release: changing behavior-when-a-flag-is-omitted is part of the CLI compatibility surface — the release PR will weigh this in the SemVer decision.

Closes #372