### PR TITLE
feat(db): schema v9 — round-scoped injection index + covering latent-keys partial index

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -342,7 +342,7 @@ attempt, each with its own span.
 | v6 | `is_finite INTEGER DEFAULT 1` on `training_stats` (#289 NaN-write hardening) | additive `ALTER TABLE ... ADD COLUMN` |
 | v7 | the index sweep: the `idx_injection_stats_by_stat` secondary index on `injection_stats`; `latent_snapshots`' index reshaped to `idx_latent_snapshots_by_key` | `DROP INDEX IF EXISTS idx_latent_snapshots_filter` in the migration block; the CREATEs run in `_init_database()` and are re-executed there |
 | v8 | the `idx_inference_results_supersede` partial index on `inference_results` (`(tag, npy_path) WHERE superseded = 0`, #301) | the `if version < 8` block creates it — deliberately NOT `_init_database()`: the partial predicate needs the `superseded` column the v1 ALTER adds, so an init-time CREATE would fail on a pre-v1 file. Fresh databases reach the block too (version 0 → current) |
-| v9 | the #375 index audit: `idx_injection_stats_by_round` (`(tag, round_number, timestamp)`) + the `idx_latent_snapshots_keys` covering partial index; `+round_number` planner guards in the two injection query builders | `by_round`'s CREATE runs in `_init_database()` and is re-executed in the block (v7 convention); the latent partial lives only in the block (v8 convention — its predicate needs the v1 `superseded` column). **Upgrading an existing catalog-scale DB (~190 M `injection_stats` rows) builds `by_round` with a one-time full-table scan + sort — expect the first launch to stall for minutes to tens of minutes, and budget transient WAL disk headroom well beyond the final index size (the build's pages accumulate in the `-wal` file until checkpoint)** |
+| v9 | the #375 index audit: `idx_injection_stats_by_round` (`(tag, round_number, timestamp)`) + the `idx_latent_snapshots_keys` covering partial index; `+round_number` planner guards in the two injection query builders | `by_round`'s CREATE runs in `_init_database()` and is re-executed in the block (v7 convention); the latent partial lives only in the block (v8 convention — its predicate needs the v1 `superseded` column). **Upgrading an existing catalog-scale DB builds both indexes in one stall — `by_round` over ~190 M `injection_stats` rows and the latent partial over the live subset of ~100 M `latent_snapshots` rows, each a one-time full-table scan + sort — expect the first launch to stall for minutes to tens of minutes, and budget transient WAL disk headroom well beyond the final index sizes (the builds' pages accumulate in the `-wal` file until checkpoint)** |
 
 - **v0 → v1**: `ALTER TABLE ... ADD COLUMN superseded INTEGER DEFAULT 0` on the four tables
   above — the only in-place change SQLite supports is additive `ADD COLUMN`, which is exactly
@@ -402,9 +402,10 @@ attempt, each with its own span.
   `+round_number` planner guards in the two injection builders ship in the same change —
   without them the no-`ANALYZE` cost model moves the ~165-query plot pass onto `by_round`
   (measured 1.4–10.7× per-query regressions on production-shaped replicas), resurrecting
-  the pre-v7 pathology. Upgrade cost: building `by_round` over an existing catalog-scale
-  DB is a one-time full-table scan + sort — the first launch after upgrading stalls in
-  `_migrate_schema` for minutes to tens of minutes; later launches are unaffected.
+  the pre-v7 pathology. Upgrade cost: building `by_round` (and the latent partial) over an
+  existing catalog-scale DB is a one-time full-table scan + sort per index — the first
+  launch after upgrading stalls in `_migrate_schema` for minutes to tens of minutes; later
+  launches are unaffected.
 
 Fresh databases get the full current schema from the CREATE statements and are just stamped
 (the block-only partial indexes — v8's supersede index and v9's latent-keys index — land via

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -342,7 +342,7 @@ attempt, each with its own span.
 | v6 | `is_finite INTEGER DEFAULT 1` on `training_stats` (#289 NaN-write hardening) | additive `ALTER TABLE ... ADD COLUMN` |
 | v7 | the index sweep: the `idx_injection_stats_by_stat` secondary index on `injection_stats`; `latent_snapshots`' index reshaped to `idx_latent_snapshots_by_key` | `DROP INDEX IF EXISTS idx_latent_snapshots_filter` in the migration block; the CREATEs run in `_init_database()` and are re-executed there |
 | v8 | the `idx_inference_results_supersede` partial index on `inference_results` (`(tag, npy_path) WHERE superseded = 0`, #301) | the `if version < 8` block creates it — deliberately NOT `_init_database()`: the partial predicate needs the `superseded` column the v1 ALTER adds, so an init-time CREATE would fail on a pre-v1 file. Fresh databases reach the block too (version 0 → current) |
-| v9 | the #375 index audit: `idx_injection_stats_by_round` (`(tag, round_number, timestamp)`) + the `idx_latent_snapshots_keys` covering partial index; `+round_number` planner guards in the two injection query builders | `by_round`'s CREATE runs in `_init_database()` and is re-executed in the block (v7 convention); the latent partial lives only in the block (v8 convention — its predicate needs the v1 `superseded` column). **Upgrading an existing catalog-scale DB (~190 M `injection_stats` rows) builds `by_round` with a one-time full-table scan + sort — expect the first launch to stall for minutes to tens of minutes** |
+| v9 | the #375 index audit: `idx_injection_stats_by_round` (`(tag, round_number, timestamp)`) + the `idx_latent_snapshots_keys` covering partial index; `+round_number` planner guards in the two injection query builders | `by_round`'s CREATE runs in `_init_database()` and is re-executed in the block (v7 convention); the latent partial lives only in the block (v8 convention — its predicate needs the v1 `superseded` column). **Upgrading an existing catalog-scale DB (~190 M `injection_stats` rows) builds `by_round` with a one-time full-table scan + sort — expect the first launch to stall for minutes to tens of minutes, and budget transient WAL disk headroom well beyond the final index size (the build's pages accumulate in the `-wal` file until checkpoint)** |
 
 - **v0 → v1**: `ALTER TABLE ... ADD COLUMN superseded INTEGER DEFAULT 0` on the four tables
   above — the only in-place change SQLite supports is additive `ADD COLUMN`, which is exactly
@@ -407,7 +407,8 @@ attempt, each with its own span.
   `_migrate_schema` for minutes to tens of minutes; later launches are unaffected.
 
 Fresh databases get the full current schema from the CREATE statements and are just stamped
-(the one v8 exception above lands via the migration block either way).
+(the block-only partial indexes — v8's supersede index and v9's latent-keys index — land via
+the migration block either way).
 The pattern to follow for future changes: bump `_SCHEMA_VERSION`, add a
 `if version < N:` block with additive, idempotent statements, and rely on
 `CREATE TABLE IF NOT EXISTS` for whole new tables.

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -14,7 +14,7 @@ high-volume injection-stat chunks (#277) — drained by **one background writer 
 batches rows and commits with `executemany()`; reads open short-lived connections directly.
 Failed-attempt rows are never deleted — they're flagged `superseded = 1`, and every query
 filters them out by default. Schema evolution is a minimal `PRAGMA user_version` gate
-(currently version 8).
+(currently version 9).
 
 > [!IMPORTANT]
 > The write queue is a **thread** queue, not process-safe. Worker *processes* must never call
@@ -185,8 +185,16 @@ filters with run-wide timestamp bounds the first index can only answer by scanni
 whole timestamp range. The trailing column is deliberately `timestamp`: that shape is chosen
 by SQLite's default cost model with no `ANALYZE` stats (a `round_number`-trailing variant
 measured as never chosen without `sqlite_stat1`), and it serves the round-scoped per-round
-queries too via their span-tightened timestamp windows. No query changes: the planner picks
-the better index per query.
+queries too via their span-tightened timestamp windows. Since v9 (#375) a third index,
+`(tag, round_number, timestamp)` (`idx_injection_stats_by_round`), serves exactly two
+consumers: the training-resume supersede `UPDATE` (writer-thread-blocking; previously a
+whole-partition row fetch to test the round predicate) and the round-bounded
+`query_injection_stat_time_span` aggregate (now a covering index-only scan). It is
+**deliberately invisible to the plot-pass queries**: with no `ANALYZE` stats the planner
+would prefer its leading range over `by_stat`'s equality prefix and re-create the pre-v7
+pathology, so the round-bound terms in `query_injection_stat` /
+`query_injection_stat_stability` are written `+round_number` (SQLite's unary-plus term
+disqualification) — keep those guards if you touch either builder.
 
 ### `training_stats`
 
@@ -233,9 +241,16 @@ steps — the raw material of the latent-space GIFs.
 | `snr_base`, `snr_range` | INTEGER | Curriculum stage at capture time |
 | `superseded` | INTEGER | Default 0 |
 
-Index: `(tag, round_number, epoch_number, step_number, model_name, timestamp)`
+Indexes: `(tag, round_number, epoch_number, step_number, model_name, timestamp)`
 (`idx_latent_snapshots_by_key`, reshaped in v7 from the original
-`(tag, timestamp, model_name, round_number, epoch_number, step_number)`). The GIF pass
+`(tag, timestamp, model_name, round_number, epoch_number, step_number)`) plus, since v9
+(#375), the covering **partial** index `(tag, model_name, round_number, epoch_number,
+step_number, snr_base, snr_range, timestamp) WHERE superseded = 0`
+(`idx_latent_snapshots_keys`) for `query_latent_snapshot_keys`: its bare `superseded = 0`
+term proves the partial predicate, and the column order matches the `DISTINCT` projection
+and `ORDER BY` prefix, so the once-per-GIF-pass key enumeration is an index-only scan
+instead of a whole-partition row fetch through the `latent_vector` JSON payloads (an
+`include_superseded=True` audit call falls back to `by_key`). The GIF pass
 loads one capture per frame — up to `latent_viz_gif_max_frames` (500) queries with equality
 on the capture key and the run window trailing — and the old timestamp-second shape
 answered each by scanning the tag's whole window (measured 67× slower per frame at 2 M
@@ -327,6 +342,7 @@ attempt, each with its own span.
 | v6 | `is_finite INTEGER DEFAULT 1` on `training_stats` (#289 NaN-write hardening) | additive `ALTER TABLE ... ADD COLUMN` |
 | v7 | the index sweep: the `idx_injection_stats_by_stat` secondary index on `injection_stats`; `latent_snapshots`' index reshaped to `idx_latent_snapshots_by_key` | `DROP INDEX IF EXISTS idx_latent_snapshots_filter` in the migration block; the CREATEs run in `_init_database()` and are re-executed there |
 | v8 | the `idx_inference_results_supersede` partial index on `inference_results` (`(tag, npy_path) WHERE superseded = 0`, #301) | the `if version < 8` block creates it — deliberately NOT `_init_database()`: the partial predicate needs the `superseded` column the v1 ALTER adds, so an init-time CREATE would fail on a pre-v1 file. Fresh databases reach the block too (version 0 → current) |
+| v9 | the #375 index audit: `idx_injection_stats_by_round` (`(tag, round_number, timestamp)`) + the `idx_latent_snapshots_keys` covering partial index; `+round_number` planner guards in the two injection query builders | `by_round`'s CREATE runs in `_init_database()` and is re-executed in the block (v7 convention); the latent partial lives only in the block (v8 convention — its predicate needs the v1 `superseded` column). **Upgrading an existing catalog-scale DB (~190 M `injection_stats` rows) builds `by_round` with a one-time full-table scan + sort — expect the first launch to stall for minutes to tens of minutes** |
 
 - **v0 → v1**: `ALTER TABLE ... ADD COLUMN superseded INTEGER DEFAULT 0` on the four tables
   above — the only in-place change SQLite supports is additive `ADD COLUMN`, which is exactly
@@ -377,6 +393,18 @@ attempt, each with its own span.
   adds, so an init-time CREATE would precede the ALTER and fail on a pre-v1 file. Fresh
   databases reach the block too (version 0 → current), so both paths land the same final
   index set.
+- **v8 → v9** (the #375 index audit): `idx_injection_stats_by_round` follows the v7
+  convention (CREATE in `_init_database()`, re-executed in the block — its columns all
+  pre-date v1), `idx_latent_snapshots_keys` the v8 convention (block-only — partial
+  predicate on `superseded`). The audit also verified every pre-existing index against the
+  live query set (none dropped: each traced to concrete consumers) and rejected a
+  `system_resources` per-series candidate the planner would never choose unforced. The
+  `+round_number` planner guards in the two injection builders ship in the same change —
+  without them the no-`ANALYZE` cost model moves the ~165-query plot pass onto `by_round`
+  (measured 1.4–10.7× per-query regressions on production-shaped replicas), resurrecting
+  the pre-v7 pathology. Upgrade cost: building `by_round` over an existing catalog-scale
+  DB is a one-time full-table scan + sort — the first launch after upgrading stalls in
+  `_migrate_schema` for minutes to tens of minutes; later launches are unaffected.
 
 Fresh databases get the full current schema from the CREATE statements and are just stamped
 (the one v8 exception above lands via the migration block either way).
@@ -412,12 +440,14 @@ bounded to a round range), or `None` when no rows match. It is a single whole-pa
 aggregate with **no timestamp filter and no superseded/`is_finite` filtering** — a deliberate
 **superset bound**: the span covers every row a filtered query could return for those rounds,
 so a caller that intersects its own time window with the span can only narrow index scans,
-never change a result set. It exists because `idx_injection_stats_filter` leads with
-`(tag, timestamp)` and `round_number` is not in the index, so a round-scoped query with a
-run-wide window re-scans the tag's entire row history (measured 10.5× slower at 12M rows,
-quadratic over a campaign as history accumulates) — `plot_injection_stats` issues ~165 such
-queries per call and now pays this one aggregate up front, tightening every window to the
-plotted rounds' actual span (±1 s).
+never change a result set. It exists because the row-level plot queries run on the
+timestamp/stat-leading indexes (their round terms carry the `+` planner guard since v9), so
+a round-scoped query with a run-wide window would re-scan the tag's entire row history
+(measured 10.5× slower at 12M rows, quadratic over a campaign as history accumulates) —
+`plot_injection_stats` issues ~165 such queries per call and now pays this one aggregate up
+front, tightening every window to the plotted rounds' actual span (±1 s). Since v9 the
+aggregate itself runs on `idx_injection_stats_by_round` as a covering index-only scan
+(previously it row-fetched the whole tag partition to test the round predicate).
 
 **`query_system_resource_decimated(tag, start_time, end_time, max_points_per_series)`**
 (#301) returns a per-series uniformly-strided subset of `system_resources` rows (same dict

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -88,7 +88,18 @@ _MARK_SUPERSEDED_SENTINEL = object()
 #     index led with (tag, timestamp, ...), so the once-per-cadence supersede UPDATE (which
 #     BLOCKS the inference thread via the writer-queue sentinel) visited every live row of
 #     the tag partition — a quadratic-in-catalog term on RFI-dense 6k-cadence runs (#301).
-_SCHEMA_VERSION = 8
+# v9: the #375 index audit. Added idx_injection_stats_by_round (tag, round_number,
+#     timestamp) — before it, round_number appeared in NO injection_stats index, so the
+#     training-resume supersede UPDATE (writer-thread-blocking) and the round-bounded
+#     time-span aggregate each row-fetched the tag's entire partition (~190M rows on a
+#     catalog DB) to test the round predicate. Because the no-ANALYZE planner prefers a
+#     leading-range index over by_stat's equality columns, the round-bound terms in
+#     query_injection_stat / query_injection_stat_stability are written `+round_number`
+#     (unary plus = not usable for index selection) so the v7 plot-pass plans are
+#     untouched. Also added idx_latent_snapshots_keys, a covering partial index (WHERE
+#     superseded = 0) for query_latent_snapshot_keys' DISTINCT scan — previously a
+#     whole-partition row fetch through latent_vector JSON payloads once per GIF pass.
+_SCHEMA_VERSION = 9
 
 
 # Per-process cache for get_system_metadata(): every field (hostname, user, outbound IP, PID)
@@ -357,6 +368,21 @@ class Database:
             cursor.execute("""
                 CREATE INDEX IF NOT EXISTS idx_injection_stats_by_stat
                 ON injection_stats(tag, stat_name, signal_type, injection_stage, timestamp)
+            """)
+
+            # Round-scoped index (schema v9, #375): serves exactly two consumers — the
+            # training-resume supersede UPDATE (superseded=0 AND tag=? AND round_number>=?,
+            # which blocks the writer thread) and query_injection_stat_time_span's round
+            # bounds — as a bounded (tag, round-range) seek instead of a whole-partition
+            # row fetch. DELIBERATELY invisible to the plot-pass queries: without ANALYZE
+            # (which this pipeline never runs) SQLite's cost model would prefer this
+            # leading-range shape over by_stat's equality prefix and re-create the ~6h
+            # pathology v7 fixed, so query_injection_stat / query_injection_stat_stability
+            # disqualify it with unary-plus round terms (`+round_number`). Keep those
+            # guards if you touch either builder.
+            cursor.execute("""
+                CREATE INDEX IF NOT EXISTS idx_injection_stats_by_round
+                ON injection_stats(tag, round_number, timestamp)
             """)
 
             # Training statistics table
@@ -635,6 +661,30 @@ class Database:
                 ON inference_results(tag, npy_path) WHERE superseded = 0
             """)
             logger.info("Schema migration: v8 supersede partial index applied")
+
+        if version < 9:
+            # v9: the #375 index audit (see the version-history comment). The by_round
+            # CREATE mirrors _init_database (idempotent recording, v7 convention); the
+            # latent-keys partial index lives ONLY here, for the same reason as v8: its
+            # WHERE superseded = 0 predicate needs the column the v1 block above adds.
+            # NOTE: on an existing catalog-scale DB (~190M injection_stats rows / 80 GB)
+            # the by_round build is a one-time full-table scan + sort — expect the FIRST
+            # pipeline launch against such a DB after this upgrade to stall here for
+            # minutes to tens of minutes. Subsequent launches are unaffected.
+            cursor.execute("""
+                CREATE INDEX IF NOT EXISTS idx_injection_stats_by_round
+                ON injection_stats(tag, round_number, timestamp)
+            """)
+            cursor.execute("""
+                CREATE INDEX IF NOT EXISTS idx_latent_snapshots_keys
+                ON latent_snapshots(tag, model_name, round_number, epoch_number,
+                                    step_number, snr_base, snr_range, timestamp)
+                WHERE superseded = 0
+            """)
+            logger.info(
+                "Schema migration: v9 index audit applied "
+                "(injection_stats by_round + latent_snapshots keys partial)"
+            )
 
         # PRAGMA doesn't support parameter binding; _SCHEMA_VERSION is a module-level int constant
         cursor.execute(f"PRAGMA user_version = {_SCHEMA_VERSION:d}")
@@ -2037,11 +2087,14 @@ class Database:
         MIN/MAX timestamp over a tag's injection_stats rows, optionally bounded to a round
         range. One deliberate full-partition aggregate (no timestamp filter; superseded and
         non-finite rows included) that lets callers tighten the (tag, timestamp) index window
-        for the many row-level queries that follow — idx_injection_stats_filter leads with
-        (tag, timestamp) and round_number is not in it, so a run-wide window makes every
-        round-scoped query re-scan the tag's whole history. The span covers every row a
-        filtered query could return for those rounds, so intersecting a query window with it
-        never changes that query's result set. Returns None when no rows match.
+        for the many row-level queries that follow — those run on the timestamp/stat-leading
+        indexes (their round terms carry the `+` planner guard, see query_injection_stat), so
+        a run-wide window would make every round-scoped query re-scan the tag's whole
+        history. This aggregate itself is the intended reader of idx_injection_stats_by_round
+        (v9): tag equality + round range + in-index timestamp make it a covering index-only
+        scan. The span covers every row a filtered query could return for those rounds, so
+        intersecting a query window with it never changes that query's result set. Returns
+        None when no rows match.
         """
         with self._get_connection() as conn:
             cursor = conn.cursor()
@@ -2111,12 +2164,17 @@ class Database:
             if stat_name:
                 query = self._add_str_filter(query, params, "stat_name", stat_name)
 
+            # `+round_number`: the unary plus keeps the term out of index selection
+            # (semantics unchanged). Without it, the no-ANALYZE planner prefers
+            # idx_injection_stats_by_round's leading range over by_stat's equality
+            # prefix for the ~165-query plot pass — re-creating the pre-v7 pathology
+            # (see the v9 entry in the version-history comment).
             if start_round_number is not None:
-                query += " AND round_number >= ?"
+                query += " AND +round_number >= ?"
                 params.append(start_round_number)
 
             if end_round_number is not None:
-                query += " AND round_number <= ?"
+                query += " AND +round_number <= ?"
                 params.append(end_round_number)
 
             if start_chunk_number is not None:
@@ -2223,12 +2281,14 @@ class Database:
             if stat_name:
                 query = self._add_str_filter(query, params, "stat_name", stat_name)
 
+            # `+round_number` planner guard — same rationale as query_injection_stat
+            # (keep the per-round aggregation on by_stat/filter, not by_round).
             if start_round_number is not None:
-                query += " AND round_number >= ?"
+                query += " AND +round_number >= ?"
                 params.append(start_round_number)
 
             if end_round_number is not None:
-                query += " AND round_number <= ?"
+                query += " AND +round_number <= ?"
                 params.append(end_round_number)
 
             if injection_stage:
@@ -2248,7 +2308,11 @@ class Database:
             if not include_superseded:
                 query += " AND superseded = 0"
 
-            query += " GROUP BY round_number ORDER BY round_number"
+            # `+round_number` here too: without it, a call with no timestamp bounds lets the
+            # planner pick by_round(tag=?) purely for its free GROUP BY ordering — the
+            # whole-partition row-fetch plan the term guards above exist to prevent. The
+            # span-tightened caller shape is safe either way; this covers every shape.
+            query += " GROUP BY +round_number ORDER BY +round_number"
 
             cursor.execute(query, params)
 
@@ -2459,11 +2523,13 @@ class Database:
             if not include_superseded:
                 query += " AND superseded = 0"
 
-            # The DISTINCT set includes snr_base/snr_range, which no index carries, so this
-            # is a tag-partition scan regardless of index shape — the tag prefix of
-            # idx_latent_snapshots_by_key still bounds it to one tag. It runs once per GIF
-            # pass, and the resulting key set is small enough that the filesort for this
-            # ORDER BY (model_name leading, unlike the index) is negligible
+            # The bare `superseded = 0` above proves idx_latent_snapshots_keys' partial
+            # predicate (v9), whose column order after the tag equality matches this
+            # DISTINCT projection and ORDER BY prefix exactly — so the default-path query
+            # is a covering index-only scan (timestamp bounds evaluate in-index on the
+            # trailing column), never touching the latent_vector row payloads. An
+            # include_superseded=True audit call can't use the partial index and falls
+            # back to a tag-bounded scan of idx_latent_snapshots_by_key — accepted.
             query += " ORDER BY model_name, round_number, epoch_number, step_number"
 
             cursor.execute(query, params)

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -456,6 +456,10 @@ class Database:
                 ON latent_snapshots(tag, round_number, epoch_number, step_number,
                                     model_name, timestamp)
             """)
+            # A second latent_snapshots index exists — idx_latent_snapshots_keys, the v9
+            # covering partial for query_latent_snapshot_keys — but its CREATE lives only
+            # in _migrate_schema (its WHERE superseded = 0 predicate needs the v1 column;
+            # same convention as idx_inference_results_supersede below).
 
             # Inference results table
             cursor.execute("""
@@ -670,7 +674,13 @@ class Database:
             # NOTE: on an existing catalog-scale DB (~190M injection_stats rows / 80 GB)
             # the by_round build is a one-time full-table scan + sort — expect the FIRST
             # pipeline launch against such a DB after this upgrade to stall here for
-            # minutes to tens of minutes. Subsequent launches are unaffected.
+            # minutes to tens of minutes (and budget transient WAL disk headroom well
+            # beyond the final index size). Subsequent launches are unaffected.
+            logger.info(
+                "Schema migration: v9 building idx_injection_stats_by_round — on a "
+                "catalog-scale DB this is a one-time full-table scan + sort that can take "
+                "minutes to tens of minutes; do not interrupt"
+            )
             cursor.execute("""
                 CREATE INDEX IF NOT EXISTS idx_injection_stats_by_round
                 ON injection_stats(tag, round_number, timestamp)
@@ -2165,10 +2175,12 @@ class Database:
                 query = self._add_str_filter(query, params, "stat_name", stat_name)
 
             # `+round_number`: the unary plus keeps the term out of index selection
-            # (semantics unchanged). Without it, the no-ANALYZE planner prefers
-            # idx_injection_stats_by_round's leading range over by_stat's equality
-            # prefix for the ~165-query plot pass — re-creating the pre-v7 pathology
-            # (see the v9 entry in the version-history comment).
+            # (semantics unchanged for the int-typed params this API takes — the `+` also
+            # drops column affinity, so a numeric *string* bound here would no longer
+            # coerce; the signature's `int | None` is the boundary). Without it, the
+            # no-ANALYZE planner prefers idx_injection_stats_by_round's leading range over
+            # by_stat's equality prefix for the ~165-query plot pass — re-creating the
+            # pre-v7 pathology (see the v9 entry in the version-history comment).
             if start_round_number is not None:
                 query += " AND +round_number >= ?"
                 params.append(start_round_number)

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -683,9 +683,10 @@ class Database:
             # upgrade that actually pays the build.
             if cursor.execute("SELECT EXISTS(SELECT 1 FROM injection_stats)").fetchone()[0]:
                 logger.info(
-                    "Schema migration: v9 building idx_injection_stats_by_round — on a "
-                    "catalog-scale DB this is a one-time full-table scan + sort that can "
-                    "take minutes to tens of minutes; do not interrupt"
+                    "Schema migration: v9 building idx_injection_stats_by_round and "
+                    "idx_latent_snapshots_keys — on a catalog-scale DB this is a one-time "
+                    "full-table scan + sort per index that can take minutes to tens of "
+                    "minutes; do not interrupt"
                 )
             cursor.execute("""
                 CREATE INDEX IF NOT EXISTS idx_injection_stats_by_round

--- a/src/aetherscan/db/db.py
+++ b/src/aetherscan/db/db.py
@@ -676,11 +676,17 @@ class Database:
             # pipeline launch against such a DB after this upgrade to stall here for
             # minutes to tens of minutes (and budget transient WAL disk headroom well
             # beyond the final index size). Subsequent launches are unaffected.
-            logger.info(
-                "Schema migration: v9 building idx_injection_stats_by_round — on a "
-                "catalog-scale DB this is a one-time full-table scan + sort that can take "
-                "minutes to tens of minutes; do not interrupt"
-            )
+            # Warn only when there are rows to scan: fresh databases hit this block too
+            # (version 0 -> current), and a scary tens-of-minutes warning against an empty
+            # table would land in Slack (INFO forwards) on every new output path. The
+            # EXISTS probe is O(1) at any table size and keeps the warning for the one
+            # upgrade that actually pays the build.
+            if cursor.execute("SELECT EXISTS(SELECT 1 FROM injection_stats)").fetchone()[0]:
+                logger.info(
+                    "Schema migration: v9 building idx_injection_stats_by_round — on a "
+                    "catalog-scale DB this is a one-time full-table scan + sort that can "
+                    "take minutes to tens of minutes; do not interrupt"
+                )
             cursor.execute("""
                 CREATE INDEX IF NOT EXISTS idx_injection_stats_by_round
                 ON injection_stats(tag, round_number, timestamp)

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -1015,14 +1015,23 @@ class TestV9IndexPlannerContracts:
     def _plan_of_last(self, db, captured, needle):
         """EXPLAIN QUERY PLAN of the most recent captured statement containing `needle`.
         Works whether the trace delivers placeholder or expanded SQL: unbound placeholders
-        plan identically to bound ones, so Nones suffice."""
-        stmt = next(s for s in reversed(captured) if needle in s and not s.startswith("EXPLAIN"))
+        plan identically to bound ones, so Nones suffice. The plan string carries the
+        SQLite version so a failure years from now reads as 'the toolchain's planner
+        changed' rather than 'someone deleted a guard'."""
+        stmt = next(
+            (s for s in reversed(captured) if needle in s and not s.startswith("EXPLAIN")), None
+        )
+        assert stmt is not None, (
+            f"no captured statement contains {needle!r} — builder refactor? "
+            f"{len(captured)} statements captured"
+        )
         conn = sqlite3.connect(db.db_path)
         try:
             rows = conn.execute("EXPLAIN QUERY PLAN " + stmt, [None] * stmt.count("?")).fetchall()
         finally:
             conn.close()
-        return stmt, " | ".join(str(row) for row in rows)
+        plan = " | ".join(str(row) for row in rows)
+        return stmt, f"{plan} [sqlite {sqlite3.sqlite_version}]"
 
     def _seed_injection(self, db):
         rows = _bulk_rows(6, round_number=1) + _bulk_rows(6, round_number=2)
@@ -1074,7 +1083,9 @@ class TestV9IndexPlannerContracts:
             end_round_number=2,
         )
         stmt, plan = self._plan_of_last(db, captured, "FROM injection_stats")
-        assert "+round_number" in stmt, stmt
+        # COUNT, not substring: both the start- and end-bound terms must carry the guard —
+        # deleting either one alone would still satisfy an `in` check.
+        assert stmt.count("+round_number") == 2, stmt
         assert "idx_injection_stats_by_round" not in plan, (stmt, plan)
         assert "idx_injection_stats_by_stat" in plan, (stmt, plan)
 
@@ -1084,10 +1095,15 @@ class TestV9IndexPlannerContracts:
         # guards the GROUP BY/ORDER BY with `+` as well.
         db, captured = traced
         self._seed_injection(db)
-        db.query_injection_stat_stability(tag="plan_v1", stat_name="eti_snr", start_round_number=1)
+        db.query_injection_stat_stability(
+            tag="plan_v1", stat_name="eti_snr", start_round_number=1, end_round_number=2
+        )
         stmt, plan = self._plan_of_last(db, captured, "GROUP BY")
-        assert "+round_number" in stmt, stmt
+        # All four guarded sites, individually deletable, individually pinned: the two WHERE
+        # bounds plus GROUP BY plus ORDER BY.
+        assert stmt.count("+round_number") == 4, stmt
         assert "GROUP BY +round_number" in stmt, stmt
+        assert "ORDER BY +round_number" in stmt, stmt
         assert "idx_injection_stats_by_round" not in plan, (stmt, plan)
         assert "idx_injection_stats_by_stat" in plan, (stmt, plan)
 
@@ -1098,6 +1114,9 @@ class TestV9IndexPlannerContracts:
         stmt, plan = self._plan_of_last(db, captured, "SELECT DISTINCT")
         assert "idx_latent_snapshots_keys" in plan, (stmt, plan)
         assert "COVERING" in plan.upper(), plan
+        # Index-only AND sort-free: DISTINCT + ORDER BY must come from index order, not a
+        # temp b-tree — the full "index-only scan" claim in DATABASE.md.
+        assert "TEMP B-TREE" not in plan.upper(), plan
 
     def test_latent_per_frame_query_keeps_by_key(self, traced):
         # The new partial index is also predicate-eligible here (bare superseded = 0);

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -624,14 +624,18 @@ class TestSchemaMigration:
         "inference_results",
     )
 
-    # The complete expected index set per table — the v7 index sweep's final state. Both
-    # _init_database() (fresh dbs) and the `if version < 7` migration block (pre-v7 dbs)
-    # must land exactly here, so tests assert equality, not membership.
+    # The complete expected index set per table — the v9 audit's final state. Both
+    # _init_database() (fresh dbs) and the migration blocks (older dbs) must land exactly
+    # here, so tests assert equality, not membership.
     _EXPECTED_INDEXES = {
         "system_resources": {"idx_system_resources_filter"},
-        "injection_stats": {"idx_injection_stats_filter", "idx_injection_stats_by_stat"},
+        "injection_stats": {
+            "idx_injection_stats_filter",
+            "idx_injection_stats_by_stat",
+            "idx_injection_stats_by_round",
+        },
         "training_stats": {"idx_training_stats_filter"},
-        "latent_snapshots": {"idx_latent_snapshots_by_key"},
+        "latent_snapshots": {"idx_latent_snapshots_by_key", "idx_latent_snapshots_keys"},
         "inference_results": {"idx_inference_results_filter", "idx_inference_results_supersede"},
         "inference_cadences": {"idx_inference_cadences_filter"},
         "pipeline_stages": {"idx_pipeline_stages_filter"},
@@ -975,6 +979,103 @@ class TestInjectionStatTimeSpan:
         assert _wait_backlog_empty(db)
         db.mark_superseded("injection_stats", tag="span_v2", round_ge=1)
         assert db.query_injection_stat_time_span(tag="span_v2") == (50.0, 60.0)
+
+
+class TestV9IndexPlannerContracts:
+    """The v9 by_round index (#375) must serve the supersede/time-span shapes WITHOUT
+    stealing the plot-pass plans from idx_injection_stats_by_stat — the `+round_number`
+    guards in query_injection_stat / query_injection_stat_stability enforce the latter.
+    Pin both directions with EXPLAIN QUERY PLAN on the real schema (no ANALYZE, matching
+    production, where the un-stat'd cost model would otherwise prefer the leading-range
+    index). The SQL literals mirror the shapes the builders emit."""
+
+    def _plan(self, db, sql, params=()):
+        conn = sqlite3.connect(db.db_path)
+        try:
+            rows = conn.execute(f"EXPLAIN QUERY PLAN {sql}", params).fetchall()
+        finally:
+            conn.close()
+        return " | ".join(str(row) for row in rows)
+
+    @pytest.fixture()
+    def seeded(self, db):
+        # A few real rows so the planner works against a non-degenerate table.
+        rows = _bulk_rows(6, round_number=1) + _bulk_rows(6, round_number=2)
+        db.write_injection_stats_bulk(rows, tag="plan_v1")
+        assert _wait_backlog_empty(db)
+        return db
+
+    def test_supersede_update_shape_uses_by_round(self, seeded):
+        plan = self._plan(
+            seeded,
+            "UPDATE injection_stats SET superseded = 1"
+            " WHERE superseded = 0 AND tag = ? AND round_number >= ?",
+            ("plan_v1", 2),
+        )
+        assert "idx_injection_stats_by_round" in plan
+
+    def test_time_span_shape_uses_by_round_covering(self, seeded):
+        plan = self._plan(
+            seeded,
+            "SELECT MIN(timestamp), MAX(timestamp) FROM injection_stats"
+            " WHERE tag = ? AND round_number >= ? AND round_number <= ?",
+            ("plan_v1", 1, 2),
+        )
+        assert "idx_injection_stats_by_round" in plan
+        assert "COVERING" in plan.upper()
+
+    def test_guarded_plot_shape_stays_off_by_round(self, seeded):
+        # query_injection_stat's guarded round terms (`+round_number`): the v7 stat-scoped
+        # plan must survive by_round's presence.
+        plan = self._plan(
+            seeded,
+            "SELECT * FROM injection_stats WHERE 1=1 AND stat_name = ?"
+            " AND +round_number >= ? AND +round_number <= ?"
+            " AND injection_stage = ? AND tag = ? AND superseded = 0",
+            ("drift_hz", 1, 2, "post", "plan_v1"),
+        )
+        assert "idx_injection_stats_by_round" not in plan
+
+    def test_guarded_stability_shape_stays_off_by_round(self, seeded):
+        # query_injection_stat_stability's guarded aggregate shape, WITHOUT timestamp
+        # bounds — the hardest case: with a bare GROUP BY round_number the planner picks
+        # by_round(tag=?) purely for its free grouping order, so the builder guards the
+        # GROUP BY/ORDER BY with `+` as well.
+        plan = self._plan(
+            seeded,
+            "SELECT round_number, COUNT(*) FROM injection_stats"
+            " WHERE 1=1 AND stat_name = ? AND +round_number >= ? AND tag = ?"
+            " AND superseded = 0 GROUP BY +round_number ORDER BY +round_number",
+            ("drift_hz", 1, "plan_v1"),
+        )
+        assert "idx_injection_stats_by_round" not in plan
+
+    def test_latent_keys_query_is_covering_on_partial_index(self, db):
+        db.write_latent_snapshot(
+            model_name="beta_vae",
+            round_number=1,
+            epoch_number=1,
+            step_number=10,
+            cadence_index=0,
+            signal_type="true_only_eti",
+            latent_vector=[0.0] * 8,
+            snr_base=1,
+            snr_range=99,
+            tag="plan_v2",
+        )
+        assert db.flush(timeout=10.0)
+        # query_latent_snapshot_keys' default shape: bare superseded = 0 proves the
+        # partial predicate; the projection + ORDER BY come from index order.
+        plan = self._plan(
+            db,
+            "SELECT DISTINCT model_name, round_number, epoch_number, step_number,"
+            " snr_base, snr_range FROM latent_snapshots"
+            " WHERE 1=1 AND tag = ? AND timestamp >= ? AND superseded = 0"
+            " ORDER BY model_name, round_number, epoch_number, step_number",
+            ("plan_v2", 0.0),
+        )
+        assert "idx_latent_snapshots_keys" in plan
+        assert "COVERING" in plan.upper()
 
 
 class TestBulkLane:

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -10,6 +10,7 @@ import json
 import os
 import sqlite3
 import time
+from contextlib import contextmanager
 
 import numpy as np
 import pytest
@@ -984,98 +985,146 @@ class TestInjectionStatTimeSpan:
 class TestV9IndexPlannerContracts:
     """The v9 by_round index (#375) must serve the supersede/time-span shapes WITHOUT
     stealing the plot-pass plans from idx_injection_stats_by_stat — the `+round_number`
-    guards in query_injection_stat / query_injection_stat_stability enforce the latter.
-    Pin both directions with EXPLAIN QUERY PLAN on the real schema (no ANALYZE, matching
-    production, where the un-stat'd cost model would otherwise prefer the leading-range
-    index). The SQL literals mirror the shapes the builders emit."""
-
-    def _plan(self, db, sql, params=()):
-        conn = sqlite3.connect(db.db_path)
-        try:
-            rows = conn.execute(f"EXPLAIN QUERY PLAN {sql}", params).fetchall()
-        finally:
-            conn.close()
-        return " | ".join(str(row) for row in rows)
+    guards in query_injection_stat / query_injection_stat_stability enforce the latter —
+    and the latent partial index must serve the keys query without stealing the per-frame
+    or supersede shapes from by_key. Pin every direction with EXPLAIN QUERY PLAN on the
+    real schema (no ANALYZE, matching production, where the un-stat'd cost model would
+    otherwise prefer a leading-range index). The SQL under test is captured from the REAL
+    builders via a connection trace, so dropping a `+` guard in db.py fails here — the
+    assertions cover the builders, not hand-written literals that could drift from them."""
 
     @pytest.fixture()
-    def seeded(self, db):
-        # A few real rows so the planner works against a non-degenerate table.
+    def traced(self, db, monkeypatch):
+        """(db, captured): every statement the Database's own connections execute lands in
+        `captured` — including the inline (no-writer) mark_superseded path."""
+        captured: list[str] = []
+        orig = Database._get_connection
+
+        @contextmanager
+        def traced_connection(db_self):
+            with orig(db_self) as conn:
+                conn.set_trace_callback(captured.append)
+                try:
+                    yield conn
+                finally:
+                    conn.set_trace_callback(None)
+
+        monkeypatch.setattr(Database, "_get_connection", traced_connection)
+        return db, captured
+
+    def _plan_of_last(self, db, captured, needle):
+        """EXPLAIN QUERY PLAN of the most recent captured statement containing `needle`.
+        Works whether the trace delivers placeholder or expanded SQL: unbound placeholders
+        plan identically to bound ones, so Nones suffice."""
+        stmt = next(s for s in reversed(captured) if needle in s and not s.startswith("EXPLAIN"))
+        conn = sqlite3.connect(db.db_path)
+        try:
+            rows = conn.execute("EXPLAIN QUERY PLAN " + stmt, [None] * stmt.count("?")).fetchall()
+        finally:
+            conn.close()
+        return stmt, " | ".join(str(row) for row in rows)
+
+    def _seed_injection(self, db):
         rows = _bulk_rows(6, round_number=1) + _bulk_rows(6, round_number=2)
         db.write_injection_stats_bulk(rows, tag="plan_v1")
         assert _wait_backlog_empty(db)
-        return db
 
-    def test_supersede_update_shape_uses_by_round(self, seeded):
-        plan = self._plan(
-            seeded,
-            "UPDATE injection_stats SET superseded = 1"
-            " WHERE superseded = 0 AND tag = ? AND round_number >= ?",
-            ("plan_v1", 2),
+    def _seed_latent(self, db):
+        for step in (10, 20):
+            db.write_latent_snapshot(
+                model_name="beta_vae",
+                round_number=1,
+                epoch_number=1,
+                step_number=step,
+                cadence_index=0,
+                signal_type="true_only_eti",
+                latent_vector=[0.0] * 8,
+                snr_base=1,
+                snr_range=99,
+                tag="plan_v2",
+            )
+        assert db.flush(timeout=10.0)
+
+    def test_injection_supersede_update_uses_by_round(self, traced):
+        db, captured = traced
+        self._seed_injection(db)
+        db.stop()  # no writer → mark_superseded executes inline through _get_connection
+        db.mark_superseded("injection_stats", tag="plan_v1", round_ge=2)
+        stmt, plan = self._plan_of_last(db, captured, "UPDATE injection_stats")
+        assert "idx_injection_stats_by_round" in plan, (stmt, plan)
+
+    def test_time_span_uses_by_round_covering(self, traced):
+        db, captured = traced
+        self._seed_injection(db)
+        db.query_injection_stat_time_span(tag="plan_v1", start_round_number=1, end_round_number=2)
+        stmt, plan = self._plan_of_last(db, captured, "MIN(timestamp)")
+        assert "idx_injection_stats_by_round" in plan, (stmt, plan)
+        assert "COVERING" in plan.upper(), plan
+
+    def test_guarded_plot_query_keeps_by_stat(self, traced):
+        # The builder must emit `+round_number` (the guard itself) AND the resulting plan
+        # must keep the v7 stat-scoped index — positive and negative pinned together.
+        db, captured = traced
+        self._seed_injection(db)
+        db.query_injection_stat(
+            tag="plan_v1",
+            stat_name="eti_snr",
+            injection_stage="post",
+            start_round_number=1,
+            end_round_number=2,
         )
-        assert "idx_injection_stats_by_round" in plan
+        stmt, plan = self._plan_of_last(db, captured, "FROM injection_stats")
+        assert "+round_number" in stmt, stmt
+        assert "idx_injection_stats_by_round" not in plan, (stmt, plan)
+        assert "idx_injection_stats_by_stat" in plan, (stmt, plan)
 
-    def test_time_span_shape_uses_by_round_covering(self, seeded):
-        plan = self._plan(
-            seeded,
-            "SELECT MIN(timestamp), MAX(timestamp) FROM injection_stats"
-            " WHERE tag = ? AND round_number >= ? AND round_number <= ?",
-            ("plan_v1", 1, 2),
-        )
-        assert "idx_injection_stats_by_round" in plan
-        assert "COVERING" in plan.upper()
+    def test_guarded_stability_query_keeps_by_stat(self, traced):
+        # No timestamp bounds — the hardest case: with a bare GROUP BY round_number the
+        # planner picks by_round(tag=?) purely for its free grouping order, so the builder
+        # guards the GROUP BY/ORDER BY with `+` as well.
+        db, captured = traced
+        self._seed_injection(db)
+        db.query_injection_stat_stability(tag="plan_v1", stat_name="eti_snr", start_round_number=1)
+        stmt, plan = self._plan_of_last(db, captured, "GROUP BY")
+        assert "+round_number" in stmt, stmt
+        assert "GROUP BY +round_number" in stmt, stmt
+        assert "idx_injection_stats_by_round" not in plan, (stmt, plan)
+        assert "idx_injection_stats_by_stat" in plan, (stmt, plan)
 
-    def test_guarded_plot_shape_stays_off_by_round(self, seeded):
-        # query_injection_stat's guarded round terms (`+round_number`): the v7 stat-scoped
-        # plan must survive by_round's presence.
-        plan = self._plan(
-            seeded,
-            "SELECT * FROM injection_stats WHERE 1=1 AND stat_name = ?"
-            " AND +round_number >= ? AND +round_number <= ?"
-            " AND injection_stage = ? AND tag = ? AND superseded = 0",
-            ("drift_hz", 1, 2, "post", "plan_v1"),
-        )
-        assert "idx_injection_stats_by_round" not in plan
+    def test_latent_keys_query_is_covering_on_partial_index(self, traced):
+        db, captured = traced
+        self._seed_latent(db)
+        db.query_latent_snapshot_keys(tag="plan_v2", start_time=0.0)
+        stmt, plan = self._plan_of_last(db, captured, "SELECT DISTINCT")
+        assert "idx_latent_snapshots_keys" in plan, (stmt, plan)
+        assert "COVERING" in plan.upper(), plan
 
-    def test_guarded_stability_shape_stays_off_by_round(self, seeded):
-        # query_injection_stat_stability's guarded aggregate shape, WITHOUT timestamp
-        # bounds — the hardest case: with a bare GROUP BY round_number the planner picks
-        # by_round(tag=?) purely for its free grouping order, so the builder guards the
-        # GROUP BY/ORDER BY with `+` as well.
-        plan = self._plan(
-            seeded,
-            "SELECT round_number, COUNT(*) FROM injection_stats"
-            " WHERE 1=1 AND stat_name = ? AND +round_number >= ? AND tag = ?"
-            " AND superseded = 0 GROUP BY +round_number ORDER BY +round_number",
-            ("drift_hz", 1, "plan_v1"),
-        )
-        assert "idx_injection_stats_by_round" not in plan
-
-    def test_latent_keys_query_is_covering_on_partial_index(self, db):
-        db.write_latent_snapshot(
+    def test_latent_per_frame_query_keeps_by_key(self, traced):
+        # The new partial index is also predicate-eligible here (bare superseded = 0);
+        # by_key's full six-column seek must keep winning.
+        db, captured = traced
+        self._seed_latent(db)
+        db.query_latent_snapshots(
             model_name="beta_vae",
             round_number=1,
             epoch_number=1,
             step_number=10,
-            cadence_index=0,
-            signal_type="true_only_eti",
-            latent_vector=[0.0] * 8,
-            snr_base=1,
-            snr_range=99,
             tag="plan_v2",
+            start_time=0.0,
+            end_time=99.0,
         )
-        assert db.flush(timeout=10.0)
-        # query_latent_snapshot_keys' default shape: bare superseded = 0 proves the
-        # partial predicate; the projection + ORDER BY come from index order.
-        plan = self._plan(
-            db,
-            "SELECT DISTINCT model_name, round_number, epoch_number, step_number,"
-            " snr_base, snr_range FROM latent_snapshots"
-            " WHERE 1=1 AND tag = ? AND timestamp >= ? AND superseded = 0"
-            " ORDER BY model_name, round_number, epoch_number, step_number",
-            ("plan_v2", 0.0),
-        )
-        assert "idx_latent_snapshots_keys" in plan
-        assert "COVERING" in plan.upper()
+        stmt, plan = self._plan_of_last(db, captured, "FROM latent_snapshots")
+        assert "idx_latent_snapshots_by_key" in plan, (stmt, plan)
+        assert "idx_latent_snapshots_keys" not in plan, (stmt, plan)
+
+    def test_latent_supersede_update_keeps_by_key(self, traced):
+        db, captured = traced
+        self._seed_latent(db)
+        db.stop()
+        db.mark_superseded("latent_snapshots", tag="plan_v2", round_ge=1)
+        stmt, plan = self._plan_of_last(db, captured, "UPDATE latent_snapshots")
+        assert "idx_latent_snapshots_by_key" in plan, (stmt, plan)
+        assert "idx_latent_snapshots_keys" not in plan, (stmt, plan)
 
 
 class TestBulkLane:

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -1084,8 +1084,10 @@ class TestV9IndexPlannerContracts:
         )
         stmt, plan = self._plan_of_last(db, captured, "FROM injection_stats")
         # COUNT, not substring: both the start- and end-bound terms must carry the guard —
-        # deleting either one alone would still satisfy an `in` check.
+        # deleting either one alone would still satisfy an `in` check. The negative states
+        # the invariant directly: no unguarded round_number term reaches the planner.
         assert stmt.count("+round_number") == 2, stmt
+        assert "AND round_number" not in stmt, stmt
         assert "idx_injection_stats_by_round" not in plan, (stmt, plan)
         assert "idx_injection_stats_by_stat" in plan, (stmt, plan)
 
@@ -1100,10 +1102,14 @@ class TestV9IndexPlannerContracts:
         )
         stmt, plan = self._plan_of_last(db, captured, "GROUP BY")
         # All four guarded sites, individually deletable, individually pinned: the two WHERE
-        # bounds plus GROUP BY plus ORDER BY.
+        # bounds plus GROUP BY plus ORDER BY — and no unguarded round_number term anywhere
+        # (the negative also catches a guard MOVED rather than deleted).
         assert stmt.count("+round_number") == 4, stmt
         assert "GROUP BY +round_number" in stmt, stmt
         assert "ORDER BY +round_number" in stmt, stmt
+        assert "AND round_number" not in stmt, stmt
+        assert "GROUP BY round_number" not in stmt, stmt
+        assert "ORDER BY round_number" not in stmt, stmt
         assert "idx_injection_stats_by_round" not in plan, (stmt, plan)
         assert "idx_injection_stats_by_stat" in plan, (stmt, plan)
 


### PR DESCRIPTION
## Summary

The #375 index audit: every `CREATE INDEX` in `db.py` checked against every query in `db.py` + `dashboard.py`, via two independent full-inventory analyses cross-checked by adversarial `EXPLAIN QUERY PLAN` verification on production-shaped replicas (no `ANALYZE`, matching production). Performance over disk, per the issue.

## Outcome

**Keep all 9 live indexes.** Each traced to concrete consumers (details in the commit message); the v7-retired shape stays dropped; the idempotent migration-block re-creates stay for pre-v7 upgrade correctness.

**Add `idx_injection_stats_by_round (tag, round_number, timestamp)`.** `round_number` appeared in *no* `injection_stats` index, leaving the two worst uncovered shapes in the audit on the largest table (~190 M rows / 80 GB at catalog scale):
- the training-resume supersede `UPDATE` (blocks the writer thread; whole-partition row fetch → bounded seek; replica-measured 8.5 s → 0.46 s), and
- round-bounded `query_injection_stat_time_span` (row fetch per partition entry → covering index-only scan; 8.8 s → 0.2 s hot).

**With planner guards — the load-bearing subtlety.** Verification proved the naive ADD is a regression: with no `sqlite_stat1`, SQLite's cost model prefers `by_round`'s leading range over `by_stat`'s four-equality prefix, flipping the ~165-query end-of-run plot pass onto whole-round-range row fetches (measured 1.4–10.7× per query; the exact pathology schema v7 shipped `by_stat` to fix). So `query_injection_stat` and `query_injection_stat_stability` write their round terms as `+round_number` (SQLite's unary-plus term disqualification — semantics identical), and stability additionally guards `GROUP BY +round_number ORDER BY +round_number`: empirically, a bare `GROUP BY round_number` re-attracts `by_round` on timestamp-less shapes purely for its free grouping order.

**Add `idx_latent_snapshots_keys` — covering partial (`WHERE superseded = 0`).** `query_latent_snapshot_keys`' bare `superseded = 0` proves the partial predicate; after the tag equality the column order matches its `DISTINCT` projection and `ORDER BY` prefix exactly, so the once-per-GIF-pass key enumeration becomes an index-only scan instead of a whole-partition row fetch dragging `latent_vector` JSON payloads (~2 M rows/tag, ~100 M at release scale). `include_superseded=True` audit calls fall back to `by_key` — accepted.

**Rejected: a `system_resources (tag, resource_type, resource_name, timestamp)` candidate** for the teardown decimation pass — verified the planner never chooses it unforced for *any* live query (3/3 refutations), so it would be pure write-cost.

## Migration

- `by_round` follows the v7 convention (CREATE in `_init_database`, re-executed in the v9 block); the latent partial follows the v8 convention (block-only — its predicate needs the v1-ALTER `superseded` column). `_SCHEMA_VERSION` 8 → 9.
- **Operator-visible**: upgrading an existing catalog-scale DB builds `by_round` via a one-time full-table scan + sort — the first launch stalls in `_migrate_schema` for minutes to tens of minutes. Documented in `DATABASE.md`'s migration table + prose.

## Tests & verification

- `_EXPECTED_INDEXES` updated — its equality assertions make the existing fresh-DB and v0→current migration tests cover the new final state automatically.
- New `TestV9IndexPlannerContracts`: `EXPLAIN QUERY PLAN` pins **both directions** — the supersede/time-span shapes *use* `by_round` (covering for the aggregate), the guarded plot/stability shapes *stay off* it, and the latent-keys shape is a covering scan on the partial index.
- Ran the full contract set + builder-level result correctness (guarded SQL returns identical rows/aggregates) against the real `Database` init/migration path locally on sqlite 3.50.4 — all green. (Local *pytest* remains broken in this dev env — TF wheel needs AVX, unavailable under Rosetta — so the pytest execution proof is this PR's CI matrix; the local run exercised the same assertions directly.)
- One merge-order note: this PR and #378 both touch nearby `docs/DATABASE.md` text; whichever merges second may need a trivial rebase.

Closes #375