### PR TITLE
release: v1.1.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,8 +15,8 @@ authors:
     given-names: "Matt"
     orcid: "https://orcid.org/0000-0002-7042-7566"
 title: "Aetherscan: Breakthrough Listen's first end-to-end production-grade DL pipeline for SETI @ scale"
-version: 1.0.0
-date-released: 2026-08-01
+version: 1.1.0
+date-released: 2026-08-06
 url: "https://github.com/zachtheyek/Aetherscan"
 repository-code: "https://github.com/zachtheyek/Aetherscan"
 keywords:

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ To pre-pull explicitly (optional):
 
 ```bash
 # Apptainer (Ampere) or SingularityCE (Blackwell) — either converts the OCI image to a native .sif
-apptainer   pull aetherscan-ngc25.02.sif docker://ghcr.io/zachtheyek/aetherscan:v1.0.0
-singularity pull aetherscan-ngc25.02.sif docker://ghcr.io/zachtheyek/aetherscan:v1.0.0
+apptainer   pull aetherscan-ngc25.02.sif docker://ghcr.io/zachtheyek/aetherscan:v1.1.0
+singularity pull aetherscan-ngc25.02.sif docker://ghcr.io/zachtheyek/aetherscan:v1.1.0
 ```
 
 A **manual** pull (or build) writes no `<sif>.pulled-tag` sidecar, so the wrapper treats the result like a local build and keeps it across version bumps. Let `run_container.sh` do the pulling if you want it to track the pinned ref (`repo:tag`, so both a version bump and an `AETHERSCAN_IMAGE` change trigger a re-pull) for you; otherwise `rm` the `.sif` when you bump versions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,8 @@ keywords = [
 ]
 classifiers = [
     # Revisit in every release PR per docs/RELEASE.md. v1.0.0 ships blessed release weights +
-    # a stable CLI/config contract, so: Production/Stable.
+    # a stable CLI/config contract, so: Production/Stable. Re-affirmed for v1.1.0 (same
+    # weights re-blessed, contract intact).
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ name = "aetherscan"
 # via importlib.metadata). Kept a pre-release between releases; the release PR bumps it to
 # the final X.Y.Z, and the CD workflow (.github/workflows/release.yml) enforces that the
 # pushed git tag matches it exactly.
-version = "1.0.1.dev0"
+version = "1.1.0"
 authors = [
     { name = "Zach Yek", email = "xiaoxiyek1.5@gmail.com" },
 ]


### PR DESCRIPTION
## Summary

The v1.1.0 release PR per [docs/RELEASE.md](docs/RELEASE.md)'s runbook step 3: `pyproject.toml` version → **1.1.0** (the single source the CD tag guard enforces), `CITATION.cff` version + date-released, Development-Status classifier kept at `5 - Production/Stable`.

## Version determination — v1.1.0 (MINOR)

Per the SemVer policy (highest bump wins):
- **MINOR floor**: backward-compatible features since v1.0.0 — #318 inference-observability viz, #322 display-tag, #346 rf-variant-identity-guard, #365 GHCR image publish, #375 DB v9 indexes (in-place, additive migration), #359 SHAP-cache self-validation.
- **PATCH rider**: #340 (`tf_keras` legacy-Keras packaging, closes #323).
- **The judgment call — #372's config-default changes (50 rounds, SNR 1–100) are MINOR, not MAJOR**: they force no invocation, config, or artifact change — every prior explicit invocation behaves identically, every released artifact and saved config still loads, no runtime floor moves. Only bare-default *future* runs change behavior, deliberately and documented (release notes will flag it prominently). RELEASE.md's own worked example names exactly this bundle a MINOR → `v1.1.0`.

## What this PR deliberately does NOT change

- **README System Requirements** — same weights re-blessed (`train_20260729_152426`), no new full-scale runs; the measured v1.0.0-run figures and their provenance note remain correct. The 50-round disk derivation already landed via #387.
- **Weights/image inputs** — none here; note the image WILL rebuild rather than retag this release (Dockerfile + requirements-container.txt changed since v1.0.0 via #340), which is the designed input-change path. The release checklist includes the reviewer-suggested `pip freeze` diff of the new image against v1.0.0's digest.

## After this merges (runbook order)

TestPyPI dry run → HF bless (`hf_tag_release.py --save-tag train_20260729_152426 --release v1.1.0`) → signed tag push (maintainer-authorized) → CD (guard → tests → HF-verify → build + image → PyPI → GitHub Release) → post-publish smoke: `pip install aetherscan==1.1.0` + bare inference on an Ampere box, i.e. the #323 acceptance repro → dev-version reset PR.

Closes #388