### PR TITLE
Content-addressed stamp cache + unified cache root under data_path/cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1060,14 +1060,16 @@ options:
                         overlap-search stamps (default: 0.5)
   --preprocess-output-dir PREPROCESS_OUTPUT_DIR
                         Directory for per-cadence .npy outputs from
-                        preprocessing. Default: a per-CSV directory {data_path
-                        }/inference/preprocessed/<csv_stem>_ed<hash>/ keyed on
-                        the energy-detection config fingerprint — runs sharing
-                        an ED config reuse each other's stamps automatically,
-                        and any ED-config change resolves to a fresh
-                        directory. Pass a directory explicitly to pin/share
-                        one location (reuse is still guarded by the sidecar's
-                        recorded h5 paths and ED fingerprint)
+                        preprocessing. Default: the content-addressed stamp
+                        cache {data_path}/cache/stamps/ed_<hash>/ keyed on the
+                        energy-detection config fingerprint, with filenames
+                        hashed from each cadence's ordered h5 path list — runs
+                        sharing an ED config reuse each other's stamps
+                        automatically regardless of catalog name, and any ED-
+                        config change resolves to a fresh directory. Pass a
+                        directory explicitly to pin/share one location (reuse
+                        is still guarded by the sidecar's recorded h5 paths,
+                        ED fingerprint, and per-file size/mtime)
   --prune-stamps, --no-prune-stamps
                         Delete each cadence's stamp .npy right after its
                         'inferred' manifest row lands, keeping the metadata
@@ -1077,7 +1079,7 @@ options:
                         stamps are retained (~1 GB/cadence average) so re-
                         scoring the same data under the same energy-detection
                         config (new weights, threshold sweeps) skips
-                        preprocessing entirely via the fingerprint-scoped
+                        preprocessing entirely via the content-addressed
                         cache. Pass --prune-stamps on catalog-scale runs:
                         without pruning a full catalog writes ~30-90 TB of
                         stamps and dies on disk.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -94,7 +94,7 @@ flowchart TB
         CSV["CSV catalog(s)<br/>{data_path}/inference/"] --> GROUP["group_observations_from_csv()<br/>rows → 6-obs cadences"]
         H5[".h5 filterbank files"] --> ED
         GROUP --> ED["energy detection per cadence<br/>DC spike → bandpass flatten → k² threshold"]
-        ED --> NPY["per-cadence stamp .npy + metadata .json<br/>preprocessed/&lt;csv_stem&gt;_ed&lt;hash12&gt;/"]
+        ED --> NPY["per-cadence stamp .npy + metadata .json<br/>cache/stamps/ed_&lt;fingerprint12&gt;/"]
         NPY --> ENC["InferencePipeline.run_inference()<br/>encoder → latents → RF P(true)"]
         ART -. "trained models" .-> ENC
         ENC -. "inference_results (positives) + inference_cadences manifest" .-> DB
@@ -236,10 +236,12 @@ Three roots, set by `AETHERSCAN_{DATA,MODEL,OUTPUT}_PATH` (defaults under
 {data_path}/
 ├── training/                          # background plate .npy files (config.data.train_files)
 ├── testing/                           # preprocessed test .npy files (config.data.test_files)
-└── inference/                         # CSV catalogs (config.data.inference_files)
-    └── preprocessed/<csv_stem>_ed<hash12>/ # per-cadence stamp .npy + metadata .json
-                                       #   (ED-config-fingerprint-scoped: runs sharing an
-                                       #    energy-detection config reuse each other's stamps)
+├── inference/                         # CSV catalogs (config.data.inference_files)
+└── cache/                             # unified preprocessing-cache root (#412)
+    ├── stamps/ed_<fingerprint12>/     # content-addressed per-cadence stamp .npy + metadata
+    │                                  #   .json — <sha12-of-ordered-h5-paths>.npy: runs and
+    │                                  #   catalogs sharing an ED config reuse each other's stamps
+    └── pfb/pfb_response_*.npy         # content-addressed PFB passband responses (tag-independent)
 
 {model_path}/
 ├── vae_encoder_{tag}.keras            # final encoder (the inference model)
@@ -260,7 +262,6 @@ Three roots, set by `AETHERSCAN_{DATA,MODEL,OUTPUT}_PATH` (defaults under
 ├── inference_reference_cloud_{tag}.npz # MC-scored survey reference cloud (candidate uncertainty plot)
 ├── db/aetherscan.db                   # SQLite (WAL) — all stats/results tables
 ├── logs/aetherscan_{tag}.log          # this run's log (mode="w": overwrites the same tag's log on rerun)
-├── cache/pfb/pfb_response_*.npy       # content-addressed PFB passband responses (tag-independent)
 ├── round_data/{tag}/round_XX/         # per-round training memmaps (deleted after the round trains)
 │   └── rf/                            #   plus the RF training dataset
 └── plots/

--- a/docs/INFERENCE_PIPELINE.md
+++ b/docs/INFERENCE_PIPELINE.md
@@ -55,25 +55,28 @@ from `inference.cadence_h5_path_col` (default `".h5 path"`):
   raises `KeyError` for that CSV (logged, and the CSV is skipped).
 
 `DataPreprocessor.plan_cadences()` turns the valid groups into `PendingCadence` work units,
-each paired with a deterministic output path
-`{output_dir}/{csv_stem}_{sanitized_group_key}.npy`. The output directory default is
-**ED-fingerprint-scoped per CSV** (#298) —
-`{data_path}/inference/preprocessed/<csv_stem>_ed<hash12>/`, where the hash is
+each paired with a deterministic, **content-addressed** output path (#298/#412):
+`{output_dir}/<sha12-of-ordered-h5-paths>.npy` — 12 sha256 hex chars over the cadence's
+ordered h5 path list (CSV row order: ABACAD order is scientifically meaningful, so the same
+files listed in a different order are a different cadence and miss). The output directory
+default is **ED-fingerprint-scoped and shared by every catalog** —
+`{data_path}/cache/stamps/ed_<fingerprint12>/`, where the fingerprint is
 `run_state.preprocessing_config_fingerprint`: a fail-safe **denylist** hash of the inference
 config minus its scoring/model/viz/retry/batching keys, plus the data-section geometry.
-Energy detection is deterministic given (csv, h5 files, ED config), so **runs sharing an ED
-config share stamps** — a threshold sweep or a re-inference with new weights skips
-preprocessing entirely — while any ED-config change lands in a different directory by
+A cadence's stamps are a pure function of exactly (ordered h5 paths, ED config), and the
+cache key encodes exactly that — the catalog's name appears nowhere in it, so **runs
+sharing an ED config share stamps regardless of catalog name**: a threshold sweep, a
+re-inference with new weights, or a renamed/subset/superset catalog over the same files
+skips preprocessing entirely, while any ED-config change lands in a different directory by
 construction (an unknown new config key over-invalidates rather than ever reusing wrong
 stamps). Published `.npy` files can't be stale (atomic per-run-unique tmp → `os.replace`
-publication), and the resume guard additionally verifies each sidecar's `h5_paths` and
-recorded `ed_config_fingerprint` before reuse; only scores stay tag-scoped (in the DB).
-Pass `--preprocess-output-dir` explicitly to pin one directory across runs and CSVs (reuse
-is still guarded). Because both the output directory and per-cadence stamp filenames are
-keyed on the CSV basename stem, all `inference_files` entries must have **unique basename
-stems** — `plan_cadences()` raises `ValueError` naming both colliding entries if two share
-a stem (e.g. `runA/x.csv` and `runB/x.csv`). The fix is to rename one CSV so basenames are
-distinct.
+publication), and the resume guard additionally verifies each sidecar's `h5_paths`,
+recorded `ed_config_fingerprint`, and per-file `(size, mtime)` before reuse — the last
+warns and re-extracts when an h5 was re-staged or repaired at the same path since
+extraction (#412); size/mtime live only in the sidecar, never in the key, so a benign
+re-stage re-extracts in place without churning keys. Only scores stay tag-scoped (in the
+DB). Pass `--preprocess-output-dir` explicitly to pin a different directory (reuse is
+still guarded).
 
 ## Model loading
 
@@ -281,7 +284,7 @@ proportionally longer.)
    average on disk (380 GB for the 350-cadence subset benchmark) and buys free re-scores —
    preprocessing is the measured bulk of inference wall time (25.8k stage-seconds of the
    subset run's 12.6k-second wall), and any rerun under the same ED config (new weights,
-   threshold sweeps) skips it entirely via the fingerprint-scoped cache, so the default
+   threshold sweeps) skips it entirely via the content-addressed cache, so the default
    favors the common subset-scale iteration loop. Pruning exists for catalog scale:
    without it a full catalog writes ~30–90 TB of stamps and dies on disk after a few
    hundred cadences — **catalog runs must pass `--prune-stamps`** (the run start logs a
@@ -488,7 +491,7 @@ flagged while later writes stay live (`Database.mark_superseded`).
 
 | Artifact | Where | Notes |
 | --- | --- | --- |
-| Stamp arrays + metadata | `{data_path}/inference/preprocessed/<csv_stem>_ed<hash12>/*.npy` + `.json` | Shared across runs with the same ED config (#298) — though with pruning ON (#302, the default for this directory) each `.npy` is deleted once its cadence is scored, leaving the `.json`. The `.json` carries hit provenance: stamp starts/frequencies/statistics/p-values, ED statistic histograms, the pre-binned `hit_spectrum_hist` + merged hit list and stored `bandpass_envelopes` (#301 — the raw per-hit frequency list is no longer stored; see [`PREPROCESSING.md`](PREPROCESSING.md)), the `.h5` header, and the `ed_config_fingerprint` the resume guard checks. |
+| Stamp arrays + metadata | `{data_path}/cache/stamps/ed_<fingerprint12>/<sha12>.npy` + `.json` | Content-addressed (#298/#412): shared across runs and catalogs with the same ED config — though with pruning ON (#302; OFF by default since #399) each `.npy` is deleted once its cadence is scored, leaving the `.json`. The `.json` carries hit provenance: stamp starts/frequencies/statistics/p-values, ED statistic histograms, the pre-binned `hit_spectrum_hist` + merged hit list and stored `bandpass_envelopes` (#301 — the raw per-hit frequency list is no longer stored; see [`PREPROCESSING.md`](PREPROCESSING.md)), the `.h5` header, and the `ed_config_fingerprint` + per-file `(size, mtime)` the resume guard checks (#412). |
 | Candidate snippet sidecars | same directory, `*.candidates.npz` | Written by the pruning step (#302): each pruned cadence's candidate snippets (~196 KB each), atomically published; `load_display_cadence` falls back to it when the stamp `.npy` is gone, so candidate figures and galleries survive pruning. |
 | Candidate rows | `inference_results` table | Positives only, with latents + provenance + the two-pass scores (`screening_proba`/`mc_mean`/`mc_std`, schema v5). |
 | Run manifest | `inference_cadences` table | Per-cadence stages, aggregates, durations. |
@@ -496,11 +499,11 @@ flagged while later writes stay live (`Database.mark_superseded`).
 | Config snapshot | `{output_path}/config_{tag}.json` | The resolved (saved-config + CLI) view this run actually used. |
 | Figures | `{output_path}/plots/inference/{tag}/` | The visualization suite below; also uploaded to the run's Slack thread. |
 | Resource plot | `{output_path}/plots/resource_utilization_{tag}.png` | Written by the monitor at shutdown. |
-| PFB response cache | `{output_path}/cache/pfb/pfb_response_*.npy` | Content-addressed by channelization geometry; one file per `(width, coarse count, taps)`, shared across all `.h5` and all runs. See [The PFB response cache](#the-pfb-response-cache). |
+| PFB response cache | `{data_path}/cache/pfb/pfb_response_*.npy` | Content-addressed by channelization geometry; one file per `(width, coarse count, taps)`, shared across all `.h5` and all runs. Moved from `{output_path}` into the unified `{data_path}/cache/` root by #412. See [The PFB response cache](#the-pfb-response-cache). |
 
 ### The PFB response cache
 
-`{output_path}/cache/pfb/pfb_response_w{W}_c{C}_t{T}.npy` caches the **static PFB coarse-channel
+`{data_path}/cache/pfb/pfb_response_w{W}_c{C}_t{T}.npy` caches the **static PFB coarse-channel
 passband response** — the filter shape that `pfb.equalize_passband` divides each coarse channel by
 during bandpass flattening. It is **not** a cache of preprocessed `.h5` output: it holds a single
 ~8 MB array, computed once per channelization *geometry* by an ~`n_chans`-point FFT

--- a/docs/INFERENCE_PIPELINE.md
+++ b/docs/INFERENCE_PIPELINE.md
@@ -75,18 +75,34 @@ recorded `ed_config_fingerprint`, and per-file `(size, mtime)` before reuse — 
 warns and re-extracts when an h5 was re-staged or repaired at the same path since
 extraction (#412); size/mtime live only in the sidecar, never in the key, so a benign
 re-stage re-extracts in place without churning keys. Only scores stay tag-scoped (in the
-DB). Pass `--preprocess-output-dir` explicitly to pin a different directory (reuse is
-still guarded).
+DB). Cadences whose ordered h5 list repeats across a run's `inference_files` — including
+within **one** catalog, e.g. the same six files listed at two hit frequencies (the default
+`cadence_group_by_cols` include `Frequency`, which energy detection never reads: hits are
+re-derived over the whole band, so such rows' stamps and scores are identical by
+construction) — are **planned once**, first occurrence wins: one manifest row, one
+`group.key`, one candidate set. A truncated-digest collision between two genuinely
+*different* cadences raises a `ValueError` naming the cadence rather than silently dropping
+one. Cache keys compare the h5 **path strings byte-for-byte** (deliberately no
+`normpath`/`realpath` — resolution would break the unreachable-raws re-score case), so a
+symlink alias or a different mount prefix for the same files misses the cache; keep catalog
+path spellings stable across regenerations. Pass `--preprocess-output-dir` explicitly to
+pin a different directory (reuse is still guarded).
 
 > **Migrating from the pre-#412 layout.** The old trees —
 > `{data_path}/inference/preprocessed/<csv_stem>_ed<hash12>/` and `{output_path}/cache/pfb/`
 > — are orphaned by the re-keying (nothing reads or deletes them): delete them by hand after
 > upgrading (both are regenerable; the PFB response can alternatively be `mv`'d to
-> `{data_path}/cache/pfb/`). Leaving old stamp trees in place transiently doubles the stamp
-> footprint on scratch while the new cache warms. And don't resume a `--save-tag` started
-> pre-#412 across the upgrade: resume and supersede both key on `npy_path`, so such a run
-> re-preprocesses and re-infers every cadence at the new paths while the old-layout rows
-> under that tag stay live — start a fresh tag instead.
+> `{data_path}/cache/pfb/`). A large stamp cache can instead be **re-keyed without
+> re-extraction**: every old sidecar records `h5_paths`, and the new name is exactly
+> `sha256(json.dumps(h5_paths).encode()).hexdigest()[:12] + ".npy"` — rename each
+> `.npy`/`.json` pair accordingly and move it under `{data_path}/cache/stamps/ed_<fp12>/`.
+> Stamps inside a pinned `--preprocess-output-dir` are orphaned in place the same way (the
+> planner now looks for content-hashed names in that directory too). Leaving old stamp
+> trees in place transiently doubles the stamp footprint on scratch while the new cache
+> warms. And don't resume a `--save-tag` started pre-#412 across the upgrade: resume and
+> supersede both key on `npy_path`, so such a run re-preprocesses and re-infers every
+> cadence at the new paths while the old-layout rows under that tag stay live — start a
+> fresh tag instead.
 
 ## Model loading
 

--- a/docs/INFERENCE_PIPELINE.md
+++ b/docs/INFERENCE_PIPELINE.md
@@ -80,7 +80,10 @@ within **one** catalog, e.g. the same six files listed at two hit frequencies (t
 `cadence_group_by_cols` include `Frequency`, which energy detection never reads: hits are
 re-derived over the whole band, so such rows' stamps and scores are identical by
 construction) — are **planned once**, first occurrence wins: one manifest row, one
-`group.key`, one candidate set. A truncated-digest collision between two genuinely
+`group.key`, one candidate set. The same collapse extends **across runs under one
+`--save-tag`**: resume keys on `npy_path`, so a cadence shared by catalog A on Monday and
+catalog B on Tuesday resume-skips under B, and its only manifest row names A's key. A
+truncated-digest collision between two genuinely
 *different* cadences raises a `ValueError` naming the cadence rather than silently dropping
 one. Cache keys compare the h5 **path strings byte-for-byte** (deliberately no
 `normpath`/`realpath` — resolution would break the unreachable-raws re-score case), so a
@@ -95,7 +98,9 @@ pin a different directory (reuse is still guarded).
 > `{data_path}/cache/pfb/`). A large stamp cache can instead be **re-keyed without
 > re-extraction**: every old sidecar records `h5_paths`, and the new name is exactly
 > `sha256(json.dumps(h5_paths).encode()).hexdigest()[:12] + ".npy"` — rename each
-> `.npy`/`.json` pair accordingly and move it under `{data_path}/cache/stamps/ed_<fp12>/`.
+> `.npy`/`.json` pair accordingly and move it under `{data_path}/cache/stamps/ed_<fp12>/`
+> (the `<fp12>` is the same 12-hex fingerprint already sitting in the old directory's
+> `<csv_stem>_ed<hash12>` name — no need to re-derive it).
 > Stamps inside a pinned `--preprocess-output-dir` are orphaned in place the same way (the
 > planner now looks for content-hashed names in that directory too). Leaving old stamp
 > trees in place transiently doubles the stamp footprint on scratch while the new cache
@@ -332,7 +337,9 @@ proportionally longer.)
    can't recover an earlier process's pruned pixels, so the stamp gallery may show blank
    columns for earlier-run cadences; and two runs sharing the default cache dir with pruning
    ON can race (one deletes/overwrites a `.npy` or `.candidates.npz` another is mid-read of —
-   contained, self-heals via retry). Run concurrently in one dir only with a per-run
+   contained, self-heals via retry) — and since #412 that dir is shared by *every* catalog,
+   so this now covers concurrent runs over differently-named catalogs that overlap in `.h5`
+   files, not just reruns of one catalog. Run concurrently in one dir only with a per-run
    `--preprocess-output-dir` or with pruning left at its off default (a deliberate design
    choice — cross-process file locking was deferred as disproportionate for a self-healing,
    science-neutral race).

--- a/docs/INFERENCE_PIPELINE.md
+++ b/docs/INFERENCE_PIPELINE.md
@@ -78,6 +78,16 @@ re-stage re-extracts in place without churning keys. Only scores stay tag-scoped
 DB). Pass `--preprocess-output-dir` explicitly to pin a different directory (reuse is
 still guarded).
 
+> **Migrating from the pre-#412 layout.** The old trees —
+> `{data_path}/inference/preprocessed/<csv_stem>_ed<hash12>/` and `{output_path}/cache/pfb/`
+> — are orphaned by the re-keying (nothing reads or deletes them): delete them by hand after
+> upgrading (both are regenerable; the PFB response can alternatively be `mv`'d to
+> `{data_path}/cache/pfb/`). Leaving old stamp trees in place transiently doubles the stamp
+> footprint on scratch while the new cache warms. And don't resume a `--save-tag` started
+> pre-#412 across the upgrade: resume and supersede both key on `npy_path`, so such a run
+> re-preprocesses and re-infers every cadence at the new paths while the old-layout rows
+> under that tag stay live — start a fresh tag instead.
+
 ## Model loading
 
 ### Artifact resolution: local paths or the HuggingFace Hub

--- a/docs/PREPROCESSING.md
+++ b/docs/PREPROCESSING.md
@@ -96,7 +96,7 @@ reference implementation):
 
 At GBT scale the one-time FFT is an ~`n_chans`-point transform with a tens-of-GB transient,
 so it runs **once in the parent**, is persisted to a content-addressed sidecar
