### PR TITLE
chore: reset master to 1.1.1.dev0 after v1.1.0 + release-cycle follow-ups

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -677,7 +677,7 @@ export TF_USE_LEGACY_KERAS=1
 
 ### Status
 
-**Mitigated** (workaround above) — fixed on `master` by PR #340 and shipping from v1.1.0: `tf_keras==2.17.*` is a declared dependency in `pyproject.toml` / `environment.yml`, and `src/aetherscan/__init__.py` sets `TF_USE_LEGACY_KERAS=1` via `os.environ.setdefault` at package-import time (`aetherscan.def`'s `%environment` and the `Dockerfile`'s `ENV` export it explicitly too). The workaround is needed only for the published **v1.0.0** wheel / env manifest; flip this entry to **Closed** once v1.1.0 is on PyPI.
+**Closed.** Fixed in **v1.1.0** by PR #340: `tf_keras==2.17.*` is a declared dependency in `pyproject.toml` / `environment.yml`, and `src/aetherscan/__init__.py` sets `TF_USE_LEGACY_KERAS=1` via `os.environ.setdefault` at package-import time (`aetherscan.def`'s `%environment` and the `Dockerfile`'s `ENV` export it explicitly too). The workaround remains necessary only for the published **v1.0.0** wheel / env manifest.
 
 ### Related Code
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -424,13 +424,14 @@ moves `:latest`, but a backfill dispatch does **not** (its `latest` input defaul
 publishing an older version never regresses `:latest`, which `run_container.sh` pulls for `.devN`
 checkouts. If you ever need to move it, pass `-f latest=true`.
 
-**Until the first release *after* this lands, there is no `:latest`** — the backfill above publishes
-`:v1.0.0` (plus its internal `fp-<hash>` marker tag) and does **not** move `:latest`. A
-`.devN`/`master` checkout therefore can't pull and must build from `aetherscan.def`
-(the wrapper says so and exits). This is deliberate: master's `requirements-container.txt` has
-already moved past v1.0.0's (notably the `streamlit` security bump), so pinning `:latest` to the
-backfilled v1.0.0 image would serve dev checkouts a knowingly stale dependency set. The next real
-release moves `:latest` and closes the gap.
+**A backfill never creates or moves `:latest`** — the dispatch above publishes the version tag
+(plus its internal `fp-<hash>` marker tag) only. Historical note: between the v1.0.0 backfill and
+the v1.1.0 release there was **no** `:latest` at all, so `.devN`/`master` checkouts had to build
+from `aetherscan.def` — deliberate, because master's `requirements-container.txt` had already
+moved past v1.0.0's (notably the `streamlit` security bump), and pinning `:latest` to the
+backfilled image would have served dev checkouts a knowingly stale dependency set. Since v1.1.0's
+CD run, `:latest` exists and tracks the newest real release, so dev checkouts pull normally
+(until their `requirements-container.txt` moves past the last release again).
 
 Verify: `docker buildx imagetools inspect ghcr.io/zachtheyek/aetherscan:v1.0.0`, or just pull it on
 a cluster via `utils/run_container.sh`.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -424,14 +424,18 @@ moves `:latest`, but a backfill dispatch does **not** (its `latest` input defaul
 publishing an older version never regresses `:latest`, which `run_container.sh` pulls for `.devN`
 checkouts. If you ever need to move it, pass `-f latest=true`.
 
-**A backfill never creates or moves `:latest`** — the dispatch above publishes the version tag
-(plus its internal `fp-<hash>` marker tag) only. Historical note: between the v1.0.0 backfill and
-the v1.1.0 release there was **no** `:latest` at all, so `.devN`/`master` checkouts had to build
-from `aetherscan.def` — deliberate, because master's `requirements-container.txt` had already
-moved past v1.0.0's (notably the `streamlit` security bump), and pinning `:latest` to the
-backfilled image would have served dev checkouts a knowingly stale dependency set. Since v1.1.0's
-CD run, `:latest` exists and tracks the newest real release, so dev checkouts pull normally
-(until their `requirements-container.txt` moves past the last release again).
+Historical note: between the v1.0.0 backfill and the v1.1.0 release there was **no** `:latest`
+at all, so `.devN`/`master` checkouts had to build from `aetherscan.def` — deliberate, because
+master's `requirements-container.txt` had already moved past v1.0.0's (notably the `streamlit`
+security bump), and pinning `:latest` to the backfilled image would have served dev checkouts a
+knowingly stale dependency set. Since v1.1.0's CD run, `:latest` exists and tracks the newest
+real release. Note the failure mode changed **kind** with it: in the no-`:latest` window a dev
+checkout failed *hard* (the pull found nothing; the wrapper printed build instructions and
+exited), whereas now a dev checkout whose `requirements-container.txt` has moved past the last
+release **still pulls the released `:latest`, silently stale** — the wrapper never inspects
+requirements drift, so building from `aetherscan.def` in that state is on the user (and a
+`.devN` checkout keeps whatever `.sif` it first cached even as `:latest` moves — see the
+`<sif>.pulled-tag` sidecar logic in `run_container.sh`).
 
 Verify: `docker buildx imagetools inspect ghcr.io/zachtheyek/aetherscan:v1.0.0`, or just pull it on
 a cluster via `utils/run_container.sh`.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -79,7 +79,8 @@ tests/
 │   ├── test_dashboard_cli.py        # aetherscan-dashboard console entry: exec-argv builder + streamlit-missing guard
 │   ├── test_dashboard_launcher.py   # dashboard launcher argv builder + guard paths
 │   ├── test_logger.py               # StreamToLogger redirect probes + log_path_for_tag / tagged FileHandler
-│   └── test_legacy_keras_env.py     # TF_USE_LEGACY_KERAS default: import sets it, explicit value kept, tf.keras == tf_keras
+│   ├── test_legacy_keras_env.py     # TF_USE_LEGACY_KERAS default: import sets it, explicit value kept, tf.keras == tf_keras
+│   └── test_release_metadata.py     # CITATION.cff version tracks pyproject.toml (release-PR coupling)
 └── integration/                 # marked integration+gpu+cluster: needs real GPUs + cluster data
     ├── conftest.py                  # repo-root launcher + cluster path resolution
     ├── test_train_smoke.py          # known-good training smoke config, end to end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ name = "aetherscan"
 # via importlib.metadata). Kept a pre-release between releases; the release PR bumps it to
 # the final X.Y.Z, and the CD workflow (.github/workflows/release.yml) enforces that the
 # pushed git tag matches it exactly.
-version = "1.1.0"
+version = "1.1.1.dev0"
 authors = [
     { name = "Zach Yek", email = "xiaoxiyek1.5@gmail.com" },
 ]

--- a/tests/unit/test_release_metadata.py
+++ b/tests/unit/test_release_metadata.py
@@ -38,27 +38,53 @@ def _pyproject_version() -> str:
         raise AssertionError("no version line found in pyproject.toml") from None
 
 
-def _citation_version() -> str:
+def _citation_field(name: str) -> str:
     with open(os.path.join(_REPO_ROOT, "CITATION.cff"), encoding="utf-8") as f:
         for line in f:
-            # 'cff-version:' must not match; anchor to line start on the bare field.
-            match = re.match(r"^version:\s*(\S+)\s*$", line)
+            # Anchor to line start so e.g. 'cff-version:' can't match 'version:'. Strip
+            # optional YAML quotes — most other scalars in the file are quoted, so a quoted
+            # version is a plausible future edit that must not read as a version mismatch.
+            match = re.match(rf"^{re.escape(name)}:\s*(\S+)\s*$", line)
             if match:
-                return match.group(1)
-    raise AssertionError("no version field found in CITATION.cff")
+                return match.group(1).strip("\"'")
+    raise AssertionError(f"no {name} field found in CITATION.cff")
 
 
 def test_citation_version_tracks_pyproject():
     py_version = _pyproject_version()
-    cff_version = _citation_version()
+    cff_version = _citation_field("version")
+    # Only .devN is recognized as the between-releases marker — deliberate coupling to
+    # docs/RELEASE.md's versioning policy, which documents no other pre-release form.
     if ".dev" in py_version:
         next_release = py_version.split(".dev")[0]
         assert cff_version != next_release, (
             f"CITATION.cff ({cff_version}) already claims the unreleased {next_release} — "
             f"it must only be bumped in the release PR that drops the .dev suffix"
         )
+        # ...and it must not be AHEAD of the next release either (plain X.Y.Z numbering
+        # per the release policy, so an int-tuple compare suffices).
+        assert tuple(map(int, cff_version.split("."))) < tuple(map(int, next_release.split("."))), (
+            f"CITATION.cff ({cff_version}) is ahead of the next pre-release "
+            f"({py_version}) — it must lag pyproject between releases"
+        )
     else:
         assert cff_version == py_version, (
             f"CITATION.cff version ({cff_version}) != pyproject.toml version ({py_version}) "
             f"— a release PR must bump both"
         )
+
+
+def test_citation_release_date_is_valid_and_not_future():
+    """Runbook step 3 bumps `date-released` alongside `version`; guard the format and the
+    obvious wrongness (a date after today means the release PR predicted and nobody
+    re-confirmed at tag time)."""
+    import datetime  # noqa: PLC0415
+
+    date_released = _citation_field("date-released")
+    parsed = datetime.date.fromisoformat(date_released)  # raises on non-ISO dates
+    # +1 day of latitude: the maintainer's timezone (GMT+8) is ahead of CI's UTC clock, so
+    # a release dated "today" locally is legitimately tomorrow from UTC's view.
+    assert parsed <= datetime.date.today() + datetime.timedelta(days=1), (
+        f"CITATION.cff date-released ({date_released}) is in the future — re-confirm it at "
+        f"release time"
+    )

--- a/tests/unit/test_release_metadata.py
+++ b/tests/unit/test_release_metadata.py
@@ -1,0 +1,64 @@
+"""Release-metadata coupling: CITATION.cff must track pyproject.toml's version.
+
+The CD guard enforces tag == pyproject version and the wheel smoke enforces
+__version__ == guarded version, but CITATION.cff was on the honor system — a release PR
+that bumps one file and not the other ships silently wrong citation metadata (#389 review).
+
+The invariant has two phases:
+- On a release commit (no ``.devN`` suffix) the two versions must be identical.
+- Between releases pyproject carries the next ``X.Y.(Z+1).devN`` pre-release while
+  CITATION.cff stays at the last *published* version — so equality is wrong there;
+  instead CITATION must not already claim the unreleased number.
+
+Plain text parsing on the CITATION side (no yaml dependency); tomllib is stdlib on 3.11+,
+with a line-parse fallback for 3.10 (the field is static, single, and quoted).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def _pyproject_version() -> str:
+    path = os.path.join(_REPO_ROOT, "pyproject.toml")
+    try:
+        import tomllib  # noqa: PLC0415 — stdlib on 3.11+; the fallback covers 3.10
+
+        with open(path, "rb") as f:
+            return tomllib.load(f)["project"]["version"]
+    except ModuleNotFoundError:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                match = re.match(r'^version\s*=\s*"([^"]+)"\s*$', line)
+                if match:
+                    return match.group(1)
+        raise AssertionError("no version line found in pyproject.toml") from None
+
+
+def _citation_version() -> str:
+    with open(os.path.join(_REPO_ROOT, "CITATION.cff"), encoding="utf-8") as f:
+        for line in f:
+            # 'cff-version:' must not match; anchor to line start on the bare field.
+            match = re.match(r"^version:\s*(\S+)\s*$", line)
+            if match:
+                return match.group(1)
+    raise AssertionError("no version field found in CITATION.cff")
+
+
+def test_citation_version_tracks_pyproject():
+    py_version = _pyproject_version()
+    cff_version = _citation_version()
+    if ".dev" in py_version:
+        next_release = py_version.split(".dev")[0]
+        assert cff_version != next_release, (
+            f"CITATION.cff ({cff_version}) already claims the unreleased {next_release} — "
+            f"it must only be bumped in the release PR that drops the .dev suffix"
+        )
+    else:
+        assert cff_version == py_version, (
+            f"CITATION.cff version ({cff_version}) != pyproject.toml version ({py_version}) "
+            f"— a release PR must bump both"
+        )


### PR DESCRIPTION
## Summary

The standard post-release chore ([docs/RELEASE.md](docs/RELEASE.md) runbook step 9) plus the three follow-ups explicitly deferred here during the release cycle's review loops:

- **`pyproject.toml` → `1.1.1.dev0`** — master stops advertising a shipped stable version; the `.devN` number is a placeholder, not a commitment (`docs/RELEASE.md` §Versioning policy).
- **`docs/RELEASE.md` `:latest` paragraph** (deferred from #389 review, item 2): "until the first release after this lands, there is no `:latest`" inverted the moment v1.1.0's CD ran. Rewritten to keep the durable rule (backfills never move `:latest`), record the v1.0.0→v1.1.0 no-`:latest` window as history with its original rationale, and state the current behavior (dev checkouts pull `:latest` until their `requirements-container.txt` moves past the last release).
- **`tests/unit/test_release_metadata.py`** (deferred from #389 review, item 3): CITATION.cff was the one version consumer on the honor system. The test enforces equality on release commits and — the phase we're in now — that CITATION does *not* pre-claim the unreleased `.dev`-stripped number between releases. TF-free, in the default CI selection; green locally against both phases (it ran against the release commit's state and this branch's).
- **KNOWN_ISSUES entry 19 → Closed** — v1.1.0 is on PyPI; the entry's own "flip once on PyPI" transition, executed. Its Related-Code section and the v1.0.0 workaround guidance stay for pinned installs.

## Verification

New test green locally (`1 passed`); `ruff check`/`format` clean. The Development-Status classifier is untouched (maturity unchanged between releases per the runbook).

Closes #390