-(`{output_path}/cache/pfb/pfb_response_w{W}_c{C}_t{T}.npy`, atomic write), and workers just
+(`{data_path}/cache/pfb/pfb_response_w{W}_c{C}_t{T}.npy`, atomic write), and workers just
 read the ~8 MB file (cached per process by `_load_pfb_response`). Afterwards, flattening a
 channel is a single vectorized divide — versus a fresh spline fit per channel per file.
 
@@ -247,8 +247,10 @@ stamps.
 
 The metadata JSON also carries the full ED provenance for the visualization suite —
 per-stamp starts/frequencies/statistics/p-values, the per-ON-file statistic histograms, and
-the `.h5` header — plus the `ed_config_fingerprint` the stamp-cache resume guard verifies
-(#298). Hit frequencies are stored **pre-binned** since #301: `hit_spectrum_hist` (8,192
+the `.h5` header — plus the `ed_config_fingerprint` and per-h5 `(size, mtime)` (recorded at
+extraction) that the stamp-cache resume guard verifies before reuse (#298/#412 — a
+size/mtime mismatch means the h5 was re-staged at the same path, and that cadence warns and
+re-extracts). Hit frequencies are stored **pre-binned** since #301: `hit_spectrum_hist` (8,192
 bins spanning the file band — `freq_lo`/`freq_hi`/`n_bins`, raw + merged counts, and the
 exact raw-hit min/max so the figure reproduces the historical axis bounds) replaces the raw
 per-hit frequency list, which ran ~19 MB of JSON on an RFI-dense cadence and had exactly

--- a/src/aetherscan/cli.py
+++ b/src/aetherscan/cli.py
@@ -1020,14 +1020,14 @@ def _add_inference_flags_to(parser):
         "--preprocess-output-dir",
         type=str,
         default=None,
-        help="Directory for per-cadence .npy outputs from preprocessing. Default: a per-CSV directory {data_path}/inference/preprocessed/<csv_stem>_ed<hash>/ keyed on the energy-detection config fingerprint — runs sharing an ED config reuse each other's stamps automatically, and any ED-config change resolves to a fresh directory. Pass a directory explicitly to pin/share one location (reuse is still guarded by the sidecar's recorded h5 paths and ED fingerprint)",
+        help="Directory for per-cadence .npy outputs from preprocessing. Default: the content-addressed stamp cache {data_path}/cache/stamps/ed_<hash>/ keyed on the energy-detection config fingerprint, with filenames hashed from each cadence's ordered h5 path list — runs sharing an ED config reuse each other's stamps automatically regardless of catalog name, and any ED-config change resolves to a fresh directory. Pass a directory explicitly to pin/share one location (reuse is still guarded by the sidecar's recorded h5 paths, ED fingerprint, and per-file size/mtime)",
     )
 
     parser.add_argument(
         "--prune-stamps",
         action=argparse.BooleanOptionalAction,
         default=None,
-        help="Delete each cadence's stamp .npy right after its 'inferred' manifest row lands, keeping the metadata .json plus a ~196 KB snippet sidecar per candidate — resume rides the DB row, and only stamps this run freshly extracted are ever pruned. Default: DISABLED — stamps are retained (~1 GB/cadence average) so re-scoring the same data under the same energy-detection config (new weights, threshold sweeps) skips preprocessing entirely via the fingerprint-scoped cache. Pass --prune-stamps on catalog-scale runs: without pruning a full catalog writes ~30-90 TB of stamps and dies on disk.",
+        help="Delete each cadence's stamp .npy right after its 'inferred' manifest row lands, keeping the metadata .json plus a ~196 KB snippet sidecar per candidate — resume rides the DB row, and only stamps this run freshly extracted are ever pruned. Default: DISABLED — stamps are retained (~1 GB/cadence average) so re-scoring the same data under the same energy-detection config (new weights, threshold sweeps) skips preprocessing entirely via the content-addressed cache. Pass --prune-stamps on catalog-scale runs: without pruning a full catalog writes ~30-90 TB of stamps and dies on disk.",
     )
 
     parser.add_argument(

--- a/src/aetherscan/config.py
+++ b/src/aetherscan/config.py
@@ -549,12 +549,14 @@ class InferenceConfig:
     side_channel_count: int = 0
 
     # Per-cadence .npy output directory for energy-detection preprocessing. None (default)
-    # resolves per CSV to {data_path}/inference/preprocessed/<csv_stem>_ed<hash12>/, keyed
-    # on the ED-config fingerprint (#298 I3): runs sharing an ED config share stamps (a
-    # threshold sweep or re-inference with new weights skips preprocessing entirely), while
-    # any ED-config change lands in a different directory by construction. Set explicitly
-    # to pin one directory across runs and CSVs (the resume guard still verifies each
-    # sidecar's h5_paths and recorded fingerprint before reuse).
+    # resolves to the content-addressed stamp cache {data_path}/cache/stamps/ed_<hash12>/
+    # (#298 I3 + #412), keyed on the ED-config fingerprint with filenames hashed from each
+    # cadence's ordered h5 path list: runs sharing an ED config share stamps regardless of
+    # catalog name (a threshold sweep, re-inference with new weights, or a renamed/subset
+    # catalog over the same files skips preprocessing entirely), while any ED-config change
+    # lands in a different directory by construction. Set explicitly to pin one directory
+    # across runs and CSVs (the resume guard still verifies each sidecar's h5_paths,
+    # recorded fingerprint, and per-file (size, mtime) before reuse).
     preprocess_output_dir: str | None = None
     # Stamp-cache pruning (#302; default flipped OFF by #399): when ON, delete a cadence's
     # stamp .npy right after its 'inferred' manifest row lands (metadata .json always kept;
@@ -562,7 +564,7 @@ class InferenceConfig:
     # .candidates.npz sidecar so the candidate figures survive, and a bounded top-K pixel
     # pool — persisted across the in-process retry attempts, #305 — keeps the stamp gallery
     # whole within one run). None (default) = OFF: stamps are RETAINED so the
-    # fingerprint-scoped cache works out of the box — re-scoring the same data under the
+    # content-addressed cache works out of the box — re-scoring the same data under the
     # same ED config (new weights, threshold sweeps) skips preprocessing entirely, the
     # measured bulk of inference wall time (#399: 25.8k stage-seconds of the subset run's
     # 12.6k-second wall). The trade is disk: ~1 GB/cadence average (380 GB for the

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -1658,7 +1658,9 @@ class DataPreprocessor:
         """
         Group every CSV in config.data.inference_files into per-cadence work units without
         processing anything. Returns one PendingCadence (valid group + target .npy path) per
-        valid cadence, in CSV order — the unit list the streaming inference loop iterates.
+        distinct valid cadence, in CSV order — the unit list the streaming inference loop
+        iterates. Cadences whose content identity (ordered h5 path list) repeats across the
+        run's CSVs are planned once (first occurrence wins, #412).
         """
         inference_files = self.config.data.inference_files
         if not inference_files:
@@ -1692,6 +1694,7 @@ class DataPreprocessor:
         expected_obs = self.config.inference.cadence_expected_obs
 
         units: list[PendingCadence] = []
+        planned_npy_paths: set[str] = set()
 
         for csv_filename in inference_files:
             csv_path = self.config.get_inference_file_path(csv_filename)
@@ -1713,14 +1716,21 @@ class DataPreprocessor:
             )
 
             for group in valid_groups:
-                npy_filename = self._cadence_npy_filename(group.h5_paths)
-                units.append(
-                    PendingCadence(
-                        group=group,
-                        npy_path=os.path.join(output_dir, npy_filename),
-                        index=len(units) + 1,
+                npy_path = os.path.join(output_dir, self._cadence_npy_filename(group.h5_paths))
+                # Dedupe by content identity (#412): overlapping catalogs in one run can
+                # list the SAME cadence (same ordered h5 files) more than once. Identical
+                # cadences produce identical stamps and scores, and letting two units share
+                # one npy_path would double the work and let pruning race the duplicate's
+                # prefetch — plan the first occurrence only.
+                if npy_path in planned_npy_paths:
+                    logger.info(
+                        f"Skipping duplicate cadence {group.key} from {csv_filename}: an "
+                        f"identical cadence (same ordered h5 files) is already planned this "
+                        f"run ({npy_path})"
                     )
-                )
+                    continue
+                planned_npy_paths.add(npy_path)
+                units.append(PendingCadence(group=group, npy_path=npy_path, index=len(units) + 1))
 
         logger.info(
             f"Planned {len(units)} cadence work unit(s) across {len(inference_files)} CSV(s)"
@@ -1790,10 +1800,14 @@ class DataPreprocessor:
         key, so a benign re-stage re-extracts in place rather than churning keys). With the
         content-addressed default directory the h5_paths + fingerprint checks verify exactly
         what the key encodes; they are also what protects an EXPLICIT
-        --preprocess-output-dir against reusing another catalog's stamps. Missing/unreadable
-        metadata or a metadata file without a given field (a pre-#298/pre-#412 artifact)
-        degrades to a warn-and-reuse / skip-that-check — the historical, unguarded
-        behavior — never a hard failure.
+        --preprocess-output-dir against reusing another catalog's stamps. Fail-open on
+        anything that prevents VERIFYING rather than proves staleness: missing/unreadable
+        metadata (e.g. a crash between the .npy and .json publications), a sidecar without a
+        given field, or an un-stat-able h5 (raws archived, or a container run without the
+        raw-data bind — cached stamps are exactly what such a re-score run needs) all
+        degrade to warn-and-reuse / skip-that-check. Only positive evidence of staleness
+        (mismatched paths/fingerprint/stats) or a malformed sidecar re-extracts; the guard
+        itself never hard-fails the cadence.
         """
         try:
             with open(metadata_path) as f:
@@ -1825,29 +1839,49 @@ class DataPreprocessor:
 
         recorded_stats = metadata.get("h5_file_stats")
         if recorded_stats is not None:
-            if len(recorded_stats) != len(group.h5_paths):
+            # The try contains type-level malformation (a non-list value, non-dict
+            # entries): a foreign or hand-edited sidecar must degrade to a warn +
+            # re-extract, never crash the streaming loop (this call site sits outside
+            # process_pending_cadence's containment).
+            try:
+                if len(recorded_stats) != len(group.h5_paths):
+                    logger.warning(
+                        f"Cadence {group.key}: sidecar for {npy_path} records "
+                        f"{len(recorded_stats)} h5_file_stats entries for "
+                        f"{len(group.h5_paths)} files (malformed); reprocessing instead of "
+                        f"reusing"
+                    )
+                    return False
+                for h5_path, recorded in zip(group.h5_paths, recorded_stats, strict=True):
+                    try:
+                        stat = os.stat(h5_path)
+                    except OSError as e:
+                        # Cannot verify is not "verified stale": the raw h5 may be
+                        # legitimately unreachable (archived, or no raw-data bind in this
+                        # container) while the cached stamps are exactly what a warm
+                        # re-score needs — skip this file's check, don't invalidate.
+                        logger.warning(
+                            f"Cadence {group.key}: could not stat {h5_path} ({e}); reusing "
+                            f"stamps at {npy_path} without (size, mtime) verification for "
+                            f"this file"
+                        )
+                        continue
+                    if stat.st_size != recorded.get("size") or stat.st_mtime != recorded.get(
+                        "mtime"
+                    ):
+                        logger.warning(
+                            f"Cadence {group.key}: {h5_path} changed on disk since its "
+                            f"stamps were extracted (size/mtime mismatch — re-staged or "
+                            f"repaired?); reprocessing instead of reusing stamps at "
+                            f"{npy_path}"
+                        )
+                        return False
+            except (TypeError, AttributeError) as e:
                 logger.warning(
-                    f"Cadence {group.key}: sidecar for {npy_path} records "
-                    f"{len(recorded_stats)} h5_file_stats entries for "
-                    f"{len(group.h5_paths)} files (malformed); reprocessing instead of reusing"
+                    f"Cadence {group.key}: sidecar for {npy_path} has malformed "
+                    f"h5_file_stats ({e}); reprocessing instead of reusing"
                 )
                 return False
-            for h5_path, recorded in zip(group.h5_paths, recorded_stats, strict=True):
-                try:
-                    stat = os.stat(h5_path)
-                except OSError as e:
-                    logger.warning(
-                        f"Cadence {group.key}: could not stat {h5_path} ({e}); "
-                        f"reprocessing instead of reusing stamps at {npy_path}"
-                    )
-                    return False
-                if stat.st_size != recorded.get("size") or stat.st_mtime != recorded.get("mtime"):
-                    logger.warning(
-                        f"Cadence {group.key}: {h5_path} changed on disk since its stamps "
-                        f"were extracted (size/mtime mismatch — re-staged or repaired?); "
-                        f"reprocessing instead of reusing stamps at {npy_path}"
-                    )
-                    return False
         return True
 
     # NOTE: come back to this later (based on docstring, we're processing cadences sequentially. if so, any way to parallelize?)
@@ -1954,6 +1988,17 @@ class DataPreprocessor:
         downsample_factor = self.config.data.downsample_factor if store_downsampled else 1
         time_bins = self.config.data.time_bins
         n_processes = self.config.manager.n_processes
+
+        # Snapshot each h5's (size, mtime) BEFORE the first read (#412): the sidecar must
+        # describe the files the stamps were extracted FROM. Snapshotting after extraction
+        # would let an h5 re-staged mid-extraction (a multi-minute window) record the NEW
+        # file's stats against stamps holding pre-restage bytes — permanently certifying
+        # them; with a pre-read snapshot that re-stage instead surfaces as a (size, mtime)
+        # mismatch on the next resume check.
+        h5_file_stats = [
+            {"size": stat.st_size, "mtime": stat.st_mtime}
+            for stat in (os.stat(p) for p in group.h5_paths)
+        ]
 
         # Read header / metadata from the first ON-source file
         on_source_paths = [group.h5_paths[i] for i in (0, 2, 4)]
@@ -2338,14 +2383,12 @@ class DataPreprocessor:
             "key": group.key,
             "csv_path": group.csv_path,
             "h5_paths": group.h5_paths,
-            # Per-file (size, mtime) at extraction time (#412), aligned with h5_paths —
-            # compared by the resume guard so an h5 re-staged/repaired at the same path
-            # re-extracts instead of silently serving stale stamps. Sidecar-only: keeping
-            # these OUT of the cache key means a benign re-stage never churns keys.
-            "h5_file_stats": [
-                {"size": stat.st_size, "mtime": stat.st_mtime}
-                for stat in (os.stat(p) for p in group.h5_paths)
-            ],
+            # Per-file (size, mtime) snapshotted before this cadence's first h5 read
+            # (#412), aligned with h5_paths — compared by the resume guard so an h5
+            # re-staged/repaired at the same path re-extracts instead of silently serving
+            # stale stamps. Sidecar-only: keeping these OUT of the cache key means a
+            # benign re-stage never churns keys.
+            "h5_file_stats": h5_file_stats,
             "header": header,
             "stamp_starts": [int(start) for start, _, _ in stamp_centers],
             "stamp_width": stamp_width,

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -13,11 +13,11 @@ import csv
 import functools
 import gc
 import glob
+import hashlib
 import json
 import logging
 import math
 import os
-import re
 import signal
 import time
 import uuid
@@ -1659,45 +1659,33 @@ class DataPreprocessor:
         Group every CSV in config.data.inference_files into per-cadence work units without
         processing anything. Returns one PendingCadence (valid group + target .npy path) per
         valid cadence, in CSV order — the unit list the streaming inference loop iterates.
-        Raises ValueError when two inference_files entries share a basename stem (their
-        output dir and stamp filenames would collide).
         """
         inference_files = self.config.data.inference_files
         if not inference_files:
             logger.warning("plan_cadences() called with no inference_files configured")
             return []
 
-        # Fail fast on duplicate CSV basename stems: both the fingerprint-scoped default
-        # output dir and the per-cadence stamp .npy names are keyed on the stem, so two
-        # entries like runA/x.csv and runB/x.csv would silently share a directory (and/or
-        # stamp filenames) and cross-resume each other's cadences.
-        stem_sources: dict[str, str] = {}
-        for csv_filename in inference_files:
-            stem = os.path.splitext(os.path.basename(csv_filename))[0]
-            if stem in stem_sources:
-                raise ValueError(
-                    f"Duplicate inference CSV basename stem '{stem}' "
-                    f"('{stem_sources[stem]}' vs '{csv_filename}'): output directories and "
-                    f"stamp filenames are keyed on the basename, so these entries would "
-                    f"overwrite/resume each other. Rename one so basenames are unique."
-                )
-            stem_sources[stem] = csv_filename
-
-        # Output directory resolution (#298 I3): an explicit --preprocess-output-dir is
-        # used as-is (shared across CSVs); otherwise each CSV gets its own ED-FINGERPRINT-
-        # scoped default, {data_path}/inference/preprocessed/<csv_stem>_ed<hash12>/. Energy
-        # detection is deterministic given (csv, h5 files, ED config), so any run sharing
-        # the ED config reuses the stamps — threshold sweeps and re-inference with new
-        # weights skip preprocessing entirely — while any ED-config change lands in a
-        # different directory by construction (the fingerprint is a fail-safe denylist —
-        # see run_state.preprocessing_config_fingerprint). Staleness is impossible for a
-        # published .npy (atomic tmp -> os.replace publication + per-run-unique tmp names);
-        # the resume guard additionally verifies each sidecar's h5_paths and fingerprint.
-        # This deliberately replaces the old <csv_stem>_<save_tag> tag-scoped default
-        # (maintainer decision on #298): scores stay tag-scoped in the DB — only the
-        # deterministic preprocessing artifacts are shared.
+        # Output directory resolution (#298 I3, content-addressed by #412): an explicit
+        # --preprocess-output-dir is used as-is (shared across CSVs); otherwise every CSV
+        # shares the ED-FINGERPRINT-scoped default {data_path}/cache/stamps/ed_<hash12>/.
+        # A cadence's stamps are a pure function of (ordered h5 path list, ED config), and
+        # the cache key encodes exactly that: the directory carries the ED fingerprint (a
+        # fail-safe denylist — see run_state.preprocessing_config_fingerprint) and the
+        # filename hashes the ordered h5 paths (_cadence_npy_filename). The catalog's name
+        # appears nowhere in the key, so renamed/subset/superset catalogs over the same
+        # files hit the same entries, and any ED-config change lands in a different
+        # directory by construction. Staleness is impossible for a published .npy (atomic
+        # tmp -> os.replace publication + per-run-unique tmp names); the resume guard
+        # additionally verifies each sidecar's h5_paths, fingerprint, and per-file
+        # (size, mtime). Scores stay tag-scoped in the DB — only the deterministic
+        # preprocessing artifacts are shared.
         explicit_output_dir = self.config.inference.preprocess_output_dir
         ed_fingerprint = preprocessing_config_fingerprint(self.config.to_dict())
+        output_dir = explicit_output_dir or os.path.join(
+            self.config.data_path, "cache", "stamps", f"ed_{ed_fingerprint[:12]}"
+        )
+        os.makedirs(output_dir, exist_ok=True)
+        logger.info(f"Stamp cache directory: {output_dir}")
 
         group_by_cols = self.config.inference.cadence_group_by_cols
         h5_path_col = self.config.inference.cadence_h5_path_col
@@ -1724,16 +1712,8 @@ class DataPreprocessor:
                 f"CSV {csv_filename}: {len(valid_groups)} valid, {len(flagged_groups)} flagged"
             )
 
-            csv_stem = os.path.splitext(os.path.basename(csv_path))[0]
-
-            output_dir = explicit_output_dir or self.config.get_inference_file_path(
-                os.path.join("preprocessed", f"{csv_stem}_ed{ed_fingerprint[:12]}")
-            )
-            os.makedirs(output_dir, exist_ok=True)
-            logger.info(f"Preprocessing output directory for {csv_filename}: {output_dir}")
-
             for group in valid_groups:
-                npy_filename = self._cadence_npy_filename(csv_stem, group.key)
+                npy_filename = self._cadence_npy_filename(group.h5_paths)
                 units.append(
                     PendingCadence(
                         group=group,
@@ -1801,15 +1781,19 @@ class DataPreprocessor:
 
     def _resume_provenance_ok(self, group: CadenceGroup, npy_path: str, metadata_path: str) -> bool:
         """
-        Provenance guard on stamp reuse (#298 I3): an existing .npy is trusted only when its
-        sidecar metadata's h5_paths match this cadence's files and its recorded
-        ed_config_fingerprint (when present) matches the current config's. With the
-        fingerprint-scoped default directory the fingerprint check is belt-and-braces (a
-        changed ED config lands in a different directory by construction); the h5_paths
-        check is what protects an EXPLICIT --preprocess-output-dir against reusing another
-        catalog's stamps. Missing/unreadable metadata or a metadata file without the
-        fingerprint field (a pre-#298 artifact in an explicitly shared directory) degrades
-        to a warn-and-reuse — the historical, unguarded behavior — never a hard failure.
+        Provenance guard on stamp reuse (#298 I3, extended by #412): an existing .npy is
+        trusted only when its sidecar metadata's h5_paths match this cadence's files, its
+        recorded ed_config_fingerprint (when present) matches the current config's, and its
+        recorded per-file (size, mtime) (when present) still match the h5 files on disk —
+        the last closes the blind spot where an h5 re-staged/repaired AT THE SAME PATH would
+        silently serve stale stamps (size/mtime live only in the sidecar, never in the cache
+        key, so a benign re-stage re-extracts in place rather than churning keys). With the
+        content-addressed default directory the h5_paths + fingerprint checks verify exactly
+        what the key encodes; they are also what protects an EXPLICIT
+        --preprocess-output-dir against reusing another catalog's stamps. Missing/unreadable
+        metadata or a metadata file without a given field (a pre-#298/pre-#412 artifact)
+        degrades to a warn-and-reuse / skip-that-check — the historical, unguarded
+        behavior — never a hard failure.
         """
         try:
             with open(metadata_path) as f:
@@ -1838,6 +1822,32 @@ class DataPreprocessor:
                     f"a DIFFERENT energy-detection config; reprocessing instead of reusing"
                 )
                 return False
+
+        recorded_stats = metadata.get("h5_file_stats")
+        if recorded_stats is not None:
+            if len(recorded_stats) != len(group.h5_paths):
+                logger.warning(
+                    f"Cadence {group.key}: sidecar for {npy_path} records "
+                    f"{len(recorded_stats)} h5_file_stats entries for "
+                    f"{len(group.h5_paths)} files (malformed); reprocessing instead of reusing"
+                )
+                return False
+            for h5_path, recorded in zip(group.h5_paths, recorded_stats, strict=True):
+                try:
+                    stat = os.stat(h5_path)
+                except OSError as e:
+                    logger.warning(
+                        f"Cadence {group.key}: could not stat {h5_path} ({e}); "
+                        f"reprocessing instead of reusing stamps at {npy_path}"
+                    )
+                    return False
+                if stat.st_size != recorded.get("size") or stat.st_mtime != recorded.get("mtime"):
+                    logger.warning(
+                        f"Cadence {group.key}: {h5_path} changed on disk since its stamps "
+                        f"were extracted (size/mtime mismatch — re-staged or repaired?); "
+                        f"reprocessing instead of reusing stamps at {npy_path}"
+                    )
+                    return False
         return True
 
     # NOTE: come back to this later (based on docstring, we're processing cadences sequentially. if so, any way to parallelize?)
@@ -1875,17 +1885,18 @@ class DataPreprocessor:
         logger.info(f"find_hits completed: {len(results)} cadence .npy files available")
         return results
 
-    # NOTE: come back to this later (ensure filenames are structured similarly as in train_files & test_files)
     @staticmethod
-    def _cadence_npy_filename(csv_stem: str, key: tuple) -> str:
-        """Build a deterministic filename for a cadence group's .npy output."""
-        # Sanitize each key component via an allowlist: only word chars, dash, and
-        # dot survive — everything else collapses to underscore. This is broader
-        # than just stripping path separators / whitespace: CSV column values can
-        # carry quotes, control chars, shell metacharacters, or path-traversal
-        # sequences (e.g. "..") that would otherwise leak through.
-        safe_parts = [re.sub(r"[^\w\-.]+", "_", str(part)) for part in key]
-        return f"{csv_stem}_{'_'.join(safe_parts)}.npy"
+    def _cadence_npy_filename(h5_paths: list[str]) -> str:
+        """
+        Content-addressed filename for a cadence's stamp .npy (#412): the first 12 hex chars
+        of the sha256 over the ORDERED h5 path list. Order is part of the identity — ABACAD
+        order is scientifically meaningful, so the same files listed in a different order
+        are a different cadence and must miss. The catalog's name and the group key appear
+        nowhere (the sidecar keeps them as human-readable provenance), so renamed/subset
+        catalogs over the same files resolve to the same entry.
+        """
+        digest = hashlib.sha256(json.dumps(list(h5_paths)).encode()).hexdigest()
+        return f"{digest[:12]}.npy"
 
     @staticmethod
     def cadence_metadata_path(npy_path: str) -> str:
@@ -2048,7 +2059,7 @@ class DataPreprocessor:
 
         if self.config.inference.bandpass_debug_plot:
             try:
-                self._plot_bandpass_overlay(primary_h5, n_coarse_total, bandpass_flatten, npy_path)
+                self._plot_bandpass_overlay(primary_h5, n_coarse_total, bandpass_flatten)
             except Exception as e:
                 logger.error(f"Cadence {group.key}: bandpass overlay plot failed: {e}")
 
@@ -2226,15 +2237,13 @@ class DataPreprocessor:
         # metadata "<stem>.json.<pid>.<hex>.tmp", and the #302 candidate sidecar
         # "<stem>.candidates.npz.<pid>.<hex>.tmp" (the latter two ended in ".tmp" but not
         # ".tmp.npy", so the old ".*.tmp.npy" glob leaked them). The fixed pre-#298
-        # "<stem>.tmp.npy" legacy name is swept too.
+        # "<stem>.tmp.npy" legacy sweep entry is gone (#412): no historical writer ever
+        # produced it next to a content-hashed stem.
         stale_cutoff = time.time() - _STALE_TMP_MAX_AGE_S
         stem = os.path.splitext(npy_path)[0]
         escaped = glob.escape(stem)
-        stale_tmps = (
-            glob.glob(f"{escaped}.*.tmp.npy")  # stamp memmap tmps
-            + glob.glob(f"{escaped}.*.tmp")  # metadata + candidate-sidecar tmps
-            + [f"{stem}.tmp.npy"]  # fixed pre-#298 legacy name
-        )
+        # Stamp memmap tmps, then metadata + candidate-sidecar tmps
+        stale_tmps = glob.glob(f"{escaped}.*.tmp.npy") + glob.glob(f"{escaped}.*.tmp")
         for stale in stale_tmps:
             with contextlib.suppress(OSError):
                 if os.path.getmtime(stale) < stale_cutoff:
@@ -2329,6 +2338,14 @@ class DataPreprocessor:
             "key": group.key,
             "csv_path": group.csv_path,
             "h5_paths": group.h5_paths,
+            # Per-file (size, mtime) at extraction time (#412), aligned with h5_paths —
+            # compared by the resume guard so an h5 re-staged/repaired at the same path
+            # re-extracts instead of silently serving stale stamps. Sidecar-only: keeping
+            # these OUT of the cache key means a benign re-stage never churns keys.
+            "h5_file_stats": [
+                {"size": stat.st_size, "mtime": stat.st_mtime}
+                for stat in (os.stat(p) for p in group.h5_paths)
+            ],
             "header": header,
             "stamp_starts": [int(start) for start, _, _ in stamp_centers],
             "stamp_width": stamp_width,
@@ -2446,7 +2463,7 @@ class DataPreprocessor:
     ) -> str:
         """
         Compute the PFB passband response in the parent process and persist it to a
-        deterministic sidecar .npy under {output_path}/cache/pfb/, returning its path.
+        deterministic sidecar .npy under {data_path}/cache/pfb/, returning its path.
 
         The heavy work (an ~n_chans-point FFT) runs exactly once per parameter combination in
         the parent — gen_coarse_channel_response is process-cached and the file is reused when
@@ -2463,7 +2480,7 @@ class DataPreprocessor:
             fine_per_coarse, num_coarse_channels, taps_per_channel
         )
 
-        cache_dir = os.path.join(self.config.output_path, "cache", "pfb")
+        cache_dir = os.path.join(self.config.data_path, "cache", "pfb")
         os.makedirs(cache_dir, exist_ok=True)
         path = os.path.join(
             cache_dir,
@@ -2479,7 +2496,7 @@ class DataPreprocessor:
             except Exception as e:
                 logger.warning(f"PFB response cache {path} unreadable ({e}); rewriting")
 
-        # Per-writer tmp name (pid + uuid) so two runs sharing this output_path don't clobber
+        # Per-writer tmp name (pid + uuid) so two runs sharing this data_path don't clobber
         # each other's in-progress write on a single shared "{path}.tmp"; os.replace stays
         # atomic and the content is deterministic, so whichever writer lands last is harmless.
         tmp_path = f"{path}.{os.getpid()}.{uuid.uuid4().hex}.tmp"
@@ -2668,7 +2685,6 @@ class DataPreprocessor:
         h5_path: str,
         n_coarse_total: int,
         bandpass_flatten: Callable[[np.ndarray], np.ndarray],
-        npy_path: str,
     ) -> None:
         """
         Opt-in debug artifact (--bandpass-debug-plot): for a few coarse channels sampled evenly
@@ -2739,7 +2755,10 @@ class DataPreprocessor:
         display_tag_value = display_tag(tag, get_machine_name())
         save_dir = os.path.join(self.config.output_path, "plots", "inference", display_tag_value)
         os.makedirs(save_dir, exist_ok=True)
-        stem = os.path.splitext(os.path.basename(npy_path))[0]
+        # Named after the plotted ON file (matching the suptitle), not the stamp .npy: the
+        # #412 content-addressed stamp basename is an opaque hash, useless to the human this
+        # debug artifact exists for.
+        stem = os.path.splitext(os.path.basename(h5_path))[0]
         out_path = os.path.join(save_dir, f"bandpass_overlay_{stem}_{display_tag_value}.png")
         # No close/registry bookkeeping needed: an OO-API Figure is garbage-collected
         fig.savefig(out_path, dpi=120)

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -1660,7 +1660,9 @@ class DataPreprocessor:
         processing anything. Returns one PendingCadence (valid group + target .npy path) per
         distinct valid cadence, in CSV order — the unit list the streaming inference loop
         iterates. Cadences whose content identity (ordered h5 path list) repeats across the
-        run's CSVs are planned once (first occurrence wins, #412).
+        run's CSVs are planned once (first occurrence wins, #412); a truncated-digest
+        collision between two DIFFERENT cadences raises ValueError rather than silently
+        dropping one.
         """
         inference_files = self.config.data.inference_files
         if not inference_files:
@@ -1694,7 +1696,7 @@ class DataPreprocessor:
         expected_obs = self.config.inference.cadence_expected_obs
 
         units: list[PendingCadence] = []
-        planned_npy_paths: set[str] = set()
+        planned_npy_paths: dict[str, list[str]] = {}
 
         for csv_filename in inference_files:
             csv_path = self.config.get_inference_file_path(csv_filename)
@@ -1721,15 +1723,26 @@ class DataPreprocessor:
                 # list the SAME cadence (same ordered h5 files) more than once. Identical
                 # cadences produce identical stamps and scores, and letting two units share
                 # one npy_path would double the work and let pruning race the duplicate's
-                # prefetch — plan the first occurrence only.
-                if npy_path in planned_npy_paths:
-                    logger.info(
-                        f"Skipping duplicate cadence {group.key} from {csv_filename}: an "
-                        f"identical cadence (same ordered h5 files) is already planned this "
-                        f"run ({npy_path})"
+                # prefetch — plan the first occurrence only. Compare the h5 lists, not just
+                # the 48-bit digest: a truncated-hash collision between two DIFFERENT
+                # cadences must never silently drop one of them.
+                planned = planned_npy_paths.get(npy_path)
+                if planned is not None:
+                    if list(planned) == list(group.h5_paths):
+                        logger.info(
+                            f"Skipping duplicate cadence {group.key} from {csv_filename}: an "
+                            f"identical cadence (same ordered h5 files) is already planned "
+                            f"this run ({npy_path})"
+                        )
+                        continue
+                    raise ValueError(
+                        f"Stamp cache filename collision at {npy_path}: cadence "
+                        f"{group.key} from {csv_filename} hashes to the same 12-hex name as "
+                        f"an already-planned cadence over DIFFERENT .h5 files. Widen "
+                        f"_cadence_npy_filename's digest prefix rather than dropping a "
+                        f"cadence."
                     )
-                    continue
-                planned_npy_paths.add(npy_path)
+                planned_npy_paths[npy_path] = group.h5_paths
                 units.append(PendingCadence(group=group, npy_path=npy_path, index=len(units) + 1))
 
         logger.info(

--- a/src/aetherscan/preprocessing.py
+++ b/src/aetherscan/preprocessing.py
@@ -1865,19 +1865,19 @@ class DataPreprocessor:
                         f"reusing"
                     )
                     return False
+                unverifiable: list[str] = []
                 for h5_path, recorded in zip(group.h5_paths, recorded_stats, strict=True):
                     try:
                         stat = os.stat(h5_path)
-                    except OSError as e:
+                    except OSError:
                         # Cannot verify is not "verified stale": the raw h5 may be
                         # legitimately unreachable (archived, or no raw-data bind in this
                         # container) while the cached stamps are exactly what a warm
                         # re-score needs — skip this file's check, don't invalidate.
-                        logger.warning(
-                            f"Cadence {group.key}: could not stat {h5_path} ({e}); reusing "
-                            f"stamps at {npy_path} without (size, mtime) verification for "
-                            f"this file"
-                        )
+                        # Aggregated to ONE warning per cadence below: unreachable raws
+                        # are the STEADY STATE of a no-raw-bind re-score run, and 6
+                        # warnings x every cadence would flood the log (and Slack).
+                        unverifiable.append(h5_path)
                         continue
                     if stat.st_size != recorded.get("size") or stat.st_mtime != recorded.get(
                         "mtime"
@@ -1889,6 +1889,13 @@ class DataPreprocessor:
                             f"{npy_path}"
                         )
                         return False
+                if unverifiable:
+                    logger.warning(
+                        f"Cadence {group.key}: {len(unverifiable)}/{len(group.h5_paths)} h5 "
+                        f"file(s) could not be stat'd (first: {unverifiable[0]}); reusing "
+                        f"stamps at {npy_path} without (size, mtime) verification for those "
+                        f"files"
+                    )
             except (TypeError, AttributeError) as e:
                 logger.warning(
                     f"Cadence {group.key}: sidecar for {npy_path} has malformed "

--- a/src/aetherscan/run_state.py
+++ b/src/aetherscan/run_state.py
@@ -151,8 +151,8 @@ def preprocessing_config_fingerprint(config_dict: dict) -> str:
     """
     Stable hash of the PREPROCESSING-result-affecting config — everything that changes what
     energy detection writes into a stamp .npy (#298 I3). Keys the default stamp cache
-    directory ({data_path}/inference/preprocessed/<csv_stem>_ed<hash12>/), is persisted into
-    each cadence's metadata JSON as ed_config_fingerprint, and is verified by the resume
+    directory ({data_path}/cache/stamps/ed_<hash12>/, #412), is persisted into each
+    cadence's metadata JSON as ed_config_fingerprint, and is verified by the resume
     guard — so runs sharing an ED config share stamps, and any ED-config change lands in a
     different directory by construction.
     """

--- a/tests/integration/test_inference_smoke.py
+++ b/tests/integration/test_inference_smoke.py
@@ -10,11 +10,10 @@ bind by default — either bind it explicitly:
     SINGULARITY_BIND=/datag ./utils/run_container.sh python -m pytest tests/ -m "gpu or cluster" -q
 
 or rely on the resume path: preprocessing skips any cadence whose stamp .npy already exists.
-Since #298 the default stamp directory is ED-fingerprint-scoped ({data_path}/inference/
-preprocessed/<csv_stem>_ed<hash12>/), shared across runs with the same ED config — so a
-fresh-tagged run resumes automatically off any prior same-config run's stamps. When /datag
-is not mounted and only legacy stamps exist under <output>/preprocessed, the test still
-points --preprocess-output-dir at them explicitly (the pinned-directory escape hatch).
+Since #412 the default stamp cache is content-addressed ({data_path}/cache/stamps/
+ed_<fingerprint12>/<sha12-of-ordered-h5-paths>.npy), shared across catalogs and runs with
+the same ED config — so a fresh-tagged run resumes automatically off any prior
+same-config run's stamps, whatever CSV produced them.
 """
 
 from __future__ import annotations
@@ -62,15 +61,16 @@ def test_inference_smoke(cluster_paths, run_pipeline, smoke_model_tag):
         if not os.path.exists(required):
             pytest.skip(f"required cluster artifact missing: {required}")
 
-    # Raw .h5 reads need /datag; already-preprocessed stamps make it optional (and since
-    # #298 the fingerprint-scoped default cache resumes same-ED-config stamps on its own);
-    # only legacy stamps under <output>/preprocessed still need the explicit directory.
-    extra_flags: list[str] = []
-    if not os.path.exists("/datag"):
-        legacy_dir = os.path.join(output_path, "preprocessed")
-        if not glob.glob(os.path.join(legacy_dir, "subset_test_*.npy")):
-            pytest.skip("/datag not mounted and no preprocessed subset stamps to resume from")
-        extra_flags = ["--preprocess-output-dir", legacy_dir]
+    # Raw .h5 reads need /datag; already-cached stamps make it optional — the
+    # content-addressed default cache (#412) resumes same-ED-config stamps on its own,
+    # regardless of which catalog produced them. Without /datag or any cached stamps
+    # there is nothing to run against. (Coarse check: an ED-config mismatch between the
+    # cached stamps and this run would still fail on the missing /datag — acceptable for
+    # a cluster smoke.)
+    if not os.path.exists("/datag") and not glob.glob(
+        os.path.join(data_path, "cache", "stamps", "ed_*", "*.npy")
+    ):
+        pytest.skip("/datag not mounted and no cached stamps to resume from")
 
     # --save-tag takes a BARE PREFIX since #272 (the run stamps its own datetime); this
     # smoke passed a bare datetime — rejected by validation — and had been silently broken
@@ -91,7 +91,6 @@ def test_inference_smoke(cluster_paths, run_pipeline, smoke_model_tag):
             "inf",
             "--max-retries",
             "1",
-            *extra_flags,
         ]
     )
 

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -1413,6 +1413,37 @@ class TestPlanCadencesOutputDir:
 
         assert len(units) == 1
 
+    def test_true_digest_collision_raises(
+        self, initialized_runtime, make_inference_csv, monkeypatch
+    ):
+        # Two DIFFERENT cadences forced onto one 12-hex name (un-constructable for real
+        # sha256, so simulated): the planner must refuse rather than silently drop one —
+        # missing science data is far worse than a cache miss.
+        config = get_config()
+        make_inference_csv("a.csv")
+        make_inference_csv(
+            "b.csv",
+            groups=[
+                (
+                    {
+                        "Target": "HIP99999",
+                        "Session": "AGBT21B_999_32",
+                        "Band": "L",
+                        "Cadence ID": "1",
+                        "Frequency": "1400",
+                    },
+                    [f"/data/other_{i}.h5" for i in range(6)],
+                )
+            ],
+        )
+        config.data.inference_files = ["a.csv", "b.csv"]
+        monkeypatch.setattr(
+            DataPreprocessor, "_cadence_npy_filename", staticmethod(lambda h5_paths: "cafe.npy")
+        )
+
+        with pytest.raises(ValueError, match="collision"):
+            DataPreprocessor().plan_cadences()
+
     def test_explicit_override_shared_across_csvs(
         self, initialized_runtime, make_inference_csv, tmp_path
     ):

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -1,10 +1,10 @@
 # NOTE: come back to this later
 
-"""Unit tests for aetherscan.preprocessing: hit deduplication, CSV cadence grouping, filename
-sanitization, JSON coercion, DC-spike removal, spline bandpass fitting, the vectorized
-normality test (equivalence-gated against scipy.stats.normaltest), the fused energy-detection
-worker, downsample-at-extraction, provenance derivation, and the legacy-vs-downsampled
-load_inference_data paths."""
+"""Unit tests for aetherscan.preprocessing: hit deduplication, CSV cadence grouping,
+content-addressed cadence filenames, JSON coercion, DC-spike removal, spline bandpass fitting,
+the vectorized normality test (equivalence-gated against scipy.stats.normaltest), the fused
+energy-detection worker, downsample-at-extraction, provenance derivation, and the
+legacy-vs-downsampled load_inference_data paths."""
 
 from __future__ import annotations
 
@@ -13,6 +13,7 @@ import json
 import logging
 import math
 import os
+import re
 
 import numpy as np
 import pytest
@@ -220,28 +221,33 @@ class TestGroupObservationsFromCsv:
 
 
 class TestCadenceNpyFilename:
-    def test_clean_key_passes_through(self):
-        name = DataPreprocessor._cadence_npy_filename("catalog", ("HIP110750", "L", "0"))
-        assert name == "catalog_HIP110750_L_0.npy"
+    """#412: stamp filenames are content-addressed — 12 sha256 hex chars over the ORDERED h5
+    path list. No trace of the source catalog's name or the group key survives in the name."""
 
-    def test_hostile_characters_collapse_to_underscore(self):
-        name = DataPreprocessor._cadence_npy_filename(
-            "catalog", ("HIP 110750", "AGBT/18A", "a;b|c", "$(rm -rf)")
+    def test_deterministic_hex_name(self):
+        paths = [f"/data/obs_{i}.h5" for i in range(6)]
+        name = DataPreprocessor._cadence_npy_filename(paths)
+        assert re.fullmatch(r"[0-9a-f]{12}\.npy", name)
+        assert name == DataPreprocessor._cadence_npy_filename(list(paths))
+
+    def test_order_sensitive(self):
+        # ABACAD order is scientifically meaningful: the same files listed in a different
+        # order are a different cadence and must resolve to a different cache entry.
+        paths = [f"/data/obs_{i}.h5" for i in range(6)]
+        assert DataPreprocessor._cadence_npy_filename(paths) != (
+            DataPreprocessor._cadence_npy_filename(list(reversed(paths)))
         )
-        assert "/" not in name
-        assert " " not in name
-        assert ";" not in name
-        assert "$" not in name
-        assert name.startswith("catalog_")
-        assert name.endswith(".npy")
 
-    def test_dash_and_dot_survive(self):
-        name = DataPreprocessor._cadence_npy_filename("catalog", ("L-band", "1.5"))
-        assert name == "catalog_L-band_1.5.npy"
+    def test_different_files_differ(self):
+        a = DataPreprocessor._cadence_npy_filename([f"/data/a_{i}.h5" for i in range(6)])
+        b = DataPreprocessor._cadence_npy_filename([f"/data/b_{i}.h5" for i in range(6)])
+        assert a != b
 
-    def test_non_string_key_components(self):
-        name = DataPreprocessor._cadence_npy_filename("catalog", (0, 1400.5))
-        assert name == "catalog_0_1400.5.npy"
+    def test_no_concatenation_ambiguity(self):
+        # The list is JSON-encoded before hashing, so ["ab","c"] and ["a","bc"] can't collide
+        assert DataPreprocessor._cadence_npy_filename(["ab", "c"]) != (
+            DataPreprocessor._cadence_npy_filename(["a", "bc"])
+        )
 
 
 class TestToJsonSafe:
@@ -660,16 +666,18 @@ class TestProcessCadenceEndToEnd:
         os.makedirs(os.path.dirname(npy_path), exist_ok=True)
 
         # Abandoned partial outputs are age-swept (#298 I3: tmp names are per-run-unique in
-        # the shared cache dir, so only AGE proves abandonment): an expired tmp — legacy
-        # fixed name or unique-name — is removed; a fresh unique-name tmp may be a live
-        # concurrent run's in-progress write and must survive.
+        # the shared cache dir, so only AGE proves abandonment): an expired unique-name tmp
+        # is removed; a fresh unique-name tmp may be a live concurrent run's in-progress
+        # write and must survive. The fixed pre-#298 "<stem>.tmp.npy" legacy name is NOT
+        # swept anymore (#412: no historical writer ever produced it next to a
+        # content-hashed stem).
         import time as time_module  # noqa: PLC0415
 
         expired = (time_module.time() - 25 * 3600,) * 2
-        stale_tmp = os.path.splitext(npy_path)[0] + ".tmp.npy"
-        with open(stale_tmp, "wb") as f:
-            f.write(b"junk from a SIGKILLed pre-#298 run")
-        os.utime(stale_tmp, expired)
+        legacy_tmp = os.path.splitext(npy_path)[0] + ".tmp.npy"
+        with open(legacy_tmp, "wb") as f:
+            f.write(b"a fixed-name file the sweep no longer targets")
+        os.utime(legacy_tmp, expired)
         stale_unique_tmp = os.path.splitext(npy_path)[0] + ".12345.deadbeef.tmp.npy"
         with open(stale_unique_tmp, "wb") as f:
             f.write(b"junk from a SIGKILLed run")
@@ -681,7 +689,8 @@ class TestProcessCadenceEndToEnd:
         preprocessor = DataPreprocessor()
         result = preprocessor.process_pending_cadence(PendingCadence(group, npy_path))
 
-        assert not os.path.exists(stale_tmp)
+        assert os.path.exists(legacy_tmp)  # untouched: the legacy sweep entry is gone
+        os.remove(legacy_tmp)
         assert not os.path.exists(stale_unique_tmp)
         assert os.path.exists(fresh_tmp)
         os.remove(fresh_tmp)
@@ -703,6 +712,14 @@ class TestProcessCadenceEndToEnd:
         assert metadata["stamp_width"] == config.inference.stamp_width
         assert len(metadata["stamp_frequencies_mhz"]) == result.n_hits
         assert len(metadata["stamp_starts"]) == result.n_hits
+
+        # #412: per-file (size, mtime) recorded at extraction, aligned with h5_paths — the
+        # resume guard's evidence that the h5 files haven't been re-staged since extraction
+        assert len(metadata["h5_file_stats"]) == len(metadata["h5_paths"]) == 6
+        for h5_path, recorded in zip(metadata["h5_paths"], metadata["h5_file_stats"], strict=True):
+            stat = os.stat(h5_path)
+            assert recorded["size"] == stat.st_size
+            assert recorded["mtime"] == stat.st_mtime
 
         # Viz-suite provenance: per-ON-file all-window statistic histograms on the shared
         # bins, the pre-binned hit-frequency histograms (#301 — the raw per-hit list is no
@@ -1036,14 +1053,16 @@ class TestProcessCadenceEndToEnd:
         assert result is not None
         # The debug overlay is display-tagged ({command}_{machine}_{datetime}), matching the
         # inference-viz plot dir; save_tag ("inf_20260101_120000") is a real run tag, so the
-        # machine token is inserted.
+        # machine token is inserted. Named after the plotted primary ON file (#412 — the
+        # stamp .npy basename is an opaque content hash, so it no longer names the PNG).
         display_tag_value = display_tag(config.checkpoint.save_tag, get_machine_name())
+        primary_stem = os.path.splitext(os.path.basename(group.h5_paths[0]))[0]
         plot_path = os.path.join(
             config.output_path,
             "plots",
             "inference",
             display_tag_value,
-            f"bandpass_overlay_cadence_dbg_{display_tag_value}.png",
+            f"bandpass_overlay_{primary_stem}_{display_tag_value}.png",
         )
         assert os.path.exists(plot_path)
         assert os.path.getsize(plot_path) > 0
@@ -1063,9 +1082,10 @@ class TestBandpassFlattenerSelection:
         flattener = DataPreprocessor()._get_bandpass_flattener(num_coarse_channels=4)
         assert flattener.func is _pfb_flatten_bandpass
         response_path = flattener.keywords["response_path"]
-        # The sidecar file lives under the run's output path and holds exactly the response
+        # The sidecar file lives in the unified cache root under data_path (#412) and holds
+        # exactly the response
         # the parent computed for (width, coarse count, taps)
-        assert response_path.startswith(os.path.join(config.output_path, "cache", "pfb"))
+        assert response_path.startswith(os.path.join(config.data_path, "cache", "pfb"))
         expected = gen_coarse_channel_response(512, 4, config.inference.pfb_taps_per_channel)
         np.testing.assert_array_equal(np.load(response_path), expected)
 
@@ -1253,11 +1273,12 @@ class TestDecimateForPlot:
 
 
 class TestPlanCadencesOutputDir:
-    """plan_cadences resolves the .npy output dir per CSV: ED-fingerprint-scoped default
-    under {data_path}/inference/preprocessed/ (#298 I3 — runs sharing an ED config share
-    stamps), with an explicit --preprocess-output-dir shared across CSVs."""
+    """plan_cadences resolves the .npy output dir to the content-addressed stamp cache
+    {data_path}/cache/stamps/ed_<fingerprint12>/ (#298 I3 + #412 — catalog-name-free, shared
+    across CSVs and runs with the same ED config), with an explicit --preprocess-output-dir
+    pinning one directory instead."""
 
-    def test_default_is_fingerprint_scoped_not_tag_scoped(
+    def test_default_is_content_addressed_not_catalog_or_tag_scoped(
         self, initialized_runtime, make_inference_csv
     ):
         config = get_config()
@@ -1269,12 +1290,31 @@ class TestPlanCadencesOutputDir:
 
         assert len(units) == 1
         fingerprint = preprocessing_config_fingerprint(config.to_dict())
-        expected_dir = os.path.join(
-            config.data_path, "inference", "preprocessed", f"subset_ed{fingerprint[:12]}"
-        )
+        expected_dir = os.path.join(config.data_path, "cache", "stamps", f"ed_{fingerprint[:12]}")
         assert os.path.dirname(units[0].npy_path) == expected_dir
         assert os.path.isdir(expected_dir)
-        assert "test_v1" not in os.path.basename(expected_dir)
+        # Neither the save tag nor the catalog's name may leak into the cache key
+        assert "test_v1" not in units[0].npy_path
+        assert "subset" not in os.path.relpath(units[0].npy_path, config.data_path)
+        assert os.path.basename(units[0].npy_path) == (
+            DataPreprocessor._cadence_npy_filename(units[0].group.h5_paths)
+        )
+
+    def test_renamed_catalog_resolves_to_same_entries(
+        self, initialized_runtime, make_inference_csv
+    ):
+        # The point of #412: the same files under a renamed/copied catalog must hit the
+        # same cache entries instead of re-preprocessing from scratch.
+        config = get_config()
+        make_inference_csv("subset.csv")
+        make_inference_csv("renamed_copy.csv")
+
+        config.data.inference_files = ["subset.csv"]
+        first = DataPreprocessor().plan_cadences()
+        config.data.inference_files = ["renamed_copy.csv"]
+        second = DataPreprocessor().plan_cadences()
+
+        assert [u.npy_path for u in first] == [u.npy_path for u in second]
 
     def test_scoring_change_reuses_directory(self, initialized_runtime, make_inference_csv):
         # The point of #298 I3: a new threshold / model must land in the SAME stamp dir
@@ -1308,16 +1348,20 @@ class TestPlanCadencesOutputDir:
         # otherwise resume-skip the cadence off stamps produced under a different ED config.
         assert not os.path.exists(second[0].npy_path)
 
-    def test_duplicate_csv_basenames_rejected(self, initialized_runtime, make_inference_csv):
-        # Same basename in different subdirectories would collide into one tag-scoped
-        # output dir (and shared stamp filenames) — plan_cadences fails fast instead.
+    def test_duplicate_csv_basenames_plan_cleanly(self, initialized_runtime, make_inference_csv):
+        # Pre-#412 the stem-keyed layout had to reject duplicate CSV basenames (they would
+        # have collided into one directory and cross-resumed). Content addressing removes
+        # the collision by construction: identical cadences resolve to the SAME cache entry
+        # (shared, atomically published), distinct cadences to different ones.
         config = get_config()
         make_inference_csv("run_a/subset.csv")
         make_inference_csv("run_b/subset.csv")
         config.data.inference_files = ["run_a/subset.csv", "run_b/subset.csv"]
 
-        with pytest.raises(ValueError, match="subset"):
-            DataPreprocessor().plan_cadences()
+        units = DataPreprocessor().plan_cadences()
+
+        assert len(units) == 2
+        assert units[0].npy_path == units[1].npy_path  # same files -> same entry
 
     def test_explicit_override_shared_across_csvs(
         self, initialized_runtime, make_inference_csv, tmp_path
@@ -1336,8 +1380,10 @@ class TestPlanCadencesOutputDir:
 
 
 class TestResumeProvenanceGuard:
-    """#298 I3: an existing stamp .npy is only reused when its metadata sidecar's h5_paths
-    and recorded ED fingerprint match; missing/legacy metadata degrades to warn-and-reuse."""
+    """#298 I3 + #412: an existing stamp .npy is only reused when its metadata sidecar's
+    h5_paths and recorded ED fingerprint match AND its recorded per-file (size, mtime) still
+    match the h5 files on disk; missing/legacy metadata (or a legacy sidecar without a given
+    field) degrades to warn-and-reuse / skip-that-check."""
 
     def _group_and_paths(self, tmp_path, h5_paths=None):
         from aetherscan.preprocessing import CadenceGroup  # noqa: PLC0415
@@ -1392,6 +1438,90 @@ class TestResumeProvenanceGuard:
         preprocessor = DataPreprocessor()
         group, npy_path, metadata_path = self._group_and_paths(tmp_path)
         self._write_metadata(metadata_path, h5_paths=group.h5_paths)
+        assert preprocessor._resume_provenance_ok(group, npy_path, metadata_path)
+
+    def _group_with_real_files(self, tmp_path):
+        """Like _group_and_paths but with real (stat-able) h5 stand-ins, for the #412
+        (size, mtime) guard tests."""
+        h5_paths = []
+        for i in range(6):
+            path = tmp_path / f"obs_{i}.h5"
+            path.write_bytes(b"x" * (100 + i))
+            h5_paths.append(str(path))
+        return self._group_and_paths(tmp_path, h5_paths=h5_paths)
+
+    @staticmethod
+    def _stats_for(h5_paths):
+        return [{"size": os.stat(p).st_size, "mtime": os.stat(p).st_mtime} for p in h5_paths]
+
+    def test_matching_file_stats_reuse(self, tmp_path, initialized_runtime):
+        preprocessor = DataPreprocessor()
+        group, npy_path, metadata_path = self._group_with_real_files(tmp_path)
+        self._write_metadata(
+            metadata_path,
+            h5_paths=group.h5_paths,
+            ed_config_fingerprint=preprocessing_config_fingerprint(get_config().to_dict()),
+            h5_file_stats=self._stats_for(group.h5_paths),
+        )
+        assert preprocessor._resume_provenance_ok(group, npy_path, metadata_path)
+
+    def test_size_change_reprocesses_with_warning(self, tmp_path, initialized_runtime, caplog):
+        preprocessor = DataPreprocessor()
+        group, npy_path, metadata_path = self._group_with_real_files(tmp_path)
+        self._write_metadata(
+            metadata_path, h5_paths=group.h5_paths, h5_file_stats=self._stats_for(group.h5_paths)
+        )
+        with open(group.h5_paths[2], "ab") as f:  # a re-staged file grew at the same path
+            f.write(b"extra")
+        with caplog.at_level("WARNING", logger="aetherscan.preprocessing"):
+            assert not preprocessor._resume_provenance_ok(group, npy_path, metadata_path)
+        assert any("changed on disk" in r.message for r in caplog.records)
+
+    def test_mtime_change_reprocesses(self, tmp_path, initialized_runtime):
+        preprocessor = DataPreprocessor()
+        group, npy_path, metadata_path = self._group_with_real_files(tmp_path)
+        self._write_metadata(
+            metadata_path, h5_paths=group.h5_paths, h5_file_stats=self._stats_for(group.h5_paths)
+        )
+        # Same size, shifted mtime — a byte-identical re-stage still invalidates (the guard
+        # cannot cheaply prove content identity, so it errs toward re-extraction)
+        stat = os.stat(group.h5_paths[4])
+        os.utime(group.h5_paths[4], (stat.st_atime, stat.st_mtime + 60.0))
+        assert not preprocessor._resume_provenance_ok(group, npy_path, metadata_path)
+
+    def test_missing_h5_reprocesses_with_warning(self, tmp_path, initialized_runtime, caplog):
+        preprocessor = DataPreprocessor()
+        group, npy_path, metadata_path = self._group_with_real_files(tmp_path)
+        self._write_metadata(
+            metadata_path, h5_paths=group.h5_paths, h5_file_stats=self._stats_for(group.h5_paths)
+        )
+        os.remove(group.h5_paths[0])
+        with caplog.at_level("WARNING", logger="aetherscan.preprocessing"):
+            assert not preprocessor._resume_provenance_ok(group, npy_path, metadata_path)
+        assert any("could not stat" in r.message for r in caplog.records)
+
+    def test_malformed_stats_length_reprocesses(self, tmp_path, initialized_runtime, caplog):
+        preprocessor = DataPreprocessor()
+        group, npy_path, metadata_path = self._group_with_real_files(tmp_path)
+        self._write_metadata(
+            metadata_path,
+            h5_paths=group.h5_paths,
+            h5_file_stats=self._stats_for(group.h5_paths)[:3],  # truncated: 3 entries, 6 files
+        )
+        with caplog.at_level("WARNING", logger="aetherscan.preprocessing"):
+            assert not preprocessor._resume_provenance_ok(group, npy_path, metadata_path)
+        assert any("malformed" in r.message for r in caplog.records)
+
+    def test_legacy_sidecar_without_file_stats_reuses(self, tmp_path, initialized_runtime):
+        # A pre-#412 sidecar has no h5_file_stats — the guard skips that check (its h5
+        # paths need not even exist on disk to reuse, matching historical behavior).
+        preprocessor = DataPreprocessor()
+        group, npy_path, metadata_path = self._group_and_paths(tmp_path)
+        self._write_metadata(
+            metadata_path,
+            h5_paths=group.h5_paths,
+            ed_config_fingerprint=preprocessing_config_fingerprint(get_config().to_dict()),
+        )
         assert preprocessor._resume_provenance_ok(group, npy_path, metadata_path)
 
 

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -1600,9 +1600,14 @@ class TestResumeProvenanceGuard:
             metadata_path, h5_paths=group.h5_paths, h5_file_stats=self._stats_for(group.h5_paths)
         )
         os.remove(group.h5_paths[0])
+        os.remove(group.h5_paths[1])
         with caplog.at_level("WARNING", logger="aetherscan.preprocessing"):
             assert preprocessor._resume_provenance_ok(group, npy_path, metadata_path)
-        assert any("could not stat" in r.message for r in caplog.records)
+        # ONE aggregated warning per cadence (not one per file): unreachable raws are the
+        # steady state of a no-raw-bind re-score, and WARNING-level records reach Slack.
+        stat_warnings = [r for r in caplog.records if "could not be stat'd" in r.message]
+        assert len(stat_warnings) == 1
+        assert "2/6" in stat_warnings[0].message
 
     def test_unreachable_h5_does_not_mask_a_real_mismatch(self, tmp_path, initialized_runtime):
         # One file un-stat-able (skipped) while another genuinely changed: still a miss.

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -1406,12 +1406,73 @@ class TestPlanCadencesOutputDir:
         # race the duplicate's prefetch.
         config = get_config()
         make_inference_csv("run_a/subset.csv")
-        make_inference_csv("run_b/subset.csv")
+        default_h5 = [f"/data/obs_{i}.h5" for i in range(6)]
+        make_inference_csv(
+            "run_b/subset.csv",
+            groups=[
+                # Same ordered h5 list under a DIFFERENT group key (a fixed Target typo):
+                # same cadence content -> deduped, first occurrence's key survives
+                (
+                    {
+                        "Target": "HIP_RENAMED",
+                        "Session": "AGBT21B_999_31",
+                        "Band": "L",
+                        "Cadence ID": "0",
+                        "Frequency": "1400",
+                    },
+                    default_h5,
+                ),
+                # A genuinely distinct cadence must survive the dedupe
+                (
+                    {
+                        "Target": "HIP99999",
+                        "Session": "AGBT21B_999_32",
+                        "Band": "L",
+                        "Cadence ID": "1",
+                        "Frequency": "1400",
+                    },
+                    [f"/data/other_{i}.h5" for i in range(6)],
+                ),
+            ],
+        )
         config.data.inference_files = ["run_a/subset.csv", "run_b/subset.csv"]
 
         units = DataPreprocessor().plan_cadences()
 
+        assert len(units) == 2
+        # First occurrence wins: run_a's key survives, the renamed duplicate's doesn't
+        assert units[0].group.key[0] == "HIP110750"
+        assert units[1].group.key[0] == "HIP99999"
+        # unit.index stays contiguous across the skip (stage-timer span names ride on it)
+        assert [u.index for u in units] == [1, 2]
+
+    def test_same_csv_duplicate_cadences_plan_once(self, initialized_runtime, make_inference_csv):
+        # The common real-catalog shape (#417 review note 2): ONE catalog listing the same
+        # six files at two hit frequencies makes two groups with identical ordered h5
+        # lists — the default cadence_group_by_cols include Frequency, which energy
+        # detection never reads (hits are re-derived over the whole band), so the rows'
+        # stamps and scores are identical by construction: one planned unit.
+        config = get_config()
+        h5_paths = [f"/data/obs_{i}.h5" for i in range(6)]
+        base_key = {
+            "Target": "HIP110750",
+            "Session": "AGBT21B_999_31",
+            "Band": "L",
+            "Cadence ID": "0",
+        }
+        make_inference_csv(
+            "subset.csv",
+            groups=[
+                ({**base_key, "Frequency": "1400"}, h5_paths),
+                ({**base_key, "Frequency": "1670"}, h5_paths),
+            ],
+        )
+        config.data.inference_files = ["subset.csv"]
+
+        units = DataPreprocessor().plan_cadences()
+
         assert len(units) == 1
+        assert units[0].group.key[-1] == "1400"  # first occurrence wins
 
     def test_true_digest_collision_raises(
         self, initialized_runtime, make_inference_csv, monkeypatch

--- a/tests/unit/test_preprocessing.py
+++ b/tests/unit/test_preprocessing.py
@@ -249,6 +249,15 @@ class TestCadenceNpyFilename:
             DataPreprocessor._cadence_npy_filename(["a", "bc"])
         )
 
+    def test_golden_digest_is_a_cross_version_contract(self):
+        # The exact digest is persisted on-disk state: every future release must compute
+        # sha256(json.dumps(list(h5_paths)))[:12] byte-for-byte (json.dumps's default ", "
+        # separator included), or every existing cache entry is silently orphaned. If this
+        # test fails, you are breaking cache compatibility — that needs to be a deliberate,
+        # documented decision, not a refactor side effect.
+        paths = [f"/data/obs_{i}.h5" for i in range(6)]
+        assert DataPreprocessor._cadence_npy_filename(paths) == "a182acea8ce3.npy"
+
 
 class TestToJsonSafe:
     def test_bytes_decode(self):
@@ -801,6 +810,46 @@ class TestProcessCadenceEndToEnd:
         assert metadata["stored_width"] == config.inference.stamp_width
         assert metadata["downsample_factor_applied"] == 1
 
+    def test_stats_mismatch_actually_reextracts(self, tmp_path, initialized_runtime, caplog):
+        """The re-extract half of #412's warn+re-extract: a cached .npy whose sidecar
+        (size, mtime) no longer matches the h5 on disk must fall through the resume guard
+        into a real re-extraction (fresh .npy + fresh sidecar), not be skipped."""
+        from aetherscan.preprocessing import CadenceGroup  # noqa: PLC0415
+
+        self._configure("spline")
+        h5_paths = self._make_cadence(tmp_path)
+        group = CadenceGroup(
+            key=("T4", "S1", "L", "10", "2251"),
+            h5_paths=h5_paths,
+            csv_path="unused.csv",
+            expected_obs=6,
+            is_valid=True,
+        )
+        npy_path = str(tmp_path / "out" / "cadence_restage.npy")
+        os.makedirs(os.path.dirname(npy_path), exist_ok=True)
+
+        first = DataPreprocessor().process_pending_cadence(PendingCadence(group, npy_path))
+        assert first is not None and first.freshly_extracted is True
+        with open(first.metadata_path) as f:
+            first_stats = json.load(f)["h5_file_stats"]
+
+        # Simulate a re-stage at the same path: bump one h5's mtime
+        stat = os.stat(h5_paths[2])
+        os.utime(h5_paths[2], (stat.st_atime, stat.st_mtime + 60.0))
+
+        # A DIFFERENT preprocessor (fresh process/operator) must re-extract, not resume
+        with caplog.at_level("WARNING", logger="aetherscan.preprocessing"):
+            second = DataPreprocessor().process_pending_cadence(PendingCadence(group, npy_path))
+        assert any("changed on disk" in r.message for r in caplog.records)
+        assert second is not None and second.freshly_extracted is True
+        assert second.n_hits == first.n_hits  # same bytes -> same stamps
+        with open(second.metadata_path) as f:
+            second_stats = json.load(f)["h5_file_stats"]
+        # The rewritten sidecar records the NEW mtime, so a third run resumes cleanly
+        assert second_stats != first_stats
+        third = DataPreprocessor().process_pending_cadence(PendingCadence(group, npy_path))
+        assert third is not None and third.freshly_extracted is False
+
     @pytest.mark.parametrize("missing_attr", ["foff", "fch1"])
     def test_missing_header_attr_raises_keyerror(self, tmp_path, initialized_runtime, missing_attr):
         """A cadence whose primary ON-source .h5 lacks a required header attr (fch1/foff)
@@ -1348,11 +1397,13 @@ class TestPlanCadencesOutputDir:
         # otherwise resume-skip the cadence off stamps produced under a different ED config.
         assert not os.path.exists(second[0].npy_path)
 
-    def test_duplicate_csv_basenames_plan_cleanly(self, initialized_runtime, make_inference_csv):
+    def test_duplicate_cadences_plan_once(self, initialized_runtime, make_inference_csv):
         # Pre-#412 the stem-keyed layout had to reject duplicate CSV basenames (they would
         # have collided into one directory and cross-resumed). Content addressing removes
-        # the collision by construction: identical cadences resolve to the SAME cache entry
-        # (shared, atomically published), distinct cadences to different ones.
+        # the collision by construction, and identical cadences (same ordered h5 files)
+        # across a run's CSVs dedupe to one planned unit — scoring the same cadence twice
+        # under one tag is pure waste, and two units sharing an npy_path would let pruning
+        # race the duplicate's prefetch.
         config = get_config()
         make_inference_csv("run_a/subset.csv")
         make_inference_csv("run_b/subset.csv")
@@ -1360,15 +1411,30 @@ class TestPlanCadencesOutputDir:
 
         units = DataPreprocessor().plan_cadences()
 
-        assert len(units) == 2
-        assert units[0].npy_path == units[1].npy_path  # same files -> same entry
+        assert len(units) == 1
 
     def test_explicit_override_shared_across_csvs(
         self, initialized_runtime, make_inference_csv, tmp_path
     ):
         config = get_config()
         make_inference_csv("a.csv")
-        make_inference_csv("b.csv")
+        # Distinct h5 files so the two CSVs stay two distinct cadences (identical
+        # cadences would dedupe to one planned unit, #412)
+        make_inference_csv(
+            "b.csv",
+            groups=[
+                (
+                    {
+                        "Target": "HIP99999",
+                        "Session": "AGBT21B_999_32",
+                        "Band": "L",
+                        "Cadence ID": "1",
+                        "Frequency": "1400",
+                    },
+                    [f"/data/other_{i}.h5" for i in range(6)],
+                )
+            ],
+        )
         config.data.inference_files = ["a.csv", "b.csv"]
         override = str(tmp_path / "shared_preproc")
         config.inference.preprocess_output_dir = override
@@ -1471,8 +1537,12 @@ class TestResumeProvenanceGuard:
         self._write_metadata(
             metadata_path, h5_paths=group.h5_paths, h5_file_stats=self._stats_for(group.h5_paths)
         )
-        with open(group.h5_paths[2], "ab") as f:  # a re-staged file grew at the same path
+        # Grow one file, then restore its original mtime — ONLY the size arm can fire
+        # (a re-stage with preserved timestamps, e.g. rsync -t / cp -p, must still miss)
+        original = os.stat(group.h5_paths[2])
+        with open(group.h5_paths[2], "ab") as f:
             f.write(b"extra")
+        os.utime(group.h5_paths[2], (original.st_atime, original.st_mtime))
         with caplog.at_level("WARNING", logger="aetherscan.preprocessing"):
             assert not preprocessor._resume_provenance_ok(group, npy_path, metadata_path)
         assert any("changed on disk" in r.message for r in caplog.records)
@@ -1489,7 +1559,10 @@ class TestResumeProvenanceGuard:
         os.utime(group.h5_paths[4], (stat.st_atime, stat.st_mtime + 60.0))
         assert not preprocessor._resume_provenance_ok(group, npy_path, metadata_path)
 
-    def test_missing_h5_reprocesses_with_warning(self, tmp_path, initialized_runtime, caplog):
+    def test_unreachable_h5_reuses_with_warning(self, tmp_path, initialized_runtime, caplog):
+        # Cannot-verify is not verified-stale: with the raws unreachable (archived, or a
+        # container run without the raw-data bind) the cached stamps are exactly what a
+        # warm re-score needs — the guard warns and reuses rather than invalidating.
         preprocessor = DataPreprocessor()
         group, npy_path, metadata_path = self._group_with_real_files(tmp_path)
         self._write_metadata(
@@ -1497,8 +1570,20 @@ class TestResumeProvenanceGuard:
         )
         os.remove(group.h5_paths[0])
         with caplog.at_level("WARNING", logger="aetherscan.preprocessing"):
-            assert not preprocessor._resume_provenance_ok(group, npy_path, metadata_path)
+            assert preprocessor._resume_provenance_ok(group, npy_path, metadata_path)
         assert any("could not stat" in r.message for r in caplog.records)
+
+    def test_unreachable_h5_does_not_mask_a_real_mismatch(self, tmp_path, initialized_runtime):
+        # One file un-stat-able (skipped) while another genuinely changed: still a miss.
+        preprocessor = DataPreprocessor()
+        group, npy_path, metadata_path = self._group_with_real_files(tmp_path)
+        self._write_metadata(
+            metadata_path, h5_paths=group.h5_paths, h5_file_stats=self._stats_for(group.h5_paths)
+        )
+        os.remove(group.h5_paths[0])
+        stat = os.stat(group.h5_paths[3])
+        os.utime(group.h5_paths[3], (stat.st_atime, stat.st_mtime + 60.0))
+        assert not preprocessor._resume_provenance_ok(group, npy_path, metadata_path)
 
     def test_malformed_stats_length_reprocesses(self, tmp_path, initialized_runtime, caplog):
         preprocessor = DataPreprocessor()
@@ -1508,6 +1593,20 @@ class TestResumeProvenanceGuard:
             h5_paths=group.h5_paths,
             h5_file_stats=self._stats_for(group.h5_paths)[:3],  # truncated: 3 entries, 6 files
         )
+        with caplog.at_level("WARNING", logger="aetherscan.preprocessing"):
+            assert not preprocessor._resume_provenance_ok(group, npy_path, metadata_path)
+        assert any("malformed" in r.message for r in caplog.records)
+
+    @pytest.mark.parametrize("bad_stats", [5, [[100, 1.5]] * 6, ["x"] * 6])
+    def test_malformed_stats_types_reprocess_contained(
+        self, tmp_path, initialized_runtime, caplog, bad_stats
+    ):
+        # Type-level malformation (non-list value, non-dict entries) must degrade to a
+        # warn + re-extract, never raise out of the guard — the resume call site sits
+        # outside process_pending_cadence's per-cadence containment.
+        preprocessor = DataPreprocessor()
+        group, npy_path, metadata_path = self._group_with_real_files(tmp_path)
+        self._write_metadata(metadata_path, h5_paths=group.h5_paths, h5_file_stats=bad_stats)
         with caplog.at_level("WARNING", logger="aetherscan.preprocessing"):
             assert not preprocessor._resume_provenance_ok(group, npy_path, metadata_path)
         assert any("malformed" in r.message for r in caplog.records)


### PR DESCRIPTION
Closes #412

Re-keys the stamp cache to its true content identity and unifies both preprocessing caches under one root, per the issue's design:

- **Content-addressed stamp cache**: `{data_path}/cache/stamps/ed_<fingerprint12>/<sha12-of-ordered-h5-paths>.npy`. A cadence's stamps are a pure function of exactly (ordered h5 path list, ED config), and the key now encodes exactly that — the catalog's basename stem appears nowhere (it was baked into both the directory and every filename), so renamed/subset/superset catalogs over the same files hit the same entries instead of re-preprocessing ~3 h a piece. Path-list **order stays in the hash** (ABACAD order is scientifically meaningful; same files reordered must miss), pinned by an order-sensitivity test plus a golden-digest test that makes the exact digest a deliberate cross-version contract rather than a refactor casualty.
- **(size, mtime) guard**: the sidecar records each h5's `(size, mtime)`, snapshotted **before the cadence's first h5 read** (recording after extraction would let a mid-extraction re-stage record the new file's stats against stamps holding pre-restage bytes, permanently certifying them). The resume guard compares on reuse and warns + re-extracts on mismatch — closing the stale-stamps-after-restage blind spot — while keeping size/mtime **out of the key** so benign re-stages never churn it. Guard semantics are deliberately fail-open: an *un-stat-able* h5 (archived raws, container without the raw-data bind) degrades to warn-and-reuse — cannot-verify is not verified-stale, and the documented no-raw-bind warm re-score workflow depends on it; only positive evidence (mismatch, malformed sidecar) re-extracts, and type-malformed `h5_file_stats` are contained to a warn + re-extract (the guard's call site sits outside per-cadence containment).
- **Obsolete constraint removed**: the unique-basename-stems `ValueError` in `plan_cadences` (and its test) is gone — nothing is stem-keyed anymore. In its place, `plan_cadences` **dedupes by content identity**: overlapping catalogs in one run listing the same cadence plan it once (identical cadences produce identical stamps and scores; two units sharing one npy_path would double work and let `--prune-stamps` race the duplicate's prefetch).
- **Unified cache root**: the PFB response cache moves `{output_path}/cache/pfb/` → `{data_path}/cache/pfb/` (tiny, parameter-derived, self-verifying — moved for coherence). `--preprocess-output-dir` keeps its pin-an-explicit-dir semantics.
- **Two consequential cleanups**: the pre-#298 fixed-name tmp sweep entry is removed (no historical writer ever produced `<stem>.tmp.npy` next to a content-hashed stem), and the `--bandpass-debug-plot` PNG is named after the plotted ON file instead of the now-opaque stamp basename (matching its suptitle; it's a human-facing debug artifact).

Docs swept: INFERENCE_PIPELINE (cache paragraphs, artifacts table, PFB section, plus a **migration note** — the old trees are orphaned and should be deleted by hand, and a `--save-tag` started pre-#412 must not be resumed across the upgrade since resume/supersede key on `npy_path`), PREPROCESSING, ARCHITECTURE (data-flow node + directory trees), config comments, `--preprocess-output-dir` / `--prune-stamps` help, and the regenerated README CLI inference block (sync test green).

**Testing**: `pytest -m "not gpu and not cluster"` under the local tf-stub harness: 1200 passed, 73 failed — the failure list is byte-identical to a clean master baseline run (pre-existing local tf-stub limitations; zero new failures). New/updated unit tests: content-hash naming (determinism, order sensitivity, catalog-name freedom, concatenation non-ambiguity, golden digest), the (size,mtime) guard matrix (match, size-only mismatch with restored mtime, mtime-only, unreachable-h5 reuse + not-masking-a-real-mismatch, malformed length/type containment, legacy sidecar degradation), sidecar stats recording in the end-to-end extraction test, an end-to-end re-extract-on-mismatch test, planned-unit dedupe, and the PFB cache's new location. Cluster verification (cold/warm/renamed-catalog/touch-guard on blpc3 per the issue's acceptance list) follows post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
